### PR TITLE
Adds load interceptor mechanism

### DIFF
--- a/src/main/java/com/autotune/common/experiments/TrialSettings.java
+++ b/src/main/java/com/autotune/common/experiments/TrialSettings.java
@@ -49,6 +49,8 @@ public class TrialSettings {
     @SerializedName("measurement_cycles")
     private final String trialMeasurementCycles;
 
+    private boolean forceCollectMetrics;
+
     public TrialSettings(String trialIterations,
                          String trialWarmupDuration,
                          String trialWarmupCycles,
@@ -59,6 +61,7 @@ public class TrialSettings {
         this.trialWarmupCycles = trialWarmupCycles;
         this.trialMeasurementDuration = trialMeasurementDuration;
         this.trialMeasurementCycles = trialMeasurementCycles;
+        this.forceCollectMetrics = false;
     }
 
     public String getTrialMeasurementDuration() {
@@ -79,6 +82,14 @@ public class TrialSettings {
 
     public String getTrialMeasurementCycles() {
         return trialMeasurementCycles;
+    }
+
+    public boolean isForceCollectMetrics() {
+        return forceCollectMetrics;
+    }
+
+    public void setForceCollectMetrics(boolean forceCollectMetrics) {
+        this.forceCollectMetrics = forceCollectMetrics;
     }
 
     @Override

--- a/src/main/java/com/autotune/experimentManager/core/ExperimentTrialHandler.java
+++ b/src/main/java/com/autotune/experimentManager/core/ExperimentTrialHandler.java
@@ -22,15 +22,9 @@ import com.autotune.common.target.kubernetes.service.KubernetesServices;
 import com.autotune.common.target.kubernetes.service.impl.KubernetesServicesImpl;
 import com.autotune.experimentManager.core.interceptor.EMLoadInterceptor;
 import com.autotune.experimentManager.data.EMMapper;
-<<<<<<< HEAD
-<<<<<<< HEAD
+
 import com.autotune.experimentManager.utils.EMConstants;
-=======
-=======
-import com.autotune.experimentManager.utils.EMConstants;
->>>>>>> Adds the proceed to collection of metrics check
 import com.autotune.experimentManager.utils.EMUtil;
->>>>>>> Adds load interceptor mechanism
 import com.autotune.utils.HttpUtils;
 import com.google.gson.Gson;
 import org.json.JSONArray;
@@ -228,6 +222,7 @@ public class ExperimentTrialHandler {
                 );
             } catch (Exception e) {
                 LOGGER.error(e.toString());
+                e.printStackTrace();
             } finally {
                 if (kubernetesServices != null)
                     kubernetesServices.shutdownClient();

--- a/src/main/java/com/autotune/experimentManager/core/ExperimentTrialHandler.java
+++ b/src/main/java/com/autotune/experimentManager/core/ExperimentTrialHandler.java
@@ -174,17 +174,14 @@ public class ExperimentTrialHandler {
                         if (!deploymentHandler.isDeploymentReady()) {
                             LOGGER.debug("Giving up for ExpName {} trail No {} for {} attempt", this.experimentTrial.getExperimentName(), this.experimentTrial.getTrialInfo().getTrialNum(), i);
                         } else {
-                            //check if load applied to deployment
-
-                            // Checks if the load can be detected with the attributes of experiment trial
-                            EMUtil.InterceptorFlowDecision loadInterceptorDecision = emLoadInterceptor.verifyLoadToProceed(this.experimentTrial);
-                            switch (loadInterceptorDecision) {
-                                case PROCEED:
-                                    // Proceed as the load is detectable and available
+                            // Proceeding to load check as deployment is successful
+                            EMUtil.LoadAvailabilityStatus loadAvailabilityStatus = emLoadInterceptor.isLoadAvailable(this.experimentTrial);
+                            switch (loadAvailabilityStatus) {
+                                case LOAD_AVAILABLE:
+                                    // Proceed to collect metrics as load is available
                                     break;
-                                case EXIT:
-                                    // Exit the trial gracefully and mark the trial as failed as
-                                    // we cannot proceed to collect metrics
+                                case LOAD_NOT_AVAILABLE:
+                                    // Proceed to exit gracefully as load is not available
                                     break;
                             }
                         }

--- a/src/main/java/com/autotune/experimentManager/core/ExperimentTrialHandler.java
+++ b/src/main/java/com/autotune/experimentManager/core/ExperimentTrialHandler.java
@@ -20,8 +20,13 @@ import com.autotune.common.experiments.PodContainer;
 import com.autotune.common.experiments.TrialDetails;
 import com.autotune.common.target.kubernetes.service.KubernetesServices;
 import com.autotune.common.target.kubernetes.service.impl.KubernetesServicesImpl;
+import com.autotune.experimentManager.core.interceptor.EMLoadInterceptor;
 import com.autotune.experimentManager.data.EMMapper;
+<<<<<<< HEAD
 import com.autotune.experimentManager.utils.EMConstants;
+=======
+import com.autotune.experimentManager.utils.EMUtil;
+>>>>>>> Adds load interceptor mechanism
 import com.autotune.utils.HttpUtils;
 import com.google.gson.Gson;
 import org.json.JSONArray;
@@ -140,6 +145,7 @@ public class ExperimentTrialHandler {
     public void startExperimentTrials() {
         LOGGER.debug("Start Exp Trial");
         int numberOFIterations = Integer.parseInt(this.experimentTrial.getExperimentSettings().getTrialSettings().getTrialIterations());
+        EMLoadInterceptor emLoadInterceptor = new EMLoadInterceptor();
         String imageName = "";
         String containerName = "";
         this.experimentTrial.getTrialDetails().forEach((tracker, trialDetails) -> {
@@ -167,10 +173,19 @@ public class ExperimentTrialHandler {
                                     e.printStackTrace();
                                 }
                             }
-                            if (!deploymentHandler.isDeploymentReady())
+                            if (!deploymentHandler.isDeploymentReady()) {
                                 LOGGER.debug("Giving up for ExpName {} trail No {} for {} attempt", this.experimentTrial.getExperimentName(), this.experimentTrial.getTrialInfo().getTrialNum(), i);
-                            //check if load applied to deployment
-                            //collect warmup and measurement cycles metrics
+                            } else {
+                                //check if load applied to deployment
+
+                                // Checks if the load can be detected with the attributes of experiment trial
+                                if (EMUtil.InterceptorDetectionStatus.DETECTED == emLoadInterceptor.detect(this.experimentTrial)) {
+                                    // Proceed to check if load is available (minimal variation)
+                                    if (EMUtil.InterceptorAvailabilityStatus.AVAILABLE == emLoadInterceptor.isAvailable(this.experimentTrial)) {
+                                        // Will proceed for metric cycles if the load is detected
+                                    }
+                                }
+                            }
                         }
                 );
 

--- a/src/main/java/com/autotune/experimentManager/core/interceptor/BaseInterceptor.java
+++ b/src/main/java/com/autotune/experimentManager/core/interceptor/BaseInterceptor.java
@@ -1,0 +1,26 @@
+package com.autotune.experimentManager.core.interceptor;
+
+import com.autotune.common.experiments.ExperimentTrial;
+import com.autotune.experimentManager.utils.EMUtil;
+
+/**
+ * Base Interceptor need to be implemented by the modules which needs a check
+ * for the some entity which is needed to proceed further in EM flow
+ *
+ * It's named as interceptor as it intercepts a flow to check if that can proceed
+ */
+public interface BaseInterceptor {
+    /**
+     * Detect function need to be implemented with the logic responsible for entity detection
+     * @param experimentTrial
+     * @return
+     */
+    public EMUtil.InterceptorDetectionStatus detect(ExperimentTrial experimentTrial);
+
+    /**
+     * isAvailable need to be implemented with the logic responsible for entity availability
+     * @param experimentTrial
+     * @return
+     */
+    public EMUtil.InterceptorAvailabilityStatus isAvailable(ExperimentTrial experimentTrial);
+}

--- a/src/main/java/com/autotune/experimentManager/core/interceptor/BaseInterceptor.java
+++ b/src/main/java/com/autotune/experimentManager/core/interceptor/BaseInterceptor.java
@@ -8,6 +8,7 @@ import com.autotune.experimentManager.utils.EMUtil;
  * for the some entity which is needed to proceed further in EM flow
  *
  * It's named as interceptor as it intercepts a flow to check if that can proceed
+ *
  */
 public interface BaseInterceptor {
     /**

--- a/src/main/java/com/autotune/experimentManager/core/interceptor/EMLoadInterceptor.java
+++ b/src/main/java/com/autotune/experimentManager/core/interceptor/EMLoadInterceptor.java
@@ -1,9 +1,14 @@
 package com.autotune.experimentManager.core.interceptor;
 
 import com.autotune.common.experiments.ExperimentTrial;
+import com.autotune.experimentManager.core.ExperimentTrialHandler;
+import com.autotune.experimentManager.utils.EMConstants;
 import com.autotune.experimentManager.utils.EMUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class EMLoadInterceptor implements BaseInterceptor {
+    private static final Logger LOGGER = LoggerFactory.getLogger(EMLoadInterceptor.class);
     /**
      * Load detection module which returns DETECTED if the load can be detected
      * with attributes provided in experiment trial object
@@ -26,5 +31,47 @@ public class EMLoadInterceptor implements BaseInterceptor {
     public EMUtil.InterceptorAvailabilityStatus isAvailable(ExperimentTrial experimentTrial) {
         // Needs to be implemented
         return EMUtil.InterceptorAvailabilityStatus.AVAILABLE;
+    }
+
+    public EMUtil.InterceptorFlowDecision verifyLoadToProceed(ExperimentTrial experimentTrial) {
+        boolean proceedToMetricsCollection = false;
+        if (EMUtil.InterceptorDetectionStatus.DETECTED == this.detect(experimentTrial)) {
+            EMUtil.InterceptorAvailabilityStatus currentAvailability = this.isAvailable(experimentTrial);
+            // This loop mechanism will be part of an abstraction later (Threshold loop abstraction)
+            // for now just like deployment handler we run a for loop and constantly poll for the load availability
+            for (int j = 0; j < EMConstants.StandardDefaults.BackOffThresholds.CHECK_LOAD_AVAILABILITY_THRESHOLD; j++) {
+                // Proceed to check if load is available (minimal variation)
+                if (EMUtil.InterceptorAvailabilityStatus.AVAILABLE == currentAvailability) {
+                    // Will proceed for metric cycles if the load is detected
+                    proceedToMetricsCollection = true;
+                    // breaking the load availability loop
+                    break;
+                }
+                try {
+                    LOGGER.debug("The Load is not yet available, will be checking it again");
+                    // Will be replaced by a exponential looper mechanism
+                    Thread.sleep(EMUtil.timeToSleep(j) * 1000);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+                currentAvailability = this.isAvailable(experimentTrial);
+            }
+            if (EMUtil.InterceptorAvailabilityStatus.AVAILABLE != currentAvailability) {
+                LOGGER.debug("Load cannot be detected for the particular trial, proceed to collect metrics if it can be ignored");
+                if (experimentTrial.getExperimentSettings().getTrialSettings().isForceCollectMetrics()) {
+                    proceedToMetricsCollection = true;
+                }
+            }
+        } else {
+            LOGGER.debug("Load cannot be detected for the particular trial, proceed to collect metrics if it can be ignored");
+            if (experimentTrial.getExperimentSettings().getTrialSettings().isForceCollectMetrics()) {
+                proceedToMetricsCollection = true;
+            }
+        }
+        if (proceedToMetricsCollection) {
+            return  EMUtil.InterceptorFlowDecision.PROCEED;
+        }
+        LOGGER.debug("Proceeding to next trial and this trial cannot be completed due to lack of metrics collection. Will be marked as failed trial");
+        return EMUtil.InterceptorFlowDecision.EXIT;
     }
 }

--- a/src/main/java/com/autotune/experimentManager/core/interceptor/EMLoadInterceptor.java
+++ b/src/main/java/com/autotune/experimentManager/core/interceptor/EMLoadInterceptor.java
@@ -49,7 +49,7 @@ public class EMLoadInterceptor implements LoadInterceptor {
                 try {
                     LOGGER.debug("The Load is not yet available, will be checking it again");
                     // Will be replaced by a exponential looper mechanism
-                    Thread.sleep(EMUtil.timeToSleep(j) * 1000);
+                    Thread.sleep(EMUtil.timeToSleep(j, EMUtil.ThresholdIntervalType.EXPONENTIAL) * 1000);
                 } catch (InterruptedException e) {
                     e.printStackTrace();
                 }

--- a/src/main/java/com/autotune/experimentManager/core/interceptor/EMLoadInterceptor.java
+++ b/src/main/java/com/autotune/experimentManager/core/interceptor/EMLoadInterceptor.java
@@ -1,0 +1,30 @@
+package com.autotune.experimentManager.core.interceptor;
+
+import com.autotune.common.experiments.ExperimentTrial;
+import com.autotune.experimentManager.utils.EMUtil;
+
+public class EMLoadInterceptor implements BaseInterceptor {
+    /**
+     * Load detection module which returns DETECTED if the load can be detected
+     * with attributes provided in experiment trial object
+     * @param experimentTrial
+     * @return
+     */
+    @Override
+    public EMUtil.InterceptorDetectionStatus detect(ExperimentTrial experimentTrial) {
+        // Needs to be implemented
+        return EMUtil.InterceptorDetectionStatus.DETECTED;
+    }
+
+    /**
+     * Load availability based on the datasource result.
+     * Returns AVAILABLE if the load variation is found
+     * @param experimentTrial
+     * @return
+     */
+    @Override
+    public EMUtil.InterceptorAvailabilityStatus isAvailable(ExperimentTrial experimentTrial) {
+        // Needs to be implemented
+        return EMUtil.InterceptorAvailabilityStatus.AVAILABLE;
+    }
+}

--- a/src/main/java/com/autotune/experimentManager/core/interceptor/LoadInterceptor.java
+++ b/src/main/java/com/autotune/experimentManager/core/interceptor/LoadInterceptor.java
@@ -1,0 +1,8 @@
+package com.autotune.experimentManager.core.interceptor;
+
+import com.autotune.common.experiments.ExperimentTrial;
+import com.autotune.experimentManager.utils.EMUtil;
+
+public interface LoadInterceptor extends BaseInterceptor{
+    public EMUtil.LoadAvailabilityStatus isLoadAvailable(ExperimentTrial experimentTrial);
+}

--- a/src/main/java/com/autotune/experimentManager/utils/EMConstants.java
+++ b/src/main/java/com/autotune/experimentManager/utils/EMConstants.java
@@ -253,5 +253,15 @@ public class EMConstants {
 		public static String MEM_QUERY_NAME = "memRequest";
 		public static String THROUGHPUT = "throughput";
 		public static String RESPONSE_TIME = "response_time";
+
+		public static class BackOffThresholds {
+			private BackOffThresholds() { }
+			public static int CHECK_LOAD_AVAILABILITY_THRESHOLD = 10;
+			public static int[] EXPONENTIAL_BACKOFF_INTERVALS = {1, 3, 4, 7, 11};
+		}
+
+
 	}
+
+
 }

--- a/src/main/java/com/autotune/experimentManager/utils/EMConstants.java
+++ b/src/main/java/com/autotune/experimentManager/utils/EMConstants.java
@@ -1,6 +1,7 @@
 package com.autotune.experimentManager.utils;
 
 import java.util.Locale;
+import java.util.SplittableRandom;
 
 public class EMConstants {
 
@@ -258,9 +259,8 @@ public class EMConstants {
 			private BackOffThresholds() { }
 			public static int CHECK_LOAD_AVAILABILITY_THRESHOLD = 10;
 			public static int[] EXPONENTIAL_BACKOFF_INTERVALS = {1, 3, 4, 7, 11};
+			public static int DEFUALT_LINEAR_BACKOFF_INTERVAL = 1;
 		}
-
-
 	}
 
 

--- a/src/main/java/com/autotune/experimentManager/utils/EMUtil.java
+++ b/src/main/java/com/autotune/experimentManager/utils/EMUtil.java
@@ -190,4 +190,15 @@ public class EMUtil {
         }
         return 0;
     }
+
+    public enum InterceptorFlowDecision {
+        // To proceed ahead in the flow
+        PROCEED,
+        // To wait and check later for the intercepted entity
+        WAIT,
+        // Take another path / workflow as current workflow has issues
+        DETOUR,
+        // Couldn't proceed in anyway, gracefully exit the workflow
+        EXIT
+    }
 }

--- a/src/main/java/com/autotune/experimentManager/utils/EMUtil.java
+++ b/src/main/java/com/autotune/experimentManager/utils/EMUtil.java
@@ -183,6 +183,11 @@ public class EMUtil {
         NOT_AVAILABLE
     }
 
+    public enum LoadAvailabilityStatus {
+        LOAD_AVAILABLE,
+        LOAD_NOT_AVAILABLE
+    }
+
     public static int timeToSleep(int iteration) {
         if (0 <= iteration) {
             int index = iteration % EMConstants.StandardDefaults.BackOffThresholds.EXPONENTIAL_BACKOFF_INTERVALS.length;

--- a/src/main/java/com/autotune/experimentManager/utils/EMUtil.java
+++ b/src/main/java/com/autotune/experimentManager/utils/EMUtil.java
@@ -182,4 +182,12 @@ public class EMUtil {
         AVAILABLE,
         NOT_AVAILABLE
     }
+
+    public static int timeToSleep(int iteration) {
+        if (0 <= iteration) {
+            int index = iteration % EMConstants.StandardDefaults.BackOffThresholds.EXPONENTIAL_BACKOFF_INTERVALS.length;
+            return index;
+        }
+        return 0;
+    }
 }

--- a/src/main/java/com/autotune/experimentManager/utils/EMUtil.java
+++ b/src/main/java/com/autotune/experimentManager/utils/EMUtil.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *******************************************************************************/
-
 package com.autotune.experimentManager.utils;
 
 import com.autotune.experimentManager.data.ExperimentTrialData;
@@ -169,7 +168,6 @@ public class EMUtil {
 
     public JSONObject generateMetricsMap(ExperimentTrialData etd) {
         ArrayList<EMMetricInput> emMetricInputs = etd.getConfig().getEmConfigObject().getDeployments().getTrainingDeployment().getMetrics();
-
         return null;
     }
 
@@ -188,22 +186,25 @@ public class EMUtil {
         LOAD_NOT_AVAILABLE
     }
 
-    public static int timeToSleep(int iteration) {
-        if (0 <= iteration) {
-            int index = iteration % EMConstants.StandardDefaults.BackOffThresholds.EXPONENTIAL_BACKOFF_INTERVALS.length;
-            return index;
-        }
-        return 0;
+    public enum ThresholdIntervalType {
+        EXPONENTIAL,
+        LINEAR
     }
 
-    public enum InterceptorFlowDecision {
-        // To proceed ahead in the flow
-        PROCEED,
-        // To wait and check later for the intercepted entity
-        WAIT,
-        // Take another path / workflow as current workflow has issues
-        DETOUR,
-        // Couldn't proceed in anyway, gracefully exit the workflow
-        EXIT
+    public static int timeToSleep(int iteration, ThresholdIntervalType type) {
+        int time = 0;
+        if (type == null) {
+            type = ThresholdIntervalType.LINEAR;
+        }
+        if (0 <= iteration) {
+            int index = 0;
+            if (type == ThresholdIntervalType.LINEAR) {
+                time = EMConstants.StandardDefaults.BackOffThresholds.DEFUALT_LINEAR_BACKOFF_INTERVAL;
+            } else if (type == ThresholdIntervalType.EXPONENTIAL) {
+                index = iteration % EMConstants.StandardDefaults.BackOffThresholds.EXPONENTIAL_BACKOFF_INTERVALS.length;
+                time = EMConstants.StandardDefaults.BackOffThresholds.EXPONENTIAL_BACKOFF_INTERVALS[index];
+            }
+        }
+        return time;
     }
 }

--- a/src/main/java/com/autotune/experimentManager/utils/EMUtil.java
+++ b/src/main/java/com/autotune/experimentManager/utils/EMUtil.java
@@ -172,4 +172,14 @@ public class EMUtil {
 
         return null;
     }
+
+    public enum InterceptorDetectionStatus {
+        DETECTED,
+        NOT_DETECTED
+    }
+
+    public enum InterceptorAvailabilityStatus {
+        AVAILABLE,
+        NOT_AVAILABLE
+    }
 }


### PR DESCRIPTION
The metrics collection should be started only if there is a load on the deployment. This PR adds a base implementation of the load detection.

Work which needs to be done on top of this PR:
- Check for pod metrics in experiment trial and decide load can be detected
- Check for minimal variation required in pod metrics (if available and if not alternate metrics) to decide if load is available

Signed-off-by: bharathappali <abharath@redhat.com>