### PR TITLE
Adds get deployments API to UISM

### DIFF
--- a/manifests/autotune-operator-role.yaml
+++ b/manifests/autotune-operator-role.yaml
@@ -19,6 +19,7 @@ rules:
   - endpoints
   - persistentvolumeclaims
   - events
+  - namespaces
   verbs:
   - '*'
 - apiGroups:

--- a/src/main/java/com/autotune/Autotune.java
+++ b/src/main/java/com/autotune/Autotune.java
@@ -15,6 +15,7 @@
  *******************************************************************************/
 package com.autotune;
 
+import com.autotune.UserInterfaceSupport.UISM;
 import com.autotune.analyzer.Analyzer;
 import com.autotune.analyzer.utils.ServerContext;
 import com.autotune.experimentManager.ExperimentManager;
@@ -44,7 +45,6 @@ public class Autotune
 		context.setContextPath(ServerContext.ROOT_CONTEXT);
 		server.setHandler(context);
 		addAutotuneServlets(context);
-
 		String autotuneMode = System.getenv(AutotuneConstants.StartUpMode.AUTOTUNE_MODE);
 
 		if (null != autotuneMode) {
@@ -86,5 +86,6 @@ public class Autotune
 	private static void startAutotuneNormalMode(ServletContextHandler contextHandler) {
 		Analyzer.start(contextHandler);
 		ExperimentManager.start(contextHandler);
+		UISM.start(contextHandler);
 	}
 }

--- a/src/main/java/com/autotune/UserInterfaceSupport/UISM.java
+++ b/src/main/java/com/autotune/UserInterfaceSupport/UISM.java
@@ -1,0 +1,56 @@
+package com.autotune.UserInterfaceSupport;
+
+import com.autotune.UserInterfaceSupport.services.GetNamespaces;
+import com.autotune.experimentManager.services.CreateExperimentTrial;
+import com.autotune.experimentManager.services.ListTrialStatus;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+
+import static com.autotune.analyzer.utils.ServerContext.*;
+
+/**
+ * The UISM (User Interface support Manager) provides the support API's and backed functionality
+ * required to serve the UI components. It initialises the servlets for the API endpoints which are
+ * contacted by the UI for it's data representation purposes.
+ *
+ * Some of the functionalities (but are not limited to) are listed here:
+ *  - serve list of namespaces
+ *  - serve list of deployments in a requested namespace
+ *  - getting the config YAML from the frontend
+ */
+public class UISM {
+    /**
+     * Method: initializeUISM
+     * Scope: A private method which needs to be called only from `start`
+     * Description: This method contains the necessary functionality which is needed at the time of
+     * UISM initialization
+     * Status: Yet to be implemented based on the requirement
+     */
+
+    private static void initializeUISM() {
+        // Need to implement any functionality required at the time of UISM initialization
+    }
+
+
+    /**
+     * Method: start
+     * Scope: A public method which needs to be called at a point where UISM needs to be started (Autotune.java -> main)
+     * Description: Starts the UISM service
+     *
+     * @param contextHandler
+     */
+    public static void start(ServletContextHandler contextHandler) {
+        initializeUISM();
+        addUISMServlets(contextHandler);
+    }
+
+    /**
+     * Method: addUISMServlets
+     * Scope: A private method which needs to be called after initializing UISM service (UISM.java -> start)
+     * Description: Adds the UISM related servlets to main Servlet context handler
+     * @param context
+     */
+
+    private static void addUISMServlets(ServletContextHandler context) {
+        context.addServlet(GetNamespaces.class,GET_NAMESPACES);
+    }
+}

--- a/src/main/java/com/autotune/UserInterfaceSupport/UISM.java
+++ b/src/main/java/com/autotune/UserInterfaceSupport/UISM.java
@@ -28,6 +28,7 @@ public class UISM {
 
     private static void initializeUISM() {
         // Need to implement any functionality required at the time of UISM initialization
+        System.out.println("In Initialisation module");
     }
 
 

--- a/src/main/java/com/autotune/UserInterfaceSupport/UISM.java
+++ b/src/main/java/com/autotune/UserInterfaceSupport/UISM.java
@@ -1,5 +1,6 @@
 package com.autotune.UserInterfaceSupport;
 
+import com.autotune.UserInterfaceSupport.services.GetDeployments;
 import com.autotune.UserInterfaceSupport.services.GetNamespaces;
 import com.autotune.experimentManager.services.CreateExperimentTrial;
 import com.autotune.experimentManager.services.ListTrialStatus;
@@ -53,5 +54,6 @@ public class UISM {
 
     private static void addUISMServlets(ServletContextHandler context) {
         context.addServlet(GetNamespaces.class,GET_NAMESPACES);
+        context.addServlet(GetDeployments.class, GET_DEPLOYMENTS);
     }
 }

--- a/src/main/java/com/autotune/UserInterfaceSupport/services/GetDeployments.java
+++ b/src/main/java/com/autotune/UserInterfaceSupport/services/GetDeployments.java
@@ -38,8 +38,13 @@ public class GetDeployments extends HttpServlet {
      */
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) {
+        response.addHeader("Access-Control-Allow-Origin", "*");
+        response.addHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE, HEAD");
+        response.addHeader("Access-Control-Allow-Headers", "X-PINGOTHER, Origin, X-Requested-With, Content-Type, Accept");
+        response.addHeader("Access-Control-Max-Age", "1728000");
         try {
             String inputData = request.getReader().lines().collect(Collectors.joining());
+            System.out.println("Input Data : " + inputData);
             JSONObject inputJson = new JSONObject(inputData);
             if (!inputJson.has(AutotuneConstants.UISMConstants.UISMJsonKeys.NAMESPACE)) {
                 response.setStatus(HttpServletResponse.SC_BAD_REQUEST);

--- a/src/main/java/com/autotune/UserInterfaceSupport/services/GetDeployments.java
+++ b/src/main/java/com/autotune/UserInterfaceSupport/services/GetDeployments.java
@@ -1,0 +1,98 @@
+package com.autotune.UserInterfaceSupport.services;
+
+import com.autotune.UserInterfaceSupport.util.UISMUtils;
+import com.autotune.utils.AutotuneConstants;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.stream.Collectors;
+
+public class GetDeployments extends HttpServlet {
+    private static final Logger LOGGER = LoggerFactory.getLogger(GetDeployments.class);
+
+    /**
+     * This API returns the list of deployments available in the namespace
+     *
+     * Sample response body of the API
+     * {
+     *   "uism_version" : "v0.1",
+     *   "status": "success",
+     *   "data": {
+     *     "namespace": "default",
+     *     "deployments" : [
+     *       "petclinic",
+     *       "techempower"
+     *     ]
+     *   }
+     * }
+     *
+     * @param request
+     * @param response
+     */
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) {
+        try {
+            String inputData = request.getReader().lines().collect(Collectors.joining());
+            JSONObject inputJson = new JSONObject(inputData);
+            if (!inputJson.has(AutotuneConstants.UISMConstants.UISMJsonKeys.NAMESPACE)) {
+                response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            } else if (null == inputJson.getString(AutotuneConstants.UISMConstants.UISMJsonKeys.NAMESPACE)
+                    || inputJson.getString(AutotuneConstants.UISMConstants.UISMJsonKeys.NAMESPACE).isBlank()
+                    || inputJson.getString(AutotuneConstants.UISMConstants.UISMJsonKeys.NAMESPACE).isEmpty()) {
+                response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            } else {
+                String namespace = inputJson.getString(AutotuneConstants.UISMConstants.UISMJsonKeys.NAMESPACE);
+                if (UISMUtils.checkIfNamespaceExists(namespace)) {
+                    JSONObject returnJson = new JSONObject();
+                    JSONObject dataJson = new JSONObject();
+                    JSONArray deploymentsList = new JSONArray();
+                    KubernetesClient client = new DefaultKubernetesClient();
+                    client.apps().deployments().inNamespace(namespace).list().getItems().forEach(deployment -> {
+                        deploymentsList.put(deployment.getMetadata().getName());
+                    });
+                    dataJson.put(
+                            AutotuneConstants.UISMConstants.UISMJsonKeys.DEPLOYMENTS,
+                            deploymentsList
+                    );
+                    dataJson.put(
+                            AutotuneConstants.UISMConstants.UISMJsonKeys.NAMESPACE,
+                            namespace
+                    );
+                    returnJson.put(
+                            AutotuneConstants.UISMConstants.UISMJsonKeys.UISM_VERSION,
+                            AutotuneConstants.UISMConstants.UISMDefaults.UISM_VERSION
+                    );
+                    returnJson.put(
+                            AutotuneConstants.UISMConstants.UISMJsonKeys.STATUS,
+                            AutotuneConstants.UISMConstants.UISMStandard.SUCCESS_STATUS
+                    );
+                    returnJson.put(
+                            AutotuneConstants.UISMConstants.UISMJsonKeys.DATA,
+                            dataJson
+                    );
+                    response.setContentType("application/json");
+                    response.setCharacterEncoding("UTF-8");
+                    response.setStatus(HttpServletResponse.SC_OK);
+                    response.getWriter().println(returnJson.toString(4));
+                } else {
+                    response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.error("{}", e);
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) {
+        doPost(request, response);
+    }
+}

--- a/src/main/java/com/autotune/UserInterfaceSupport/services/GetNamespaces.java
+++ b/src/main/java/com/autotune/UserInterfaceSupport/services/GetNamespaces.java
@@ -1,0 +1,75 @@
+package com.autotune.UserInterfaceSupport.services;
+
+import com.autotune.utils.AutotuneConstants;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class GetNamespaces extends HttpServlet {
+    private static final Logger LOGGER = LoggerFactory.getLogger(GetNamespaces.class);
+
+    /**
+     * This API returns the list of namespaces available in the cluster
+     *
+     * Sample response body of the API
+     * {
+     *   "uism_version" : "v0.1",
+     *   "status": "success",
+     *   "data": {
+     *     "namespaces" : [
+     *       "default",
+     *       "monitoring"
+     *     ]
+     *   }
+     * }
+     *
+     * @param request
+     * @param response
+     */
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) {
+        try {
+            JSONObject returnJson = new JSONObject();
+            JSONObject dataJson = new JSONObject();
+            JSONArray namespacesList = new JSONArray();
+            KubernetesClient client = new DefaultKubernetesClient();
+            client.namespaces().list().getItems().forEach(namespace -> {
+                namespacesList.put(namespace.getMetadata().getName());
+            });
+            dataJson.put(
+                    AutotuneConstants.UISMConstants.UISMJsonKeys.NAMESPACES,
+                    namespacesList
+            );
+            returnJson.put(
+                    AutotuneConstants.UISMConstants.UISMJsonKeys.UISM_VERSION,
+                    AutotuneConstants.UISMConstants.UISMDefaults.UISM_VERSION
+            );
+            returnJson.put(
+                    AutotuneConstants.UISMConstants.UISMJsonKeys.STATUS,
+                    AutotuneConstants.UISMConstants.UISMStandard.SUCCESS_STATUS
+            );
+            returnJson.put(
+                    AutotuneConstants.UISMConstants.UISMJsonKeys.DATA,
+                    dataJson
+            );
+            response.setStatus(HttpServletResponse.SC_OK);
+            response.getWriter().println(returnJson.toString(4));
+        } catch (Exception e) {
+            LOGGER.error("{}", e);
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) {
+        doPost(request, response);
+    }
+}

--- a/src/main/java/com/autotune/UserInterfaceSupport/services/GetNamespaces.java
+++ b/src/main/java/com/autotune/UserInterfaceSupport/services/GetNamespaces.java
@@ -60,6 +60,8 @@ public class GetNamespaces extends HttpServlet {
                     AutotuneConstants.UISMConstants.UISMJsonKeys.DATA,
                     dataJson
             );
+            response.setContentType("application/json");
+            response.setCharacterEncoding("UTF-8");
             response.setStatus(HttpServletResponse.SC_OK);
             response.getWriter().println(returnJson.toString(4));
         } catch (Exception e) {

--- a/src/main/java/com/autotune/UserInterfaceSupport/services/GetNamespaces.java
+++ b/src/main/java/com/autotune/UserInterfaceSupport/services/GetNamespaces.java
@@ -36,6 +36,10 @@ public class GetNamespaces extends HttpServlet {
      */
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) {
+        response.addHeader("Access-Control-Allow-Origin", "*");
+        response.addHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE, HEAD");
+        response.addHeader("Access-Control-Allow-Headers", "X-PINGOTHER, Origin, X-Requested-With, Content-Type, Accept");
+        response.addHeader("Access-Control-Max-Age", "1728000");
         try {
             JSONObject returnJson = new JSONObject();
             JSONObject dataJson = new JSONObject();

--- a/src/main/java/com/autotune/UserInterfaceSupport/util/UISMUtils.java
+++ b/src/main/java/com/autotune/UserInterfaceSupport/util/UISMUtils.java
@@ -1,0 +1,32 @@
+package com.autotune.UserInterfaceSupport.util;
+
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+
+/**
+ * A class to wrap all the utilies needed by the UISM module
+ */
+public class UISMUtils {
+    /**
+     * Checks if the namespace exists
+     * @param checkNamespace
+     * @return
+     */
+    public static boolean checkIfNamespaceExists(String checkNamespace) {
+        AtomicBoolean exists = new AtomicBoolean(false);
+        try {
+            KubernetesClient client = new DefaultKubernetesClient();
+            client.namespaces().list().getItems().forEach(namespace -> {
+                if (namespace.getMetadata().getName().equals(checkNamespace)){
+                    exists.set(true);
+                }
+            });
+            return exists.get();
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/autotune/analyzer/utils/ServerContext.java
+++ b/src/main/java/com/autotune/analyzer/utils/ServerContext.java
@@ -24,6 +24,7 @@ public class ServerContext
 	public static final int AUTOTUNE_PORT = 8080;
 
 	public static final String ROOT_CONTEXT = "/";
+	public static final String UI_CONTEXT = ROOT_CONTEXT + "ui/";
 	public static final String HEALTH_SERVICE = ROOT_CONTEXT + "health";
 	public static final String METRICS_SERVICE = ROOT_CONTEXT + "metrics";
 	public static final String LIST_STACKS = ROOT_CONTEXT + "listStacks";
@@ -33,4 +34,6 @@ public class ServerContext
 	public static final String SEARCH_SPACE = ROOT_CONTEXT + "searchSpace";
 	public static final String CREATE_EXPERIMENT_TRIAL = ServerContext.ROOT_CONTEXT + "createExperimentTrial";
 	public static final String LIST_TRIAL_STATUS = ServerContext.ROOT_CONTEXT + "listTrialStatus";
+	public static final String GET_NAMESPACES = ServerContext.UI_CONTEXT + "getNamespaces";
+	public static final String GET_DEPLOYMENTS = ServerContext.UI_CONTEXT + "getDeployments";
 }

--- a/src/main/java/com/autotune/utils/AutotuneConstants.java
+++ b/src/main/java/com/autotune/utils/AutotuneConstants.java
@@ -31,4 +31,26 @@ public class AutotuneConstants {
         public static final String EM_ONLY_MODE = "EM_ONLY";
     }
 
+    public static class UISMConstants {
+        private UISMConstants() { }
+        public static class UISMJsonKeys {
+            private UISMJsonKeys() { }
+            public static final String UISM_VERSION = "uism_version";
+            public static final String NAMESPACES = "namespaces";
+            public static final String DATA = "data";
+            public static final String STATUS = "status";
+        }
+
+        public static class UISMDefaults {
+            private UISMDefaults() { }
+            public static final String UISM_VERSION = "v0.1";
+        }
+
+        public static class UISMStandard {
+            private UISMStandard() { }
+            public static final String SUCCESS_STATUS = "success";
+            public static final String FAILURE_STATUS = "failure";
+        }
+    }
+
 }

--- a/src/main/java/com/autotune/utils/AutotuneConstants.java
+++ b/src/main/java/com/autotune/utils/AutotuneConstants.java
@@ -37,6 +37,8 @@ public class AutotuneConstants {
             private UISMJsonKeys() { }
             public static final String UISM_VERSION = "uism_version";
             public static final String NAMESPACES = "namespaces";
+            public static final String NAMESPACE = "namespace";
+            public static final String DEPLOYMENTS = "deployments";
             public static final String DATA = "data";
             public static final String STATUS = "status";
         }


### PR DESCRIPTION
UI needs to populate the deployments in a namespace after selecting the namespace. This Api provides the list of deployments in the selected namespace (if it exists).

PS: This PR is an extension to #444. So holds the changes of #444. Need to be merged after #444. Will rebase once #444 is merged


