### PR TITLE
 Datasource abstraction

### DIFF
--- a/src/main/java/com/autotune/common/data/datasource/AutotuneDatasource.java
+++ b/src/main/java/com/autotune/common/data/datasource/AutotuneDatasource.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2022 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package com.autotune.common.data.datasource;
+
+import com.autotune.common.utils.CommonUtils.AutotuneDatasourceTypes;
+
+/**
+ * AutotuneDatasource is an abstraction which needs to be implemented
+ * by every datasource type which is used in Autotune
+ *
+ * Currently Supported Implementations:
+ *  - Prometheus
+ *
+ *  The Implementation should maintain 3 variables : Name, Type and Source and
+ *  should be set or get using these API's
+ *
+ *  var name:   Type String
+ *  var type:   Type AutotuneDatasourceTypes
+ *  var source: Type String
+ */
+
+public interface AutotuneDatasource {
+
+    /**
+     * Function to return the name of the datasource
+     * @return name of the datasource
+     */
+    public String getName();
+
+    /**
+     * Fucntion to set the name of the datasource
+     * @param name Name of the datasource
+     */
+    public void setName(String name);
+
+    /**
+     * Return the type of AutotuneDatasource
+     * @return Type of AutotuneDatasource
+     */
+    public AutotuneDatasourceTypes getType();
+
+    /**
+     * Set the type of AutotuneDatasource
+     * @param type
+     */
+    public void setType(AutotuneDatasourceTypes type);
+
+    /**
+     * Return the source
+     * The source can be an entity or a way how we access the datasource
+     * Example:
+     *
+     *  For promethues the source would be the instance URL
+     *  For a file based datasource teh source would be the location/path to the file
+     * @return the source
+     */
+    public String getSource();
+
+    /**
+     * Set the source
+     * The source can be an entity or a way how we access the datasource
+     * Example:
+     *
+     *  For promethues the source would be the instance URL
+     *  For a file based datasource teh source would be the location/path to the file
+     * @param source
+     */
+    public void setSource(String source);
+}

--- a/src/main/java/com/autotune/common/data/datasource/AutotuneDatasource.java
+++ b/src/main/java/com/autotune/common/data/datasource/AutotuneDatasource.java
@@ -31,6 +31,13 @@ import com.autotune.common.utils.CommonUtils.AutotuneDatasourceTypes;
  *  var name:   Type String
  *  var type:   Type AutotuneDatasourceTypes
  *  var source: Type String
+ *
+ *  Example for prometheus implementation:
+ *
+ *  - name: Prometheus
+ *  - type: AutotuneDatasourceTypes.QUERYABLE
+ *  - source: http://10.98.45.63:9090
+ *
  */
 
 public interface AutotuneDatasource {

--- a/src/main/java/com/autotune/common/data/datasource/AutotuneDatasourceCollection.java
+++ b/src/main/java/com/autotune/common/data/datasource/AutotuneDatasourceCollection.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2022 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package com.autotune.common.data.datasource;
+
+import com.autotune.common.exceptions.AutotuneDatasourceAlreadyExists;
+import com.autotune.common.exceptions.AutotuneDatasourceDoesNotExist;
+import com.autotune.common.utils.CommonUtils;
+
+import java.util.Map;
+
+/**
+ * AutotuneDatasourceCollection is an abstraction which needs to be implemented
+ * by every entity which needs a datasource collection used in Autotune
+ *
+ * Currently Supported Implementations:
+ *  - ExperimentDatasourceCollection
+ */
+
+public interface AutotuneDatasourceCollection {
+    /**
+     * Adds datasource to the collection map using its name as key
+     * @param autotuneDatasource AutotuneDatasource Object which has the datasource details
+     * @return Appropriate value of AddDataSourceStatus
+     *          SUCCESS on successfully adding the datasource
+     *          FAILURE on failing to add datasource
+     *          DATASOURCE_NOT_REACHABLE if the added datasource is not reachable
+     * @throws AutotuneDatasourceAlreadyExists
+     */
+    public CommonUtils.AddDataSourceStatus addDataSource(AutotuneDatasource autotuneDatasource) throws AutotuneDatasourceAlreadyExists;
+
+    /**
+     * Return a particular datasource with the name passed
+     * @param datasourceName name of the datasource to be returned
+     * @return the particular AutotuneDatasource object
+     */
+    public AutotuneDatasource getDatasource(String datasourceName);
+
+    /**
+     * Returns the datasource collection map
+     * @return Map of AutotuneDatasources
+     */
+    public Map<String, AutotuneDatasource> getDatasourceMap();
+
+    /**
+     * Remove a particular datasource matching the passed name
+     * @param datasourceName the name of the datasource which needs to be removed
+     * @throws AutotuneDatasourceDoesNotExist
+     */
+    public void removeDataSource (String datasourceName) throws AutotuneDatasourceDoesNotExist;
+}

--- a/src/main/java/com/autotune/common/data/datasource/AutotuneDatasourceServiceability.java
+++ b/src/main/java/com/autotune/common/data/datasource/AutotuneDatasourceServiceability.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2022 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package com.autotune.common.data.datasource;
+
+import com.autotune.common.utils.CommonUtils;
+
+/**
+ * AutotuneDatasourceServiceability holds the possible functions of a datasources which can state
+ * that the datasource is serviceable
+ */
+public interface AutotuneDatasourceServiceability {
+
+    /**
+     * Check if a datasource is reachable, implementation of this function
+     * should check and return the reachability status (REACHABLE, NOT_REACHABLE)
+     * @return DatasourceReachabilityStatus
+     */
+    public CommonUtils.DatasourceReachabilityStatus isReachable();
+
+    /**
+     * Check if a datasource is reliable to use, implementation of this function
+     * should check and return the reachability status (RELIABLE, NOT RELIABLE)
+     * @return DatasourceReliabilityStatus
+     */
+    public CommonUtils.DatasourceReliabilityStatus isReliable(Object... objects);
+}

--- a/src/main/java/com/autotune/common/exceptions/AutotuneDatasourceAlreadyExists.java
+++ b/src/main/java/com/autotune/common/exceptions/AutotuneDatasourceAlreadyExists.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2022 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package com.autotune.common.exceptions;
+
+/**
+ * AutotuneDatasourceAlreadyExists is an exception which needs to be raised when there is
+ * a duplicate entry trying to get added in the collection of datasources
+ */
+public class AutotuneDatasourceAlreadyExists extends Exception {
+    public AutotuneDatasourceAlreadyExists() {
+    }
+
+    public AutotuneDatasourceAlreadyExists(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/autotune/common/exceptions/AutotuneDatasourceDoesNotExist.java
+++ b/src/main/java/com/autotune/common/exceptions/AutotuneDatasourceDoesNotExist.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2022 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package com.autotune.common.exceptions;
+
+/**
+ * AutotuneDatasourceDoesNotExist is a exception which needs to be raised when the datasource
+ * doesnot exist in the collection we search
+ */
+
+public class AutotuneDatasourceDoesNotExist extends Exception {
+    public AutotuneDatasourceDoesNotExist() {
+    }
+
+    public AutotuneDatasourceDoesNotExist(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/autotune/common/utils/CommonUtils.java
+++ b/src/main/java/com/autotune/common/utils/CommonUtils.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2022 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package com.autotune.common.utils;
+
+/**
+ * This Class holds the utilities needed by the classes in common package
+ */
+public class CommonUtils {
+
+    /**
+     * AutotuneDatasourceTypes is an ENUM which holds different types of
+     * datasources supported by Autotune
+     *
+     * For now only Queryable and File based datasources are supported
+     */
+    public enum AutotuneDatasourceTypes {
+        QUERYABLE,
+        FILE,
+    }
+
+    /**
+     * AddDataSourceStatus is an ENUM which holds the possible statuses
+     * to return for adding a datasource to a collection in Autotune
+     *
+     * For now Success and Datasource not reachable are two possibilities
+     * Failure status is parked as a placeholder for now to fit for an exact use case which might arise
+     */
+    public enum AddDataSourceStatus {
+        SUCCESS,
+        FAILURE,
+        DATASOURCE_NOT_REACHABLE
+    }
+
+    /**
+     * DatasourceReachabilityStatus is a ENUM which holds the possible statuses
+     * to return for checking if a datasource is reachable
+     *
+     * REACHABLE - states that the datasource is reachable
+     * NOT_REACHABLE - states that the datasource is not reachable
+     */
+    public enum DatasourceReachabilityStatus {
+        REACHABLE,
+        NOT_REACHABLE,
+    }
+
+    /**
+     * DatasourceReliabilityStatus is a ENUM which holds the possible statuses
+     * to return for checking if a datasource is reliable
+     *
+     * RELIABLE - states that the datasource is reliable
+     * NOT_RELIABLE -  states that the datasource is not reliable
+     */
+    public enum DatasourceReliabilityStatus {
+        RELIABLE,
+        NOT_RELIABLE,
+    }
+}

--- a/src/main/java/com/autotune/common/utils/CommonUtils.java
+++ b/src/main/java/com/autotune/common/utils/CommonUtils.java
@@ -28,7 +28,13 @@ public class CommonUtils {
      * For now only Queryable and File based datasources are supported
      */
     public enum AutotuneDatasourceTypes {
+        /**
+         * If the datasource is queryable (datastore, database)
+         */
         QUERYABLE,
+        /**
+         * If the datasource is file based (Cgroup files)
+         */
         FILE,
     }
 
@@ -65,7 +71,13 @@ public class CommonUtils {
      * NOT_RELIABLE -  states that the datasource is not reliable
      */
     public enum DatasourceReliabilityStatus {
+        /**
+         * We set the status as Reliable if the datasource is up and running and it provides information
+         */
         RELIABLE,
+        /**
+         * We set the status as Not Reliable if the datasource is up and not providing information
+         */
         NOT_RELIABLE,
     }
 }


### PR DESCRIPTION
This PR adds the datasource abstraction for the autotune datasources.

PR holds only the interfaces and the respective utils and exceptions added.

**Interfaces:**
```
AutotuneDatasource.java
AutotuneDatasourceCollection.java
AutotuneDatasourceServiceability.java
```

**Exceptions:**
```
AutotuneDatasourceDoesNotExist.java
AutotuneDatasourceAlreadyExists.java
```

**Utilities:**
```
CommonUtils.java
```

All the files are added to `com.autotune.common` package

Signed-off-by: bharathappali <abharath@redhat.com>