### PR TITLE
adds quotes to read directory names with space in between

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -42,8 +42,8 @@ AUTOTUNE_DOCKER_IMAGE=${AUTOTUNE_DOCKER_REPO}:${AUTOTUNE_VERSION}
 OPTUNA_DOCKER_IMAGE=${OPTUNA_DOCKER_REPO}:${AUTOTUNE_VERSION}
 
 # source all the helpers scripts
-. ${SCRIPTS_DIR}/minikube-helpers.sh
-. ${SCRIPTS_DIR}/common_utils.sh
+. "${SCRIPTS_DIR}"/minikube-helpers.sh
+. "${SCRIPTS_DIR}"/common_utils.sh
 
 # Defaults for the script
 # minikube is the default cluster type


### PR DESCRIPTION
Changes in deploy.sh to read directory names having spaces in between. 

Signed-off-by: Bhanvi Menghani bmenghan@redhat.com