### PR TITLE
Adds EM Stage Processor class structures

### DIFF
--- a/src/main/java/com/autotune/experimentManager/ExperimentManager.java
+++ b/src/main/java/com/autotune/experimentManager/ExperimentManager.java
@@ -18,6 +18,8 @@ package com.autotune.experimentManager;
 
 import com.autotune.experimentManager.core.EMExecutorService;
 import com.autotune.experimentManager.settings.EMSettings;
+import com.autotune.experimentManager.core.EMScheduledStageProcessor;
+import com.autotune.experimentManager.core.EMStageProcessor;
 import com.autotune.experimentManager.utils.EMConstants;
 
 import org.apache.logging.log4j.Level;
@@ -28,10 +30,14 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 
 public class ExperimentManager {
     public static EMExecutorService emExecutorService;
+    public static EMStageProcessor emStageProcessor;
+    public static EMScheduledStageProcessor emScheduledStageProcessor;
 
     public static void initializeEM() {
         // Initializes the executor services needed by the EM
         emExecutorService = EMExecutorService.getInstance();
+        emStageProcessor = new EMStageProcessor();
+        emScheduledStageProcessor = new EMScheduledStageProcessor();
     }
 
     public static void start(ServletContextHandler contextHandler) {
@@ -41,5 +47,15 @@ public class ExperimentManager {
 
         // Set the initial executors based on settings
         emExecutorService.createExecutors(EMSettings.getController().getCurrentExecutors());
+        emExecutorService.initiateExperimentStageProcessor(emStageProcessor);
+        emExecutorService.initiateExperimentStageProcessor(emScheduledStageProcessor);
+    }
+
+    public static void notifyQueueProcessor() {
+        emStageProcessor.notifyProcessor();
+    }
+
+    public static void notifyScheduledQueueProcessor() {
+        emScheduledStageProcessor.notifyProcessor();
     }
 }

--- a/src/main/java/com/autotune/experimentManager/core/EMScheduledStageProcessor.java
+++ b/src/main/java/com/autotune/experimentManager/core/EMScheduledStageProcessor.java
@@ -18,6 +18,13 @@ package com.autotune.experimentManager.core;
 
 import java.util.concurrent.Callable;
 
+/**
+ * EMScheduledStageProcessor polls the EM Scheduled transitions
+ * queues and processes the stage transition based on the current
+ * and target stage. It's implemented as a infinite loop which
+ * polls when the queue is not empty and sleeps when queue is
+ * empty.
+ */
 public class EMScheduledStageProcessor implements Callable {
     public EMExecutorService emExecutorService;
 

--- a/src/main/java/com/autotune/experimentManager/core/EMScheduledStageProcessor.java
+++ b/src/main/java/com/autotune/experimentManager/core/EMScheduledStageProcessor.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package com.autotune.experimentManager.core;
+
+import java.util.concurrent.Callable;
+
+public class EMScheduledStageProcessor implements Callable {
+    public EMExecutorService emExecutorService;
+
+    public EMScheduledStageProcessor() {
+        emExecutorService = EMExecutorService.getInstance();
+    }
+
+    @Override
+    public Object call() throws Exception {
+        // TODO: Need to be implemented
+        return null;
+    }
+
+    public void notifyProcessor() {
+        synchronized (this) {
+            notify();
+        }
+    }
+}

--- a/src/main/java/com/autotune/experimentManager/core/EMStageProcessor.java
+++ b/src/main/java/com/autotune/experimentManager/core/EMStageProcessor.java
@@ -18,6 +18,13 @@ package com.autotune.experimentManager.core;
 
 import java.util.concurrent.Callable;
 
+/**
+ * EMStageProcessor polls the EM Regular transitions queues
+ * and processes the stage transition based on the current
+ * and target stage. It's implemented as a infinite loop which
+ * polls when the queue is not empty and sleeps when queue is
+ * empty.
+ */
 public class EMStageProcessor implements Callable {
     public EMExecutorService emExecutorService;
 

--- a/src/main/java/com/autotune/experimentManager/core/EMStageProcessor.java
+++ b/src/main/java/com/autotune/experimentManager/core/EMStageProcessor.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package com.autotune.experimentManager.core;
+
+import java.util.concurrent.Callable;
+
+public class EMStageProcessor implements Callable {
+    public EMExecutorService emExecutorService;
+
+    public EMStageProcessor() {
+        emExecutorService = EMExecutorService.getInstance();
+    }
+
+    @Override
+    public Object call() throws Exception {
+        // TODO: Need to be implemented
+        return null;
+    }
+
+    public void notifyProcessor() {
+        synchronized (this) {
+            notify();
+        }
+    }
+}


### PR DESCRIPTION
This PR is related to #278 needs to be merged after merging #278. 

Description:

The current EM implementation has the Executor service and this PR adds two stage processors, which are responsible for making the regular and scheduled transitions. Stage Processors are the classes that implement Callable and these are given to the executor service to start them. The PR currently adds the base structure for the Stage Processors (EMStageProcessor, EMScheduledStageProcessor)

Signed-off-by: bharathappali <abharath@redhat.com>