### PR TITLE
Add support for tunables of different types in Optuna implementation of Bayesian Optimization

### DIFF
--- a/hyperparameter_tuning/bayes_optuna/optuna_hpo.py
+++ b/hyperparameter_tuning/bayes_optuna/optuna_hpo.py
@@ -62,7 +62,7 @@ class Objective(object):
                 tunable_value = trial.suggest_int(
                     tunable["name"], tunable["lower_bound"], tunable["upper_bound"], tunable["step"]
                 )
-            elif tunable["value_type"].lower() == "string":
+            elif tunable["value_type"].lower() == "categorical":
                 tunable_value = trial.suggest_categorical(tunable["name"], tunable["choices"])
 
             experiment_tunables.append({"tunable_name": tunable["name"], "tunable_value": tunable_value})


### PR DESCRIPTION
- [x] Add support for tunables of type int
- [x] Add support for categorical tunables

Signed-off-by: Rounak Agarwal <rounag16@in.ibm.com>