### PR TITLE
Enable prometheus '/metrics' endpoint for Autotune.

### DIFF
--- a/manifests/autotune-operator-deployment.yaml_template
+++ b/manifests/autotune-operator-deployment.yaml_template
@@ -36,7 +36,7 @@ spec:
             valueFrom:
               configMapKeyRef:
                 name: autotune-config
-                key: cluster_type 
+                key: cluster_type
           - name: K8S_TYPE
             valueFrom:
               configMapKeyRef:
@@ -46,7 +46,7 @@ spec:
             valueFrom:
               configMapKeyRef:
                 name: autotune-config
-                key: auth_type 
+                key: auth_type
                 optional: true
           - name: AUTH_TOKEN
             valueFrom:
@@ -75,19 +75,20 @@ spec:
                 name: autotune-config
                 key: logging_level
                 optional: true
-        envFrom: 
+        envFrom:
           - configMapRef:
-              name: autotune-config 
+              name: autotune-config
         ports:
-         - name: http
+         - name: autotune-port
            containerPort: 8080
 ---
-kind: Service
 apiVersion: v1
+kind: Service
 metadata:
   name: autotune
   annotations:
     prometheus.io/scrape: 'true'
+    prometheus.io/path: '/metrics'
   labels:
     app: autotune
 spec:
@@ -95,6 +96,6 @@ spec:
   selector:
     app: autotune
   ports:
-  - name: http
+  - name: autotune-port
     port: 8080
     targetPort: 8080

--- a/manifests/servicemonitor/autotune-service-monitor.yaml
+++ b/manifests/servicemonitor/autotune-service-monitor.yaml
@@ -9,7 +9,8 @@ spec:
     matchLabels:
       app: autotune
   endpoints:
-  - port: http
+  - port: autotune-port
+    path: '/metrics'
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: Prometheus

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         <jetty-version>9.4.44.v20210927</jetty-version>
         <slf4j-version>2.17.1</slf4j-version>
         <java-version>17</java-version>
+        <prometheus-simpleclient>0.14.1</prometheus-simpleclient>
         <maven-compiler-plugin-version>3.8.0</maven-compiler-plugin-version>
         <maven-assembly-plugin-version>2.2</maven-assembly-plugin-version>
         <appassembler-maven-plugin-version>1.1.1</appassembler-maven-plugin-version>
@@ -23,6 +24,7 @@
             <artifactId>kubernetes-client</artifactId>
             <version>${fabric8-version}</version>
         </dependency>
+
         <!-- https://mvnrepository.com/artifact/org.json/json -->
         <dependency>
             <groupId>org.json</groupId>
@@ -65,6 +67,32 @@
             <version>${slf4j-version}</version>
             <scope>compile</scope>
         </dependency>
+
+		<!-- The Prometheus client -->
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <version>${prometheus-simpleclient}</version>
+        </dependency>
+        <!-- Hotspot JVM metrics-->
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_hotspot</artifactId>
+            <version>${prometheus-simpleclient}</version>
+        </dependency>
+        <!-- Exposition HTTPServer-->
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_httpserver</artifactId>
+            <version>${prometheus-simpleclient}</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/io.prometheus/simpleclient_servlet -->
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_servlet</artifactId>
+            <version>0.14.1</version>
+        </dependency>
+
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/com/autotune/Autotune.java
+++ b/src/main/java/com/autotune/Autotune.java
@@ -19,16 +19,18 @@ import com.autotune.analyzer.Analyzer;
 import com.autotune.analyzer.utils.ServerContext;
 import com.autotune.experimentManager.ExperimentManager;
 import com.autotune.service.HealthService;
+import io.prometheus.client.exporter.MetricsServlet;
+import io.prometheus.client.hotspot.DefaultExports;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.autotune.analyzer.utils.ServerContext.*;
+
 public class Autotune
 {
-	private static final int PORT = 8080;
-	private static final String ROOT_CONTEXT = "/";
-	private static final String HEALTH_SERVICE = ROOT_CONTEXT + "health";
 	private static final Logger LOGGER = LoggerFactory.getLogger(Autotune.class);
 
 	public static void main(String[] args) {
@@ -36,7 +38,7 @@ public class Autotune
 
 		disableServerLogging();
 
-		Server server = new Server(PORT);
+		Server server = new Server(AUTOTUNE_PORT);
 		context = new ServletContextHandler();
 		context.setContextPath(ServerContext.ROOT_CONTEXT);
 		server.setHandler(context);
@@ -54,6 +56,9 @@ public class Autotune
 
 	private static void addAutotuneServlets(ServletContextHandler context) {
 		context.addServlet(HealthService.class, HEALTH_SERVICE);
+		// Start the Prometheus end point (/metrics) for Autotune
+		context.addServlet(new ServletHolder(new MetricsServlet()), METRICS_SERVICE);
+		DefaultExports.initialize();
 	}
 
 	private static void disableServerLogging() {

--- a/src/main/java/com/autotune/analyzer/utils/ServerContext.java
+++ b/src/main/java/com/autotune/analyzer/utils/ServerContext.java
@@ -21,7 +21,11 @@ package com.autotune.analyzer.utils;
 public class ServerContext
 {
 	private ServerContext() { }
+	public static final int AUTOTUNE_PORT = 8080;
+
 	public static final String ROOT_CONTEXT = "/";
+	public static final String HEALTH_SERVICE = ROOT_CONTEXT + "health";
+	public static final String METRICS_SERVICE = ROOT_CONTEXT + "metrics";
 	public static final String LIST_STACKS = ROOT_CONTEXT + "listStacks";
 	public static final String LIST_STACK_LAYERS = ROOT_CONTEXT + "listStackLayers";
 	public static final String LIST_STACK_TUNABLES = ROOT_CONTEXT + "listStackTunables";


### PR DESCRIPTION
This PR adds the prometheus-simpleclient dependency and starts the metrics end point.
Also rename the default port in the deployment yaml to 'autotune-port` to be more descriptive.

Signed-off-by: Dinakar Guniguntala <dgunigun@redhat.com>