### PR TITLE
 Rename dependencyAnalyzer to analyzer in the constants based on latest code changes

### DIFF
--- a/tests/scripts/app_autotune_yaml_constants.sh
+++ b/tests/scripts/app_autotune_yaml_constants.sh
@@ -27,6 +27,8 @@ app_autotune_yaml="app_autotune_yaml"
 testcase_matched=0
 module="da"
 path="${MANIFESTS}/${module}/${app_autotune_yaml}"
+autotune_object_create_msg="com.autotune.analyzer.deployment.AutotuneDeployment - Added autotune object"
+autotune_exception="com.autotune.analyzer.exceptions.InvalidValueException:"
 
 # testcases for application autotune yaml
 app_autotune_tests=("objective_function"
@@ -177,12 +179,15 @@ objective_function_autotune_objects=([blank-objective-function]='true'
 
 # Expected log message for objective function
 declare -A objective_function_expected_log_msgs
-objective_function_expected_log_msgs=([blank-objective-function]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: function_variable transaction_response_time missing in objective_function' 
-[invalid-objective-function]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: function_variable transaction_response_time missing in objective_function'
-[no-objective-function]='error: error validating "'${path}/${app_autotune_tests[0]}/no-objective-function.yaml'": error validating data: ValidationError(Autotune.spec.sla): missing required field "objective_function" in com.recommender.v1.Autotune.spec.sla; if you choose to ignore these errors, turn validation off with --validate=false'
-[no-objective-function-value]='error: error validating "'${path}/${app_autotune_tests[0]}/no-objective-function-value.yaml'": error validating data: ValidationError(Autotune.spec.sla): missing required field "objective_function" in com.recommender.v1.Autotune.spec.sla; if you choose to ignore these errors, turn validation off with --validate=false'
-[null-objective-function]='error: error validating "'${path}/${app_autotune_tests[0]}/null-objective-function.yaml'": error validating data: ValidationError(Autotune.spec.sla): missing required field "objective_function" in com.recommender.v1.Autotune.spec.sla; if you choose to ignore these errors, turn validation off with --validate=false'
-[numerical-objective-function]='The Autotune "numerical-objective-function" is invalid: spec.sla.objective_function: Invalid value: "integer": spec.sla.objective_function in body must be of type string: "integer"'
+yaml_test_path="${path}/${app_autotune_tests[0]}"
+obj_fun_kubectl_error=': error validating data: ValidationError(Autotune.spec.sla): missing required field "objective_function" in com.recommender.v1.Autotune.spec.sla; if you choose to ignore these errors, turn validation off with --validate=false'
+objective_function_expected_log_msgs=([blank-objective-function]=''${autotune_exception}' function_variable transaction_response_time missing in objective_function' 
+[invalid-objective-function]=''${autotune_exception}' function_variable transaction_response_time missing in objective_function' 
+[no-objective-function]='error: error validating "'${yaml_test_path}/no-objective-function.yaml'"'${obj_fun_kubectl_error}'' 
+[no-objective-function-value]='error: error validating "'${yaml_test_path}/no-objective-function-value.yaml'"'${obj_fun_kubectl_error}'' 
+[null-objective-function]='error: error validating "'${yaml_test_path}/null-objective-function.yaml'"'${obj_fun_kubectl_error}'' 
+[numerical-objective-function]='The Autotune "numerical-objective-function" is invalid: spec.sla.objective_function: Invalid value: "integer": spec.sla.objective_function in body must be of type string: "integer"' 
+[valid-objective-function]=''${autotune_object_create_msg}' valid-objective-function')
 
 # Expected autotune object for sla class
 declare -A sla_class_autotune_objects
@@ -198,15 +203,17 @@ sla_class_autotune_objects=([blank-slaclass]='true'
 
 # Expected log message for sla class
 declare -A sla_class_expected_log_msgs
-sla_class_expected_log_msgs=([blank-slaclass]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotune object blank-slaclass'
-[invalid-slaclass]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: sla_class: rgyedg not supported'
-[no-sla]='error: error validating "'${path}/${app_autotune_tests[1]}/no-sla.yaml'": error validating data: ValidationError(Autotune.spec): missing required field "sla" in com.recommender.v1.Autotune.spec; if you choose to ignore these errors, turn validation off with --validate=false'
-[no-slaclass]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotune object no-slaclass'
-[no-sla-value]='error: error validating "'${path}/${app_autotune_tests[1]}/no-sla-value.yaml'": error validating data: ValidationError(Autotune.spec): missing required field "sla" in com.recommender.v1.Autotune.spec; if you choose to ignore these errors, turn validation off with --validate=false'
-[no-slaclass-value]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotune object no-slaclass-value-slaclass'
-[null-slaclass]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotune object null-slaclass'
-[numerical-slaclass]='The Autotune "numerical-slaclass" is invalid: spec.sla.sla_class: Invalid value: "integer": spec.sla.sla_class in body must be of type string: "integer"'
-[valid-slaclass]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotune object valid-slaclass')
+yaml_test_path="${path}/${app_autotune_tests[1]}"
+sla_kubectl_error=': error validating data: ValidationError(Autotune.spec): missing required field "sla" in com.recommender.v1.Autotune.spec; if you choose to ignore these errors, turn validation off with --validate=false'
+sla_class_expected_log_msgs=([blank-slaclass]=''${autotune_object_create_msg}' blank-slaclass' 
+[invalid-slaclass]=''${autotune_exception}' sla_class: rgyedg not supported' 
+[no-sla]='error: error validating "'${yaml_test_path}/no-sla.yaml'"'${sla_kubectl_error}''
+[no-slaclass]=''${autotune_object_create_msg}' no-slaclass'
+[no-sla-value]='error: error validating "'${yaml_test_path}/no-sla-value.yaml'"'${sla_kubectl_error}'' 
+[no-slaclass-value]=''${autotune_object_create_msg}' no-slaclass-value' 
+[null-slaclass]=''${autotune_object_create_msg}' null-slaclass' 
+[numerical-slaclass]='The Autotune "numerical-slaclass" is invalid: spec.sla.sla_class: Invalid value: "integer": spec.sla.sla_class in body must be of type string: "integer"' 
+[valid-slaclass]=''${autotune_object_create_msg}' valid-slaclass')
 
 # Expected autotune object for direction
 declare -A direction_autotune_objects
@@ -220,13 +227,15 @@ direction_autotune_objects=([blank-direction]='true'
 
 # Expected log message for direction
 declare -A direction_expected_log_msgs
-direction_expected_log_msgs=([blank-direction]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: Invalid direction for autotune kind'
-[invalid-direction]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: Invalid direction for autotune kind'
-[no-direction]='error: error validating "'${path}/${app_autotune_tests[2]}/no-direction.yaml'": error validating data: ValidationError(Autotune.spec.sla): missing required field "direction" in com.recommender.v1.Autotune.spec.sla; if you choose to ignore these errors, turn validation off with --validate=false'
-[no-direction-value]='error: error validating "'${path}/${app_autotune_tests[2]}/no-direction-value.yaml'": error validating data: ValidationError(Autotune.spec.sla): missing required field "direction" in com.recommender.v1.Autotune.spec.sla; if you choose to ignore these errors, turn validation off with --validate=false'
-[null-direction]='error: error validating "'${path}/${app_autotune_tests[2]}/null-direction.yaml'": error validating data: ValidationError(Autotune.spec.sla): missing required field "direction" in com.recommender.v1.Autotune.spec.sla; if you choose to ignore these errors, turn validation off with --validate=false'
-[numerical-direction]='The Autotune "numerical-direction" is invalid: spec.sla.direction: Invalid value: "integer": spec.sla.direction in body must be of type string: "integer"'
-[valid-direction]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotune object valid-direction')
+yaml_test_path="${path}/${app_autotune_tests[2]}"
+direction_kubectl_error=': error validating data: ValidationError(Autotune.spec.sla): missing required field "direction" in com.recommender.v1.Autotune.spec.sla; if you choose to ignore these errors, turn validation off with --validate=false'
+direction_expected_log_msgs=([blank-direction]=''${autotune_exception}' Invalid direction for autotune kind' 
+[invalid-direction]=''${autotune_exception}' Invalid direction for autotune kind' 
+[no-direction]='error: error validating "'${yaml_test_path}/no-direction.yaml'"'${direction_kubectl_error}'' 
+[no-direction-value]='error: error validating "'${yaml_test_path}/no-direction-value.yaml'"'${direction_kubectl_error}'' 
+[null-direction]='error: error validating "'${yaml_test_path}/null-direction.yaml'"'${direction_kubectl_error}'' 
+[numerical-direction]='The Autotune "numerical-direction" is invalid: spec.sla.direction: Invalid value: "integer": spec.sla.direction in body must be of type string: "integer"' 
+[valid-direction]=''${autotune_object_create_msg}' valid-direction')
 
 # Expected autotune object for function variable name
 declare -A function_variable_name_autotune_objects
@@ -240,13 +249,15 @@ function_variable_name_autotune_objects=([blank-function-variable-name]='true'
 
 # Expected log message for function variable name
 declare -A function_variable_name_expected_log_msgs
-function_variable_name_expected_log_msgs=([blank-function-variable-name]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: function_variable   missing in objective_function'
-[invalid-function-variable-name]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: function_variable transme missing in objective_function'
-[no-function-variable-name]='error: error validating "'${path}/${app_autotune_tests[3]}/no-function-variable-name.yaml'": error validating data: ValidationError(Autotune.spec.sla.function_variables): invalid type for com.recommender.v1.Autotune.spec.sla.function_variables: got "map", expected "array"; if you choose to ignore these errors, turn validation off with --validate=false'
-[no-function-variable-name-value]='error: error validating "'${path}/${app_autotune_tests[3]}/no-function-variable-name-value.yaml'": error validating data: ValidationError(Autotune.spec.sla.function_variables\[0\]): missing required field "name" in com.recommender.v1.Autotune.spec.sla.function_variables; if you choose to ignore these errors, turn validation off with --validate=false'
-[null-function-variable-name]='error: error validating "'${path}/${app_autotune_tests[3]}/null-function-variable-name.yaml'": error validating data: ValidationError(Autotune.spec.sla.function_variables\[0\]): missing required field "name" in com.recommender.v1.Autotune.spec.sla.function_variables; if you choose to ignore these errors, turn validation off with --validate=false'
-[numerical-function-variable-name]='The Autotune "numerical-function-variable-name" is invalid: spec.sla.function_variables.name: Invalid value: "integer": spec.sla.function_variables.name in body must be of type string: "integer"'
-[valid-function-variable-name]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotune object valid-function-variable-name')
+yaml_test_path="${path}/${app_autotune_tests[3]}"
+fun_var_name_kubectl_error=': error validating data: ValidationError(Autotune.spec.sla.function_variables\[0\]): missing required field "name" in com.recommender.v1.Autotune.spec.sla.function_variables; if you choose to ignore these errors, turn validation off with --validate=false'
+function_variable_name_expected_log_msgs=([blank-function-variable-name]=''${autotune_exception}' function_variable   missing in objective_function' 
+[invalid-function-variable-name]=''${autotune_exception}' function_variable transme missing in objective_function' 
+[no-function-variable-name]='error: error validating "'${yaml_test_path}/no-function-variable-name.yaml'": error validating data: ValidationError(Autotune.spec.sla.function_variables): invalid type for com.recommender.v1.Autotune.spec.sla.function_variables: got "map", expected "array"; if you choose to ignore these errors, turn validation off with --validate=false' 
+[no-function-variable-name-value]='error: error validating "'${yaml_test_path}/no-function-variable-name-value.yaml'"'${fun_var_name_kubectl_error}'' 
+[null-function-variable-name]='error: error validating "'${yaml_test_path}/null-function-variable-name.yaml'"'${fun_var_name_kubectl_error}'' 
+[numerical-function-variable-name]='The Autotune "numerical-function-variable-name" is invalid: spec.sla.function_variables.name: Invalid value: "integer": spec.sla.function_variables.name in body must be of type string: "integer"' 
+[valid-function-variable-name]=''${autotune_object_create_msg}' valid-function-variable-name')
 
 # Expected autotune object for function variable query
 declare -A function_variable_query_autotune_objects
@@ -260,13 +271,15 @@ function_variable_query_autotune_objects=([blank-function-variable-query]='true'
 
 # Expected log message for function variable query
 declare -A function_variable_query_expected_log_msgs
-function_variable_query_expected_log_msgs=([blank-function-variable-query]='validation from da'
-[invalid-function-variable-query]='validation from da'
-[no-function-variable-query]='error: error validating "'${path}/${app_autotune_tests[4]}/no-function-variable-query.yaml'": error validating data: ValidationError(Autotune.spec.sla.function_variables\[0\]): missing required field "query" in com.recommender.v1.Autotune.spec.sla.function_variables; if you choose to ignore these errors, turn validation off with --validate=false'
-[no-function-variable-query-value]='error: error validating "'${path}/${app_autotune_tests[4]}/no-function-variable-query-value.yaml'": error validating data: ValidationError(Autotune.spec.sla.function_variables\[0\]): missing required field "query" in com.recommender.v1.Autotune.spec.sla.function_variables; if you choose to ignore these errors, turn validation off with --validate=false'
-[null-function-variable-query]='error: error validating "'${path}/${app_autotune_tests[4]}/null-function-variable-query.yaml'": error validating data: ValidationError(Autotune.spec.sla.function_variables\[0\]): missing required field "query" in com.recommender.v1.Autotune.spec.sla.function_variables; if you choose to ignore these errors, turn validation off with --validate=false'
-[numerical-function-variable-query]='The Autotune "numerical-function-variable-query" is invalid: spec.sla.function_variables.query: Invalid value: "integer": spec.sla.function_variables.query in body must be of type string: "integer"'
-[valid-function-variable-query]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotune object valid-function-variable-query')
+yaml_test_path="${path}/${app_autotune_tests[4]}"
+fun_var_query_kubectl_error=': error validating data: ValidationError(Autotune.spec.sla.function_variables\[0\]): missing required field "query" in com.recommender.v1.Autotune.spec.sla.function_variables; if you choose to ignore these errors, turn validation off with --validate=false'
+function_variable_query_expected_log_msgs=([blank-function-variable-query]='validation from da' 
+[invalid-function-variable-query]='validation from da' 
+[no-function-variable-query]='error: error validating "'${yaml_test_path}/no-function-variable-query.yaml'"'${fun_var_query_kubectl_error}'' 
+[no-function-variable-query-value]='error: error validating "'${yaml_test_path}/no-function-variable-query-value.yaml'"'${fun_var_query_kubectl_error}'' 
+[null-function-variable-query]='error: error validating "'${yaml_test_path}/null-function-variable-query.yaml'"'${fun_var_query_kubectl_error}'' 
+[numerical-function-variable-query]='The Autotune "numerical-function-variable-query" is invalid: spec.sla.function_variables.query: Invalid value: "integer": spec.sla.function_variables.query in body must be of type string: "integer"' 
+[valid-function-variable-query]=''${autotune_object_create_msg}' valid-function-variable-query')
 
 # Expected autotune object for function variable datasource
 declare -A function_variable_datasource_autotune_objects
@@ -280,13 +293,14 @@ function_variable_datasource_autotune_objects=([blank-function-variable-datasour
 
 # Expected log message for sla function variable datasource
 declare -A function_variable_datasource_expected_log_msgs
-function_variable_datasource_expected_log_msgs=([blank-function-variable-datasource]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: function_variable: transaction_response_time datasource not supported'
-[invalid-function-variable-datasource]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: function_variable: transaction_response_time datasource not supported'
-[no-function-variable-datasource]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: function_variable: transaction_response_time datasource not supported'
-[no-function-variable-datasource-value]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: function_variable: transaction_response_time datasource not supported'
-[null-function-variable-datasource]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: function_variable: transaction_response_time datasource not supported'
-[numerical-function-variable-datasource]='The Autotune "numerical-function-variable-datasource" is invalid: spec.sla.function_variables.datasource: Invalid value: "integer": spec.sla.function_variables.datasource in body must be of type string: "integer"'
-[valid-function-variable-datasource]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotune object valid-function-variable-datasource')
+function_var_exception="${autotune_exception} function_variable: transaction_response_time datasource not supported"
+function_variable_datasource_expected_log_msgs=([blank-function-variable-datasource]=''${function_var_exception}'' 
+[invalid-function-variable-datasource]=''${function_var_exception}'' 
+[no-function-variable-datasource]=''${function_var_exception}'' 
+[no-function-variable-datasource-value]=''${function_var_exception}'' 
+[null-function-variable-datasource]=''${function_var_exception}'' 
+[numerical-function-variable-datasource]='The Autotune "numerical-function-variable-datasource" is invalid: spec.sla.function_variables.datasource: Invalid value: "integer": spec.sla.function_variables.datasource in body must be of type string: "integer"' 
+[valid-function-variable-datasource]=''${autotune_object_create_msg}' valid-function-variable-datasource' )
 
 # Expected autotune object for function variable value type
 declare -A function_variable_value_type_autotune_objects
@@ -300,13 +314,15 @@ function_variable_value_type_autotune_objects=([blank-function-variable-value-ty
 
 # Expected log message for function variable value type
 declare -A function_variable_value_type_expected_log_msgs
-function_variable_value_type_expected_log_msgs=([blank-function-variable-value-type]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: function_variable: transaction_response_time value_type not supported'
-[invalid-function-variable-value-type]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: function_variable: transaction_response_time value_type not supported'
-[no-function-variable-value-type]='error: error validating "'${path}/${app_autotune_tests[6]}/no-function-variable-value-type.yaml'": error validating data: ValidationError(Autotune.spec.sla.function_variables\[0\]): missing required field "value_type" in com.recommender.v1.Autotune.spec.sla.function_variables; if you choose to ignore these errors, turn validation off with --validate=false'
-[no-function-variable-value-type-value]='error: error validating "'${path}/${app_autotune_tests[6]}/no-function-variable-value-type-value.yaml'": error validating data: ValidationError(Autotune.spec.sla.function_variables\[0\]): missing required field "value_type" in com.recommender.v1.Autotune.spec.sla.function_variables; if you choose to ignore these errors, turn validation off with --validate=false'
-[null-function-variable-value-type]='error: error validating "'${path}/${app_autotune_tests[6]}/null-function-variable-value-type.yaml'": error validating data: ValidationError(Autotune.spec.sla.function_variables\[0\]): missing required field "value_type" in com.recommender.v1.Autotune.spec.sla.function_variables; if you choose to ignore these errors, turn validation off with --validate=false'
-[numerical-function-variable-value-type]='The Autotune "numerical-function-variable-value-type" is invalid: spec.sla.function_variables.value_type: Invalid value: "integer": spec.sla.function_variables.value_type in body must be of type string: "integer"'
-[valid-function-variable-value-type]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotune object valid-function-variable-value-type')
+yaml_test_path="${path}/${app_autotune_tests[6]}"
+fun_var_type_kubectl_error=': error validating data: ValidationError(Autotune.spec.sla.function_variables\[0\]): missing required field "value_type" in com.recommender.v1.Autotune.spec.sla.function_variables; if you choose to ignore these errors, turn validation off with --validate=false'
+function_variable_value_type_expected_log_msgs=([blank-function-variable-value-type]=''${autotune_exception}' function_variable: transaction_response_time value_type not supported' 
+[invalid-function-variable-value-type]=''${autotune_exception}' function_variable: transaction_response_time value_type not supported' 
+[no-function-variable-value-type]='error: error validating "'${yaml_test_path}/no-function-variable-value-type.yaml'"'${fun_var_type_kubectl_error}'' 
+[no-function-variable-value-type-value]='error: error validating "'${yaml_test_path}/no-function-variable-value-type-value.yaml'"'${fun_var_type_kubectl_error}'' 
+[null-function-variable-value-type]='error: error validating "'${yaml_test_path}/null-function-variable-value-type.yaml'"'${fun_var_type_kubectl_error}'' 
+[numerical-function-variable-value-type]='The Autotune "numerical-function-variable-value-type" is invalid: spec.sla.function_variables.value_type: Invalid value: "integer": spec.sla.function_variables.value_type in body must be of type string: "integer"' 
+[valid-function-variable-value-type]=''${autotune_object_create_msg}' valid-function-variable-value-type' )
 
 # Expected autotune object for hpo_algo_impl
 declare -A hpo_algo_impl_autotune_objects
@@ -319,12 +335,12 @@ hpo_algo_impl_autotune_objects=([blank-hpo-algo-impl]='true'
 
 # Expected log message for hpo_algo_impl
 declare -A hpo_algo_impl_expected_log_msgs
-hpo_algo_impl_expected_log_msgs=([blank-hpo-algo-impl]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: Hyperparameter Optimization Algorithm   not supported'
-[invalid-hpo-algo-impl]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: Hyperparameter Optimization Algorithm xyz not supported'
+hpo_algo_impl_expected_log_msgs=([blank-hpo-algo-impl]=''${autotune_exception}' Hyperparameter Optimization Algorithm   not supported'
+[invalid-hpo-algo-impl]=''${autotune_exception}' Hyperparameter Optimization Algorithm xyz not supported'
 [no-hpo-algo-impl-value]='validation from da'
 [null-hpo-algo-impl]='validation from da'
 [numerical-hpo-algo-impl]='The Autotune "numerical-hpo-algo-impl" is invalid: spec.sla.hpo_algo_impl: Invalid value: "integer": spec.sla.hpo_algo_impl in body must be of type string: "integer"'
-[valid-hpo-algo-impl]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotune object valid-hpo-algo-impl')
+[valid-hpo-algo-impl]=''${autotune_object_create_msg}' valid-hpo-algo-impl')
 
 # Expected autotune object for mode
 declare -A mode_autotune_objects
@@ -338,13 +354,15 @@ mode_autotune_objects=([blank-mode]='true'
 
 # Expected log message for mode
 declare -A mode_expected_log_msgs
-mode_expected_log_msgs=([blank-mode]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: Autotune object mode not supported'
-[invalid-mode]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: Autotune object mode not supported'
-[no-mode]='error: error validating "'${path}/${app_autotune_tests[8]}/no-mode.yaml'": error validating data: ValidationError(Autotune.spec): missing required field "mode" in com.recommender.v1.Autotune.spec; if you choose to ignore these errors, turn validation off with --validate=false'
-[no-mode-value]='error: error validating "'${path}/${app_autotune_tests[8]}/no-mode-value.yaml'": error validating data: ValidationError(Autotune.spec): missing required field "mode" in com.recommender.v1.Autotune.spec; if you choose to ignore these errors, turn validation off with --validate=false'
-[null-mode]='error: error validating "'${path}/${app_autotune_tests[8]}/null-mode.yaml'": error validating data: ValidationError(Autotune.spec): missing required field "mode" in com.recommender.v1.Autotune.spec; if you choose to ignore these errors, turn validation off with --validate=false'
-[numerical-mode]='The Autotune "numerical-mode" is invalid: spec.mode: Invalid value: "integer": spec.mode in body must be of type string: "integer"'
-[valid-mode]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotune object valid-mode')
+yaml_test_path="${path}/${app_autotune_tests[8]}"
+mode_kubectl_error=': error validating data: ValidationError(Autotune.spec): missing required field "mode" in com.recommender.v1.Autotune.spec; if you choose to ignore these errors, turn validation off with --validate=false'
+mode_expected_log_msgs=([blank-mode]=''${autotune_exception}' Autotune object mode not supported' 
+[invalid-mode]=''${autotune_exception}' Autotune object mode not supported' 
+[no-mode]='error: error validating "'${yaml_test_path}/no-mode.yaml'"'${mode_kubectl_error}'' 
+[no-mode-value]='error: error validating "'${yaml_test_path}/no-mode-value.yaml'"'${mode_kubectl_error}'' 
+[null-mode]='error: error validating "'${yaml_test_path}/null-mode.yaml'"'${mode_kubectl_error}'' 
+[numerical-mode]='The Autotune "numerical-mode" is invalid: spec.mode: Invalid value: "integer": spec.mode in body must be of type string: "integer"' 
+[valid-mode]=''${autotune_object_create_msg}' valid-mode' )
 
 # Expected autotune object for label
 declare -A label_autotune_objects
@@ -358,13 +376,14 @@ label_autotune_objects=([blank-label]='true'
 
 # Expected log message for label
 declare -A label_expected_log_msgs
-label_expected_log_msgs=([blank-label]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: label:   not supported'
-[invalid-label]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: label:   not supported'
-[no-label]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: Invalid MatchLabel'
-[no-label-value]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: Invalid MatchLabel'
-[null-label]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: Invalid MatchLabel'
-[numerical-label]='The Autotune "numerical-label" is invalid: spec.selector.matchLabel: Invalid value: "integer": spec.selector.matchLabel in body must be of type string: "integer"'
-[valid-label]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotune object valid-label')
+exception_invalid_label=''${autotune_exception}' Invalid MatchLabel'
+label_expected_log_msgs=([blank-label]=''${exception_invalid_label}' in selector' 
+[invalid-label]=''${autotune_exception}' label:   not supported' 
+[no-label]=''${exception_invalid_label}'' 
+[no-label-value]=''${exception_invalid_label}'' 
+[null-label]=''${exception_invalid_label}'' 
+[numerical-label]='The Autotune "numerical-label" is invalid: spec.selector.matchLabel: Invalid value: "integer": spec.selector.matchLabel in body must be of type string: "integer"' 
+[valid-label]=''${autotune_object_create_msg}' valid-label' )
 
 # Expected autotune object for label value
 declare -A labelvalue_autotune_objects
@@ -378,13 +397,13 @@ labelvalue_autotune_objects=([blank-labelvalue]='true'
 
 # Expected log message for label value
 declare -A labelvalue_expected_log_msgs
-labelvalue_expected_log_msgs=([blank-labelvalue]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: labelvalue:   not supported'
-[invalid-labelvalue]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: labelvalue:   not supported'
-[no-labelvalue]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: Invalid MatchLabelValue'
-[no-labelvalue-value]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: Invalid MatchLabelValue'
-[null-labelvalue]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: Invalid MatchLabelValue'
-[numerical-labelvalue]='The Autotune "numerical-labelvalue" is invalid: spec.selector.matchLabelValue: Invalid value: "integer": spec.selector.matchLabelValue in body must be of type string: "integer"'
-[valid-labelvalue]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotune object valid-labelvalue')
+labelvalue_expected_log_msgs=([blank-labelvalue]=''${autotune_exception}' Invalid or blank MatchLabelValue in selector' 
+[invalid-labelvalue]=''${autotune_exception}' labelvalue:   not supported' 
+[no-labelvalue]=''${exception_invalid_label}'Value' 
+[no-labelvalue-value]=''${exception_invalid_label}'Value' 
+[null-labelvalue]=''${exception_invalid_label}'Value' 
+[numerical-labelvalue]='The Autotune "numerical-labelvalue" is invalid: spec.selector.matchLabelValue: Invalid value: "integer": spec.selector.matchLabelValue in body must be of type string: "integer"' 
+[valid-labelvalue]=''${autotune_object_create_msg}' valid-labelvalue' )
 
 # Expected autotune object for datasource name
 declare -A datasource_name_autotune_objects
@@ -398,13 +417,15 @@ datasource_name_autotune_objects=([blank-datasource-name]='true'
 
 # Expected log message for datasource name
 declare -A datasource_name_expected_log_msgs
-datasource_name_expected_log_msgs=([blank-datasource-name]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: datasource-name:   not supported'
-[invalid-datasource-name]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: datasource-name:   not supported'
-[no-datasource-name]='error: error validating "'${path}/${app_autotune_tests[11]}/no-datasource-name.yaml'": error validating data: ValidationError(Autotune.spec.datasource): missing required field "name" in com.recommender.v1.Autotune.spec.datasource; if you choose to ignore these errors, turn validation off with --validate=false'
-[no-datasource-name-value]='error: error validating "'${path}/${app_autotune_tests[11]}/no-datasource-name-value.yaml'": error validating data: ValidationError(Autotune.spec.datasource): missing required field "name" in com.recommender.v1.Autotune.spec.datasource; if you choose to ignore these errors, turn validation off with --validate=false'
-[null-datasource-name]='error: error validating "'${path}/${app_autotune_tests[11]}/null-datasource-name.yaml'": error validating data: ValidationError(Autotune.spec.datasource): missing required field "name" in com.recommender.v1.Autotune.spec.datasource; if you choose to ignore these errors, turn validation off with --validate=false'
+yaml_test_path="${path}/${app_autotune_tests[11]}"
+datasource_name_kubectl_error=': error validating data: ValidationError(Autotune.spec.datasource): missing required field "name" in com.recommender.v1.Autotune.spec.datasource; if you choose to ignore these errors, turn validation off with --validate=false'
+datasource_name_expected_log_msgs=([blank-datasource-name]=''${autotune_exception}' datasource-name:   not supported'
+[invalid-datasource-name]=''${autotune_exception}' datasource-name:   not supported'
+[no-datasource-name]='error: error validating "'${yaml_test_path}/no-datasource-name.yaml'"'${datasource_name_kubectl_error}''
+[no-datasource-name-value]='error: error validating "'${yaml_test_path}/no-datasource-name-value.yaml'"'${datasource_name_kubectl_error}''
+[null-datasource-name]='error: error validating "'${yaml_test_path}/null-datasource-name.yaml'"'${datasource_name_kubectl_error}''
 [numerical-datasource-name]='The Autotune "numerical-datasource-name" is invalid: spec.datasource.name: Invalid value: "integer": spec.datasource.name in body must be of type string: "integer"'
-[valid-datasource-name]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotune object valid-datasource-name')
+[valid-datasource-name]=''${autotune_object_create_msg}' valid-datasource-name')
 
 # Expected autotune object for datasource url
 declare -A datasource_url_autotune_objects
@@ -418,13 +439,15 @@ datasource_url_autotune_objects=([blank-datasource-url]='true'
 
 # Expected log message for datasource url
 declare -A datasource_url_expected_log_msgs
-datasource_url_expected_log_msgs=([blank-datasource-url]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: datasource-url:   not supported'
-[invalid-datasource-url]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: datasource-name:   not supported'
-[no-datasource-url]='error: error validating "'${path}/${app_autotune_tests[12]}/no-datasource-url.yaml'": error validating data: ValidationError(Autotune.spec.datasource): missing required field "value" in com.recommender.v1.Autotune.spec.datasource; if you choose to ignore these errors, turn validation off with --validate=false'
-[no-datasource-url-value]='error: error validating "'${path}/${app_autotune_tests[12]}/no-datasource-url-value.yaml'": error validating data: ValidationError(Autotune.spec.datasource): missing required field "value" in com.recommender.v1.Autotune.spec.datasource; if you choose to ignore these errors, turn validation off with --validate=false'
-[null-datasource-url]='error: error validating "'${path}/${app_autotune_tests[12]}/null-datasource-url.yaml'": error validating data: ValidationError(Autotune.spec.datasource): missing required field "value" in com.recommender.v1.Autotune.spec.datasource; if you choose to ignore these errors, turn validation off with --validate=false'
+yaml_test_path="${path}/${app_autotune_tests[12]}"
+datasource_url_kubectl_error=': error validating data: ValidationError(Autotune.spec.datasource): missing required field "value" in com.recommender.v1.Autotune.spec.datasource; if you choose to ignore these errors, turn validation off with --validate=false'
+datasource_url_expected_log_msgs=([blank-datasource-url]=''${autotune_exception}' datasource-url:   not supported'
+[invalid-datasource-url]=''${autotune_exception}' datasource-url:   not supported'
+[no-datasource-url]='error: error validating "'${yaml_test_path}/no-datasource-url.yaml'"'${datasource_url_kubectl_error}''
+[no-datasource-url-value]='error: error validating "'${yaml_test_path}/no-datasource-url-value.yaml'"'${datasource_url_kubectl_error}''
+[null-datasource-url]='error: error validating "'${yaml_test_path}/null-datasource-url.yaml'"'${datasource_url_kubectl_error}''
 [numerical-datasource-url]='The Autotune "numerical-datasource-url" is invalid: spec.datasource.value: Invalid value: "integer": spec.datasource.value in body must be of type string: "integer"'
-[valid-datasource-url]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotune object valid-datasource-url')
+[valid-datasource-url]=''${autotune_object_create_msg}' valid-datasource-url')
 
 # Expected autotune object for other test cases
 declare -A autotune_other_autotune_objects

--- a/tests/scripts/autotune_config_constants.sh
+++ b/tests/scripts/autotune_config_constants.sh
@@ -27,6 +27,9 @@ autotune_config_testsuite="autotune_config_yaml"
 testcase_matched=0
 module="da"
 yaml_path="${MANIFESTS}/${module}/${autotune_config_testsuite}"
+autotune_config_obj_create_msg='com.autotune.analyzer.deployment.AutotuneDeployment - Added autotuneconfig'
+exception="com.autotune.analyzer.exceptions.InvalidValueException:"
+invalid_bound_exception='com.autotune.analyzer.exceptions.InvalidBoundsException'
 
 # testcases for autotune config yaml
 autotune_config_tests=("layer_name"
@@ -152,6 +155,7 @@ tunable_upper_bound_testcases=("blank-tunable-upper-bound"
 "no-tunable-upper-bound-value"
 "null-tunable-upper-bound"
 "char-tunable-upper-bound"
+"zero-tunable-upper-bound" 
 "valid-tunable-upper-bound")
 
 # tests for tunable lower bound
@@ -161,11 +165,11 @@ tunable_lower_bound_testcases=("blank-tunable-lower-bound"
 "no-tunable-lower-bound-value"
 "null-tunable-lower-bound"
 "char-tunable-lower-bound"
+"zero-tunable-lower-bound"
 "valid-tunable-lower-bound")
 
 # tests for step
 step_testcases=("invalid-step"
-"no-step"
 "no-step-value"
 "null-step"
 "char-step"
@@ -221,12 +225,14 @@ layer_name_autotune_objects=([blank-layer-name]='true'
 
 # Expected log message for layer-name
 declare -A layer_name_expected_log_msgs
-layer_name_expected_log_msgs=([blank-layer-name]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: AutotuneConfig object name cannot be null or empty'
-[no-layer-name]='error: error validating "'${yaml_path}/${autotune_config_tests[0]}/no-layer-name.yaml'": error validating data: ValidationError(AutotuneConfig): missing required field "layer_name" in com.recommender.v1.AutotuneConfig; if you choose to ignore these errors, turn validation off with --validate=false'
-[no-layer-name-value]='error: error validating "'${yaml_path}/${autotune_config_tests[0]}/no-layer-name-value.yaml'": error validating data: ValidationError(AutotuneConfig): missing required field "layer_name" in com.recommender.v1.AutotuneConfig; if you choose to ignore these errors, turn validation off with --validate=false'
-[null-layer-name]='error: error validating "'${yaml_path}/${autotune_config_tests[0]}/null-layer-name.yaml'": error validating data: ValidationError(AutotuneConfig): missing required field "layer_name" in com.recommender.v1.AutotuneConfig; if you choose to ignore these errors, turn validation off with --validate=false'
+layer_name_yaml_path="${yaml_path}/${autotune_config_tests[0]}"
+layer_name_kubectl_error=': error validating data: ValidationError(AutotuneConfig): missing required field "layer_name" in com.recommender.v1.AutotuneConfig; if you choose to ignore these errors, turn validation off with --validate=false'
+layer_name_expected_log_msgs=([blank-layer-name]=''${exception}' AutotuneConfig object name cannot be null or empty'
+[no-layer-name]='error: error validating "'${layer_name_yaml_path}/no-layer-name.yaml'"'${layer_name_kubectl_error}''
+[no-layer-name-value]='error: error validating "'${layer_name_yaml_path}/no-layer-name-value.yaml'"'${layer_name_kubectl_error}''
+[null-layer-name]='error: error validating "'${layer_name_yaml_path}/null-layer-name.yaml'"'${layer_name_kubectl_error}''
 [numerical-layer-name]='The AutotuneConfig "numerical-layer-name" is invalid: layer_name: Invalid value: "integer": layer_name in body must be of type string: "integer"'
-[valid-layer-name]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotuneconfig valid-layer-name')
+[valid-layer-name]=''${autotune_config_obj_create_msg}' valid-layer-name')
 
 # Expected autotune object for layer-level
 declare -A layer_level_autotune_objects
@@ -240,12 +246,14 @@ layer_level_autotune_objects=([char-layer-level]='false'
 
 # Expected log message for layer-level
 declare -A layer_level_expected_log_msgs
-layer_level_expected_log_msgs=([char-layer-level]='error: error validating "'${yaml_path}/${autotune_config_tests[1]}/char-layer-level.yaml'": error validating data: ValidationError(AutotuneConfig.layer_level): invalid type for com.recommender.v1.AutotuneConfig.layer_level: got "string", expected "integer"; if you choose to ignore these errors, turn validation off with --validate=false'
-[invalid-layer-level]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: Layer level must be a non-negative integer'
-[no-layer-level]='error: error validating "'${yaml_path}/${autotune_config_tests[1]}/no-layer-level.yaml'": error validating data: ValidationError(AutotuneConfig): missing required field "layer_level" in com.recommender.v1.AutotuneConfig; if you choose to ignore these errors, turn validation off with --validate=false'
-[no-layer-level-value]='error: error validating "'${yaml_path}/${autotune_config_tests[1]}/no-layer-level-value.yaml'": error validating data: ValidationError(AutotuneConfig): missing required field "layer_level" in com.recommender.v1.AutotuneConfig; if you choose to ignore these errors, turn validation off with --validate=false'
-[null-layer-level]='error: error validating "'${yaml_path}/${autotune_config_tests[1]}/null-layer-level.yaml'": error validating data: ValidationError(AutotuneConfig): missing required field "layer_level" in com.recommender.v1.AutotuneConfig; if you choose to ignore these errors, turn validation off with --validate=false'
-[valid-layer-level]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotuneconfig valid-layer-level')
+layer_level_yaml_path="${yaml_path}/${autotune_config_tests[1]}"
+layer_level_kubectl_error=': error validating data: ValidationError(AutotuneConfig): missing required field "layer_level" in com.recommender.v1.AutotuneConfig; if you choose to ignore these errors, turn validation off with --validate=false'
+layer_level_expected_log_msgs=([char-layer-level]='error: error validating "'${layer_level_yaml_path}/char-layer-level.yaml'": error validating data: ValidationError(AutotuneConfig.layer_level): invalid type for com.recommender.v1.AutotuneConfig.layer_level: got "string", expected "integer"; if you choose to ignore these errors, turn validation off with --validate=false'
+[invalid-layer-level]=''${exception}' Layer level must be a non-negative integer'
+[no-layer-level]='error: error validating "'${layer_level_yaml_path}/no-layer-level.yaml'"'${layer_level_kubectl_error}''
+[no-layer-level-value]='error: error validating "'${layer_level_yaml_path}/no-layer-level-value.yaml'"'${layer_level_kubectl_error}''
+[null-layer-level]='error: error validating "'${layer_level_yaml_path}/null-layer-level.yaml'"'${layer_level_kubectl_error}''
+[valid-layer-level]=''${autotune_config_obj_create_msg}' valid-layer-level')
 
 # Expected autotune object for presence
 declare -A presence_autotune_objects
@@ -259,13 +267,15 @@ presence_autotune_objects=([blank-presence]='true'
 
 #Expected log message for presence
 declare -A presence_expected_log_msgs
-presence_expected_log_msgs=([blank-presence]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: Layer presence missing! Must be indicated through a presence field, layerPresenceQuery or layerPresenceLabel'
-[invalid-presence]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: Layer presence missing! Must be indicated through a presence field, layerPresenceQuery or layerPresenceLabel'
-[no-presence]='error: error validating "'${yaml_path}/${autotune_config_tests[2]}/no-presence.yaml'": error validating data: ValidationError(AutotuneConfig): missing required field "layerPresence" in com.recommender.v1.AutotuneConfig; if you choose to ignore these errors, turn validation off with --validate=false'
-[no-presence-value]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: Layer presence missing! Must be indicated through a presence field, layerPresenceQuery or layerPresenceLabel'
-[null-presence]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: Layer presence missing! Must be indicated through a presence field, layerPresenceQuery or layerPresenceLabel'
+presence_yaml_path="${yaml_path}/${autotune_config_tests[2]}"
+presence_exception='Layer presence missing! Must be indicated through a presence field, layerPresenceQuery or layerPresenceLabel'
+presence_expected_log_msgs=([blank-presence]=''${exception}' '${presence_exception}''
+[invalid-presence]=''${exception}' '${presence_exception}''
+[no-presence]='error: error validating "'${presence_yaml_path}/no-presence.yaml'": error validating data: ValidationError(AutotuneConfig): missing required field "layerPresence" in com.recommender.v1.AutotuneConfig; if you choose to ignore these errors, turn validation off with --validate=false'
+[no-presence-value]=''${exception}' '${presence_exception}''
+[null-presence]=''${exception}' '${presence_exception}''
 [numerical-presence]='The AutotuneConfig "numerical-presence" is invalid: layerPresence.presence: Invalid value: "integer": layerPresence.presence in body must be of type string: "integer"'
-[valid-presence]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotuneconfig valid-presence')
+[valid-presence]=''${autotune_config_obj_create_msg}' valid-presence')
 
 # Expected autotune object for layer preseence query
 declare -A layer_presence_query_datasource_autotune_objects
@@ -279,13 +289,15 @@ layer_presence_query_datasource_autotune_objects=([blank-layer-presence-query-da
 
 #Expected log message for layer preseence query
 declare -A layer_presence_query_datasource_expected_log_msgs
-layer_presence_query_datasource_expected_log_msgs=([blank-layer-presence-query-datasource]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: Layer presence missing! Must be indicated through a presence field, layerPresenceQuery or layerPresenceLabel'
-[invalid-layer-presence-query-datasource]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: Layer presence missing! Must be indicated through a presence field, layerPresenceQuery or layerPresenceLabel'
-[no-layer-presence-query-datasource]='error: error validating "'${yaml_path}/${autotune_config_tests[3]}/no-layer-presence-query-datasource.yaml'": error validating data: ValidationError(AutotuneConfig.layerPresence.query.datasource): invalid type for com.recommender.v1.AutotuneConfig.layerPresence.query.datasource: got "map", expected "array"; if you choose to ignore these errors, turn validation off with --validate=false'
-[no-layer-presence-query-datasource-value]='error: error validating "'${yaml_path}/${autotune_config_tests[3]}/no-layer-presence-query-datasource-value.yaml'": error validating data: ValidationError(AutotuneConfig.layerPresence.query.datasource\[0\]): missing required field "name" in com.recommender.v1.AutotuneConfig.layerPresence.query.datasource; if you choose to ignore these errors, turn validation off with --validate=false'
-[null-layer-presence-query-datasource]='error: error validating "'${yaml_path}/${autotune_config_tests[3]}/null-layer-presence-query-datasource.yaml'": error validating data: ValidationError(AutotuneConfig.layerPresence.query.datasource\[0\]): missing required field "name" in com.recommender.v1.AutotuneConfig.layerPresence.query.datasource; if you choose to ignore these errors, turn validation off with --validate=false'
+layer_presence_query_ds_yaml_path="${yaml_path}/${autotune_config_tests[3]}"
+layer_presence_query_ds_kubectl_error=': error validating data: ValidationError(AutotuneConfig.layerPresence.query.datasource\[0\]): missing required field "name" in com.recommender.v1.AutotuneConfig.layerPresence.query.datasource; if you choose to ignore these errors, turn validation off with --validate=false'
+layer_presence_query_datasource_expected_log_msgs=([blank-layer-presence-query-datasource]=''${exception}' '${presence_exception}''
+[invalid-layer-presence-query-datasource]=''${exception}' '${presence_exception}''
+[no-layer-presence-query-datasource]='error: error validating "'${layer_presence_query_ds_yaml_path}/no-layer-presence-query-datasource.yaml'": error validating data: ValidationError(AutotuneConfig.layerPresence.query.datasource): invalid type for com.recommender.v1.AutotuneConfig.layerPresence.query.datasource: got "map", expected "array"; if you choose to ignore these errors, turn validation off with --validate=false'
+[no-layer-presence-query-datasource-value]='error: error validating "'${layer_presence_query_ds_yaml_path}/no-layer-presence-query-datasource-value.yaml'"'${layer_presence_query_ds_kubectl_error}''
+[null-layer-presence-query-datasource]='error: error validating "'${layer_presence_query_ds_yaml_path}/null-layer-presence-query-datasource.yaml'"'${layer_presence_query_ds_kubectl_error}''
 [numerical-layer-presence-query-datasource]='The AutotuneConfig "numerical-layer-presence-query-datasource" is invalid: layerPresence.query.datasource.name: Invalid value: "integer": layerPresence.query.datasource.name in body must be of type string: "integer"'
-[valid-layer-presence-query-datasource]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotuneconfig valid-layer-presence-query-datasource')
+[valid-layer-presence-query-datasource]=''${autotune_config_obj_create_msg}' valid-layer-presence-query-datasource')
 
 # Expected autotune object for layer presence query
 declare -A layer_presence_query_autotune_objects
@@ -299,13 +311,15 @@ layer_presence_query_autotune_objects=([blank-layer-presence-query]='true'
 
 #Expected log message for layer presence query
 declare -A layer_presence_query_expected_log_msgs
-layer_presence_query_expected_log_msgs=([blank-layer-presence-query]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Could not get the applications for the layer blank-layer-presence-query' 
+layer_presence_query_yaml_path="${yaml_path}/${autotune_config_tests[4]}"
+layer_presence_query_kubectl_error=': error validating data: ValidationError(AutotuneConfig.layerPresence.query.datasource\[0\]): missing required field "query" in com.recommender.v1.AutotuneConfig.layerPresence.query.datasource; if you choose to ignore these errors, turn validation off with --validate=false'
+layer_presence_query_expected_log_msgs=([blank-layer-presence-query]='com.autotune.analyzer.deployment.AutotuneDeployment - Could not get the applications for the layer blank-layer-presence-query'
 [invalid-layer-presence-query]='validation from da'
-[no-layer-presence-query]='error: error validating "'${yaml_path}/${autotune_config_tests[4]}/no-layer-presence-query.yaml'": error validating data: ValidationError(AutotuneConfig.layerPresence.query.datasource\[0\]): missing required field "query" in com.recommender.v1.AutotuneConfig.layerPresence.query.datasource; if you choose to ignore these errors, turn validation off with --validate=false'
-[no-layer-presence-query-value]='error: error validating "'${yaml_path}/${autotune_config_tests[4]}/no-layer-presence-query-value.yaml'": error validating data: ValidationError(AutotuneConfig.layerPresence.query.datasource\[0\]): missing required field "query" in com.recommender.v1.AutotuneConfig.layerPresence.query.datasource; if you choose to ignore these errors, turn validation off with --validate=false'
-[null-layer-presence-query]='error: error validating "'${yaml_path}/${autotune_config_tests[4]}/null-layer-presence-query.yaml'": error validating data: ValidationError(AutotuneConfig.layerPresence.query.datasource\[0\]): missing required field "query" in com.recommender.v1.AutotuneConfig.layerPresence.query.datasource; if you choose to ignore these errors, turn validation off with --validate=false'
+[no-layer-presence-query]='error: error validating "'${layer_presence_query_yaml_path}/no-layer-presence-query.yaml'"'${layer_presence_query_kubectl_error}''
+[no-layer-presence-query-value]='error: error validating "'${layer_presence_query_yaml_path}/no-layer-presence-query-value.yaml'"'${layer_presence_query_kubectl_error}''
+[null-layer-presence-query]='error: error validating "'${layer_presence_query_yaml_path}/null-layer-presence-query.yaml'"'${layer_presence_query_kubectl_error}''
 [numerical-layer-presence-query]='The AutotuneConfig "numerical-layer-presence-query" is invalid: layerPresence.query.datasource.query: Invalid value: "integer": layerPresence.query.datasource.query in body must be of type string: "integer"'
-[valid-layer-presence-query]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotuneconfig valid-layer-presence-query')
+[valid-layer-presence-query]=''${autotune_config_obj_create_msg}' valid-layer-presence-query')
 
 # Expected autotune object for layer presence query key
 declare -A layer_presence_query_key_autotune_objects
@@ -319,13 +333,15 @@ layer_presence_query_key_autotune_objects=([blank-layer-presence-query-key]='tru
 
 # Expected autotune object for layer presence query key
 declare -A layer_presence_query_key_expected_log_msgs
+layer_presence_query_key_yaml_path="${yaml_path}/${autotune_config_tests[5]}"
+layer_presence_query_key_kubectl_error=': error validating data: ValidationError(AutotuneConfig.layerPresence.query.datasource\[0\]): missing required field "key" in com.recommender.v1.AutotuneConfig.layerPresence.query.datasource; if you choose to ignore these errors, turn validation off with --validate=false'
 layer_presence_query_key_expected_log_msgs=([blank-layer-presence-query-key]='validation from da'
 [invalid-layer-presence-query-key]='validation from da'
-[no-layer-presence-query-key]='error: error validating "'${yaml_path}/${autotune_config_tests[5]}/no-layer-presence-query-key.yaml'": error validating data: ValidationError(AutotuneConfig.layerPresence.query.datasource\[0\]): missing required field "key" in com.recommender.v1.AutotuneConfig.layerPresence.query.datasource; if you choose to ignore these errors, turn validation off with --validate=false'
-[no-layer-presence-query-key-value]='error: error validating "'${yaml_path}/${autotune_config_tests[5]}/no-layer-presence-query-key-value.yaml'": error validating data: ValidationError(AutotuneConfig.layerPresence.query.datasource\[0\]): missing required field "key" in com.recommender.v1.AutotuneConfig.layerPresence.query.datasource; if you choose to ignore these errors, turn validation off with --validate=false'
-[null-layer-presence-query-key]='error: error validating "'${yaml_path}/${autotune_config_tests[5]}/null-layer-presence-query-key.yaml'": error validating data: ValidationError(AutotuneConfig.layerPresence.query.datasource\[0\]): missing required field "key" in com.recommender.v1.AutotuneConfig.layerPresence.query.datasource; if you choose to ignore these errors, turn validation off with --validate=false'
+[no-layer-presence-query-key]='error: error validating "'${layer_presence_query_key_yaml_path}/no-layer-presence-query-key.yaml'"'${layer_presence_query_key_kubectl_error}''
+[no-layer-presence-query-key-value]='error: error validating "'${layer_presence_query_key_yaml_path}/no-layer-presence-query-key-value.yaml'"'${layer_presence_query_key_kubectl_error}''
+[null-layer-presence-query-key]='error: error validating "'${layer_presence_query_key_yaml_path}/null-layer-presence-query-key.yaml'"'${layer_presence_query_key_kubectl_error}''
 [numerical-layer-presence-query-key]='The AutotuneConfig "numerical-layer-presence-query-key" is invalid: layerPresence.query.datasource.key: Invalid value: "integer": layerPresence.query.datasource.key in body must be of type string: "integer"'
-[valid-layer-presence-query-key]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotuneconfig valid-layer-presence-query-key')
+[valid-layer-presence-query-key]=''${autotune_config_obj_create_msg}' valid-layer-presence-query-key')
 
 # Expected autotune object for layer presence label name
 declare -A layer_presence_label_name_autotune_objects
@@ -345,7 +361,7 @@ layer_presence_label_name_expected_log_msgs=([blank-layer-presence-label-name]='
 [no-layer-presence-label-name-value]='validation from crd'
 [null-layer-presence-label-name]='validation from crd'
 [numerical-layer-presence-label-name]='The AutotuneConfig "numerical-layer-presence-label-name" is invalid: layerPresence.label.name: Invalid value: "integer": layerPresence.label.name in body must be of type string: "integer"'
-[valid-layer-presence-label-name]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotuneconfig valid-layer-presence-label-name')
+[valid-layer-presence-label-name]=''${autotune_config_obj_create_msg}' valid-layer-presence-label-name')
 
 # Expected autotune object for layer-presence-labelvalue
 declare -A layer_presence_labelvalue_autotune_objects
@@ -359,13 +375,14 @@ layer_presence_labelvalue_autotune_objects=([blank-layer-presence-labelvalue]='t
 
 # Expected log message for layer-presence-labelvalue
 declare -A layer_presence_labelvalue_expected_log_msgs
+layer_presence_labelvalue_error=': layerPresence.label.value in body must be of type string:'
 layer_presence_labelvalue_expected_log_msgs=([blank-layer-presence-labelvalue]='Validation from da'
 [invalid-layer-presence-labelvalue]='validation from da'
 [no-layer-presence-labelvalue]='validation from crd'
-[no-layer-presence-labelvalue-value]='The AutotuneConfig "no-layer-presence-labelvalue-value" is invalid: layerPresence.label.value: Invalid value: "null": layerPresence.label.value in body must be of type string: "null"'
-[null-layer-presence-labelvalue]='The AutotuneConfig "null-layer-presence-labelvalue" is invalid: layerPresence.label.value: Invalid value: "null": layerPresence.label.value in body must be of type string: "null"'
-[numerical-layer-presence-labelvalue]='The AutotuneConfig "numerical-layer-presence-labelvalue" is invalid: layerPresence.label.value: Invalid value: "integer": layerPresence.label.value in body must be of type string: "integer"'
-[valid-layer-presence-labelvalue]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotuneconfig valid-layer-presence-labelvalue')
+[no-layer-presence-labelvalue-value]='The AutotuneConfig "no-layer-presence-labelvalue-value" is invalid: layerPresence.label.value: Invalid value: "null"'${layer_presence_labelvalue_error}' "null"'
+[null-layer-presence-labelvalue]='The AutotuneConfig "null-layer-presence-labelvalue" is invalid: layerPresence.label.value: Invalid value: "null"'${layer_presence_labelvalue_error}' "null"'
+[numerical-layer-presence-labelvalue]='The AutotuneConfig "numerical-layer-presence-labelvalue" is invalid: layerPresence.label.value: Invalid value: "integer"'${layer_presence_labelvalue_error}' "integer"'
+[valid-layer-presence-labelvalue]=''${autotune_config_obj_create_msg}' valid-layer-presence-labelvalue')
 
 # Expected autotune object for layer presence
 declare -A layer_presence_autotune_objects
@@ -381,15 +398,17 @@ layer_presence_autotune_objects=([complete-layer-presence]='true'
 
 # Expected log message for layer presence
 declare -A layer_presence_expected_log_msgs
-layer_presence_expected_log_msgs=([complete-layer-presence]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: Both layerPresenceQuery and layerPresenceLabel cannot be set'
-[empty-layer-presence]='error: error validating "'${yaml_path}/${autotune_config_tests[8]}/empty-layer-presence.yaml'": error validating data: ValidationError(AutotuneConfig): missing required field "layerPresence" in com.recommender.v1.AutotuneConfig; if you choose to ignore these errors, turn validation off with --validate=false'
-[no-label-layer-presence]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotuneconfig no-label-layer-presence'
-[no-layer-presence]='error: error validating "'${yaml_path}/${autotune_config_tests[8]}/no-layer-presence.yaml'": error validating data: ValidationError(AutotuneConfig): missing required field "layerPresence" in com.recommender.v1.AutotuneConfig; if you choose to ignore these errors, turn validation off with --validate=false'
-[no-presence-layer-presence]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: Both layerPresenceQuery and layerPresenceLabel cannot be set'
-[no-query-layer-presence]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotuneconfig no-query-layer-presence'
-[only-label-layer-presence]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotuneconfig only-label-layer-presence'
-[only-query-layer-presence]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotuneconfig only-query-layer-presence'
-[valid-layer-presence]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotuneconfig valid-layer-presence')
+layer_presence_yaml_path="${yaml_path}/${autotune_config_tests[8]}"
+layer_presence_kubectl_error=': error validating data: ValidationError(AutotuneConfig): missing required field "layerPresence" in com.recommender.v1.AutotuneConfig; if you choose to ignore these errors, turn validation off with --validate=false'
+layer_presence_expected_log_msgs=([complete-layer-presence]=''${exception}' Both layerPresenceQuery and layerPresenceLabel cannot be set'
+[empty-layer-presence]='error: error validating "'${layer_presence_yaml_path}/empty-layer-presence.yaml'"'${layer_presence_kubectl_error}''
+[no-label-layer-presence]=''${autotune_config_obj_create_msg}' no-label-layer-presence'
+[no-layer-presence]='error: error validating "'${layer_presence_yaml_path}/no-layer-presence.yaml'"'${layer_presence_kubectl_error}''
+[no-presence-layer-presence]=''${exception}' Both layerPresenceQuery and layerPresenceLabel cannot be set'
+[no-query-layer-presence]=''${autotune_config_obj_create_msg}' no-query-layer-presence'
+[only-label-layer-presence]=''${autotune_config_obj_create_msg}' only-label-layer-presence'
+[only-query-layer-presence]=''${autotune_config_obj_create_msg}' only-query-layer-presence'
+[valid-layer-presence]=''${autotune_config_obj_create_msg}' valid-layer-presence')
 
 # Expected autotune object for tunable-name
 declare -A tunable_name_autotune_objects
@@ -401,11 +420,13 @@ tunable_name_autotune_objects=([blank-tunable-name]='true'
 
 # Expected log message for tunable-name
 declare -A tunable_name_expected_log_msgs
-tunable_name_expected_log_msgs=([blank-tunable-name]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: Tunable name cannot be empty'
-[no-tunable-name-value]='error: error validating "'${yaml_path}/${autotune_config_tests[9]}/no-tunable-name-value.yaml'": error validating data: ValidationError(AutotuneConfig.tunables\[0\]): missing required field "name" in com.recommender.v1.AutotuneConfig.tunables; if you choose to ignore these errors, turn validation off with --validate=false'
-[null-tunable-name]='error: error validating "'${yaml_path}/${autotune_config_tests[9]}/null-tunable-name.yaml'": error validating data: ValidationError(AutotuneConfig.tunables\[0\]): missing required field "name" in com.recommender.v1.AutotuneConfig.tunables; if you choose to ignore these errors, turn validation off with --validate=false'
+tunable_name_yaml_path="${yaml_path}/${autotune_config_tests[9]}"
+tunable_name_kubectl_error=': error validating data: ValidationError(AutotuneConfig.tunables\[0\]): missing required field "name" in com.recommender.v1.AutotuneConfig.tunables; if you choose to ignore these errors, turn validation off with --validate=false'
+tunable_name_expected_log_msgs=([blank-tunable-name]=''${exception}' Tunable name cannot be empty'
+[no-tunable-name-value]='error: error validating "'${tunable_name_yaml_path}/no-tunable-name-value.yaml'"'${tunable_name_kubectl_error}''
+[null-tunable-name]='error: error validating "'${tunable_name_yaml_path}/null-tunable-name.yaml'"'${tunable_name_kubectl_error}''
 [numerical-tunable-name]='The AutotuneConfig "numerical-tunable-name" is invalid: tunables.name: Invalid value: "integer": tunables.name in body must be of type string: "integer"'
-[valid-tunable-name]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotuneconfig valid-tunable-name')
+[valid-tunable-name]=''${autotune_config_obj_create_msg}' valid-tunable-name')
 
 # Expected autotune object for tunable-value-type
 declare -A tunable_value_type_autotune_objects
@@ -419,58 +440,69 @@ tunable_value_type_autotune_objects=([blank-tunable-value-type]='true'
 
 # Expected log message for tunable-value-type
 declare -A tunable_value_type_expected_log_msgs
+tunable_value_yaml_path="${yaml_path}/${autotune_config_tests[10]}"
+tunable_value_kubectl_error=': error validating data: ValidationError(AutotuneConfig.tunables\[0\]): missing required field "value_type" in com.recommender.v1.AutotuneConfig.tunables; if you choose to ignore these errors, turn validation off with --validate=false'
 tunable_value_type_expected_log_msgs=([blank-tunable-value-type]='Validation from da'
 [invalid-tunable-value-type]='validation from da'
-[no-tunable-value-type]='error: error validating "'${yaml_path}/${autotune_config_tests[10]}/no-tunable-value-type.yaml'": error validating data: ValidationError(AutotuneConfig.tunables\[0\]): missing required field "value_type" in com.recommender.v1.AutotuneConfig.tunables; if you choose to ignore these errors, turn validation off with --validate=false'
-[no-tunable-value-type-value]='error: error validating '${yaml_path}/${autotune_config_tests[10]}/no-tunable-value-type-value.yaml'": error validating data: \[ValidationError(AutotuneConfig.tunables\[0\]): missing required field "value_type" in com.recommender.v1.AutotuneConfig.tunables, ValidationError(AutotuneConfig): missing required field "layer_name" in com.recommender.v1.AutotuneConfig\]; if you choose to ignore these errors, turn validation off with --validate=false'
-[null-tunable-value-type]='error: error validating "'${yaml_path}/${autotune_config_tests[10]}/null-tunable-value-type.yaml'": error validating data: ValidationError(AutotuneConfig.tunables\[0\]): missing required field "value_type" in com.recommender.v1.AutotuneConfig.tunables; if you choose to ignore these errors, turn validation off with --validate=false'
+[no-tunable-value-type]='error: error validating "'${tunable_value_yaml_path}/no-tunable-value-type.yaml'"'${tunable_value_kubectl_error}''
+[no-tunable-value-type-value]='error: error validating "'${tunable_value_yaml_path}/no-tunable-value-type-value.yaml'": error validating data: \[ValidationError(AutotuneConfig.tunables\[0\]): missing required field "value_type" in com.recommender.v1.AutotuneConfig.tunables, ValidationError(AutotuneConfig): missing required field "layer_name" in com.recommender.v1.AutotuneConfig\]; if you choose to ignore these errors, turn validation off with --validate=false'
+[null-tunable-value-type]='error: error validating "'${tunable_value_yaml_path}/null-tunable-value-type.yaml'"'${tunable_value_kubectl_error}''
 [numerical-tunable-value-type]='The AutotuneConfig "numerical-tunable-value-type" is invalid: tunables.value_type: Invalid value: "integer": tunables.value_type in body must be of type string: "integer"'
-[valid-tunable-value-type]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotuneconfig valid-tunable-value-type')
+[valid-tunable-value-type]=''${autotune_config_obj_create_msg}' valid-tunable-value-type')
 
 # Expected autotune object for tunable upper bound
 declare -A tunable_upper_bound_autotune_objects
-tunable_upper_bound_autotune_objects=([blank-tunable-upper-bound]='true'
+tunable_upper_bound_autotune_objects=([blank-tunable-upper-bound]='false'
 [invalid-tunable-upper-bound]='true'
 [no-tunable-upper-bound]='false'
 [no-tunable-upper-bound-value]='false'
 [null-tunable-upper-bound]='false'
 [char-tunable-upper-bound]='false'
+[zero-tunable-upper-bound]='true'
 [valid-tunable-upper-bound]='true')
 
 # Expected log message for tunable-upper-bound
 declare -A tunable_upper_bound_expected_log_msgs
-tunable_upper_bound_expected_log_msgs=([blank-tunable-upper-bound]='Validation from da'
-[invalid-tunable-upper-bound]='validation from da'
-[no-tunable-upper-bound]='error: error validating "'${yaml_path}/${autotune_config_tests[11]}/no-tunable-upper-bound.yaml'": error validating data: ValidationError(AutotuneConfig.tunables\[0\]): missing required field "upper_bound" in com.recommender.v1.AutotuneConfig.tunables; if you choose to ignore these errors, turn validation off with --validate=false'
-[no-tunable-upper-bound-value]='error: error validating "'${yaml_path}/${autotune_config_tests[11]}/no-tunable-upper-bound-value.yaml'": error validating data: ValidationError(AutotuneConfig.tunables\[0\]): missing required field "upper_bound" in com.recommender.v1.AutotuneConfig.tunables; if you choose to ignore these errors, turn validation off with --validate=false'
-[null-tunable-upper-bound]='error: error validating "'${yaml_path}/${autotune_config_tests[11]}/null-tunable-upper-bound.yaml'": error validating data: ValidationError(AutotuneConfig.tunables\[0\]): missing required field "upper_bound" in com.recommender.v1.AutotuneConfig.tunables; if you choose to ignore these errors, turn validation off with --validate=false'
-[char-tunable-upper-bound]='validation from da'
-[valid-tunable-upper-bound]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotuneconfig valid-tunable-upper-bound')
+tunable_upper_bound_yaml_path="${yaml_path}/${autotune_config_tests[11]}"
+tunable_upper_bound_kubectl_error=': error validating data: ValidationError(AutotuneConfig.tunables\[0\]): missing required field "upper_bound" in com.recommender.v1.AutotuneConfig.tunables; if you choose to ignore these errors, turn validation off with --validate=false'
+invalid_upper_bound_error=': error validating data: ValidationError(AutotuneConfig.tunables\[0\].upper_bound): invalid type for com.recommender.v1.AutotuneConfig.tunables.upper_bound: got "string", expected "number"; if you choose to ignore these errors, turn validation off with --validate=false'
+tunable_upper_bound_expected_log_msgs=([blank-tunable-upper-bound]='error: error validating "'${tunable_upper_bound_yaml_path}/blank-tunable-upper-bound.yaml'"'${invalid_upper_bound_error}''
+[invalid-tunable-upper-bound]=''${invalid_bound_exception}''
+[no-tunable-upper-bound]='error: error validating "'${tunable_upper_bound_yaml_path}/no-tunable-upper-bound.yaml'"'${tunable_upper_bound_kubectl_error}''
+[no-tunable-upper-bound-value]='error: error validating "'${tunable_upper_bound_yaml_path}/no-tunable-upper-bound-value.yaml'"'${tunable_upper_bound_kubectl_error}''
+[null-tunable-upper-bound]='error: error validating "'${tunable_upper_bound_yaml_path}/null-tunable-upper-bound.yaml'"'${tunable_upper_bound_kubectl_error}''
+[char-tunable-upper-bound]='error: error validating "'${tunable_upper_bound_yaml_path}/char-tunable-upper-bound.yaml'"'${invalid_upper_bound_error}''
+[zero-tunable-upper-bound]=''${invalid_bound_exception}''
+[valid-tunable-upper-bound]=''${autotune_config_obj_create_msg}' valid-tunable-upper-bound')
 
 # Expected autotune object for tunable lower bound
 declare -A tunable_lower_bound_autotune_objects
-tunable_lower_bound_autotune_objects=([blank-tunable-lower-bound]='true'
+tunable_lower_bound_autotune_objects=([blank-tunable-lower-bound]='false'
 [invalid-tunable-lower-bound]='true'
 [no-tunable-lower-bound]='false'
 [no-tunable-lower-bound-value]='false'
 [null-tunable-lower-bound]='false'
 [char-tunable-lower-bound]='false'
+[zero-tunable-lower-bound]='true'
 [valid-tunable-lower-bound]='true')
 
 # Expected log message for tunable-lower-bound
 declare -A tunable_lower_bound_expected_log_msgs
-tunable_lower_bound_expected_log_msgs=([blank-tunable-lower-bound]='validation from da'
-[invalid-tunable-lower-bound]='validation from da'
-[no-tunable-lower-bound]='error: error validating "'${yaml_path}/${autotune_config_tests[12]}/no-tunable-lower-bound.yaml'": error validating data: ValidationError(AutotuneConfig.tunables\[0\]): missing required field "lower_bound" in com.recommender.v1.AutotuneConfig.tunables; if you choose to ignore these errors, turn validation off with --validate=false'
-[no-tunable-lower-bound-value]='error: error validating "'${yaml_path}/${autotune_config_tests[12]}/no-tunable-lower-bound-value.yaml'": error validating data: ValidationError(AutotuneConfig.tunables\[0\]): missing required field "lower_bound" in com.recommender.v1.AutotuneConfig.tunables; if you choose to ignore these errors, turn validation off with --validate=false'
-[null-tunable-lower-bound]='error: error validating "'${yaml_path}/${autotune_config_tests[12]}/null-tunable-lower-bound.yaml'": error validating data: ValidationError(AutotuneConfig.tunables\[0\]): missing required field "lower_bound" in com.recommender.v1.AutotuneConfig.tunables; if you choose to ignore these errors, turn validation off with --validate=false'
-[char-tunable-lower-bound]='validation from da'
-[valid-tunable-lower-bound]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotuneconfig valid-tunable-lower-bound')
+tunable_lower_bound_yaml_path="${yaml_path}/${autotune_config_tests[12]}"
+tunable_lower_bound_kubectl_error=': error validating data: ValidationError(AutotuneConfig.tunables\[0\]): missing required field "lower_bound" in com.recommender.v1.AutotuneConfig.tunables; if you choose to ignore these errors, turn validation off with --validate=false'
+invalid_lower_bound_error=': error validating data: ValidationError(AutotuneConfig.tunables\[0\].lower_bound): invalid type for com.recommender.v1.AutotuneConfig.tunables.lower_bound: got "string", expected "number"; if you choose to ignore these errors, turn validation off with --validate=false'
+tunable_lower_bound_expected_log_msgs=([blank-tunable-lower-bound]='error: error validating "'${tunable_lower_bound_yaml_path}/blank-tunable-lower-bound.yaml'"'${invalid_lower_bound_error}''
+[invalid-tunable-lower-bound]=''${invalid_bound_exception}''
+[no-tunable-lower-bound]='error: error validating "'${tunable_lower_bound_yaml_path}/no-tunable-lower-bound.yaml'"'${tunable_lower_bound_kubectl_error}''
+[no-tunable-lower-bound-value]='error: error validating "'${tunable_lower_bound_yaml_path}/no-tunable-lower-bound-value.yaml'"'${tunable_lower_bound_kubectl_error}''
+[null-tunable-lower-bound]='error: error validating "'${tunable_lower_bound_yaml_path}/null-tunable-lower-bound.yaml'"'${tunable_lower_bound_kubectl_error}''
+[char-tunable-lower-bound]='error: error validating "'${tunable_lower_bound_yaml_path}/char-tunable-lower-bound.yaml'"'${invalid_lower_bound_error}''
+[zero-tunable-lower-bound]=''${autotune_config_obj_create_msg}' zero-tunable-lower-bound'
+[valid-tunable-lower-bound]=''${autotune_config_obj_create_msg}' valid-tunable-lower-bound')
 
 # Expected autotune object for step
 declare -A step_autotune_objects
 step_autotune_objects=([invalid-step]='true'
-[no-step]='true'
 [no-step-value]='true'
 [null-step]='true'
 [char-step]='false'
@@ -479,13 +511,13 @@ step_autotune_objects=([invalid-step]='true'
 
 # Expected log message for tunable-lower-bound
 declare -A step_expected_log_msgs
-step_expected_log_msgs=([invalid-step]='validation from da'
-[no-step]='validation from da'
+step_yaml_path="${yaml_path}/${autotune_config_tests[13]}"
+step_expected_log_msgs=([invalid-step]=''${invalid_bound_exception}''
 [no-step-value]='validation from da'
 [null-step]='validation from da'
-[char-step]='error: error validating "'${yaml_path}/${autotune_config_tests[13]}/char-step.yaml'": error validating data: \[ValidationError(AutotuneConfig.tunables\[0\].step): invalid type for com.recommender.v1.AutotuneConfig.tunables.step: got "string", expected "number", ValidationError(AutotuneConfig.tunables\[1\].step): invalid type for com.recommender.v1.AutotuneConfig.tunables.step: got "string", expected "number"\]; if you choose to ignore these errors, turn validation off with --validate=false'
-[zero-step]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: Tunable step cannot be 0'
-[valid-step]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotuneconfig valid-step')
+[char-step]='error: error validating "'${step_yaml_path}/char-step.yaml'": error validating data: \[ValidationError(AutotuneConfig.tunables\[0\].step): invalid type for com.recommender.v1.AutotuneConfig.tunables.step: got "string", expected "number", ValidationError(AutotuneConfig.tunables\[1\].step): invalid type for com.recommender.v1.AutotuneConfig.tunables.step: got "string", expected "number"\]; if you choose to ignore these errors, turn validation off with --validate=false'
+[zero-step]=''${exception}' Tunable step cannot be 0'
+[valid-step]=''${autotune_config_obj_create_msg}' valid-step')
 
 # Expected autotune object for tunable query
 declare -A tunable_query_autotune_objects
@@ -499,40 +531,44 @@ tunable_query_autotune_objects=([blank-tunable-query]='true'
 
 # Expected log message for tunable query
 declare -A tunable_query_expected_log_msgs
-tunable_query_expected_log_msgs=([blank-tunable-query]='validation from da'
-[invalid-tunable-query]='validation from da'
-[no-tunable-query]='error: error validating "'${yaml_path}/${autotune_config_tests[14]}/no-tunable-query.yaml'": error validating data: ValidationError(AutotuneConfig.tunables\[0\].queries.datasource\[0\]): missing required field "query" in com.recommender.v1.AutotuneConfig.tunables.queries.datasource; if you choose to ignore these errors, turn validation off with --validate=false'
-[no-tunable-query-value]='error: error validating "'${yaml_path}/${autotune_config_tests[14]}/no-tunable-query-value.yaml'": error validating data: ValidationError(AutotuneConfig.tunables\[0\].queries.datasource\[0\]): missing required field "query" in com.recommender.v1.AutotuneConfig.tunables.queries.datasource; if you choose to ignore these errors, turn validation off with --validate=false'
-[null-tunable-query]='error: error validating "'${yaml_path}/${autotune_config_tests[14]}/null-tunable-query.yaml'": error validating data: ValidationError(AutotuneConfig.tunables\[0\].queries.datasource\[0\]): missing required field "query" in com.recommender.v1.AutotuneConfig.tunables.queries.datasource; if you choose to ignore these errors, turn validation off with --validate=false'
-[numerical-tunable-query]='The AutotuneConfig "numerical-tunable-query" is invalid: tunables.queries.datasource.query: Invalid value: "integer": tunables.queries.datasource.query in body must be of type string: "integer"'
-[valid-tunable-query]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotuneconfig valid-tunable-query')
+tunable_query_yaml_path="${yaml_path}/${autotune_config_tests[14]}"
+tunable_query_kubectl_error=': error validating data: ValidationError(AutotuneConfig.tunables\[0\].queries.datasource\[0\]): missing required field "query" in com.recommender.v1.AutotuneConfig.tunables.queries.datasource; if you choose to ignore these errors, turn validation off with --validate=false'
+tunable_query_expected_log_msgs=([blank-tunable-query]='validation from da' 
+[invalid-tunable-query]='validation from da' 
+[no-tunable-query]='error: error validating "'${tunable_query_yaml_path}/no-tunable-query.yaml'"'${tunable_query_kubectl_error}'' 
+[no-tunable-query-value]='error: error validating "'${tunable_query_yaml_path}/no-tunable-query-value.yaml'"'${tunable_query_kubectl_error}'' 
+[null-tunable-query]='error: error validating "'${tunable_query_yaml_path}/null-tunable-query.yaml'"'${tunable_query_kubectl_error}'' 
+[numerical-tunable-query]='The AutotuneConfig "numerical-tunable-query" is invalid: tunables.queries.datasource.query: Invalid value: "integer": tunables.queries.datasource.query in body must be of type string: "integer"' 
+[valid-tunable-query]=''${autotune_config_obj_create_msg}' valid-tunable-query' )
 
 # Expected autotune object for tunable datasource name
 declare -A tunable_datasource_name_autotune_objects
 tunable_datasource_name_autotune_objects=([blank-tunable-datasource-name]='true'
 [invalid-tunable-datasource-name]='true'
-[no-tunable-datasource-name]='true'
-[no-tunable-datasource-name-value]='true'
-[null-tunable-datasource-name]='true'
+[no-tunable-datasource-name]='false'
+[no-tunable-datasource-name-value]='false'
+[null-tunable-datasource-name]='false'
 [numerical-tunable-datasource-name]='false'
 [valid-tunable-datasource-name]='true')
 
 # Expected log message for tunable datasource name
 declare -A tunable_datasource_name_expected_log_msgs
-tunable_datasource_name_expected_log_msgs=([blank-tunable-datasource-name]='error from da'
-[invalid-tunable-datasource-name]='error from da'
-[no-tunable-datasource-name]='validation from da'
-[no-tunable-datasource-name-value]='validation from da'
-[null-tunable-datasource-name]='validation from da'
-[numerical-tunable-datasource-name]='The AutotuneConfig "numerical-tunable-datasource-name" is invalid: tunables.queries.datasource.name: Invalid value: "integer": tunables.queries.datasource.name in body must be of type string: "integer"'
-[valid-tunable-datasource-name]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotuneconfig valid-tunable-datasource-name')
+tunable_datasource_name_yaml_path="${yaml_path}/${autotune_config_tests[15]}"
+tunable_datasource_name_kubectl_error=': error validating data: ValidationError(AutotuneConfig.tunables\[0\].queries.datasource\[0\]): missing required field "name" in com.recommender.v1.AutotuneConfig.tunables.queries.datasource; if you choose to ignore these errors, turn validation off with --validate=false'
+tunable_datasource_name_expected_log_msgs=([blank-tunable-datasource-name]='validation form da' 
+[invalid-tunable-datasource-name]='error from da' 
+[no-tunable-datasource-name]='error: error validating "'${tunable_datasource_name_yaml_path}/no-tunable-datasource-name.yaml'": error validating data: ValidationError(AutotuneConfig.tunables\[0\].queries.datasource): invalid type for com.recommender.v1.AutotuneConfig.tunables.queries.datasource: got "map", expected "array"; if you choose to ignore these errors, turn validation off with --validate=false' 
+[no-tunable-datasource-name-value]='error: error validating "'${tunable_datasource_name_yaml_path}/no-tunable-datasource-name-value.yaml'"'${tunable_datasource_name_kubectl_error}'' 
+[null-tunable-datasource-name]='error: error validating "'${tunable_datasource_name_yaml_path}/null-tunable-datasource-name.yaml'"'${tunable_datasource_name_kubectl_error}'' 
+[numerical-tunable-datasource-name]='The AutotuneConfig "numerical-tunable-datasource-name" is invalid: tunables.queries.datasource.name: Invalid value: "integer": tunables.queries.datasource.name in body must be of type string: "integer"' 
+[valid-tunable-datasource-name]=''${autotune_config_obj_create_msg}' valid-tunable-datasource-name' )
 
 # Expected autotune object for sla class
 declare -A tunable_sla_class_autotune_objects
 tunable_sla_class_autotune_objects=([blank-tunable-sla-class]='true'
 [invalid-tunable-sla-class]='true'
 [empty-tunable-sla-class]='false'
-[no-sla-tunable-class]='true'
+[no-sla-tunable-class]='false'
 [no-tunable-sla-class-value]='false'
 [null-tunable-sla-class]='false'
 [numerical-tunable-sla-value]='false'
@@ -540,14 +576,17 @@ tunable_sla_class_autotune_objects=([blank-tunable-sla-class]='true'
 
 # Expected log message for sla class
 declare -A tunable_sla_class_expected_log_msgs
-tunable_sla_class_expected_log_msgs=([blank-tunable-sla-class]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: Invalid sla_class for tunable memoryRequest'
-[invalid-tunable-sla-class]='com.autotune.dependencyAnalyzer.exceptions.InvalidValueException: Invalid sla_class for tunable memoryRequest'
-[empty-tunable-sla-class]='error: error validating "'${yaml_path}/${autotune_config_tests[16]}/empty-tunable-sla-class.yaml'": error validating data: ValidationError(AutotuneConfig.tunables\[0\]): missing required field "sla_class" in com.recommender.v1.AutotuneConfig.tunables; if you choose to ignore these errors, turn validation off with --validate=false'
-[no-tunable-sla-class]='error: error validating "'${yaml_path}/${autotune_config_tests[16]}/no-tunable-sla-class.yaml'": error validating data: ValidationError(AutotuneConfig.tunables\[0\]): missing required field "sla_class" in com.recommender.v1.AutotuneConfig.tunables; if you choose to ignore these errors, turn validation off with --validate=false'
-[no-tunable-sla-class-value]='error: error validating "'${yaml_path}/${autotune_config_tests[16]}/no-tunable-sla-class-value.yaml'": error validating data: \[ValidationError(AutotuneConfig.tunables\[0\].sla_class): unknown object type "nil" in AutotuneConfig.tunables\[0\].sla_class\[0\], ValidationError(AutotuneConfig.tunables\[0\].sla_class): unknown object type "nil" in AutotuneConfig.tunables\[0\].sla_class\[1\], ValidationError(AutotuneConfig.tunables\[0\].sla_class): unknown object type "nil" in AutotuneConfig.tunables\[0\].sla_class\[2\]\]; if you choose to ignore these errors, turn validation off with --validate=false'
-[null-tunable-sla-class]='error: error validating "'${yaml_path}/${autotune_config_tests[16]}/null-tunable-sla-class.yaml'": error validating data: ValidationError(AutotuneConfig.tunables\[0\].sla_class): unknown object type "nil" in AutotuneConfig.tunables\[0\].sla_class\[0\]; if you choose to ignore these errors, turn validation off with --validate=false'
-[numerical-tunable-sla-class]='The AutotuneConfig "numerical-tunable-sla-class" is invalid: tunables.sla_class: Invalid value: "integer": tunables.sla_class in body must be of type string: "integer"'
-[valid-tunable-sla-class]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotuneconfig valid-tunable-sla-class')
+tunable_sla_class_yaml_path="${yaml_path}/${autotune_config_tests[16]}"
+tunable_sla_class_kubectl_error=': error validating data: ValidationError(AutotuneConfig.tunables\[0\]): missing required field "sla_class" in com.recommender.v1.AutotuneConfig.tunables; if you choose to ignore these errors, turn validation off with --validate=false'
+validation_error='ValidationError(AutotuneConfig.tunables\[0\].sla_class): unknown object type "nil" in AutotuneConfig.tunables\[0\]'
+tunable_sla_class_expected_log_msgs=([blank-tunable-sla-class]=''${exception}' Invalid sla_class for tunable memoryRequest' 
+[invalid-tunable-sla-class]=''${exception}' Invalid sla_class for tunable memoryRequest' 
+[empty-tunable-sla-class]='error: error validating "'${tunable_sla_class_yaml_path}/empty-tunable-sla-class.yaml'"'${tunable_sla_class_kubectl_error}'' 
+[no-tunable-sla-class]='error: error validating "'${tunable_sla_class_yaml_path}/no-tunable-sla-class.yaml'"'${tunable_sla_class_kubectl_error}'' 
+[no-tunable-sla-class-value]='error: error validating "'${tunable_sla_class_yaml_path}/no-tunable-sla-class-value.yaml'": error validating data: \['${validation_error}'.sla_class\[0\], '${validation_error}'.sla_class\[1\], '${validation_error}'.sla_class\[2\]\]; if you choose to ignore these errors, turn validation off with --validate=false' 
+[null-tunable-sla-class]='error: error validating "'${tunable_sla_class_yaml_path}/null-tunable-sla-class.yaml'": error validating data: '${validation_error}'.sla_class\[0\]; if you choose to ignore these errors, turn validation off with --validate=false' 
+[numerical-tunable-sla-class]='The AutotuneConfig "numerical-tunable-sla-class" is invalid: tunables.sla_class: Invalid value: "integer": tunables.sla_class in body must be of type string: "integer"' 
+[valid-tunable-sla-class]=''${autotune_config_obj_create_msg}' valid-tunable-sla-class')
 
 # Expected autotune object for tunables
 declare -A tunables_autotune_objects
@@ -556,13 +595,15 @@ tunables_autotune_objects=([interchanged-bound]='true'
 [no-tunables-queries]='true'
 [no-tunables-sla-class]='false'
 [valid-tunables]='true')
+
 # Expected log message for tunables
 declare -A tunables_expected_log_msgs
-tunables_expected_log_msgs=([interchanged-bound]='validation from da'
-[no-tunables]='error: error validating "'${yaml_path}/${autotune_config_tests[17]}/no-tunables.yaml'": error validating data: ValidationError(AutotuneConfig): missing required field "tunables" in com.recommender.v1.AutotuneConfig; if you choose to ignore these errors, turn validation off with --validate=false'
-[no-tunables-queries]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotuneconfig no-tunables-queries'
-[no-tunables-sla-class]='error: error validating "'${yaml_path}/${autotune_config_tests[17]}/no-tunables-sla-class.yaml'": error validating data: ValidationError(AutotuneConfig.tunables\[0\]): missing required field "sla_class" in com.recommender.v1.AutotuneConfig.tunables; if you choose to ignore these errors, turn validation off with --validate=false'
- [valid-tunables]='com.autotune.dependencyAnalyzer.deployment.AutotuneDeployment - Added autotuneconfig valid-tunables')
+tunables_yaml_path="${yaml_path}/${autotune_config_tests[17]}"
+tunables_expected_log_msgs=([interchanged-bound]=''${invalid_bound_exception}'' 
+[no-tunables]='error: error validating "'${tunables_yaml_path}/no-tunables.yaml'": error validating data: ValidationError(AutotuneConfig): missing required field "tunables" in com.recommender.v1.AutotuneConfig; if you choose to ignore these errors, turn validation off with --validate=false' 
+[no-tunables-queries]=''${autotune_config_obj_create_msg}' no-tunables-queries' 
+[no-tunables-sla-class]='error: error validating "'${tunables_yaml_path}/no-tunables-sla-class.yaml'": error validating data: ValidationError(AutotuneConfig.tunables\[0\]): missing required field "sla_class" in com.recommender.v1.AutotuneConfig.tunables; if you choose to ignore these errors, turn validation off with --validate=false'
+ [valid-tunables]=''${autotune_config_obj_create_msg}' valid-tunables' )
 
 # Expected autotune object for other test cases
 declare -A autotuneconfig_other_autotune_objects

--- a/tests/scripts/configmap_constants.sh
+++ b/tests/scripts/configmap_constants.sh
@@ -58,8 +58,9 @@ configmap_minikube_autotune_objects=([minikube-invalid-cluster-type]='true'
 
 # Expected log message for minikube configmap
 declare -A configmap_minikube_expected_log_msgs
-configmap_minikube_expected_log_msgs=([minikube-invalid-cluster-type]='com.autotune.dependencyAnalyzer.deployment.DeploymentInfo - Cluster type kube8 is not supported'
-[minikube-invalid-k8s-type]='com.autotune.dependencyAnalyzer.deployment.DeploymentInfo - k8s type docker is not suppported'
-[minikube-invalid-monitoring-agent]='com.autotune.dependencyAnalyzer.deployment.DeploymentInfo - Monitoring agent promo  is not supported'
-[minikube-invalid-monitoring-service]='com.autotune.dependencyAnalyzer.datasource.DataSourceFactory - Monitoring agent endpoint not found'
+deployment_info='com.autotune.analyzer.deployment.DeploymentInfo'
+configmap_minikube_expected_log_msgs=([minikube-invalid-cluster-type]=''${deployment_info}' - Cluster type kube8 is not supported'
+[minikube-invalid-k8s-type]=''${deployment_info}' - k8s type docker is not suppported'
+[minikube-invalid-monitoring-agent]=''${deployment_info}' - Monitoring agent promo  is not supported'
+[minikube-invalid-monitoring-service]='com.autotune.analyzer.datasource.DataSourceFactory - Monitoring agent endpoint not found'
 [minikube-debug-config]='DEBUG' )


### PR DESCRIPTION
Signed-off-by: Shruthi <Shruthi.Acharya@ibm.com>

- Rename dependencyAnalyzer to analyzer
- Store the repeated error messages in variables for reusability