### PR TITLE
Adds the classes required for extracting the results from output json

### DIFF
--- a/src/main/java/com/autotune/shared/data/interfaces/ConvertToJSON.java
+++ b/src/main/java/com/autotune/shared/data/interfaces/ConvertToJSON.java
@@ -1,0 +1,7 @@
+package com.autotune.shared.data.interfaces;
+
+import org.json.JSONObject;
+
+public interface ConvertToJSON {
+    public JSONObject toJSON();
+}

--- a/src/main/java/com/autotune/shared/data/metrics/EMMetricGenericResults.java
+++ b/src/main/java/com/autotune/shared/data/metrics/EMMetricGenericResults.java
@@ -1,0 +1,85 @@
+package com.autotune.shared.data.metrics;
+
+import com.autotune.shared.data.interfaces.ConvertToJSON;
+import com.autotune.utils.AutotuneConstants;
+import org.json.JSONObject;
+
+public class EMMetricGenericResults implements ConvertToJSON {
+    private float score;
+    private float error;
+    private float mean;
+    private float mode;
+    private float spike;
+
+    public EMMetricGenericResults() {
+        score = Float.MIN_VALUE;
+        error = Float.MIN_VALUE;
+        mean = Float.MIN_VALUE;
+        mode = Float.MIN_VALUE;
+        spike = Float.MIN_VALUE;
+    }
+
+    public EMMetricGenericResults(JSONObject jsonObject) {
+        this.score = (jsonObject.has(AutotuneConstants.JSONKeys.SCORE)) ? jsonObject.getFloat(AutotuneConstants.JSONKeys.SCORE) : Float.MIN_VALUE;
+        this.error = (jsonObject.has(AutotuneConstants.JSONKeys.ERROR)) ? jsonObject.getFloat(AutotuneConstants.JSONKeys.ERROR) : Float.MIN_VALUE;
+        this.mean = (jsonObject.has(AutotuneConstants.JSONKeys.MEAN)) ? jsonObject.getFloat(AutotuneConstants.JSONKeys.MEAN) : Float.MIN_VALUE;
+        this.mode = (jsonObject.has(AutotuneConstants.JSONKeys.MODE)) ? jsonObject.getFloat(AutotuneConstants.JSONKeys.MODE) : Float.MIN_VALUE;
+        this.spike = (jsonObject.has(AutotuneConstants.JSONKeys.SPIKE)) ? jsonObject.getFloat(AutotuneConstants.JSONKeys.SPIKE) : Float.MIN_VALUE;
+    }
+
+    public float getScore() {
+        return score;
+    }
+
+    public void setScore(float score) {
+        this.score = score;
+    }
+
+    public float getError() {
+        return error;
+    }
+
+    public void setError(float error) {
+        this.error = error;
+    }
+
+    public float getMean() {
+        return mean;
+    }
+
+    public void setMean(float mean) {
+        this.mean = mean;
+    }
+
+    public float getMode() {
+        return mode;
+    }
+
+    public void setMode(float mode) {
+        this.mode = mode;
+    }
+
+    public float getSpike() {
+        return spike;
+    }
+
+    public void setSpike(float spike) {
+        this.spike = spike;
+    }
+
+    @Override
+    public JSONObject toJSON() {
+        JSONObject jsonObject = new JSONObject();
+        if (this.spike != Float.MIN_VALUE)
+            jsonObject.put(AutotuneConstants.JSONKeys.SPIKE, spike);
+        if (this.error != Float.MIN_VALUE)
+            jsonObject.put(AutotuneConstants.JSONKeys.ERROR, error);
+        if (this.mode != Float.MIN_VALUE)
+            jsonObject.put(AutotuneConstants.JSONKeys.MODE, mode);
+        if (this.mean != Float.MIN_VALUE)
+            jsonObject.put(AutotuneConstants.JSONKeys.MEAN, mean);
+        if (this.score != Float.MIN_VALUE)
+            jsonObject.put(AutotuneConstants.JSONKeys.SCORE, score);
+        return jsonObject;
+    }
+}

--- a/src/main/java/com/autotune/shared/data/metrics/EMMetricGenericResults.java
+++ b/src/main/java/com/autotune/shared/data/metrics/EMMetricGenericResults.java
@@ -10,6 +10,8 @@ public class EMMetricGenericResults implements ConvertToJSON {
     private float mean;
     private float mode;
     private float spike;
+    private float min;
+    private float max;
 
     public EMMetricGenericResults() {
         score = Float.MIN_VALUE;
@@ -17,6 +19,8 @@ public class EMMetricGenericResults implements ConvertToJSON {
         mean = Float.MIN_VALUE;
         mode = Float.MIN_VALUE;
         spike = Float.MIN_VALUE;
+        min = Float.MIN_VALUE;
+        max = Float.MIN_VALUE;
     }
 
     public EMMetricGenericResults(JSONObject jsonObject) {
@@ -25,6 +29,24 @@ public class EMMetricGenericResults implements ConvertToJSON {
         this.mean = (jsonObject.has(AutotuneConstants.JSONKeys.MEAN)) ? jsonObject.getFloat(AutotuneConstants.JSONKeys.MEAN) : Float.MIN_VALUE;
         this.mode = (jsonObject.has(AutotuneConstants.JSONKeys.MODE)) ? jsonObject.getFloat(AutotuneConstants.JSONKeys.MODE) : Float.MIN_VALUE;
         this.spike = (jsonObject.has(AutotuneConstants.JSONKeys.SPIKE)) ? jsonObject.getFloat(AutotuneConstants.JSONKeys.SPIKE) : Float.MIN_VALUE;
+        this.max = (jsonObject.has(AutotuneConstants.JSONKeys.MAX)) ? jsonObject.getFloat(AutotuneConstants.JSONKeys.MAX) : Float.MIN_VALUE;
+        this.min = (jsonObject.has(AutotuneConstants.JSONKeys.MIN)) ? jsonObject.getFloat(AutotuneConstants.JSONKeys.MIN) : Float.MIN_VALUE;
+    }
+
+    public float getMin() {
+        return min;
+    }
+
+    public void setMin(float min) {
+        this.min = min;
+    }
+
+    public float getMax() {
+        return max;
+    }
+
+    public void setMax(float max) {
+        this.max = max;
     }
 
     public float getScore() {
@@ -80,6 +102,10 @@ public class EMMetricGenericResults implements ConvertToJSON {
             jsonObject.put(AutotuneConstants.JSONKeys.MEAN, mean);
         if (this.score != Float.MIN_VALUE)
             jsonObject.put(AutotuneConstants.JSONKeys.SCORE, score);
+        if (this.max != Float.MIN_VALUE)
+            jsonObject.put(AutotuneConstants.JSONKeys.MAX, max);
+        if (this.min != Float.MIN_VALUE)
+            jsonObject.put(AutotuneConstants.JSONKeys.MIN, min);
         return jsonObject;
     }
 }

--- a/src/main/java/com/autotune/shared/data/metrics/EMMetricPercentileResults.java
+++ b/src/main/java/com/autotune/shared/data/metrics/EMMetricPercentileResults.java
@@ -1,0 +1,137 @@
+package com.autotune.shared.data.metrics;
+
+import com.autotune.shared.data.interfaces.ConvertToJSON;
+import com.autotune.utils.AutotuneConstants;
+import org.json.JSONObject;
+
+public class EMMetricPercentileResults implements ConvertToJSON {
+    private float percentile50;
+    private float percentile97;
+    private float percentile95;
+    private float percentile99;
+    private float percentile99Point9;
+    private float percentile99Point99;
+    private float percentile99Point999;
+    private float percentile99Point9999;
+    private float percentile100;
+
+    public EMMetricPercentileResults() {
+        this.percentile50 = Float.MIN_VALUE;
+        this.percentile97 = Float.MIN_VALUE;
+        this.percentile95 = Float.MIN_VALUE;
+        this.percentile99 = Float.MIN_VALUE;
+        this.percentile99Point9 = Float.MIN_VALUE;
+        this.percentile99Point99 = Float.MIN_VALUE;
+        this.percentile99Point999 = Float.MIN_VALUE;
+        this.percentile99Point9999 = Float.MIN_VALUE;
+        this.percentile100 = Float.MIN_VALUE;
+    }
+
+    public EMMetricPercentileResults(JSONObject jsonObject) {
+        this.percentile50 = (jsonObject.has(AutotuneConstants.JSONKeys.P_50_0)) ? jsonObject.getFloat(AutotuneConstants.JSONKeys.P_50_0) : Float.MIN_VALUE;
+        this.percentile95 = (jsonObject.has(AutotuneConstants.JSONKeys.P_95_0)) ? jsonObject.getFloat(AutotuneConstants.JSONKeys.P_95_0) : Float.MIN_VALUE;
+        this.percentile97 = (jsonObject.has(AutotuneConstants.JSONKeys.P_97_0)) ? jsonObject.getFloat(AutotuneConstants.JSONKeys.P_97_0) : Float.MIN_VALUE;
+        this.percentile99 = (jsonObject.has(AutotuneConstants.JSONKeys.P_99_0)) ? jsonObject.getFloat(AutotuneConstants.JSONKeys.P_99_0) : Float.MIN_VALUE;
+        this.percentile99Point9 = (jsonObject.has(AutotuneConstants.JSONKeys.P_99_9)) ? jsonObject.getFloat(AutotuneConstants.JSONKeys.P_99_9) : Float.MIN_VALUE;
+        this.percentile99Point99 = (jsonObject.has(AutotuneConstants.JSONKeys.P_99_99)) ? jsonObject.getFloat(AutotuneConstants.JSONKeys.P_99_99) : Float.MIN_VALUE;
+        this.percentile99Point999 = (jsonObject.has(AutotuneConstants.JSONKeys.P_99_999)) ? jsonObject.getFloat(AutotuneConstants.JSONKeys.P_99_999) : Float.MIN_VALUE;
+        this.percentile99Point9999 = (jsonObject.has(AutotuneConstants.JSONKeys.P_99_9999)) ? jsonObject.getFloat(AutotuneConstants.JSONKeys.P_99_9999) : Float.MIN_VALUE;
+        this.percentile100 = (jsonObject.has(AutotuneConstants.JSONKeys.P_100_0)) ? jsonObject.getFloat(AutotuneConstants.JSONKeys.P_100_0) : Float.MIN_VALUE;
+    }
+
+    public float getPercentile50() {
+        return percentile50;
+    }
+
+    public void setPercentile50(float percentile50) {
+        this.percentile50 = percentile50;
+    }
+
+    public float getPercentile97() {
+        return percentile97;
+    }
+
+    public void setPercentile97(float percentile97) {
+        this.percentile97 = percentile97;
+    }
+
+    public float getPercentile95() {
+        return percentile95;
+    }
+
+    public void setPercentile95(float percentile95) {
+        this.percentile95 = percentile95;
+    }
+
+    public float getPercentile99() {
+        return percentile99;
+    }
+
+    public void setPercentile99(float percentile99) {
+        this.percentile99 = percentile99;
+    }
+
+    public float getPercentile99Point9() {
+        return percentile99Point9;
+    }
+
+    public void setPercentile99Point9(float percentile99Point9) {
+        this.percentile99Point9 = percentile99Point9;
+    }
+
+    public float getPercentile99Point99() {
+        return percentile99Point99;
+    }
+
+    public void setPercentile99Point99(float percentile99Point99) {
+        this.percentile99Point99 = percentile99Point99;
+    }
+
+    public float getPercentile99Point999() {
+        return percentile99Point999;
+    }
+
+    public void setPercentile99Point999(float percentile99Point999) {
+        this.percentile99Point999 = percentile99Point999;
+    }
+
+    public float getPercentile99Point9999() {
+        return percentile99Point9999;
+    }
+
+    public void setPercentile99Point9999(float percentile99Point9999) {
+        this.percentile99Point9999 = percentile99Point9999;
+    }
+
+    public float getPercentile100() {
+        return percentile100;
+    }
+
+    public void setPercentile100(float percentile100) {
+        this.percentile100 = percentile100;
+    }
+
+    @Override
+    public JSONObject toJSON() {
+        JSONObject jsonObject = new JSONObject();
+        if (this.percentile50 != Float.MIN_VALUE)
+            jsonObject.put(AutotuneConstants.JSONKeys.P_50_0, percentile50);
+        if (this.percentile95 != Float.MIN_VALUE)
+            jsonObject.put(AutotuneConstants.JSONKeys.P_95_0, percentile95);
+        if (this.percentile97 != Float.MIN_VALUE)
+            jsonObject.put(AutotuneConstants.JSONKeys.P_97_0, percentile97);
+        if (this.percentile99 != Float.MIN_VALUE)
+            jsonObject.put(AutotuneConstants.JSONKeys.P_99_0, percentile99);
+        if (this.percentile99Point9 != Float.MIN_VALUE)
+            jsonObject.put(AutotuneConstants.JSONKeys.P_99_9, percentile99Point9);
+        if (this.percentile99Point99 != Float.MIN_VALUE)
+            jsonObject.put(AutotuneConstants.JSONKeys.P_99_99, percentile99Point99);
+        if (this.percentile99Point999 != Float.MIN_VALUE)
+            jsonObject.put(AutotuneConstants.JSONKeys.P_99_999, percentile99Point999);
+        if (this.percentile99Point9999 != Float.MIN_VALUE)
+            jsonObject.put(AutotuneConstants.JSONKeys.P_99_9999, percentile99Point9999);
+        if (this.percentile100 != Float.MIN_VALUE)
+            jsonObject.put(AutotuneConstants.JSONKeys.P_100_0, percentile100);
+        return jsonObject;
+    }
+}

--- a/src/main/java/com/autotune/shared/data/metrics/EMMetricResult.java
+++ b/src/main/java/com/autotune/shared/data/metrics/EMMetricResult.java
@@ -1,0 +1,48 @@
+package com.autotune.shared.data.metrics;
+
+import com.autotune.shared.data.interfaces.ConvertToJSON;
+import com.autotune.experimentManager.exceptions.IncompatibleInputJSONException;
+import com.autotune.utils.AutotuneConstants;
+import org.json.JSONObject;
+
+public class EMMetricResult implements ConvertToJSON {
+    private EMMetricGenericResults emMetricGenericResults;
+    private EMMetricPercentileResults emMetricPercentileResults;
+    private boolean isPercentileResultsAvailable;
+
+    public boolean isPercentileResultsAvailable() {
+        return isPercentileResultsAvailable;
+    }
+
+    public void setPercentileResultsAvailable(boolean percentileResultsAvailable) {
+        isPercentileResultsAvailable = percentileResultsAvailable;
+    }
+
+    public EMMetricResult () {
+        emMetricGenericResults = new EMMetricGenericResults();
+        emMetricPercentileResults = new EMMetricPercentileResults();
+    }
+
+    public EMMetricResult(JSONObject jsonObject) throws IncompatibleInputJSONException {
+        if (!jsonObject.has(AutotuneConstants.JSONKeys.GENERAL_INFO) ||
+            !jsonObject.has(AutotuneConstants.JSONKeys.PERCENTILE_INFO)) {
+            throw new IncompatibleInputJSONException();
+        }
+        if (jsonObject.has(AutotuneConstants.JSONKeys.PERCENTILE_INFO)) {
+            isPercentileResultsAvailable = true;
+        }
+        emMetricGenericResults = new EMMetricGenericResults(jsonObject.getJSONObject(AutotuneConstants.JSONKeys.GENERAL_INFO));
+        emMetricPercentileResults = new EMMetricPercentileResults(jsonObject.getJSONObject(AutotuneConstants.JSONKeys.PERCENTILE_INFO));
+    }
+
+
+    @Override
+    public JSONObject toJSON() {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put(AutotuneConstants.JSONKeys.GENERAL_INFO, emMetricGenericResults.toJSON());
+        if (isPercentileResultsAvailable) {
+            jsonObject.put(AutotuneConstants.JSONKeys.PERCENTILE_INFO, emMetricPercentileResults.toJSON());
+        }
+        return jsonObject;
+    }
+}

--- a/src/main/java/com/autotune/utils/AutotuneConstants.java
+++ b/src/main/java/com/autotune/utils/AutotuneConstants.java
@@ -96,6 +96,8 @@ public class AutotuneConstants {
         public static String P_99_999 = "99.999p";
         public static String P_99_9999 = "99.9999p";
         public static String P_100_0 = "100p";
+        public static String MAX = "max";
+        public static String MIN = "min";
         public static String CYCLES = "cycles";
         public static String DURATION = "duration";
         public static String PERCENTILE_INFO = "percentile_info";

--- a/src/main/java/com/autotune/utils/AutotuneConstants.java
+++ b/src/main/java/com/autotune/utils/AutotuneConstants.java
@@ -31,4 +31,73 @@ public class AutotuneConstants {
         public static final String EM_ONLY_MODE = "EM_ONLY";
     }
 
+    public static class JSONKeys {
+        private JSONKeys() { }
+        public static final String CONTAINERS = "containers";
+        public static final String IMAGE_NAME = "image_name";
+        public static final String CONTAINER_NAME = "container_name";
+        public static final String ITERATIONS = "iterations";
+
+        // Info section
+        public static String INFO = "info";
+        public static String TRIAL_INFO = "trial_info";
+        public static String DATASOURCE_INFO = "datasource_info";
+        public static String TRIAL_ID = "trial_id";
+        public static String TRIAL_NUM = "trial_num";
+        public static String TRIAL_RESULT_URL = "trial_result_url";
+        public static String URL = "url";
+        // Settings section
+        public static String TRACKERS = "trackers";
+        public static String SETTINGS = "settings";
+        public static String DEPLOYMENT_TRACKING = "deployment_tracking";
+        public static String DEPLOYMENT_POLICY = "deployment_policy";
+        public static String DEPLOYMENT_SETTINGS = "deployment_settings";
+        public static String TYPE = "type";
+        public static String DEPLOYMENT_INFO = "deployment_info";
+        public static String DEPLOYMENT_NAME = "deployment_name";
+        public static String TARGET_ENV = "target_env";
+        public static String TRIAL_SETTINGS = "trial_settings";
+        public static String TOTAL_DURATION = "total_duration";
+        public static String WARMUP_CYCLES = "warmup_cycles";
+        public static String WARMUP_DURATION = "warmup_duration";
+        public static String MEASUREMENT_CYCLES = "measurement_cycles";
+        public static String MEASUREMENT_DURATION = "measurement_duration";
+        // Metadata Section
+        public static String EXPERIMENT_ID = "experiment_id";
+        public static String EXPERIMENT_NAME = "experiment_name";
+
+        // Deployments Section
+        public static String DEPLOYMENTS = "deployments";
+        public static String NAMESPACE = "namespace";
+        public static String POD_METRICS = "pod_metrics";
+        public static String CONTAINER_METRICS = "container_metrics";
+        public static String CONFIG = "config";
+        public static String NAME = "name";
+        public static String QUERY = "query";
+        public static String DATASOURCE = "datasource";
+        public static String METRIC_INFO = "metric_info";
+        public static String METRICS_RESULTS = "metrics_results";
+        public static String WARMUP_RESULTS = "warmup_results";
+        public static String MEASUREMENT_RESULTS = "measurement_results";
+        public static String ITERATION_RESULT = "iteration_result";
+        public static String GENERAL_INFO = "general_info";
+        public static String RESULTS = "results";
+        public static String SCORE = "score";
+        public static String ERROR = "error";
+        public static String MEAN = "mean";
+        public static String MODE = "mode";
+        public static String SPIKE = "spike";
+        public static String P_50_0 = "50p";
+        public static String P_95_0 = "95p";
+        public static String P_97_0 = "97p";
+        public static String P_99_0 = "99p";
+        public static String P_99_9 = "99.9p";
+        public static String P_99_99 = "99.99p";
+        public static String P_99_999 = "99.999p";
+        public static String P_99_9999 = "99.9999p";
+        public static String P_100_0 = "100p";
+        public static String CYCLES = "cycles";
+        public static String DURATION = "duration";
+        public static String PERCENTILE_INFO = "percentile_info";
+    }
 }


### PR DESCRIPTION
The class `EMMetricResult` can be used to arrange the results in the java object structure, The user of this class needs to provide the JSON object which has both or either of the keys `general_info` and `percentile_info` at the higher level of the JSONObject

example JSON to be passed:
```
{
  "general_info": {
    "mean": 95,
    "mode": 87,
    "spike": 156,
    "error": 0,
    "score": 12
  },
  "percentile_info":  {
    "50": 800,
    "95": 800,
    "97": 800,
    "99.99": 800,
    "99.999": 800
  }
}
```

Signed-off-by: bharathappali <abharath@redhat.com>