### PR TITLE
Add private constructors to util classes

### DIFF
--- a/src/main/java/com/autotune/analyzer/datasource/DataSourceFactory.java
+++ b/src/main/java/com/autotune/analyzer/datasource/DataSourceFactory.java
@@ -35,6 +35,8 @@ import java.util.ArrayList;
  */
 public class DataSourceFactory
 {
+	private DataSourceFactory() { }
+
 	private static final Logger LOGGER = LoggerFactory.getLogger(DataSourceFactory.class);
 
 	public static DataSource getDataSource(String dataSource) throws MonitoringAgentNotFoundException {

--- a/src/main/java/com/autotune/analyzer/deployment/DeploymentInfo.java
+++ b/src/main/java/com/autotune/analyzer/deployment/DeploymentInfo.java
@@ -27,6 +27,8 @@ import org.slf4j.LoggerFactory;
  */
 public class DeploymentInfo
 {
+	private DeploymentInfo() { }
+
 	private static String clusterType;
 	private static String kubernetesType;
 	private static String authType;

--- a/src/main/java/com/autotune/analyzer/deployment/InitializeDeployment.java
+++ b/src/main/java/com/autotune/analyzer/deployment/InitializeDeployment.java
@@ -29,6 +29,8 @@ import org.apache.logging.log4j.core.config.Configurator;
  */
 public class InitializeDeployment
 {
+	private InitializeDeployment() { }
+
 	public static void setup_deployment_info() throws Exception, K8sTypeNotSupportedException, MonitoringAgentNotSupportedException, MonitoringAgentNotFoundException {
 		String k8S_type = System.getenv(AnalyzerConstants.K8S_TYPE);
 		String auth_type = System.getenv(AnalyzerConstants.AUTH_TYPE);

--- a/src/main/java/com/autotune/analyzer/k8sObjects/KubernetesContexts.java
+++ b/src/main/java/com/autotune/analyzer/k8sObjects/KubernetesContexts.java
@@ -23,6 +23,8 @@ import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
  */
 public class KubernetesContexts
 {
+	private KubernetesContexts() { }
+
 	private static final CustomResourceDefinitionContext autotuneCrdContext = new CustomResourceDefinitionContext
 			.Builder()
 			.withGroup(AnalyzerConstants.GROUP)

--- a/src/main/java/com/autotune/analyzer/k8sObjects/ValidateAutotuneConfig.java
+++ b/src/main/java/com/autotune/analyzer/k8sObjects/ValidateAutotuneConfig.java
@@ -28,6 +28,8 @@ import java.util.HashMap;
  */
 public class ValidateAutotuneConfig
 {
+	private ValidateAutotuneConfig() { }
+
 	/**
 	 * Check if the AutotuneConfig is valid
 	 * @param map

--- a/src/main/java/com/autotune/analyzer/k8sObjects/ValidateAutotuneObject.java
+++ b/src/main/java/com/autotune/analyzer/k8sObjects/ValidateAutotuneObject.java
@@ -26,6 +26,8 @@ import java.util.HashMap;
  */
 public class ValidateAutotuneObject
 {
+	private ValidateAutotuneObject() { }
+
 	/**
 	 * Check if the AutotuneObject is valid
 	 * @param map

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -22,6 +22,8 @@ import java.util.regex.Pattern;
  */
 public class AnalyzerConstants
 {
+	private AnalyzerConstants() { }
+
 	// Used to parse autotune configmaps
 	public static final String K8S_TYPE = "K8S_TYPE";
 	public static final String AUTH_TYPE = "AUTH_TYPE";
@@ -59,6 +61,8 @@ public class AnalyzerConstants
 	 * Used to parse the Autotune kind resource
 	 */
 	public static class AutotuneObjectConstants {
+		private AutotuneObjectConstants() { }
+
 		public static final String SPEC = "spec";
 		public static final String SLO = "slo";
 		public static final String SLO_CLASS = "slo_class";
@@ -91,6 +95,8 @@ public class AnalyzerConstants
 	 * Used to parse the AutotuneConfig resource
 	 */
 	public static class AutotuneConfigConstants {
+		private AutotuneConfigConstants() { }
+
 		public static final String METADATA = "metadata";
 		public static final String NAMESPACE = "namespace";
 
@@ -136,6 +142,8 @@ public class AnalyzerConstants
 	 * Contains Strings used in REST services
 	 */
 	public static class ServiceConstants {
+		private ServiceConstants() { }
+
 		public static final String APPLICATION_NAME = "application_name";
 		public static final String LAYER_DETAILS = "layer_details";
 		public static final String LAYERS = "layers";

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
@@ -20,8 +20,11 @@ package com.autotune.analyzer.utils;
  */
 public class AnalyzerErrorConstants
 {
+	private AnalyzerErrorConstants() { }
 
 	public static class AutotuneConfigErrors {
+		private AutotuneConfigErrors() { }
+
 		public final static String AUTOTUNE_CONFIG_NAME_NULL = "AutotuneConfig object name cannot be null or empty\n";
 		public final static String LAYER_PRESENCE_MISSING = "Layer presence missing! Must be indicated through a presence field, layerPresenceQuery or layerPresenceLabel\n";
 		public final static String BOTH_LAYER_QUERY_AND_LABEL_SET = "Both layerPresenceQuery and layerPresenceLabel cannot be set\n";
@@ -34,6 +37,8 @@ public class AnalyzerErrorConstants
 	}
 
 	public static class AutotuneObjectErrors {
+		private AutotuneObjectErrors() { }
+
 		public static final String AUTOTUNE_OBJECT_NAME_MISSING = "Autotune object name cannot be null or empty\n";
 		public static final String INVALID_MATCHLABEL = "Invalid MatchLabel in selector\n";
 		public static final String INVALID_MATCHLABEL_VALUE = "Invalid or blank MatchLabelValue in selector\n";

--- a/src/main/java/com/autotune/analyzer/utils/AutotuneSupportedTypes.java
+++ b/src/main/java/com/autotune/analyzer/utils/AutotuneSupportedTypes.java
@@ -24,6 +24,8 @@ import java.util.Set;
  */
 public class AutotuneSupportedTypes
 {
+	private AutotuneSupportedTypes() { }
+
 	public static final Set<String> DIRECTIONS_SUPPORTED =
 			new HashSet<>(Arrays.asList("minimize", "maximize"));
 

--- a/src/main/java/com/autotune/analyzer/utils/HttpUtils.java
+++ b/src/main/java/com/autotune/analyzer/utils/HttpUtils.java
@@ -33,6 +33,8 @@ import java.security.cert.X509Certificate;
  */
 public class HttpUtils
 {
+	private HttpUtils() { }
+
 	private static final Logger LOGGER = LoggerFactory.getLogger(HttpUtils.class);
 
 	/**

--- a/src/main/java/com/autotune/analyzer/utils/ServerContext.java
+++ b/src/main/java/com/autotune/analyzer/utils/ServerContext.java
@@ -20,6 +20,7 @@ package com.autotune.analyzer.utils;
  */
 public class ServerContext
 {
+	private ServerContext() { }
 	public static final String ROOT_CONTEXT = "/";
 	public static final String LIST_APPLICATIONS = ROOT_CONTEXT + "listApplications";
 	public static final String LIST_APP_LAYERS = ROOT_CONTEXT + "listAppLayers";

--- a/src/main/java/com/autotune/analyzer/utils/Utils.java
+++ b/src/main/java/com/autotune/analyzer/utils/Utils.java
@@ -23,6 +23,8 @@ import java.security.MessageDigest;
  */
 public class Utils
 {
+	private Utils() { }
+
 	public static String generateID(Object object) {
 		try {
 			MessageDigest digest = MessageDigest.getInstance("SHA-256");

--- a/src/main/java/com/autotune/analyzer/variables/Variables.java
+++ b/src/main/java/com/autotune/analyzer/variables/Variables.java
@@ -26,6 +26,8 @@ import java.util.Map;
  */
 public class Variables
 {
+    private Variables() { }
+
     /**
      * For a query, update the variables with the values from AutotuneQueryVariable object
      * @param application

--- a/src/main/java/com/autotune/experimentManager/ExperimentManager.java
+++ b/src/main/java/com/autotune/experimentManager/ExperimentManager.java
@@ -29,6 +29,8 @@ import org.apache.logging.log4j.core.config.Configurator;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 
 public class ExperimentManager {
+    private ExperimentManager() { }
+
     public static EMExecutorService emExecutorService;
     public static EMStageProcessor emStageProcessor;
     public static EMScheduledStageProcessor emScheduledStageProcessor;

--- a/src/main/java/com/autotune/experimentManager/utils/EMConstants.java
+++ b/src/main/java/com/autotune/experimentManager/utils/EMConstants.java
@@ -19,17 +19,25 @@ package com.autotune.experimentManager.utils;
 import com.autotune.analyzer.utils.ServerContext;
 
 public class EMConstants {
+    private EMConstants() { }
+
     public static class APIPaths {
+        private APIPaths() { }
+
         public static final String CREATE_EXPERIMENT = ServerContext.ROOT_CONTEXT + "createExperiment";
         public static final String GET_EXPERIMENTS = ServerContext.ROOT_CONTEXT + "getExperiments";
         public static final String GET_TRIAL_STATUS = ServerContext.ROOT_CONTEXT + "getTrialStatus";
     }
 
     public static class DeploymentConstants {
+        private DeploymentConstants() { }
+
         public static String NAMESPACE = "default";
     }
 
     public static class TransitionClasses {
+        private TransitionClasses() { }
+
         public static final String CREATE_CONFIG = "com.autotune.experimentManager.transitions.TransitionToCreateConfig";
         public static final String DEPLOY_CONFIG = "com.autotune.experimentManager.transitions.TransitionToDeployConfig";
         public static final String INITIATE_TRAIL_RUN_PHASE = "com.autotune.experimentManager.transitions.TransitionToInitiateTrailRunPhase";
@@ -43,26 +51,38 @@ public class EMConstants {
     }
 
     public static class DeploymentStrategies {
+        private DeploymentStrategies() { }
+
         public static String ROLLING_UPDATE = "rollingUpdate";
         public static String NEW_DEPLOYMENT = "newDeployment";
     }
 
     public static class Logs {
+        private Logs() { }
+
         public static class LoggerSettings {
+            private LoggerSettings() { }
+
             public static String DEFAULT_LOG_LEVEL = "ALL";
         }
         public static class ExperimentManager {
+            private ExperimentManager() { }
+
             public static String INITIALIZE_EM = "Initializing EM";
             public static String ADD_EM_SERVLETS = "Adding EM Servlets";
         }
 
         public static class RunExperiment {
+            private RunExperiment() { }
+
             public static String START_TRANSITION_FOR_RUNID = "Starting transition {} for RUN ID - {}";
             public static String END_TRANSITION_FOR_RUNID = "Ending transition {} for RUN ID - {}";
             public static String RUNNING_TRANSITION_ON_THREAD_ID = "Running Transition on Thread ID - {}";
         }
 
         public static class EMExecutorService {
+            private EMExecutorService() { }
+
             public static String CREATE_REGULAR_EXECUTOR = "Creating regular executor";
             public static String CREATE_SCHEDULED_EXECUTOR = "Creating scheduled executor";
             public static String START_EXECUTE_TRIAL = "Starting to execute a trial";
@@ -72,18 +92,28 @@ public class EMConstants {
     }
 
     public static class InputJsonKeys {
+        private InputJsonKeys() { }
+
         public static class GetTrailStatusInputKeys {
+            private GetTrailStatusInputKeys() { }
+
             public static String RUN_ID = "runId";
         }
 
         public static class DeploymentKeys {
+            private DeploymentKeys() { }
+
             public static String PARENT_DEPLOYMENT_NAME = "parent_deployment_name";
             public static String TRAINING_DEPLOYMENT_NAME = "training_deployment_name";
         }
     }
 
     public static class EMConfigDeployments {
+        private EMConfigDeployments() { }
+
         public static class DeploymentTypes {
+            private DeploymentTypes() { }
+
             public static String TRAINING = "training";
             public static String PRODUCTION = "production";
         }
@@ -93,6 +123,8 @@ public class EMConstants {
      * Constants for EMSettings class
      */
     public static class EMSettings {
+        private EMSettings() { }
+
         // Number of current executors per CPU core
         public static int EXECUTORS_MULTIPLIER = 1;
         // Maximum number of executors per CPU core
@@ -100,6 +132,8 @@ public class EMConstants {
     }
 
     public static class EMExecutorService {
+        private EMExecutorService() { }
+
         public static int MIN_EXECUTOR_POOL_SIZE = 1;
     }
 }

--- a/src/main/java/com/autotune/queue/AutotuneQueueFactory.java
+++ b/src/main/java/com/autotune/queue/AutotuneQueueFactory.java
@@ -25,6 +25,7 @@ import com.autotune.utils.AutotuneUtils.QueueName;
  *
  */
 public class AutotuneQueueFactory {
+	private AutotuneQueueFactory() { }
 
 	public static AutotuneQueue getQueue(String queueName) {
 		


### PR DESCRIPTION
Utility classes, which are collections of static members, are not meant to be instantiated. Even abstract utility classes, which can be extended, should not have public constructors.

Java adds an implicit public constructor to every class which does not define at least one explicitly. Hence, at least one non-public constructor should be defined.

Added private constructors to all classes consisting of just static members

Signed-off-by: Shishir Halaharvi <shishir.neo95@gmail.com>