### PR TITLE
Openshift Deployment scripts with Prometheus access code changes

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -22,16 +22,19 @@ AUTOTUNE_OPERATOR_CRD="manifests/autotune-operator-crd.yaml"
 AUTOTUNE_CONFIG_CRD="manifests/autotune-config-crd.yaml"
 AUTOTUNE_QUERY_VARIABLE_CRD="manifests/autotune-query-variable-crd.yaml"
 AUTOTUNE_DEPLOY_MANIFEST_TEMPLATE="manifests/autotune-operator-deployment.yaml_template"
+AUTOTUNE_DEPLOY_OPENSHIFT_MANIFEST_TEMPLATE="manifests/autotune-operator-openshift-deployment.yaml_template"
 AUTOTUNE_DEPLOY_MANIFEST="manifests/autotune-operator-deployment.yaml"
 AUTOTUNE_RB_MANIFEST_TEMPLATE="manifests/autotune-operator-rolebinding.yaml_template"
 AUTOTUNE_RB_MANIFEST="manifests/autotune-operator-rolebinding.yaml"
 AUTOTUNE_ROLE_MANIFEST="manifests/autotune-operator-role.yaml"
 AUTOTUNE_SA_MANIFEST="manifests/autotune-operator-sa.yaml"
 SERVICE_MONITOR_MANIFEST="manifests/servicemonitor/autotune-service-monitor.yaml"
+AUTOTUNE_OPENSHIFT_NAMESPACE="openshift-tuning"
 AUTOTUNE_SA_NAME="autotune-sa"
 AUTOTUNE_CONFIGMAPS="manifests/configmaps"
 AUTOTUNE_CONFIGS="manifests/autotune-configs"
-AUTOTUNE_QUERY_VARIABLES="manifests/autotune-query-variables"
+AUTOTUNE_QUERY_VARIABLES_MANIFEST_TEMPLATE="manifests/autotune-query-variables/query-variable.yaml_template"
+AUTOTUNE_QUERY_VARIABLES_MANIFEST="manifests/autotune-query-variables/query-variable.yaml"
 
 AUTOTUNE_PORT="8080"
 AUTOTUNE_DOCKER_REPO="kruize/autotune_operator"
@@ -43,6 +46,7 @@ OPTUNA_DOCKER_IMAGE=${OPTUNA_DOCKER_REPO}:${AUTOTUNE_VERSION}
 
 # source all the helpers scripts
 . ${SCRIPTS_DIR}/minikube-helpers.sh
+. ${SCRIPTS_DIR}/openshift-helpers.sh
 . ${SCRIPTS_DIR}/common_utils.sh
 
 # Defaults for the script
@@ -56,7 +60,7 @@ autotune_ns=""
 # docker: loop timeout is turned off by default
 timeout=-1
 
-function ctrlc_handler () {
+function ctrlc_handler() {
 	# Check if cluster type is docker
 	if [[ "$cluster_type" == "docker" ]]; then
 		# Terminate the containers [autotune && grafana && prometheus && cadvisor]
@@ -67,14 +71,14 @@ function ctrlc_handler () {
 }
 
 # Handle SIGHUP(1), SIGINT(2), SIGQUIT(3) for cleaning up containers in docker case
-trap "ctrlc_handler" 1 2 3 
+trap "ctrlc_handler" 1 2 3
 
 function usage() {
 	echo
 	echo "Usage: $0 [-a] [-k url] [-c [docker|minikube|openshift]] [-i autotune docker image] [-o optuna docker image] [-n namespace] [-d configmaps-dir ] [--timeout=x, x in seconds, for docker only]"
 	echo "       -s = start(default), -t = terminate"
 	echo " -s: Deploy autotune [Default]"
-        echo " -t: Terminate autotune deployment"
+	echo " -t: Terminate autotune deployment"
 	echo " -c: kubernetes cluster type. At present we support only minikube [Default - minikube]"
 	echo " -i: build with specific autotune operator docker image name [Default - kruize/autotune_operator:<version from pom.xml>]"
 	echo " -o: build with specific optuna docker image name [Default - kruize/autotune_optuna:<version from pom.xml>]"

--- a/manifests/autotune-operator-openshift-deployment.yaml_template
+++ b/manifests/autotune-operator-openshift-deployment.yaml_template
@@ -1,0 +1,137 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: autotune
+  labels:
+    app: autotune
+spec:
+  replicas: 1
+  selector:
+      matchLabels:
+        name: autotune
+  template:
+    metadata:
+      labels:
+        app: autotune
+        name: autotune
+        operatorframework.io/os.linux: supported
+    spec:
+      serviceAccountName: autotune-sa
+      automountServiceAccountToken: false
+      containers:
+      - name: autotune-optuna
+        image: "{{ OPTUNA_IMAGE }}"
+        imagePullPolicy: Always
+        env:
+          - name: LOGGING_LEVEL
+            valueFrom:
+              configMapKeyRef:
+                name: autotune-config
+                key: logging_level
+                optional: true
+          - name: ROOT_LOGGING_LEVEL
+            valueFrom:
+              configMapKeyRef:
+                name: autotune-config
+                key: root_logging_level
+                optional: true
+      - name: autotune
+        image: "{{ AUTOTUNE_IMAGE }}"
+        imagePullPolicy: Always
+        env:
+          - name: CLUSTER_TYPE
+            valueFrom:
+              configMapKeyRef:
+                name: autotune-config
+                key: cluster_type
+          - name: K8S_TYPE
+            valueFrom:
+              configMapKeyRef:
+                name: autotune-config
+                key: k8s_type
+          - name: AUTH_TYPE
+            valueFrom:
+              configMapKeyRef:
+                name: autotune-config
+                key: auth_type
+                optional: true
+          - name: AUTH_TOKEN
+            valueFrom:
+              configMapKeyRef:
+                name: autotune-config
+                key: auth_token
+                optional: true
+          - name: MONITORING_AGENT
+            valueFrom:
+              configMapKeyRef:
+                name: autotune-config
+                key: monitoring_agent
+          - name: MONITORING_SERVICE
+            valueFrom:
+              configMapKeyRef:
+                name: autotune-config
+                key: monitoring_service
+          - name: MONITORING_AGENT_ENDPOINT
+            valueFrom:
+              configMapKeyRef:
+                name: autotune-config
+                key: monitoring_agent_endpoint
+          - name: LOGGING_LEVEL
+            valueFrom:
+              configMapKeyRef:
+                name: autotune-config
+                key: logging_level
+                optional: true
+          - name: ROOT_LOGGING_LEVEL
+            valueFrom:
+              configMapKeyRef:
+                name: autotune-config
+                key: root_logging_level
+                optional: true
+        envFrom: 
+          - configMapRef:
+              name: autotune-config
+        ports:
+         - name: autotune-port
+           containerPort: 8080
+        volumeMounts:
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: kube-api-access
+            readOnly: true
+      volumes:
+        - name: kube-api-access
+          projected:
+            defaultMode: 420
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 3600
+                path: token
+            - configMap:
+                items:
+                - key: ca.crt
+                  path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                - fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+                  path: namespace
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: autotune
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/path: '/metrics'
+  labels:
+    app: autotune
+spec:
+  type: NodePort
+  selector:
+    app: autotune
+  ports:
+  - name: autotune-port
+    port: 8080
+    targetPort: 8080

--- a/manifests/autotune-operator-rolebinding.yaml_template
+++ b/manifests/autotune-operator-rolebinding.yaml_template
@@ -10,3 +10,42 @@ subjects:
 - kind: ServiceAccount
   name: autotune-sa
   namespace: "{{ AUTOTUNE_NAMESPACE }}"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+ name: autotune-prometheus-crb
+roleRef:
+ apiGroup: rbac.authorization.k8s.io
+ kind: ClusterRole
+ name: prometheus-operator
+subjects:
+- kind: ServiceAccount
+  name: autotune-sa
+  namespace: "{{ AUTOTUNE_NAMESPACE }}"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+ name: autotune-docker-crb
+roleRef:
+ apiGroup: rbac.authorization.k8s.io
+ kind: ClusterRole
+ name: system:build-strategy-docker
+subjects:
+- kind: ServiceAccount
+  name: autotune-sa
+  namespace: "{{ AUTOTUNE_NAMESPACE }}"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+ name: autotune-scc-crb
+roleRef:
+ apiGroup: rbac.authorization.k8s.io
+ kind: ClusterRole
+ name: system:openshift:scc:anyuid
+subjects:
+- kind: ServiceAccount
+  name: autotune-sa
+  namespace: "{{ AUTOTUNE_NAMESPACE }}"

--- a/manifests/autotune-query-variables/query-variable.yaml_template
+++ b/manifests/autotune-query-variables/query-variable.yaml_template
@@ -1,7 +1,8 @@
 apiVersion: "recommender.com/v1"
 kind: "AutotuneQueryVariable"
 metadata:
-  name: "minikube"
+  name: "{{ CLUSTER_TYPE }}"
+  namespace: "{{ AUTOTUNE_NAMESPACE }}"
 query_variables:
   - name: '$POD_LABEL$'
     value: 'pod'

--- a/manifests/configmaps/openshift-config.yaml
+++ b/manifests/configmaps/openshift-config.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: autotune-config
+data:
+  cluster_type: "kubernetes"
+  k8s_type: "openshift"
+  auth_type: ""
+  auth_token: ""
+  monitoring_agent: "prometheus"
+  monitoring_service: "prometheus-k8s"
+  monitoring_agent_endpoint: ""
+  root_logging_level: "info"
+  logging_level: "info"

--- a/scripts/common_utils.sh
+++ b/scripts/common_utils.sh
@@ -20,10 +20,10 @@
 function check_running() {
 	
 	check_pod=$1
-	prometheus_ns="monitoring"
-	kubectl_cmd="kubectl -n ${prometheus_ns}"
+	check_pod_ns=$2
+	kubectl_cmd="kubectl -n ${check_pod_ns}"
 
-	echo "Info: Waiting for ${check_pod} to come up..."
+	echo "Info: Waiting for ${check_pod} to come up....."
 	err_wait=0
 	while true;
 	do

--- a/scripts/openshift-helpers.sh
+++ b/scripts/openshift-helpers.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2020, 2021 Red Hat, IBM Corporation and others.
+# Copyright (c) 2021, 2022 Red Hat, IBM Corporation and others.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,16 +15,34 @@
 # limitations under the License.
 #
 
-###############################  v MiniKube v #################################
+###############################  v OPENSHIFT v #################################
 
-function minikube_first() {
+function check_prometheus_installation() {
+	echo
+	echo "Info: Checking pre requisites for openshift..."
+	kubectl_tool=$(which kubectl)
+	check_err "Error: Please install the kubectl tool"
+	# Check to see if kubectl supports kustomize
+	kubectl kustomize --help >/dev/null 2>/dev/null
+	check_err "Error: Please install a newer version of kubectl tool that supports the kustomize option (>=v1.12)"
+
+	kubectl_cmd="kubectl"
+	prometheus_pod_running=$(${kubectl_cmd} get pods --all-namespaces | grep "prometheus-k8s")
+	if [ "${prometheus_pod_running}" == "" ]; then
+		echo "Prometheus is not running."
+		exit 1
+	fi
+	echo "Prometheus is installed and running."
+}
+
+function openshift_first() {
 	#Create a namespace
 	echo "Create autotune namespace ${autotune_ns}"
 	kubectl create namespace ${autotune_ns}
 
 	kubectl_cmd="kubectl -n ${autotune_ns}"
 	echo "Info: One time setup - Create a service account to deploy autotune"
-	
+
 	${kubectl_cmd} apply -f ${AUTOTUNE_SA_MANIFEST}
 	check_err "Error: Failed to create service account and RBAC"
 
@@ -40,11 +58,11 @@ function minikube_first() {
 	${kubectl_cmd} apply -f ${AUTOTUNE_ROLE_MANIFEST}
 	check_err "Error: Failed to create role"
 
-	sed -e "s|{{ AUTOTUNE_NAMESPACE }}|${autotune_ns}|" ${AUTOTUNE_RB_MANIFEST_TEMPLATE} > ${AUTOTUNE_RB_MANIFEST}
+	sed -e "s|{{ AUTOTUNE_NAMESPACE }}|${autotune_ns}|" ${AUTOTUNE_RB_MANIFEST_TEMPLATE} >${AUTOTUNE_RB_MANIFEST}
 	${kubectl_cmd} apply -f ${AUTOTUNE_RB_MANIFEST}
 	check_err "Error: Failed to create role binding"
 
-	sed -e "s|{{ AUTOTUNE_NAMESPACE }}|${autotune_ns}|" -e "s|{{ CLUSTER_TYPE }}|minikube|"  ${AUTOTUNE_QUERY_VARIABLES_MANIFEST_TEMPLATE} > ${AUTOTUNE_QUERY_VARIABLES_MANIFEST}
+	sed -e "s|{{ AUTOTUNE_NAMESPACE }}|${autotune_ns}|" -e "s|{{ CLUSTER_TYPE }}|openshift|" ${AUTOTUNE_QUERY_VARIABLES_MANIFEST_TEMPLATE} >${AUTOTUNE_QUERY_VARIABLES_MANIFEST}
 	${kubectl_cmd} apply -f ${AUTOTUNE_QUERY_VARIABLES_MANIFEST}
 	check_err "Error: Failed to create query variables"
 
@@ -53,20 +71,19 @@ function minikube_first() {
 }
 
 # You can deploy using kubectl
-function minikube_deploy() {
+function openshift_deploy() {
 	echo
-	echo "Creating environment variable in minikube cluster using configMap"
+	echo "Creating environment variable in openshift cluster using configMap"
 	${kubectl_cmd} apply -f ${AUTOTUNE_CONFIGMAPS}/${cluster_type}-config.yaml
 
 	echo
 	echo "Deploying AutotuneConfig objects"
 	${kubectl_cmd} apply -f ${AUTOTUNE_CONFIGS}
 
-
-	echo "Info: Deploying autotune yaml to minikube cluster"
+	echo "Info: Deploying autotune yaml to openshift cluster"
 
 	# Replace autotune docker image in deployment yaml
-	sed -e "s|{{ AUTOTUNE_IMAGE }}|${AUTOTUNE_DOCKER_IMAGE}|" ${AUTOTUNE_DEPLOY_MANIFEST_TEMPLATE} > ${AUTOTUNE_DEPLOY_MANIFEST}
+	sed -e "s|{{ AUTOTUNE_IMAGE }}|${AUTOTUNE_DOCKER_IMAGE}|" ${AUTOTUNE_DEPLOY_MANIFEST_TEMPLATE} >${AUTOTUNE_DEPLOY_MANIFEST}
 	sed -i "s|{{ OPTUNA_IMAGE }}|${OPTUNA_DOCKER_IMAGE}|" ${AUTOTUNE_DEPLOY_MANIFEST}
 
 	${kubectl_cmd} apply -f ${AUTOTUNE_DEPLOY_MANIFEST}
@@ -77,54 +94,35 @@ function minikube_deploy() {
 		exit 1
 	fi
 
-	# Get the Autotune application port in minikube
-	MINIKUBE_IP=$(minikube ip)
+	# Get the Autotune application port in openshift
+	OPENSHIFT_IP=$(${kubectl_cmd} get pods -l=app=autotune -o wide -n ${autotune_ns} -o=custom-columns=NODE:.spec.nodeName --no-headers)
 	AUTOTUNE_PORT=$(${kubectl_cmd} get svc autotune --no-headers -o=custom-columns=PORT:.spec.ports[*].nodePort)
-	echo "Info: Access Autotune at http://${MINIKUBE_IP}:${AUTOTUNE_PORT}/listAutotuneTunables"
+	echo "Info: Access Autotune at http://$OPENSHIFT_IP:${AUTOTUNE_PORT}/listAutotuneTunables"
 	echo
 }
 
-function minikube_start() {
+function openshift_start() {
 	echo
-	echo "###   Installing autotune for minikube"
+	echo "###   Installing autotune for openshift"
 	echo
 
 	# If autotune_ns was not set by the user
 	if [ -z "$autotune_ns" ]; then
-		autotune_ns="monitoring"
+		autotune_ns=${AUTOTUNE_OPENSHIFT_NAMESPACE}
 	fi
 
 	check_prometheus_installation
-	minikube_first
-	minikube_deploy
+	openshift_first
+	openshift_deploy
 }
 
-function check_prometheus_installation() {
-	echo
-	echo "Info: Checking pre requisites for minikube..."
-	kubectl_tool=$(which kubectl)
-	check_err "Error: Please install the kubectl tool"
-	# Check to see if kubectl supports kustomize
-	kubectl kustomize --help >/dev/null 2>/dev/null
-	check_err "Error: Please install a newer version of kubectl tool that supports the kustomize option (>=v1.12)"
-
-	kubectl_cmd="kubectl"
-	prometheus_pod_running=$(${kubectl_cmd} get pods --all-namespaces | grep "prometheus-k8s-1")
-	if [ "${prometheus_pod_running}" == "" ]; then
-		echo "Prometheus is not running, use 'scripts/prometheus_on_minikube.sh' to install."
-		exit 1
-	fi
-	echo "Prometheus is installed and running."
-}
-
-
-function minikube_terminate() {
+function openshift_terminate() {
 	# If autotune_ns was not set by the user
-	if [ -z "$autotune_ns" ]; 	then
-		autotune_ns="monitoring"
+	if [ -z "$autotune_ns" ]; then
+		autotune_ns=${AUTOTUNE_OPENSHIFT_NAMESPACE}
 	fi
 
-	echo -n "###   Removing autotune for minikube"
+	echo -n "###   Removing autotune for openshift"
 
 	kubectl_cmd="kubectl -n ${autotune_ns}"
 
@@ -155,7 +153,7 @@ function minikube_terminate() {
 	echo
 	echo "Removing AutotuneQueryVariable objects"
 	${kubectl_cmd} delete -f ${AUTOTUNE_QUERY_VARIABLES_MANIFEST} 2>/dev/null
-	
+
 	echo
 	echo "Removing Autotune configmap"
 	${kubectl_cmd} delete -f ${AUTOTUNE_CONFIGMAPS}/${cluster_type}-config.yaml 2>/dev/null
@@ -174,4 +172,8 @@ function minikube_terminate() {
 
 	rm ${AUTOTUNE_DEPLOY_MANIFEST}
 	rm ${AUTOTUNE_RB_MANIFEST}
+
+	echo
+	echo "Removing Autotune namespace"
+	kubectl delete ns ${autotune_ns}
 }

--- a/scripts/prometheus_on_minikube.sh
+++ b/scripts/prometheus_on_minikube.sh
@@ -94,7 +94,7 @@ function install_prometheus() {
 			break;
 		fi
 	done
-	check_running prometheus-k8s-1
+	check_running prometheus-k8s-1 ${prometheus_ns}
 	sleep 2
 }
 

--- a/src/main/java/com/autotune/analyzer/deployment/AutotuneDeployment.java
+++ b/src/main/java/com/autotune/analyzer/deployment/AutotuneDeployment.java
@@ -647,7 +647,7 @@ public class AutotuneDeployment
 				podList = client.pods().inAnyNamespace().list();
 			}
 			if (podList == null) {
-				LOGGER.error(AnalyzerErrorConstants.AutotuneConfigErrors.COULD_NOT_GET_LIST_OF_APPLICATIONS + layer.getName());
+				LOGGER.warn(AnalyzerErrorConstants.AutotuneConfigErrors.COULD_NOT_GET_LIST_OF_APPLICATIONS + layer.getName());
 				return;
 			}
 			DataSource autotuneDataSource = null;
@@ -667,7 +667,7 @@ public class AutotuneDeployment
 								layerPresenceQuery.getLayerPresenceKey());
 						appsForAllQueries.addAll(apps);
 					} catch (MalformedURLException | NullPointerException e) {
-						LOGGER.error(AnalyzerErrorConstants.AutotuneConfigErrors.COULD_NOT_GET_LIST_OF_APPLICATIONS + layer.getName());
+						LOGGER.warn(AnalyzerErrorConstants.AutotuneConfigErrors.COULD_NOT_GET_LIST_OF_APPLICATIONS + layer.getName());
 					}
 				}
 				// We now have a list of apps that have the label and the key specified by the user.
@@ -710,10 +710,10 @@ public class AutotuneDeployment
 						}
 					}
 				} else {
-					LOGGER.error(AnalyzerErrorConstants.AutotuneConfigErrors.COULD_NOT_GET_LIST_OF_APPLICATIONS + layer.getName());
+					LOGGER.warn(AnalyzerErrorConstants.AutotuneConfigErrors.COULD_NOT_GET_LIST_OF_APPLICATIONS + layer.getName());
 				}
 			} else {
-				LOGGER.error(AnalyzerErrorConstants.AutotuneConfigErrors.COULD_NOT_GET_LIST_OF_APPLICATIONS + layer.getName());
+				LOGGER.warn(AnalyzerErrorConstants.AutotuneConfigErrors.COULD_NOT_GET_LIST_OF_APPLICATIONS + layer.getName());
 			}
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -748,7 +748,7 @@ public class AutotuneDeployment
 				}
 
 				if (podList.getItems().isEmpty()) {
-					LOGGER.error(AnalyzerErrorConstants.AutotuneConfigErrors.COULD_NOT_GET_LIST_OF_APPLICATIONS + layer.getName());
+					LOGGER.warn(AnalyzerErrorConstants.AutotuneConfigErrors.COULD_NOT_GET_LIST_OF_APPLICATIONS + layer.getName());
 					return;
 				}
 				for (Pod pod : podList.getItems()) {

--- a/src/main/java/com/autotune/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/utils/AnalyzerConstants.java
@@ -41,6 +41,7 @@ public class AnalyzerConstants {
 	public static final String PROMETHEUS_API = "/api/v1/query?query=";
 
 	public static final String HTTP_PROTOCOL = "http";
+	public static final String HTTPS_PROTOCOL = "https";
 
 	// Used in Configuration for accessing the autotune objects from kubernetes
 	public static final String SCOPE = "Namespaced";

--- a/src/main/java/com/autotune/utils/AutotuneConstants.java
+++ b/src/main/java/com/autotune/utils/AutotuneConstants.java
@@ -141,4 +141,8 @@ public class AutotuneConstants {
         public static String DURATION = "duration";
         public static String PERCENTILE_INFO = "percentile_info";
     }
+
+    public static final String AUTH_MOUNT_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/";
+    public static final String MINIKUBE = "minikube";
+    public static final String OPENSHIFT = "openshift";
 }

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -16,6 +16,8 @@ rootLogger.level = ${env:ROOT_LOGGING_LEVEL}
 rootLogger.appenderRef.stdout.ref = consoleLogger
 rootLogger.appenderRef.console.ref = consoleLogger
 logger.autotune.name = com.autotune
+logger.autotune.additivity = false
 logger.autotune.level = ${env:LOGGING_LEVEL}
 logger.autotune.appenderRef.stdout.ref = consoleLogger
 logger.autotune.appenderRef.console.ref = consoleLogger
+


### PR DESCRIPTION
Signed-off-by: msvinaykumar <vinakuma@redhat.com>

Openshift deployment scripts with Prometheus changes to access securely with access token which gets refreshed at regular interval. 
Sample snippet to access Prometheus
`
PrometheusDataSource pds = new PrometheusDataSource(getMonitoringAgentEndpoint());

		String baseUrl = getMonitoringAgentEndpoint()+ AnalyzerConstants.PROMETHEUS_API;

		LOGGER.debug(baseUrl);

		GenericRestApiClient genericRestApiClient = null;

		try {
			genericRestApiClient = new GenericRestApiClient(
					baseUrl,
					new BearerAccessToken(pds.getToken())
			);

		} catch (IOException e) {
			e.printStackTrace();
		}

		try {
			//String queryStr = "rate(http_server_requests_seconds_count{method=\"GET\",uri=\"/db\",outcome=\"SUCCESS\",status=\"200\",}[1000m])";

			String queryStr = "aggregator_unavailable_apiservice_total";

			JSONObject jsonObject = genericRestApiClient.fetchMetricsJson("GET", queryStr);

			System.out.println(jsonObject.toString(4));

		} catch (Exception e) {
			e.printStackTrace();

		}
`