### PR TITLE
Adds EMUtils, EMEvent & EMAbstractEvent

### DIFF
--- a/src/main/java/com/autotune/experimentManager/finiteStateMachine/api/EMAbstractEvent.java
+++ b/src/main/java/com/autotune/experimentManager/finiteStateMachine/api/EMAbstractEvent.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2021 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package com.autotune.experimentManager.finiteStateMachine.api;
+
+import java.util.Date;
+
+import com.autotune.experimentManager.utils.EMUtils;
+
+/**
+ * This class sets the default name and timestamp.
+ */
+
+public abstract class EMAbstractEvent implements EMEvent {
+
+    protected String name;
+    protected long timestamp;
+
+    protected EMAbstractEvent() {
+        this.name = EMUtils.DEFAULT_EVENT_NAME;
+        timestamp = System.currentTimeMillis();
+    }
+
+    protected EMAbstractEvent(final String name) {
+        this.name = name;
+        timestamp = System.currentTimeMillis();
+    }
+
+    public String getEMEventName() {
+        return name;
+    }
+
+    public long getEMEventTimestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public String toString() {
+        return "Event" +
+                "{name='" + name + '\'' +
+                ", timestamp=" + new Date(timestamp) +
+                '}';
+    }
+}

--- a/src/main/java/com/autotune/experimentManager/finiteStateMachine/api/EMEvent.java
+++ b/src/main/java/com/autotune/experimentManager/finiteStateMachine/api/EMEvent.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2021 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package com.autotune.experimentManager.finiteStateMachine.api;
+
+/**
+ * This is a top level interface for Autotune Finite state machine.
+ */
+
+public interface EMEvent {
+
+    /**
+     * Name of the experiment manager event.
+     *
+     * @return event name of experiment manager
+     */
+    String getEMEventName();
+
+    /**
+     * Timestamp of the event.
+     *
+     * @return event timestamp
+     */
+    long getEMEventTimestamp();
+}

--- a/src/main/java/com/autotune/experimentManager/utils/EMUtils.java
+++ b/src/main/java/com/autotune/experimentManager/utils/EMUtils.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2021 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package com.autotune.experimentManager.utils;
+
+/**
+ * Utility class for keeping the experiment manager specific constants, common code, utility functions etc.
+ */
+
+public final class EMUtils {
+    private EMUtils() {
+
+    }
+
+    public static final String DEFAULT_EVENT_NAME = "event";
+
+}


### PR DESCRIPTION
This patch holds the following changes:

- Declaration of `DEFAULT_EVENT_NAME` in EMUtils class
- EMEvent interface with function declarations `getEMEventName`
  and `getEMEventTimestamp`
- EMAbstractEvent abstract class which implements EMEvent

Signed-off-by: bharathappali <bharath.appali@gmail.com>