### PR TITLE
Adds mechanism to start Autotune in EM only mode

### DIFF
--- a/src/main/java/com/autotune/Autotune.java
+++ b/src/main/java/com/autotune/Autotune.java
@@ -19,6 +19,7 @@ import com.autotune.analyzer.Analyzer;
 import com.autotune.analyzer.utils.ServerContext;
 import com.autotune.experimentManager.ExperimentManager;
 import com.autotune.service.HealthService;
+import com.autotune.utils.AutotuneConstants;
 import io.prometheus.client.exporter.MetricsServlet;
 import io.prometheus.client.hotspot.DefaultExports;
 import org.eclipse.jetty.server.Server;
@@ -44,8 +45,18 @@ public class Autotune
 		server.setHandler(context);
 		addAutotuneServlets(context);
 
-		Analyzer.start(context);
-		ExperimentManager.start(context);
+		String autotuneMode = System.getenv(AutotuneConstants.StartUpMode.AUTOTUNE_MODE);
+
+		if (null != autotuneMode) {
+			if (autotuneMode.equalsIgnoreCase(AutotuneConstants.StartUpMode.EM_ONLY_MODE)) {
+				startAutotuneEMOnly(context);
+			} else {
+				startAutotuneNormalMode(context);
+			}
+		} else {
+			startAutotuneNormalMode(context);
+		}
+
 		try {
 			server.start();
 		} catch (Exception e) {
@@ -68,4 +79,12 @@ public class Autotune
 		System.setProperty("org.eclipse.jetty.LEVEL", "OFF");
 	}
 
+	private static void startAutotuneEMOnly(ServletContextHandler contextHandler) {
+		ExperimentManager.start(contextHandler);
+	}
+
+	private static void startAutotuneNormalMode(ServletContextHandler contextHandler) {
+		Analyzer.start(contextHandler);
+		ExperimentManager.start(contextHandler);
+	}
 }

--- a/src/main/java/com/autotune/utils/AutotuneConstants.java
+++ b/src/main/java/com/autotune/utils/AutotuneConstants.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package com.autotune.utils;
+
+/**
+ * Constants for Autotune module
+ */
+public class AutotuneConstants {
+    private AutotuneConstants() { }
+
+    /**
+     * Holds the constants of env vars and values to start Autotune in different Modes
+     */
+    public static class StartUpMode {
+        private StartUpMode() { }
+        public static final String AUTOTUNE_MODE = "AUTOTUNE_MODE";
+        public static final String EM_ONLY_MODE = "EM_ONLY";
+    }
+
+}


### PR DESCRIPTION
This PR adds the mechanism to start Autotune in EM-only mode for testing and other use cases.

The env variable `AUTOTUNE_MODE` needs to be set to `EM_ONLY`(no case restriction) to start Autotune in EM-only mode.

Signed-off-by: bharathappali <abharath@redhat.com>