### PR TITLE
Adds WAITING_FOR_LOAD status after deployment is ready

### DIFF
--- a/src/main/java/com/autotune/common/experiments/ExperimentTrial.java
+++ b/src/main/java/com/autotune/common/experiments/ExperimentTrial.java
@@ -90,8 +90,25 @@ public class ExperimentTrial {
     // Eg. training and production
     // uses tracker as key. tracker = "training" or "production"
 
+
     // Non JSON field
     private transient HashMap<EMUtil.EMFlowFlags, Boolean> flagsMap;
+
+    /**
+     * Will be used to update the status of the trial
+     *
+     * Valid Statuses:
+     *         CREATED,
+     *         QUEUED,
+     *         IN_PROGRESS,
+     *         WAITING_FOR_LOAD,
+     *         COLLECTING_METRICS,
+     *         COMPLETED
+     *
+     * As the project is actively developed these statuses might be changed in future,
+     * Please refer to latest at com.autotune.experimentManager.utils.EMUtil.EMExpStatus
+     */
+    private EMUtil.EMExpStatus status;
 
     public ExperimentTrial(String experimentName,
                            String mode, String environment, ResourceDetails resourceDetails, String experimentId,
@@ -110,6 +127,7 @@ public class ExperimentTrial {
         this.datasourceInfoHashMap = datasourceInfoHashMap;
         this.experimentSettings = experimentSettings;
         this.trialDetails = trialDetails;
+        this.status = EMUtil.EMExpStatus.CREATED;
         resetFlagsMap();
     }
 
@@ -166,6 +184,21 @@ public class ExperimentTrial {
     public HashMap<EMUtil.EMFlowFlags, Boolean> getFlagsMap() {
         return flagsMap;
     }
+    /**
+     * Returns the status of the trial
+     * @return EMExpStatus status
+     */
+    public EMUtil.EMExpStatus getStatus() {
+        return status;
+    }
+
+    /**
+     * Set the status of the trial
+     * @param status
+     */
+    public void setStatus(EMUtil.EMExpStatus status) {
+        this.status = status;
+    }
 
     @Override
     public String toString() {
@@ -183,8 +216,6 @@ public class ExperimentTrial {
                 ", experimentSettings=" + experimentSettings +
                 '}';
     }
-
-
 }
 
 

--- a/src/main/java/com/autotune/experimentManager/core/ExperimentTrialHandler.java
+++ b/src/main/java/com/autotune/experimentManager/core/ExperimentTrialHandler.java
@@ -145,6 +145,9 @@ public class ExperimentTrialHandler {
         LOGGER.debug("Start Exp Trial");
         int numberOFIterations = Integer.parseInt(this.experimentTrial.getExperimentSettings().getTrialSettings().getTrialIterations());
         EMLoadInterceptor emLoadInterceptor = new EMLoadInterceptor();
+        // Check for any conflicting on going trial and set the status as IN_PROGRESS, QUEUED
+        // Currently setting it to IN_PROGRESS
+        this.experimentTrial.setStatus(EMUtil.EMExpStatus.IN_PROGRESS);
         String imageName = "";
         String containerName = "";
         this.experimentTrial.getTrialDetails().forEach((tracker, trialDetails) -> {
@@ -161,14 +164,17 @@ public class ExperimentTrialHandler {
                     i -> {
                         // Check for deployment needed and proceed
                         if (this.experimentTrial.getFlagsMap().get(EMUtil.EMFlowFlags.NEEDS_DEPLOYMENT)) {
+                            this.experimentTrial.setStatus(EMUtil.EMExpStatus.CREATED);
                             deploymentHandler.initiateDeploy();
                             // Check if deployment is ready
                             EMUtil.DeploymentReadinessStatus deploymentReadinessStatus = deploymentHandler.isDeploymentReady(this.experimentTrial);
                             switch (deploymentReadinessStatus) {
                                 case READY:
+                                    this.experimentTrial.setStatus(EMUtil.EMExpStatus.DEPLOYMENT_SUCCESSFUL);
                                     break;
                                 case NOT_READY:
                                     // Gracefuly exit for this iteration
+                                    this.experimentTrial.setStatus(EMUtil.EMExpStatus.DEPLOYMENT_FAILED);
                                     LOGGER.debug("Giving up for ExpName {} trail No {} for {} attempt", this.experimentTrial.getExperimentName(), this.experimentTrial.getTrialInfo().getTrialNum(), i);
                                     break;
                             }
@@ -181,14 +187,17 @@ public class ExperimentTrialHandler {
 
                         // Check for load check needed and proceed
                         if (this.experimentTrial.getFlagsMap().get(EMUtil.EMFlowFlags.CHECK_LOAD)) {
+                            this.experimentTrial.setStatus(EMUtil.EMExpStatus.WAITING_FOR_LOAD);
                             // Proceeding to load check as deployment is successful
                             EMUtil.LoadAvailabilityStatus loadAvailabilityStatus = emLoadInterceptor.isLoadAvailable(this.experimentTrial);
                             switch (loadAvailabilityStatus) {
                                 case LOAD_AVAILABLE:
                                     // Proceed to collect metrics as load is available
+                                    this.experimentTrial.setStatus(EMUtil.EMExpStatus.LOAD_CHECK_SUCCESSFUL);
                                     break;
                                 case LOAD_NOT_AVAILABLE:
                                     // Proceed to exit gracefully as load is not available
+                                    this.experimentTrial.setStatus(EMUtil.EMExpStatus.LOAD_CHECK_FAILED);
                                     break;
                             }
                         } else {
@@ -199,7 +208,18 @@ public class ExperimentTrialHandler {
 
                         // Check for metrics collection needed and proceed
                         if (this.experimentTrial.getFlagsMap().get(EMUtil.EMFlowFlags.COLLECT_METRICS)) {
+                            this.experimentTrial.setStatus(EMUtil.EMExpStatus.COLLECTING_METRICS);
                             // Collect metrics
+                            /*
+                            TODO:
+                                Need to check if the metrics collection is successful
+
+                                Currently setting it as METRIC_COLLECTION_SUCCESSFUL
+                                if metric collection fails update it as
+                                this.experimentTrial.setStatus(EMUtil.EMExpStatus.METRIC_COLLECTION_FAILED);
+                             */
+
+                            this.experimentTrial.setStatus(EMUtil.EMExpStatus.METRIC_COLLECTION_SUCCESSFUL);
                         } else {
                             LOGGER.debug("Metrics collection not required for Experiment - \"{}\" with trial number - \"{}\"",
                                     this.experimentTrial.getExperimentName(),
@@ -207,6 +227,12 @@ public class ExperimentTrialHandler {
                         }
                     }
                 );
+                // Setting the status to `COMPLETED` as the trial is Completed
+                this.experimentTrial.setStatus(EMUtil.EMExpStatus.TRIAL_COMPLETED);
+                // Set the status to success or fail after checking the successful completion of returning trail data
+                // Currently setting as TRIAL_RESULT_SENT_SUCCESSFULLY
+                // on failure we need to set it as TRIAL_RESULT_SEND_FAILED
+                this.experimentTrial.setStatus(EMUtil.EMExpStatus.TRIAL_RESULT_SENT_SUCCESSFULLY);
             } catch (Exception e) {
                 LOGGER.error(e.toString());
                 e.printStackTrace();

--- a/src/main/java/com/autotune/experimentManager/services/util/EMAPIHandler.java
+++ b/src/main/java/com/autotune/experimentManager/services/util/EMAPIHandler.java
@@ -56,7 +56,7 @@ public class EMAPIHandler {
                         depList.add(runId);
                         EMMapper.getInstance().getMap().put(runId, trialData);
                         lastETD.setNotifyTrialCompletion(true);
-                        trialData.setStatus(EMUtil.EMExpStatus.WAIT);
+                        trialData.setStatus(EMUtil.EMExpStatus.QUEUED);
                     }
                 }
             } else {
@@ -121,7 +121,7 @@ public class EMAPIHandler {
                     HashMap<String, ExperimentTrial> trialHashMap = expMap.get(experimentName);
                     for (String key : trialHashMap.keySet()) {
                         JSONObject resJson = getDummyTrialJSON(trialHashMap.get(key), verbose);
-                        resJson.put("Status", "COMPLETED");
+                        resJson.put("Status", trialHashMap.get(key).getStatus().toString());
                         returnJson.put(key, resJson);
                     }
                     return returnJson;
@@ -129,7 +129,7 @@ public class EMAPIHandler {
                     // Scenerio - Experiment name and trial num are given
                     if (expMap.get(experimentName).containsKey(trialNum)) {
                         JSONObject resJson = getDummyTrialJSON(expMap.get(experimentName).get(trialNum), verbose);
-                        resJson.put("Status", "COMPLETED");
+                        resJson.put("Status", expMap.get(experimentName).get(trialNum).getStatus().toString());
                         returnJson.put(trialNum, resJson);
                     } else {
                         returnJson.put("Error", "Invalid trial number");

--- a/src/main/java/com/autotune/experimentManager/utils/EMUtil.java
+++ b/src/main/java/com/autotune/experimentManager/utils/EMUtil.java
@@ -140,13 +140,36 @@ public class EMUtil {
     * If a trial has completed its iterations and sent metrics to USER and exited the status would be `COMPLETED`
     */
     public enum EMExpStatus {
+        // Set at the time of creation
         CREATED,
-        WAIT,
+        // Set if the trial is in conflict with on going trial
+        QUEUED,
+        // Set if the trial starts running
         IN_PROGRESS,
+        // Set if deployment is needed
+        DEPLOYING,
+        // Set if deployment is successful
+        DEPLOYMENT_SUCCESSFUL,
+        // Set if deployment is failed
+        DEPLOYMENT_FAILED,
+        // Set if load check is needed
         WAITING_FOR_LOAD,
-        APPLYING_LOAD,
+        // Set if load check is successful
+        LOAD_CHECK_SUCCESSFUL,
+        // Set if load check is failed
+        LOAD_CHECK_FAILED,
+        // Set if the collection of metrics is needed
         COLLECTING_METRICS,
-        COMPLETED
+        // Set if metric collection is successful
+        METRIC_COLLECTION_SUCCESSFUL,
+        // Set if metric collection failed
+        METRIC_COLLECTION_FAILED,
+        // Set if the trial reached end of its cycle
+        TRIAL_COMPLETED,
+        // Set if the results are posted successfully
+        TRIAL_RESULT_SENT_SUCCESSFULLY,
+        // Set if the results are not sent to analyser / trail creator
+        TRIAL_RESULT_SEND_FAILED,
     }
 
     /**


### PR DESCRIPTION
As the trial gets executed we need a mechanism to poll and get the current status of the trial, So added a attribute `status` in `ExperimentTrial` and updating it based on the changes done on the trial

Signed-off-by: bharathappali <abharath@redhat.com>