### PR TITLE
Proceed to check "isEmpty" only if the string is "not null"

### DIFF
--- a/src/main/java/com/autotune/utils/GenericRestApiClient.java
+++ b/src/main/java/com/autotune/utils/GenericRestApiClient.java
@@ -139,7 +139,7 @@ public class GenericRestApiClient {
                 );
             }
             // Checks if auth string is null and then checks if it's not empty
-            if (this.authHeaderString != null && !this.authHeaderString.isEmpty()) {
+            if (null != this.authHeaderString && !this.authHeaderString.isEmpty()) {
                 httpRequestBase.setHeader("Authorization", this.authHeaderString);
             }
             LOGGER.debug("Executing request " + httpRequestBase.getRequestLine());

--- a/src/main/java/com/autotune/utils/GenericRestApiClient.java
+++ b/src/main/java/com/autotune/utils/GenericRestApiClient.java
@@ -138,7 +138,8 @@ public class GenericRestApiClient {
                         + URLEncoder.encode(queryString, StandardCharsets.UTF_8)
                 );
             }
-            if (this.authHeaderString != null || !this.authHeaderString.isEmpty()) {
+            // Checks if auth string is null and then checks if it's not empty
+            if (this.authHeaderString != null && !this.authHeaderString.isEmpty()) {
                 httpRequestBase.setHeader("Authorization", this.authHeaderString);
             }
             LOGGER.debug("Executing request " + httpRequestBase.getRequestLine());


### PR DESCRIPTION
We should be setting the authorization header if the `authHeaderString` is not null and not empty. The earlier check used an `or case` where the program proceeds to check if it's not empty even though the string is `null` as the OR gate checks both the conditions to decide the outcome, Now we replace it with a logical `and case` where we proceed only if the first case (`not null`) case is true.

This fix avoids the null pointer exception raised when we call `isEmpty()` over a `null`

Signed-off-by: bharathappali <abharath@redhat.com>