### PR TITLE
Move to java 17 (!) and add the HPO start script.

### DIFF
--- a/scripts/start_apps.sh
+++ b/scripts/start_apps.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+cd /opt/app
+
+# Start the HPO service
+python3 hyperparameter_tuning/service.py &
+
+# Wait for optuna to start
+sleep 2
+
+# Start Autotune
+bash target/bin/Autotune


### PR DESCRIPTION
- Use the eclipse temurin based maven java 17 image for builds
- Update ubi-minimal to 8.4
- Add script to start both python and Java servers.

Signed-off-by: Dinakar Guniguntala dgunigun@redhat.com