### PR TITLE
Adds demo metrics to listTrialStatus

### DIFF
--- a/src/main/java/com/autotune/experimentManager/services/ListTrialStatus.java
+++ b/src/main/java/com/autotune/experimentManager/services/ListTrialStatus.java
@@ -18,13 +18,17 @@ package com.autotune.experimentManager.services;
 
 import com.autotune.experimentManager.data.EMMapper;
 import com.autotune.experimentManager.data.ExperimentTrialData;
+import com.autotune.experimentManager.transitions.util.TransistionHelper;
 import com.autotune.experimentManager.utils.EMConstants;
+import com.autotune.experimentManager.utils.EMUtil;
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.ArrayList;
 
 /**
  * This class is the handler for the endpoint `listTrialStatus`
@@ -37,20 +41,53 @@ public class ListTrialStatus extends HttpServlet {
 //        String inputData = req.getReader().lines().collect(Collectors.joining());
 //        JSONObject json = new JSONObject(inputData);
 //        String runId = json.getString(EMConstants.InputJsonKeys.GetTrailStatusInputKeys.RUN_ID);
-        JSONObject API_RESPONSE = new JSONObject();
-        String runId = req.getParameter(EMConstants.InputJsonKeys.ListTrialStatusKeys.RUN_ID);
-        if (null == runId) {
-            API_RESPONSE.put(EMConstants.InputJsonKeys.ListTrialStatusKeys.ERROR, "Run ID cannot be null");
+        ArrayList<String> runIdList = new ArrayList<String>();
+        boolean validRunId = true;
+        String runIdParam = req.getParameter(EMConstants.InputJsonKeys.ListTrialStatusKeys.RUN_ID);
+        if (null != runIdParam) {
+            runIdList.add(runIdParam);
         } else {
-            if (EMMapper.getInstance().getMap().containsKey(runId)) {
-                API_RESPONSE.put(EMConstants.InputJsonKeys.ListTrialStatusKeys.STATUS, ((ExperimentTrialData) EMMapper.getInstance().getMap().get(runId)).getStatus().toString());
-            } else {
-                API_RESPONSE.put(EMConstants.InputJsonKeys.ListTrialStatusKeys.ERROR, "Invalid Run ID");
-            }
+            EMMapper.getInstance().getMap().forEach((key, value) -> {
+                runIdList.add((String) key);
+            });
         }
 
+        JSONArray API_RESPONSE_ARRAY = new JSONArray();
+
+        for (String runId : runIdList) {
+            validRunId = true;
+            JSONObject API_RESPONSE = null;
+
+            if (null == runId) {
+                API_RESPONSE = new JSONObject();
+                API_RESPONSE.put(EMConstants.InputJsonKeys.ListTrialStatusKeys.ERROR, "Run ID cannot be null");
+                validRunId = false;
+            } else if (!EMMapper.getInstance().getMap().containsKey(runId)) {
+                API_RESPONSE = new JSONObject();
+                API_RESPONSE.put(EMConstants.InputJsonKeys.ListTrialStatusKeys.ERROR, "Invalid Run ID");
+                validRunId = false;
+            }
+
+            String completeStatus = req.getParameter("completeStatus");
+            String summary = req.getParameter(EMConstants.InputJsonKeys.ListTrialStatusKeys.SUMMARY);
+
+            if(validRunId) {
+                if (null != summary && summary.equalsIgnoreCase("true")) {
+                    ExperimentTrialData etd = (ExperimentTrialData) EMMapper.getInstance().getMap().get(runId);
+                    if (etd.getStatus() == EMUtil.EMExpStatus.COMPLETED) {
+                        API_RESPONSE = TransistionHelper.MetricsFormatter.getMetricsJson(runId);
+                        API_RESPONSE.put(EMConstants.InputJsonKeys.ListTrialStatusKeys.STATUS, ((ExperimentTrialData) EMMapper.getInstance().getMap().get(runId)).getStatus().toString());
+                    }
+                }
+            }
+
+            API_RESPONSE_ARRAY.put(API_RESPONSE);
+        }
+
+
+
         resp.setStatus(HttpServletResponse.SC_OK);
-        resp.getWriter().println(API_RESPONSE.toString());
+        resp.getWriter().println(API_RESPONSE_ARRAY.toString());
     }
 
     @Override


### PR DESCRIPTION
The current PR adds the demo metrics for the summary on `listTrialStatus` api.

Currently parking this PR as work-in-progress as I need to add the tested code for `completeStatus` param on `listTrialStatus` API which gives the warm up and measurement cycle data as well 