### PR TITLE
359 Autotune logs have a lot of information being logged

### DIFF
--- a/manifests/autotune-operator-deployment.yaml_template
+++ b/manifests/autotune-operator-deployment.yaml_template
@@ -28,6 +28,12 @@ spec:
                 name: autotune-config
                 key: logging_level
                 optional: true
+          - name: ROOT_LOGGING_LEVEL
+            valueFrom:
+              configMapKeyRef:
+                name: autotune-config
+                key: root_logging_level
+                optional: true
       - name: autotune
         image: "{{ AUTOTUNE_IMAGE }}"
         imagePullPolicy: Always
@@ -74,6 +80,12 @@ spec:
               configMapKeyRef:
                 name: autotune-config
                 key: logging_level
+                optional: true
+          - name: ROOT_LOGGING_LEVEL
+            valueFrom:
+              configMapKeyRef:
+                name: autotune-config
+                key: root_logging_level
                 optional: true
         envFrom: 
           - configMapRef:

--- a/manifests/configmaps/docker-config.yaml
+++ b/manifests/configmaps/docker-config.yaml
@@ -10,5 +10,6 @@ data:
   monitoring_agent: "prometheus"
   monitoring_service: ""
   monitoring_agent_endpoint: ""
+  root_logging_level: "error"
   logging_level: "info"
 

--- a/manifests/configmaps/minikube-config.yaml
+++ b/manifests/configmaps/minikube-config.yaml
@@ -10,6 +10,7 @@ data:
   monitoring_agent: "prometheus"
   monitoring_service: "prometheus-k8s"
   monitoring_agent_endpoint: ""
+  root_logging_level: "error"
   logging_level: "info"
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -72,12 +72,7 @@
             <scope>compile</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>${slf4j-version}</version>
-            <scope>compile</scope>
-        </dependency>
+
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/com/autotune/analyzer/deployment/AutotuneDeploymentInfo.java
+++ b/src/main/java/com/autotune/analyzer/deployment/AutotuneDeploymentInfo.java
@@ -45,8 +45,8 @@ public class AutotuneDeploymentInfo
 	private static String monitoringAgentService;
 	private static String monitoringAgentEndpoint;
 	private static String loggingLevel;
+	private static String rootLoggingLevel;
 	private static Hashtable<String, Class> tunableLayerPair;
-
 	private static final Logger LOGGER = LoggerFactory.getLogger(AutotuneDeploymentInfo.class);
 
 	public static void setLayerTable() {
@@ -157,6 +157,9 @@ public class AutotuneDeploymentInfo
 	public static String getLoggingLevel() {
 		return loggingLevel;
 	}
+	public static String getRootLoggingLevel() {
+		return rootLoggingLevel;
+	}
 
 	public static void setLoggingLevel(String loggingLevel) {
 		if (loggingLevel != null)
@@ -166,6 +169,15 @@ public class AutotuneDeploymentInfo
 			AutotuneDeploymentInfo.loggingLevel = loggingLevel;
 		else
 			AutotuneDeploymentInfo.loggingLevel = "info";
+	}
+	public static void setRootLoggingLevel(String rootLoggingLevel) {
+		if (rootLoggingLevel != null)
+			rootLoggingLevel = rootLoggingLevel.toLowerCase();
+
+		if (AutotuneSupportedTypes.LOGGING_TYPES_SUPPORTED.contains(rootLoggingLevel))
+			AutotuneDeploymentInfo.rootLoggingLevel = rootLoggingLevel;
+		else
+			AutotuneDeploymentInfo.rootLoggingLevel = "error";
 	}
 
 	public static void logDeploymentInfo() {

--- a/src/main/java/com/autotune/analyzer/deployment/InitializeDeployment.java
+++ b/src/main/java/com/autotune/analyzer/deployment/InitializeDeployment.java
@@ -20,9 +20,6 @@ import com.autotune.analyzer.exceptions.K8sTypeNotSupportedException;
 import com.autotune.analyzer.exceptions.MonitoringAgentNotFoundException;
 import com.autotune.analyzer.exceptions.MonitoringAgentNotSupportedException;
 import com.autotune.analyzer.utils.AnalyzerConstants;
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.config.Configurator;
 
 /**
  * Get the deployment information from the config map and initialize
@@ -37,6 +34,7 @@ public class InitializeDeployment
 		String auth_token = System.getenv(AnalyzerConstants.AUTH_TOKEN);
 		String cluster_type = System.getenv(AnalyzerConstants.CLUSTER_TYPE);
 		String logging_level = System.getenv(AnalyzerConstants.LOGGING_LEVEL);
+		String root_logging_level = System.getenv(AnalyzerConstants.ROOT_LOGGING_LEVEL);
 		String monitoring_agent = System.getenv(AnalyzerConstants.MONITORING_AGENT);
 		String monitoring_agent_service = System.getenv(AnalyzerConstants.MONITORING_SERVICE);
 		String monitoring_agent_endpoint = System.getenv(AnalyzerConstants.MONITORING_AGENT_ENDPOINT);
@@ -48,6 +46,7 @@ public class InitializeDeployment
 		AutotuneDeploymentInfo.setAuthToken(auth_token);
 		AutotuneDeploymentInfo.setMonitoringAgentService(monitoring_agent_service);
 		AutotuneDeploymentInfo.setLoggingLevel(logging_level);
+		AutotuneDeploymentInfo.setRootLoggingLevel(root_logging_level);
 
 		//If no endpoint was specified in the configmap
 		if (monitoring_agent_endpoint == null || monitoring_agent_endpoint.isEmpty()) {
@@ -61,9 +60,6 @@ public class InitializeDeployment
 		AutotuneDeploymentInfo.setMonitoringAgentEndpoint(monitoring_agent_endpoint);
 
 		AutotuneDeploymentInfo.setLayerTable();
-
-		/* Update logging level from the env */
-		Configurator.setAllLevels(LogManager.getRootLogger().getName(), Level.toLevel(AutotuneDeploymentInfo.getLoggingLevel()));
 
 		AutotuneDeploymentInfo.logDeploymentInfo();
 	}

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -30,6 +30,7 @@ public class AnalyzerConstants
 	public static final String AUTH_TOKEN = "AUTH_TOKEN";
 	public static final String CLUSTER_TYPE = "CLUSTER_TYPE";
 	public static final String LOGGING_LEVEL = "LOGGING_LEVEL";
+	public static final String ROOT_LOGGING_LEVEL = "ROOT_LOGGING_LEVEL";
 	public static final String MONITORING_AGENT = "MONITORING_AGENT";
 	public static final String MONITORING_SERVICE = "MONITORING_SERVICE";
 	public static final String MONITORING_AGENT_ENDPOINT = "MONITORING_AGENT_ENDPOINT";

--- a/src/main/java/com/autotune/experimentManager/core/ExperimentManager.java
+++ b/src/main/java/com/autotune/experimentManager/core/ExperimentManager.java
@@ -8,9 +8,6 @@ import com.autotune.experimentManager.settings.EMS;
 import com.autotune.experimentManager.utils.EMConstants;
 
 import com.autotune.utils.ServerContext;
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.config.Configurator;
 
 import org.eclipse.jetty.servlet.ServletContextHandler;
 
@@ -32,7 +29,6 @@ public class ExperimentManager {
     }
 
     public static void launch(ServletContextHandler contextHandler) {
-        Configurator.setAllLevels(LogManager.getRootLogger().getName(), Level.toLevel(EMConstants.Logs.LoggerSettings.DEFAULT_LOG_LEVEL));
         LOGGER.info("EM version: testv1");
         initializeEM();
         addEMServlets(contextHandler);

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -1,0 +1,21 @@
+# Extra logging related to initialization of Log4j
+# Set to debug or trace if log4j initialization is failing
+status = warn  
+# Name of the configuration
+name = AutotuneConsoleLogConfig
+# Console Appender will print logs on console
+appender.console.type = Console
+appender.console.name = consoleLogger
+appender.console.target = SYSTEM_OUT
+appender.console.layout.type = PatternLayout
+# pattern of the logs
+appender.console.layout.pattern = %d{yyyy-MM-ddHH:mm:ss.SSS} %level [%t][%F(%L)]-%msg%n
+# Root logger level
+rootLogger.level = ${env:ROOT_LOGGING_LEVEL}
+# Root logger referring to console appender
+rootLogger.appenderRef.stdout.ref = consoleLogger
+rootLogger.appenderRef.console.ref = consoleLogger
+logger.autotune.name = com.autotune
+logger.autotune.level = ${env:LOGGING_LEVEL}
+logger.autotune.appenderRef.stdout.ref = consoleLogger
+logger.autotune.appenderRef.console.ref = consoleLogger


### PR DESCRIPTION
Creating meaningful log would be essential to troubleshoot. And hence Autotune modules should implement effective logging and Error/Exception handler. I have introduced log4j2.properties files to customize logging behavior.
I have used console appender with following format
             %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
            Example : 
<pre>2021-12-28 05:52:38 DEBUG Config:730 - Found service account namespace at: [/var/run/secrets/kubernetes.io/serviceaccount/namespace].
2021-12-28 05:52:39 INFO  AutotuneDeploymentInfo:172 - Cluster Type: kubernetes
2021-12-28 05:52:39 INFO  AutotuneDeploymentInfo:173 - Kubernetes Type: minikube
2021-12-28 05:52:39 INFO  AutotuneDeploymentInfo:174 - Auth Type: 
2021-12-28 05:52:39 INFO  AutotuneDeploymentInfo:175 - Monitoring Agent: prometheus
2021-12-28 05:52:39 INFO  AutotuneDeploymentInfo:176 - Monitoring Agent URL: http://10.107.224.73:9090
2021-12-28 05:52:39 INFO  AutotuneDeploymentInfo:177 - Monitoring agent service: prometheus-k8s
</pre>

Regarding #359 Autotune logs have a lot of information being logged : This PR will remove information from external package.

Signed-off-by: Vinay Kumar Mysore Sathya Kumar <vinakuma@redhat.com>