### PR TITLE
Better hotspot JVM detection.

### DIFF
--- a/manifests/autotune-configs/hotspot-micrometer-config.yaml
+++ b/manifests/autotune-configs/hotspot-micrometer-config.yaml
@@ -8,7 +8,13 @@ details: hotspot tunables
 layer_presence:
   queries:
   - datasource: 'prometheus'
-    query: 'jvm_memory_used_bytes{area="heap",}'
+    query: 'jvm_memory_used_bytes{area="heap",id=~"Eden.+"}'
+    key: pod
+  - datasource: 'prometheus'
+    query: 'jvm_memory_used_bytes{area="heap",id=~"Tenured.+"}'
+    key: pod
+  - datasource: 'prometheus'
+    query: 'jvm_memory_used_bytes{area="heap",id=~"Old.+"}'
     key: pod
 tunables:
 - name: MaxInlineLevel


### PR DESCRIPTION
Use multiple queries to better detect hotspot JVM. Closes #344 

Signed-off-by: Dinakar Guniguntala <dgunigun@redhat.com>