### PR TITLE
Dummy metric generator for autotune api's

### DIFF
--- a/src/main/java/com/autotune/experimentManager/core/ExperimentTrialHandler.java
+++ b/src/main/java/com/autotune/experimentManager/core/ExperimentTrialHandler.java
@@ -19,6 +19,7 @@ import com.autotune.common.experiments.ExperimentTrial;
 import com.autotune.common.experiments.PodContainer;
 import com.autotune.common.target.kubernetes.service.KubernetesServices;
 import com.autotune.common.target.kubernetes.service.impl.KubernetesServicesImpl;
+import com.autotune.experimentManager.data.EMMapper;
 import com.autotune.utils.HttpUtils;
 import com.google.gson.Gson;
 import org.json.JSONArray;
@@ -30,6 +31,8 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.IntStream;
 
 import static com.autotune.analyzer.loop.HPOInterface.postTrialResultToHPO;
@@ -44,6 +47,19 @@ public class ExperimentTrialHandler {
 
     public ExperimentTrialHandler(ExperimentTrial experimentTrial) {
         this.experimentTrial = experimentTrial;
+        String experimentName = experimentTrial.getExperimentName();
+        String trialNum = String.valueOf(experimentTrial.getTrialInfo().getTrialNum());
+        ConcurrentHashMap<String, HashMap<String, ExperimentTrial>> expTrialMap = EMMapper.getInstance().getExpTrialMap();
+        if (expTrialMap.containsKey(experimentName)) {
+            HashMap<String, ExperimentTrial> expMap = expTrialMap.get(experimentName);
+            if (!expMap.containsKey(trialNum)) {
+                expMap.put(trialNum, experimentTrial);
+            }
+        } else {
+            HashMap<String, ExperimentTrial> trialMap = new HashMap<String, ExperimentTrial>();
+            trialMap.put(trialNum, experimentTrial);
+            expTrialMap.put(experimentName, trialMap);
+        }
     }
 
     public static JSONObject getDummyMetricJson(ExperimentTrial experimentTrial) {

--- a/src/main/java/com/autotune/experimentManager/data/EMMapper.java
+++ b/src/main/java/com/autotune/experimentManager/data/EMMapper.java
@@ -1,6 +1,10 @@
 package com.autotune.experimentManager.data;
 
+import com.autotune.common.experiments.ExperimentTrial;
+
+import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class EMMapper {
@@ -8,9 +12,16 @@ public class EMMapper {
     private volatile ConcurrentHashMap<String, ExperimentTrialData> emMap = null;
     private volatile ConcurrentHashMap<String, LinkedList<String>> emDeploymentRunIdMap = null;
 
+    /**
+     * The  key for the emExpTrialMap is `experiment name`
+     * The key for the map which is maintained at a experiment level is the `trial number`
+     */
+    private volatile ConcurrentHashMap<String, HashMap<String, ExperimentTrial>> emExpTrialMap = null;
+
     private EMMapper() {
         emMap = new ConcurrentHashMap<String, ExperimentTrialData>();
         emDeploymentRunIdMap = new ConcurrentHashMap<String, LinkedList<String>>();
+        emExpTrialMap = new ConcurrentHashMap<String, HashMap<String, ExperimentTrial>>();
     }
 
     public static EMMapper getInstance() {
@@ -31,4 +42,6 @@ public class EMMapper {
     public ConcurrentHashMap getDeploymentRunIdMap() {
         return emDeploymentRunIdMap;
     }
+
+    public ConcurrentHashMap getExpTrialMap() { return emExpTrialMap; }
 }

--- a/src/main/java/com/autotune/experimentManager/services/util/EMAPIHandler.java
+++ b/src/main/java/com/autotune/experimentManager/services/util/EMAPIHandler.java
@@ -1,5 +1,7 @@
 package com.autotune.experimentManager.services.util;
 
+import com.autotune.common.experiments.ExperimentTrial;
+import com.autotune.common.experiments.PodContainer;
 import com.autotune.experimentManager.core.ExperimentManager;
 import com.autotune.experimentManager.data.*;
 import com.autotune.experimentManager.exceptions.EMInvalidInstanceCreation;
@@ -7,12 +9,16 @@ import com.autotune.experimentManager.exceptions.IncompatibleInputJSONException;
 import com.autotune.experimentManager.services.CreateExperimentTrial;
 import com.autotune.experimentManager.utils.EMConstants;
 import com.autotune.experimentManager.utils.EMUtil;
+import com.google.gson.Gson;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class EMAPIHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(EMAPIHandler.class);
@@ -80,5 +86,177 @@ public class EMAPIHandler {
         EMStageTransition transition = new EMStageTransition(runId, EMUtil.EMExpStages.CREATE_CONFIG);
         EMStageProcessQueue.getStageProcessQueueInstance().getQueue().add(transition);
         ExperimentManager.notifyQueueProcessor();
+    }
+
+    public static JSONObject getStatusJson(String experimentName, String trialNum, boolean verbose) {
+        // Get the experiment map
+        ConcurrentHashMap<String, HashMap<String, ExperimentTrial>> expMap = EMMapper.getInstance().getExpTrialMap();
+
+        // Create an empty return JSON which will be populated based on the given requirement
+        JSONObject returnJson = new JSONObject();
+
+        // Scenerio - No Experiment name given
+        if (null == experimentName) {
+            if (expMap.size() == 0) {
+                returnJson.put("Error", "No Experiments found");
+            } else {
+                for (String key : expMap.keySet()) {
+                    JSONObject resJson = new JSONObject();
+                    resJson.put("Status", "COMPLETED");
+                    returnJson.put(key, resJson);
+                }
+            }
+            return returnJson;
+        }
+
+
+        if (null != experimentName && expMap.containsKey(experimentName)) {
+            // Scenerio - Experiment name given but no trial given
+            if (null == trialNum) {
+                HashMap<String, ExperimentTrial> trialHashMap = expMap.get(experimentName);
+                for (String key : trialHashMap.keySet()) {
+                    JSONObject resJson = getDummyTrialJSON(trialHashMap.get(key), verbose);
+                    resJson.put("Status", "COMPLETED");
+                    returnJson.put(key, resJson);
+                }
+                return returnJson;
+            } else {
+                // Scenerio - Experiment name and trial num are given
+                if (expMap.get(experimentName).containsKey(trialNum)) {
+                    JSONObject resJson = getDummyTrialJSON(expMap.get(experimentName).get(trialNum), verbose);
+                    resJson.put("Status", "COMPLETED");
+                    returnJson.put(trialNum, resJson);
+                } else {
+                    returnJson.put("Error", "Invalid trial number");
+                }
+
+                return returnJson;
+            }
+        } else {
+            returnJson.put("Error", "Invalid Experiment Name");
+        }
+
+        return returnJson;
+    }
+
+    private static JSONObject getDummyTrialJSON(ExperimentTrial experimentTrial, boolean verbose) {
+        JSONObject percentile_info = new JSONObject().
+                put("99p", 82.59).put("97p", 64.75).put("95p", 8.94).put("50p", 0.63).
+                put("99.9p", 93.48).put("100p", 30000).put("99.99p", 111.5).put("99.999p", 198.52);
+        JSONObject general_info = new JSONObject().
+                put("min", 2.15).put("max", 2107.212121).put("mean", 31.91);
+        JSONArray podMetrics = new JSONArray();
+        for (int i = 0; i < 2; i++) {
+            JSONObject resultJSON = new JSONObject();
+            resultJSON.put("summary_results", new JSONObject().
+                            put("percentile_info", percentile_info).
+                            put("general_info", general_info)
+                    ).
+                    put("datasource", "prometheus");
+            if (verbose) {
+                JSONObject iterationResults = new JSONObject();
+                int iterations = Integer.parseInt(experimentTrial.getExperimentSettings().getTrialSettings().getTrialIterations());
+                JSONObject dummy_result = new JSONObject().put("percentile_info", percentile_info).
+                        put("general_info", general_info);
+                for (int j = 0; j < iterations; j++) {
+                    JSONObject iterationObject = new JSONObject();
+                    int warmUpCycles = Integer.parseInt(experimentTrial.getExperimentSettings().getTrialSettings().getTrialWarmupCycles());
+                    int measurementCycles = Integer.parseInt(experimentTrial.getExperimentSettings().getTrialSettings().getTrialMeasurementCycles());
+                    JSONObject warmResult = new JSONObject();
+                    JSONObject measureResult = new JSONObject();
+                    for (int warmCycle = 0; warmCycle < warmUpCycles; warmCycle++) {
+                        warmResult.put(String.valueOf(warmCycle), dummy_result);
+                    }
+                    for (int measureCycle = 0; measureCycle < measurementCycles; measureCycle++) {
+                        measureResult.put(String.valueOf(measureCycle), dummy_result);
+                    }
+                    iterationObject.put("warmup_results", warmResult);
+                    iterationObject.put("measure_results", measureResult);
+                    iterationResults.put(String.valueOf(j), iterationObject);
+                }
+                resultJSON.put("iteration_results", iterationResults);
+            }
+
+            if (i == 0) {
+                resultJSON.put("name", "request_sum");
+            } else {
+                resultJSON.put("name", "request_count");
+            }
+            podMetrics.put(resultJSON);
+        }
+
+
+        JSONArray containers = new JSONArray();
+
+        HashMap<String, PodContainer> podContainerHashMap = experimentTrial.getTrialDetails().get("training").getPodContainers();
+        String imageName = podContainerHashMap.keySet().iterator().next();
+        JSONArray containerMetrics = new JSONArray();
+        for (int i = 0; i < 2; i++) {
+            JSONObject resultJSON = new JSONObject();
+            resultJSON.put("summary_results", new JSONObject().
+                            put("percentile_info", percentile_info).
+                            put("general_info", general_info)
+                    ).
+                    put("datasource", "prometheus");
+
+            if (verbose) {
+                JSONObject iterationResults = new JSONObject();
+                int iterations = Integer.parseInt(experimentTrial.getExperimentSettings().getTrialSettings().getTrialIterations());
+                JSONObject dummy_result = new JSONObject().put("percentile_info", percentile_info).
+                        put("general_info", general_info);
+                for (int j = 0; j < iterations; j++) {
+                    JSONObject iterationObject = new JSONObject();
+                    int warmUpCycles = Integer.parseInt(experimentTrial.getExperimentSettings().getTrialSettings().getTrialWarmupCycles());
+                    int measurementCycles = Integer.parseInt(experimentTrial.getExperimentSettings().getTrialSettings().getTrialMeasurementCycles());
+                    JSONObject warmResult = new JSONObject();
+                    JSONObject measureResult = new JSONObject();
+                    for (int warmCycle = 0; warmCycle < warmUpCycles; warmCycle++) {
+                        warmResult.put(String.valueOf(warmCycle), dummy_result);
+                    }
+                    for (int measureCycle = 0; measureCycle < measurementCycles; measureCycle++) {
+                        measureResult.put(String.valueOf(measureCycle), dummy_result);
+                    }
+                    iterationObject.put("warmup_results", warmResult);
+                    iterationObject.put("measure_results", measureResult);
+                    iterationResults.put(String.valueOf(j), iterationObject);
+                }
+                resultJSON.put("iteration_results", iterationResults);
+            }
+
+            if (i == 0) {
+                resultJSON.put("name", "memoryRequest");
+            } else {
+                resultJSON.put("name", "cpuRequest");
+            }
+            containerMetrics.put(resultJSON);
+        }
+        containers.put(new JSONObject().put(
+                "image_name", imageName
+        ).put(
+                "container_name", podContainerHashMap.get(imageName).getContainerName()
+        ).put(
+                "container_metrics", containerMetrics
+        ));
+        JSONArray deployments = new JSONArray();
+        deployments.put(
+                new JSONObject().
+                        put("pod_metrics", podMetrics).
+                        put("deployment_name", experimentTrial.getTrialDetails().get("training").getDeploymentName()).
+                        put("namespace", experimentTrial.getTrialDetails().get("training").getDeploymentNameSpace()).
+                        put("type", "training").
+                        put("containers", containers)
+        );
+        JSONObject retJson = new JSONObject();
+        retJson.put("experiment_name", experimentTrial.getExperimentName());
+        retJson.put("experiment_id", experimentTrial.getExperimentId());
+        retJson.put("deployment_name", experimentTrial.getTrialDetails().get("training").getDeploymentName());
+        retJson.put("info", new JSONObject().put("trial_info",
+                new JSONObject(
+                        new Gson().toJson(experimentTrial.getTrialInfo())
+                )
+        ));
+        System.out.println(deployments);
+        retJson.put("deployments", deployments);
+        return retJson;
     }
 }

--- a/src/main/java/com/autotune/experimentManager/utils/EMConstants.java
+++ b/src/main/java/com/autotune/experimentManager/utils/EMConstants.java
@@ -142,6 +142,9 @@ public class EMConstants {
 			public static String ERROR = "error";
 			public static String SUMMARY = "summary";
 			public static String COMPLETE_STATUS = "completeStatus";
+			public static String EXPERIMENT_NAME = "experiment_name";
+			public static String TRIAL_NUM = "trial_num";
+			public static String VERBOSE = "verbose";
 		}
 		public static class DeploymentKeys {
 			private DeploymentKeys() { }


### PR DESCRIPTION
NOTE: This PR is build on top of #482 so it needs to be merged before this gets merged

This PR has the respective caller function to return the dummy api.

Changes made:
- the experiment trial is now stored in EM Mapper with a new map which holds the experiment name and trial mapping of a particular experiment trial object (needed to construct a return json which has the trial details)
- a dummy json function which generates the return json based on the experiment name, trail and verboseness