### PR TITLE
Adds validators for metrics

### DIFF
--- a/src/main/java/com/autotune/common/utils/CommonUtils.java
+++ b/src/main/java/com/autotune/common/utils/CommonUtils.java
@@ -80,4 +80,10 @@ public class CommonUtils {
          */
         NOT_RELIABLE,
     }
+
+    public enum QueryValidity {
+        VALID,
+        INVALID_PARAMS,
+        INVALID_RANGE,
+    }
 }

--- a/src/main/java/com/autotune/common/utils/CommonUtils.java
+++ b/src/main/java/com/autotune/common/utils/CommonUtils.java
@@ -102,7 +102,6 @@ public class CommonUtils {
         Matcher matcher = pattern.matcher(workingstr);
         if (matcher.find()) {
             if (null != matcher.group(1)) {
-                System.out.println("match found, integer - " + Integer.parseInt(matcher.group(1)));
                 return Integer.parseInt(matcher.group(1));
             }
         }
@@ -122,7 +121,6 @@ public class CommonUtils {
                         || trimmedDurationUnit.equalsIgnoreCase(AutotuneConstants.TimeUnitsExt.SECOND_SHORT_LC_PLURAL)
                         || trimmedDurationUnit.equalsIgnoreCase(AutotuneConstants.TimeUnitsExt.SECOND_LC_SINGULAR)
                         || trimmedDurationUnit.equalsIgnoreCase(AutotuneConstants.TimeUnitsExt.SECOND_LC_PLURAL)) {
-                    System.out.println("match found getTimeUnit seconds");
                     return TimeUnit.SECONDS;
                 }
                 if (trimmedDurationUnit.equalsIgnoreCase(AutotuneConstants.TimeUnitsExt.MINUTE_SINGLE_LC)
@@ -130,7 +128,6 @@ public class CommonUtils {
                         || trimmedDurationUnit.equalsIgnoreCase(AutotuneConstants.TimeUnitsExt.MINUTE_SHORT_LC_PLURAL)
                         || trimmedDurationUnit.equalsIgnoreCase(AutotuneConstants.TimeUnitsExt.MINUTE_LC_SINGULAR)
                         || trimmedDurationUnit.equalsIgnoreCase(AutotuneConstants.TimeUnitsExt.MINUTE_LC_PLURAL)) {
-                    System.out.println("match found getTimeUnit minutes");
                     return TimeUnit.MINUTES;
                 }
                 if (trimmedDurationUnit.equalsIgnoreCase(AutotuneConstants.TimeUnitsExt.HOUR_SINGLE_LC)
@@ -138,7 +135,6 @@ public class CommonUtils {
                         || trimmedDurationUnit.equalsIgnoreCase(AutotuneConstants.TimeUnitsExt.HOUR_SHORT_LC_PLURAL)
                         || trimmedDurationUnit.equalsIgnoreCase(AutotuneConstants.TimeUnitsExt.HOUR_LC_SINGULAR)
                         || trimmedDurationUnit.equalsIgnoreCase(AutotuneConstants.TimeUnitsExt.HOUR_LC_PLURAL)) {
-                    System.out.println("match found getTimeUnit hours");
                     return TimeUnit.HOURS;
                 }
             }

--- a/src/main/java/com/autotune/common/utils/CommonUtils.java
+++ b/src/main/java/com/autotune/common/utils/CommonUtils.java
@@ -136,7 +136,6 @@ public class CommonUtils {
         if (matcher.find()) {
             if (null != matcher.group(2).trim()) {
                 String trimmedDurationUnit = matcher.group(2).trim();
-                System.out.println(trimmedDurationUnit);
                 if (trimmedDurationUnit.equalsIgnoreCase(AutotuneConstants.TimeUnitsExt.SECOND_SINGLE_LC)
                         || trimmedDurationUnit.equalsIgnoreCase(AutotuneConstants.TimeUnitsExt.SECOND_SHORT_LC_SINGULAR)
                         || trimmedDurationUnit.equalsIgnoreCase(AutotuneConstants.TimeUnitsExt.SECOND_SHORT_LC_PLURAL)

--- a/src/main/java/com/autotune/common/utils/CommonUtils.java
+++ b/src/main/java/com/autotune/common/utils/CommonUtils.java
@@ -87,15 +87,30 @@ public class CommonUtils {
         NOT_RELIABLE,
     }
 
+    /**
+     * QueryValidity is an ENUM which holds the possible validity status to be
+     * returned after performing a query validation
+     */
     public enum QueryValidity {
+        // If the query check is done and the query is found to be valid
         VALID,
+        // If the query is found to be having invalid parameters
         INVALID_PARAMS,
+        // If the query is found to be having invalid time ranges
         INVALID_RANGE,
+        // If the query itself is found to be invalid
         INVALID_QUERY,
+        // If the query is empty
         EMPTY_QUERY,
+        // If the query is null
         NULL_QUERY
     }
 
+    /**
+     * Extracts the time value (digits) from a time string
+     * @param timestr
+     * @return
+     */
     public static int getTimeValue(String timestr) {
         String workingstr = timestr.replace(AutotuneConstants.Patterns.WHITESPACE_PATTERN, "");
         Pattern pattern = Pattern.compile(AutotuneConstants.Patterns.DURATION_PATTERN);
@@ -108,6 +123,12 @@ public class CommonUtils {
         return Integer.MIN_VALUE;
     }
 
+    /**
+     * Extracts the time units (time measurement units eg: seconds, minutes etc)
+     * from a time string
+     * @param timestr
+     * @return
+     */
     public static TimeUnit getTimeUnit(String timestr) {
         String workingstr = timestr.replace(AutotuneConstants.Patterns.WHITESPACE_PATTERN, "");
         Pattern pattern = Pattern.compile(AutotuneConstants.Patterns.DURATION_PATTERN);
@@ -142,6 +163,11 @@ public class CommonUtils {
         return null;
     }
 
+    /**
+     * Returns the short string representation of a time unit
+     * @param timeUnit
+     * @return
+     */
     public static String getShortRepOfTimeUnit(TimeUnit timeUnit) {
         if (timeUnit.equals(TimeUnit.HOURS))
             return AutotuneConstants.TimeUnitsExt.HOUR_SINGLE_LC;
@@ -153,6 +179,11 @@ public class CommonUtils {
     }
 
 
+    /**
+     * Converts the time unit to seconds
+     * @param unit
+     * @return
+     */
     public static int getTimeUnitInSeconds(TimeUnit unit) {
         if (unit.equals(TimeUnit.SECONDS)) {
             return 1;
@@ -165,6 +196,11 @@ public class CommonUtils {
         }
     }
 
+    /**
+     * Checks if the query has a time range
+     * @param query
+     * @return
+     */
     public static boolean checkIfQueryHasTimeRange(String query) {
         String workingstr = query.replace(AutotuneConstants.Patterns.WHITESPACE_PATTERN, "");
         Pattern pattern = Pattern.compile(AutotuneConstants.Patterns.QUERY_WITH_TIME_RANGE_PATTERN);
@@ -175,12 +211,23 @@ public class CommonUtils {
         return false;
     }
 
+    /**
+     * Extracts the time range from a query
+     * @param query
+     * @return
+     */
     public static String extractTimeUnitFromQuery(String query) {
         String timeContent = query.substring(query.lastIndexOf('[') + 1);
         timeContent = timeContent.substring(0, timeContent.indexOf(']'));
         return timeContent;
     }
 
+    /**
+     * Checks if two time strings represent same time
+     * @param timeStrOne
+     * @param timeStrTwo
+     * @return
+     */
     public static boolean checkTimeMatch(String timeStrOne, String timeStrTwo) {
         int timeStrOneTimeValue = CommonUtils.getTimeValue(timeStrOne);
         TimeUnit timeStrOneTimeUnit = CommonUtils.getTimeUnit(timeStrOne);

--- a/src/main/java/com/autotune/common/utils/CommonUtils.java
+++ b/src/main/java/com/autotune/common/utils/CommonUtils.java
@@ -16,6 +16,12 @@
 
 package com.autotune.common.utils;
 
+import com.autotune.utils.AutotuneConstants;
+
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * This Class holds the utilities needed by the classes in common package
  */
@@ -85,5 +91,111 @@ public class CommonUtils {
         VALID,
         INVALID_PARAMS,
         INVALID_RANGE,
+        INVALID_QUERY,
+        EMPTY_QUERY,
+        NULL_QUERY
+    }
+
+    public static int getTimeValue(String timestr) {
+        String workingstr = timestr.replace(AutotuneConstants.Patterns.WHITESPACE_PATTERN, "");
+        Pattern pattern = Pattern.compile(AutotuneConstants.Patterns.DURATION_PATTERN);
+        Matcher matcher = pattern.matcher(workingstr);
+        if (matcher.find()) {
+            if (null != matcher.group(1)) {
+                System.out.println("match found, integer - " + Integer.parseInt(matcher.group(1)));
+                return Integer.parseInt(matcher.group(1));
+            }
+        }
+        return Integer.MIN_VALUE;
+    }
+
+    public static TimeUnit getTimeUnit(String timestr) {
+        String workingstr = timestr.replace(AutotuneConstants.Patterns.WHITESPACE_PATTERN, "");
+        Pattern pattern = Pattern.compile(AutotuneConstants.Patterns.DURATION_PATTERN);
+        Matcher matcher = pattern.matcher(workingstr);
+        if (matcher.find()) {
+            if (null != matcher.group(2).trim()) {
+                String trimmedDurationUnit = matcher.group(2).trim();
+                System.out.println(trimmedDurationUnit);
+                if (trimmedDurationUnit.equalsIgnoreCase(AutotuneConstants.TimeUnitsExt.SECOND_SINGLE_LC)
+                        || trimmedDurationUnit.equalsIgnoreCase(AutotuneConstants.TimeUnitsExt.SECOND_SHORT_LC_SINGULAR)
+                        || trimmedDurationUnit.equalsIgnoreCase(AutotuneConstants.TimeUnitsExt.SECOND_SHORT_LC_PLURAL)
+                        || trimmedDurationUnit.equalsIgnoreCase(AutotuneConstants.TimeUnitsExt.SECOND_LC_SINGULAR)
+                        || trimmedDurationUnit.equalsIgnoreCase(AutotuneConstants.TimeUnitsExt.SECOND_LC_PLURAL)) {
+                    System.out.println("match found getTimeUnit seconds");
+                    return TimeUnit.SECONDS;
+                }
+                if (trimmedDurationUnit.equalsIgnoreCase(AutotuneConstants.TimeUnitsExt.MINUTE_SINGLE_LC)
+                        || trimmedDurationUnit.equalsIgnoreCase(AutotuneConstants.TimeUnitsExt.MINUTE_SHORT_LC_SINGULAR)
+                        || trimmedDurationUnit.equalsIgnoreCase(AutotuneConstants.TimeUnitsExt.MINUTE_SHORT_LC_PLURAL)
+                        || trimmedDurationUnit.equalsIgnoreCase(AutotuneConstants.TimeUnitsExt.MINUTE_LC_SINGULAR)
+                        || trimmedDurationUnit.equalsIgnoreCase(AutotuneConstants.TimeUnitsExt.MINUTE_LC_PLURAL)) {
+                    System.out.println("match found getTimeUnit minutes");
+                    return TimeUnit.MINUTES;
+                }
+                if (trimmedDurationUnit.equalsIgnoreCase(AutotuneConstants.TimeUnitsExt.HOUR_SINGLE_LC)
+                        || trimmedDurationUnit.equalsIgnoreCase(AutotuneConstants.TimeUnitsExt.HOUR_SHORT_LC_SINGULAR)
+                        || trimmedDurationUnit.equalsIgnoreCase(AutotuneConstants.TimeUnitsExt.HOUR_SHORT_LC_PLURAL)
+                        || trimmedDurationUnit.equalsIgnoreCase(AutotuneConstants.TimeUnitsExt.HOUR_LC_SINGULAR)
+                        || trimmedDurationUnit.equalsIgnoreCase(AutotuneConstants.TimeUnitsExt.HOUR_LC_PLURAL)) {
+                    System.out.println("match found getTimeUnit hours");
+                    return TimeUnit.HOURS;
+                }
+            }
+        }
+        return null;
+    }
+
+    public static String getShortRepOfTimeUnit(TimeUnit timeUnit) {
+        if (timeUnit.equals(TimeUnit.HOURS))
+            return AutotuneConstants.TimeUnitsExt.HOUR_SINGLE_LC;
+        if (timeUnit.equals(TimeUnit.MINUTES))
+            return AutotuneConstants.TimeUnitsExt.MINUTE_SINGLE_LC;
+        if (timeUnit.equals(TimeUnit.SECONDS))
+            return AutotuneConstants.TimeUnitsExt.SECOND_SINGLE_LC;
+        return null;
+    }
+
+
+    public static int getTimeUnitInSeconds(TimeUnit unit) {
+        if (unit.equals(TimeUnit.SECONDS)) {
+            return 1;
+        } else if (unit.equals(TimeUnit.MINUTES)) {
+            return AutotuneConstants.TimeConv.NO_OF_SECONDS_PER_MINUTE;
+        } else if (unit.equals(TimeUnit.HOURS)) {
+            return AutotuneConstants.TimeConv.NO_OF_MINUTES_PER_HOUR * AutotuneConstants.TimeConv.NO_OF_SECONDS_PER_MINUTE;
+        } else {
+            return Integer.MIN_VALUE;
+        }
+    }
+
+    public static boolean checkIfQueryHasTimeRange(String query) {
+        String workingstr = query.replace(AutotuneConstants.Patterns.WHITESPACE_PATTERN, "");
+        Pattern pattern = Pattern.compile(AutotuneConstants.Patterns.QUERY_WITH_TIME_RANGE_PATTERN);
+        Matcher matcher = pattern.matcher(workingstr);
+        if (matcher.find()) {
+            return true;
+        }
+        return false;
+    }
+
+    public static String extractTimeUnitFromQuery(String query) {
+        String timeContent = query.substring(query.lastIndexOf('[') + 1);
+        timeContent = timeContent.substring(0, timeContent.indexOf(']'));
+        return timeContent;
+    }
+
+    public static boolean checkTimeMatch(String timeStrOne, String timeStrTwo) {
+        int timeStrOneTimeValue = CommonUtils.getTimeValue(timeStrOne);
+        TimeUnit timeStrOneTimeUnit = CommonUtils.getTimeUnit(timeStrOne);
+        int timeStrTwoTimeValue = CommonUtils.getTimeValue(timeStrTwo);
+        TimeUnit timeStrTwoTimeUnit = CommonUtils.getTimeUnit(timeStrTwo);
+        if (Integer.MIN_VALUE != timeStrOneTimeValue
+                && Integer.MIN_VALUE != timeStrTwoTimeValue
+                && null != timeStrOneTimeUnit
+                && null != timeStrTwoTimeUnit) {
+            return timeStrOneTimeValue * getTimeUnitInSeconds(timeStrOneTimeUnit) == timeStrTwoTimeValue * getTimeUnitInSeconds(timeStrTwoTimeUnit);
+        }
+        return false;
     }
 }

--- a/src/main/java/com/autotune/common/validators/MetricsValidator.java
+++ b/src/main/java/com/autotune/common/validators/MetricsValidator.java
@@ -64,19 +64,6 @@ public class MetricsValidator {
             Metric podMetric = podMetricEntry.getValue();
             CommonUtils.QueryValidity validity = validateBaseMetricFeatures(podMetric, experimentTrial.getExperimentSettings().getTrialSettings());
             if (CommonUtils.QueryValidity.VALID != validity) {
-                if (CommonUtils.QueryValidity.EMPTY_QUERY == validity) {
-                    // Need to provide exact query which failed
-                    LOGGER.debug("Invalid Metric - {} : Query - {} is empty", podMetric.getName(), podMetric.getQuery());
-                } else if (CommonUtils.QueryValidity.NULL_QUERY == validity) {
-                    // Need to provide exact query which failed
-                    LOGGER.debug("Invalid Metric - {} : Query - {} is null", podMetric.getName(), podMetric.getQuery());
-                } else if (CommonUtils.QueryValidity.INVALID_QUERY == validity) {
-                    // Need to provide exact query which failed
-                    LOGGER.debug("Invalid Metric - {} : Query - {} is invalid as it doesn't form a expected query structure", podMetric.getName(), podMetric.getQuery());
-                } else if (CommonUtils.QueryValidity.INVALID_RANGE == validity) {
-                    // Need to provide exact query which failed
-                    LOGGER.debug("Invalid Metric - {} : Query - {} is invalid as the time range in query doesn't match the trial cycle duration", podMetric.getName(), podMetric.getQuery());
-                }
                 return validity;
             }
             validity = validatePodMetrics(podMetric);
@@ -91,19 +78,6 @@ public class MetricsValidator {
                 Metric containerMetric = containerMetricEntry.getValue();
                 CommonUtils.QueryValidity validity = validateBaseMetricFeatures(containerMetric, experimentTrial.getExperimentSettings().getTrialSettings());
                 if (CommonUtils.QueryValidity.VALID != validity) {
-                    if (CommonUtils.QueryValidity.EMPTY_QUERY == validity) {
-                        // Need to provide exact query which failed
-                        LOGGER.debug("Invalid Metric - {} : Query - {} is empty", containerMetric.getName(), containerMetric.getQuery());
-                    } else if (CommonUtils.QueryValidity.NULL_QUERY == validity) {
-                        // Need to provide exact query which failed
-                        LOGGER.debug("Invalid Metric - {} : Query - {} is null", containerMetric.getName(), containerMetric.getQuery());
-                    } else if (CommonUtils.QueryValidity.INVALID_QUERY == validity) {
-                        // Need to provide exact query which failed
-                        LOGGER.debug("Invalid Metric - {} : Query - {} is invalid as it doesn't form a expected query structure", containerMetric.getName(), containerMetric.getQuery());
-                    } else if (CommonUtils.QueryValidity.INVALID_RANGE == validity) {
-                        // Need to provide exact query which failed
-                        LOGGER.debug("Invalid Metric - {} : Query - {} is invalid as the time range in query doesn't match the trial cycle duration", containerMetric.getName(), containerMetric.getQuery());
-                    }
                     return validity;
                 }
                 validity = validateContainerMetrics(containerMetric);
@@ -148,10 +122,12 @@ public class MetricsValidator {
         String query = metric.getQuery();
         // Check if query is null and return NULL QUERY as validity
         if (null == query) {
+            LOGGER.error("Invalid Metric - {} : Query - {} is null", metric.getName(), metric.getQuery());
             return CommonUtils.QueryValidity.NULL_QUERY;
         }
         // Check if query is empty and return EMPTY QUERY as validity
         if (query.isEmpty()) {
+            LOGGER.error("Invalid Metric - {} : Query - {} is empty", metric.getName(), metric.getQuery());
             return CommonUtils.QueryValidity.EMPTY_QUERY;
         }
         // Check if query has a time range
@@ -164,6 +140,7 @@ public class MetricsValidator {
             if (checkTimeMatch) {
                 return CommonUtils.QueryValidity.VALID;
             }
+            LOGGER.error("Invalid Metric - {} : Query - {} is invalid as the time range in query doesn't match the trial cycle duration", metric.getName(), metric.getQuery());
             return CommonUtils.QueryValidity.INVALID_RANGE;
         }
         /**

--- a/src/main/java/com/autotune/common/validators/MetricsValidator.java
+++ b/src/main/java/com/autotune/common/validators/MetricsValidator.java
@@ -19,6 +19,9 @@ import com.autotune.common.experiments.ExperimentTrial;
 import com.autotune.common.experiments.TrialSettings;
 import com.autotune.common.k8sObjects.Metric;
 import com.autotune.common.utils.CommonUtils;
+import com.autotune.experimentManager.handler.PreValidationHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -27,6 +30,7 @@ import java.util.Map;
  * Class which is responsible for all metrics related validations
  */
 public class MetricsValidator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MetricsValidator.class);
     private static MetricsValidator metricsValidator = null;
 
     /**
@@ -60,6 +64,19 @@ public class MetricsValidator {
             Metric podMetric = podMetricEntry.getValue();
             CommonUtils.QueryValidity validity = validateBaseMetricFeatures(podMetric, experimentTrial.getExperimentSettings().getTrialSettings());
             if (CommonUtils.QueryValidity.VALID != validity) {
+                if (CommonUtils.QueryValidity.EMPTY_QUERY == validity) {
+                    // Need to provide exact query which failed
+                    LOGGER.debug("Invalid Metric - {} : Query - {} is empty", podMetric.getName(), podMetric.getQuery());
+                } else if (CommonUtils.QueryValidity.NULL_QUERY == validity) {
+                    // Need to provide exact query which failed
+                    LOGGER.debug("Invalid Metric - {} : Query - {} is null", podMetric.getName(), podMetric.getQuery());
+                } else if (CommonUtils.QueryValidity.INVALID_QUERY == validity) {
+                    // Need to provide exact query which failed
+                    LOGGER.debug("Invalid Metric - {} : Query - {} is invalid as it doesn't form a expected query structure", podMetric.getName(), podMetric.getQuery());
+                } else if (CommonUtils.QueryValidity.INVALID_RANGE == validity) {
+                    // Need to provide exact query which failed
+                    LOGGER.debug("Invalid Metric - {} : Query - {} is invalid as the time range in query doesn't match the trial cycle duration", podMetric.getName(), podMetric.getQuery());
+                }
                 return validity;
             }
             validity = validatePodMetrics(podMetric);
@@ -74,6 +91,19 @@ public class MetricsValidator {
                 Metric containerMetric = containerMetricEntry.getValue();
                 CommonUtils.QueryValidity validity = validateBaseMetricFeatures(containerMetric, experimentTrial.getExperimentSettings().getTrialSettings());
                 if (CommonUtils.QueryValidity.VALID != validity) {
+                    if (CommonUtils.QueryValidity.EMPTY_QUERY == validity) {
+                        // Need to provide exact query which failed
+                        LOGGER.debug("Invalid Metric - {} : Query - {} is empty", containerMetric.getName(), containerMetric.getQuery());
+                    } else if (CommonUtils.QueryValidity.NULL_QUERY == validity) {
+                        // Need to provide exact query which failed
+                        LOGGER.debug("Invalid Metric - {} : Query - {} is null", containerMetric.getName(), containerMetric.getQuery());
+                    } else if (CommonUtils.QueryValidity.INVALID_QUERY == validity) {
+                        // Need to provide exact query which failed
+                        LOGGER.debug("Invalid Metric - {} : Query - {} is invalid as it doesn't form a expected query structure", containerMetric.getName(), containerMetric.getQuery());
+                    } else if (CommonUtils.QueryValidity.INVALID_RANGE == validity) {
+                        // Need to provide exact query which failed
+                        LOGGER.debug("Invalid Metric - {} : Query - {} is invalid as the time range in query doesn't match the trial cycle duration", containerMetric.getName(), containerMetric.getQuery());
+                    }
                     return validity;
                 }
                 validity = validateContainerMetrics(containerMetric);

--- a/src/main/java/com/autotune/common/validators/MetricsValidator.java
+++ b/src/main/java/com/autotune/common/validators/MetricsValidator.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
 package com.autotune.common.validators;
 
 import com.autotune.common.experiments.ExperimentTrial;
@@ -8,12 +23,25 @@ import com.autotune.common.utils.CommonUtils;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Class which is responsible for all metrics related validations
+ */
 public class MetricsValidator {
     private static MetricsValidator metricsValidator = null;
+
+    /**
+     * private constructor as we shouldn't create instances of Metrics Validator outside this class
+     * as we maintain this as a singleton
+     */
     private MetricsValidator() {
 
     }
 
+    /**
+     * Create the instance of metrics validator if it's not initialised and return it
+     * made it protected as only Validator should be able to call this function.
+     * @return
+     */
     protected static MetricsValidator getInstance() {
         if (null == metricsValidator) {
             metricsValidator = new MetricsValidator();
@@ -21,6 +49,11 @@ public class MetricsValidator {
         return metricsValidator;
     }
 
+    /**
+     * Validates all the queries in the experiment trial
+     * @param experimentTrial
+     * @return
+     */
     public CommonUtils.QueryValidity validateTrialMetrics(ExperimentTrial experimentTrial) {
         HashMap<String, Metric> podMetrics = experimentTrial.getPodMetricsHashMap();
         for (Map.Entry<String, Metric> podMetricEntry : podMetrics.entrySet()) {
@@ -52,25 +85,51 @@ public class MetricsValidator {
         return CommonUtils.QueryValidity.VALID;
     }
 
+    /**
+     * Validates the metrics based on pod level aspects
+     * TODO: Needs to be implemented
+     * @param metric
+     * @return
+     */
     public static CommonUtils.QueryValidity validatePodMetrics(Metric metric) {
         return CommonUtils.QueryValidity.VALID;
     }
 
+    /**
+     * Validates the metrics based on container level aspects
+     * TODO: Needs to be implemented
+     * @param metric
+     * @return
+     */
     public static CommonUtils.QueryValidity validateContainerMetrics (Metric metric) {
         return CommonUtils.QueryValidity.VALID;
     }
 
+    /**
+     * Validates different aspects of the query at a generic level such as
+     *  - if time range in query matches the trial cycle duration
+     *  etc
+     *  TODO: Other aspects other than query
+     * @param metric
+     * @param trialSettings
+     * @return
+     */
     private static CommonUtils.QueryValidity validateBaseMetricFeatures(Metric metric, TrialSettings trialSettings) {
         String query = metric.getQuery();
+        // Check if query is null and return NULL QUERY as validity
         if (null == query) {
             return CommonUtils.QueryValidity.NULL_QUERY;
         }
+        // Check if query is empty and return EMPTY QUERY as validity
         if (query.isEmpty()) {
             return CommonUtils.QueryValidity.EMPTY_QUERY;
         }
+        // Check if query has a time range
         boolean timeRangeFound = CommonUtils.checkIfQueryHasTimeRange(query);
         if (timeRangeFound) {
+            // Extract time range from query
             String timeContent = CommonUtils.extractTimeUnitFromQuery(query);
+            // Check the time match and return VALID if match found
             boolean checkTimeMatch = CommonUtils.checkTimeMatch(timeContent, trialSettings.getTrialMeasurementDuration());
             if (checkTimeMatch) {
                 return CommonUtils.QueryValidity.VALID;

--- a/src/main/java/com/autotune/common/validators/MetricsValidator.java
+++ b/src/main/java/com/autotune/common/validators/MetricsValidator.java
@@ -137,15 +137,15 @@ public class MetricsValidator {
             String timeContent = CommonUtils.extractTimeUnitFromQuery(query);
             // Check the time match and return VALID if match found
             boolean checkTimeMatch = CommonUtils.checkTimeMatch(timeContent, trialSettings.getTrialMeasurementDuration());
-            if (checkTimeMatch) {
-                return CommonUtils.QueryValidity.VALID;
+            if (!checkTimeMatch) {
+                LOGGER.error("Invalid Metric - {} : Query - {} is invalid as the time range in query doesn't match the trial cycle duration", metric.getName(), metric.getQuery());
+                return CommonUtils.QueryValidity.INVALID_RANGE;
             }
-            LOGGER.error("Invalid Metric - {} : Query - {} is invalid as the time range in query doesn't match the trial cycle duration", metric.getName(), metric.getQuery());
-            return CommonUtils.QueryValidity.INVALID_RANGE;
         }
         /**
          * Need to check other possibilities but for now we return valid
          */
+        LOGGER.debug("Metric - {} is valid", metric.getName());
         return CommonUtils.QueryValidity.VALID;
     }
 }

--- a/src/main/java/com/autotune/common/validators/MetricsValidator.java
+++ b/src/main/java/com/autotune/common/validators/MetricsValidator.java
@@ -1,0 +1,66 @@
+package com.autotune.common.validators;
+
+import com.autotune.common.experiments.ExperimentTrial;
+import com.autotune.common.experiments.TrialSettings;
+import com.autotune.common.k8sObjects.Metric;
+import com.autotune.common.utils.CommonUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MetricsValidator {
+    private static MetricsValidator metricsValidator = null;
+    private MetricsValidator() {
+
+    }
+
+    protected static MetricsValidator getInstance() {
+        if (null == metricsValidator) {
+            metricsValidator = new MetricsValidator();
+        }
+        return metricsValidator;
+    }
+
+    public static CommonUtils.QueryValidity validateTrialMetrics(ExperimentTrial experimentTrial) {
+        HashMap<String, Metric> podMetrics = experimentTrial.getPodMetricsHashMap();
+        for (Map.Entry<String, Metric> podMetricEntry : podMetrics.entrySet()) {
+            Metric podMetric = podMetricEntry.getValue();
+            CommonUtils.QueryValidity validity = validateBaseMetricFeatures(podMetric, experimentTrial.getExperimentSettings().getTrialSettings());
+            if (CommonUtils.QueryValidity.VALID != validity) {
+                return validity;
+            }
+            validity = validatePodMetrics(podMetric);
+            if (CommonUtils.QueryValidity.VALID != validity) {
+                return validity;
+            }
+        }
+        HashMap<String , HashMap<String, Metric>> containerMetricMap = experimentTrial.getContainerMetricsHashMap();
+        for (Map.Entry<String, HashMap<String, Metric>> containerMetricMapEntry : containerMetricMap.entrySet()) {
+            HashMap<String, Metric> containerMetrics = containerMetricMapEntry.getValue();
+            for (Map.Entry<String, Metric> containerMetricEntry : containerMetrics.entrySet()) {
+                Metric containerMetric = containerMetricEntry.getValue();
+                CommonUtils.QueryValidity validity = validateBaseMetricFeatures(containerMetric, experimentTrial.getExperimentSettings().getTrialSettings());
+                if (CommonUtils.QueryValidity.VALID != validity) {
+                    return validity;
+                }
+                validity = validatePodMetrics(containerMetric);
+                if (CommonUtils.QueryValidity.VALID != validity) {
+                    return validity;
+                }
+            }
+        }
+        return CommonUtils.QueryValidity.VALID;
+    }
+
+    public static CommonUtils.QueryValidity validatePodMetrics(Metric metric) {
+        return CommonUtils.QueryValidity.VALID;
+    }
+
+    public static CommonUtils.QueryValidity validateContainerMetrics (Metric metric) {
+        return CommonUtils.QueryValidity.VALID;
+    }
+
+    private static CommonUtils.QueryValidity validateBaseMetricFeatures(Metric metric, TrialSettings trialSettings) {
+        return CommonUtils.QueryValidity.VALID;
+    }
+}

--- a/src/main/java/com/autotune/common/validators/MetricsValidator.java
+++ b/src/main/java/com/autotune/common/validators/MetricsValidator.java
@@ -4,11 +4,9 @@ import com.autotune.common.experiments.ExperimentTrial;
 import com.autotune.common.experiments.TrialSettings;
 import com.autotune.common.k8sObjects.Metric;
 import com.autotune.common.utils.CommonUtils;
-import com.autotune.experimentManager.utils.EMConstants;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 public class MetricsValidator {
     private static MetricsValidator metricsValidator = null;

--- a/src/main/java/com/autotune/common/validators/Validator.java
+++ b/src/main/java/com/autotune/common/validators/Validator.java
@@ -1,0 +1,11 @@
+package com.autotune.common.validators;
+
+public class Validator {
+    private Validator() {
+
+    }
+
+    public static MetricsValidator getMetricsValidator() {
+        return MetricsValidator.getInstance();
+    }
+}

--- a/src/main/java/com/autotune/common/validators/Validator.java
+++ b/src/main/java/com/autotune/common/validators/Validator.java
@@ -1,10 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
 package com.autotune.common.validators;
 
+/**
+ * Validator class provides the validators for each set of sections which needs validation
+ */
 public class Validator {
+    /**
+     * Private constructor as we shouldn't create an instance for Validator
+     */
     private Validator() {
 
     }
 
+    /**
+     * Returns the instance of Metrics Validator
+     * @return
+     */
     public static MetricsValidator getMetricsValidator() {
         return MetricsValidator.getInstance();
     }

--- a/src/main/java/com/autotune/experimentManager/handler/PreValidationHandler.java
+++ b/src/main/java/com/autotune/experimentManager/handler/PreValidationHandler.java
@@ -65,6 +65,7 @@ public class PreValidationHandler implements EMHandlerInterface {
                 /**
                  * Need to stop the experiment.
                  */
+                System.out.println("InValid metrics");
             }
             stepsMeatData.setEndTimestamp(new Timestamp(System.currentTimeMillis()));
             stepsMeatData.setStatus(EMUtil.EMExpStatus.COMPLETED);

--- a/src/main/java/com/autotune/experimentManager/handler/PreValidationHandler.java
+++ b/src/main/java/com/autotune/experimentManager/handler/PreValidationHandler.java
@@ -65,20 +65,7 @@ public class PreValidationHandler implements EMHandlerInterface {
                 /**
                  * Need to stop the experiment.
                  */
-                if (CommonUtils.QueryValidity.EMPTY_QUERY == validMetrics) {
-                    // Need to provide exact query which failed
-                    LOGGER.debug("Invalid Metrics: Query is empty");
-                } else if (CommonUtils.QueryValidity.NULL_QUERY == validMetrics) {
-                    // Need to provide exact query which failed
-                    LOGGER.debug("Invalid Metrics: Query is null");
-                } else if (CommonUtils.QueryValidity.INVALID_QUERY == validMetrics) {
-                    // Need to provide exact query which failed
-                    LOGGER.debug("Invalid Metrics: Query is invalid as it doesn't form a expected query structure");
-                } else if (CommonUtils.QueryValidity.INVALID_RANGE == validMetrics) {
-                    // Need to provide exact query which failed
-                    LOGGER.debug("Invalid Metrics: Query is invalid as the time range in query doesn't match the trial cycle duration");
-                }
-
+                LOGGER.debug("Metrics are invalid, exiting the experiment gracefully");
             }
             stepsMeatData.setEndTimestamp(new Timestamp(System.currentTimeMillis()));
             stepsMeatData.setStatus(EMUtil.EMExpStatus.COMPLETED);

--- a/src/main/java/com/autotune/experimentManager/handler/PreValidationHandler.java
+++ b/src/main/java/com/autotune/experimentManager/handler/PreValidationHandler.java
@@ -65,7 +65,7 @@ public class PreValidationHandler implements EMHandlerInterface {
                 /**
                  * Need to stop the experiment.
                  */
-                System.out.println("InValid metrics");
+                LOGGER.debug("Invalid metrics");
             }
             stepsMeatData.setEndTimestamp(new Timestamp(System.currentTimeMillis()));
             stepsMeatData.setStatus(EMUtil.EMExpStatus.COMPLETED);

--- a/src/main/java/com/autotune/experimentManager/handler/PreValidationHandler.java
+++ b/src/main/java/com/autotune/experimentManager/handler/PreValidationHandler.java
@@ -20,6 +20,9 @@ import com.autotune.common.experiments.TrialDetails;
 import com.autotune.common.parallelengine.executor.AutotuneExecutor;
 import com.autotune.common.parallelengine.worker.AutotuneWorker;
 import com.autotune.common.parallelengine.worker.CallableFactory;
+import com.autotune.common.utils.CommonUtils;
+import com.autotune.common.validators.MetricsValidator;
+import com.autotune.common.validators.Validator;
 import com.autotune.experimentManager.data.result.StepsMetaData;
 import com.autotune.experimentManager.data.result.TrialIterationMetaData;
 import com.autotune.experimentManager.handler.eminterface.EMHandlerInterface;
@@ -53,7 +56,16 @@ public class PreValidationHandler implements EMHandlerInterface {
             stepsMeatData.setBeginTimestamp(new Timestamp(System.currentTimeMillis()));
             /**
              * Implement Prevalidation Logic
+             *
+             * Adding the input JSON check for query validity
              */
+            MetricsValidator metricsValidator = Validator.getMetricsValidator();
+            CommonUtils.QueryValidity validMetrics = metricsValidator.validateTrialMetrics(experimentTrial);
+            if (CommonUtils.QueryValidity.VALID != validMetrics) {
+                /**
+                 * Need to stop the experiment.
+                 */
+            }
             stepsMeatData.setEndTimestamp(new Timestamp(System.currentTimeMillis()));
             stepsMeatData.setStatus(EMUtil.EMExpStatus.COMPLETED);
             EMStatusUpdateHandler.updateTrialIterationDataStatus(experimentTrial, trialDetails, iterationMetaData);

--- a/src/main/java/com/autotune/experimentManager/handler/PreValidationHandler.java
+++ b/src/main/java/com/autotune/experimentManager/handler/PreValidationHandler.java
@@ -65,7 +65,7 @@ public class PreValidationHandler implements EMHandlerInterface {
                 /**
                  * Need to stop the experiment.
                  */
-                LOGGER.debug("Metrics are invalid, exiting the experiment gracefully");
+                LOGGER.error("Metrics are invalid, exiting the experiment gracefully");
             }
             stepsMeatData.setEndTimestamp(new Timestamp(System.currentTimeMillis()));
             stepsMeatData.setStatus(EMUtil.EMExpStatus.COMPLETED);

--- a/src/main/java/com/autotune/experimentManager/handler/PreValidationHandler.java
+++ b/src/main/java/com/autotune/experimentManager/handler/PreValidationHandler.java
@@ -65,7 +65,20 @@ public class PreValidationHandler implements EMHandlerInterface {
                 /**
                  * Need to stop the experiment.
                  */
-                LOGGER.debug("Invalid metrics");
+                if (CommonUtils.QueryValidity.EMPTY_QUERY == validMetrics) {
+                    // Need to provide exact query which failed
+                    LOGGER.debug("Invalid Metrics: Query is empty");
+                } else if (CommonUtils.QueryValidity.NULL_QUERY == validMetrics) {
+                    // Need to provide exact query which failed
+                    LOGGER.debug("Invalid Metrics: Query is null");
+                } else if (CommonUtils.QueryValidity.INVALID_QUERY == validMetrics) {
+                    // Need to provide exact query which failed
+                    LOGGER.debug("Invalid Metrics: Query is invalid as it doesn't form a expected query structure");
+                } else if (CommonUtils.QueryValidity.INVALID_RANGE == validMetrics) {
+                    // Need to provide exact query which failed
+                    LOGGER.debug("Invalid Metrics: Query is invalid as the time range in query doesn't match the trial cycle duration");
+                }
+
             }
             stepsMeatData.setEndTimestamp(new Timestamp(System.currentTimeMillis()));
             stepsMeatData.setStatus(EMUtil.EMExpStatus.COMPLETED);

--- a/src/main/java/com/autotune/experimentManager/utils/EMConstants.java
+++ b/src/main/java/com/autotune/experimentManager/utils/EMConstants.java
@@ -149,50 +149,6 @@ public class EMConstants {
 		}
 	}
 
-	public static final class TimeUnitsExt {
-		private TimeUnitsExt() {
-		}
-
-		public static final String SECOND_LC_SINGULAR = "second";
-		public static final String SECOND_LC_PLURAL = SECOND_LC_SINGULAR + "s";
-		public static final String SECOND_UC_SINGULAR = SECOND_LC_SINGULAR.toUpperCase();
-		public static final String SECOND_UC_PLURAL = SECOND_LC_PLURAL.toUpperCase();
-
-		public static final String SECOND_SHORT_LC_SINGULAR = "sec";
-		public static final String SECOND_SHORT_LC_PLURAL = SECOND_SHORT_LC_SINGULAR + "s";
-		public static final String SECOND_SHORT_UC_SINGULAR = SECOND_SHORT_LC_SINGULAR.toUpperCase();
-		public static final String SECOND_SHORT_UC_PLURAL = SECOND_SHORT_LC_PLURAL.toUpperCase();
-
-		public static final String SECOND_SINGLE_LC = "s";
-		public static final String SECOND_SINGLE_UC = SECOND_SINGLE_LC.toUpperCase();
-
-		public static final String MINUTE_LC_SINGULAR = "minute";
-		public static final String MINUTE_LC_PLURAL = MINUTE_LC_SINGULAR + "s";
-		public static final String MINUTE_UC_SINGULAR = MINUTE_LC_SINGULAR.toUpperCase();
-		public static final String MINUTE_UC_PLURAL = MINUTE_LC_PLURAL.toUpperCase();
-
-		public static final String MINUTE_SHORT_LC_SINGULAR = "min";
-		public static final String MINUTE_SHORT_LC_PLURAL = MINUTE_SHORT_LC_SINGULAR + "s";
-		public static final String MINUTE_SHORT_UC_SINGULAR = MINUTE_SHORT_LC_SINGULAR.toUpperCase();
-		public static final String MINUTE_SHORT_UC_PLURAL = MINUTE_SHORT_LC_PLURAL.toUpperCase();
-
-		public static final String MINUTE_SINGLE_LC = "m";
-		public static final String MINUTE_SINGLE_UC = MINUTE_SINGLE_LC.toUpperCase();
-
-		public static final String HOUR_LC_SINGULAR = "hour";
-		public static final String HOUR_LC_PLURAL = HOUR_LC_SINGULAR + "s";
-		public static final String HOUR_UC_SINGULAR = HOUR_LC_SINGULAR.toUpperCase();
-		public static final String HOUR_UC_PLURAL = HOUR_LC_PLURAL.toUpperCase();
-
-		public static final String HOUR_SHORT_LC_SINGULAR = "hr";
-		public static final String HOUR_SHORT_LC_PLURAL = HOUR_SHORT_LC_SINGULAR + "s";
-		public static final String HOUR_SHORT_UC_SINGULAR = HOUR_SHORT_LC_SINGULAR.toUpperCase();
-		public static final String HOUR_SHORT_UC_PLURAL = HOUR_SHORT_LC_PLURAL.toUpperCase();
-
-		public static final String HOUR_SINGLE_LC = "h";
-		public static final String HOUR_SINGLE_UC = HOUR_SINGLE_LC.toUpperCase();
-	}
-
 	public static final class TimeConv {
 		private TimeConv() {
 		}

--- a/src/main/java/com/autotune/utils/AutotuneConstants.java
+++ b/src/main/java/com/autotune/utils/AutotuneConstants.java
@@ -143,6 +143,50 @@ public class AutotuneConstants {
         public static final String PERCENTILE_INFO = "percentile_info";
     }
 
+    public static final class TimeUnitsExt {
+        private TimeUnitsExt() {
+        }
+
+        public static final String SECOND_LC_SINGULAR = "second";
+        public static final String SECOND_LC_PLURAL = SECOND_LC_SINGULAR + "s";
+        public static final String SECOND_UC_SINGULAR = SECOND_LC_SINGULAR.toUpperCase();
+        public static final String SECOND_UC_PLURAL = SECOND_LC_PLURAL.toUpperCase();
+
+        public static final String SECOND_SHORT_LC_SINGULAR = "sec";
+        public static final String SECOND_SHORT_LC_PLURAL = SECOND_SHORT_LC_SINGULAR + "s";
+        public static final String SECOND_SHORT_UC_SINGULAR = SECOND_SHORT_LC_SINGULAR.toUpperCase();
+        public static final String SECOND_SHORT_UC_PLURAL = SECOND_SHORT_LC_PLURAL.toUpperCase();
+
+        public static final String SECOND_SINGLE_LC = "s";
+        public static final String SECOND_SINGLE_UC = SECOND_SINGLE_LC.toUpperCase();
+
+        public static final String MINUTE_LC_SINGULAR = "minute";
+        public static final String MINUTE_LC_PLURAL = MINUTE_LC_SINGULAR + "s";
+        public static final String MINUTE_UC_SINGULAR = MINUTE_LC_SINGULAR.toUpperCase();
+        public static final String MINUTE_UC_PLURAL = MINUTE_LC_PLURAL.toUpperCase();
+
+        public static final String MINUTE_SHORT_LC_SINGULAR = "min";
+        public static final String MINUTE_SHORT_LC_PLURAL = MINUTE_SHORT_LC_SINGULAR + "s";
+        public static final String MINUTE_SHORT_UC_SINGULAR = MINUTE_SHORT_LC_SINGULAR.toUpperCase();
+        public static final String MINUTE_SHORT_UC_PLURAL = MINUTE_SHORT_LC_PLURAL.toUpperCase();
+
+        public static final String MINUTE_SINGLE_LC = "m";
+        public static final String MINUTE_SINGLE_UC = MINUTE_SINGLE_LC.toUpperCase();
+
+        public static final String HOUR_LC_SINGULAR = "hour";
+        public static final String HOUR_LC_PLURAL = HOUR_LC_SINGULAR + "s";
+        public static final String HOUR_UC_SINGULAR = HOUR_LC_SINGULAR.toUpperCase();
+        public static final String HOUR_UC_PLURAL = HOUR_LC_PLURAL.toUpperCase();
+
+        public static final String HOUR_SHORT_LC_SINGULAR = "hr";
+        public static final String HOUR_SHORT_LC_PLURAL = HOUR_SHORT_LC_SINGULAR + "s";
+        public static final String HOUR_SHORT_UC_SINGULAR = HOUR_SHORT_LC_SINGULAR.toUpperCase();
+        public static final String HOUR_SHORT_UC_PLURAL = HOUR_SHORT_LC_PLURAL.toUpperCase();
+
+        public static final String HOUR_SINGLE_LC = "h";
+        public static final String HOUR_SINGLE_UC = HOUR_SINGLE_LC.toUpperCase();
+    }
+
     public static final String AUTH_MOUNT_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/";
     public static final String MINIKUBE = "minikube";
     public static final String OPENSHIFT = "openshift";

--- a/src/main/java/com/autotune/utils/AutotuneConstants.java
+++ b/src/main/java/com/autotune/utils/AutotuneConstants.java
@@ -187,6 +187,20 @@ public class AutotuneConstants {
         public static final String HOUR_SINGLE_UC = HOUR_SINGLE_LC.toUpperCase();
     }
 
+    public static class TimeConv {
+        private TimeConv() { }
+        public static int NO_OF_SECONDS_PER_MINUTE = 60;
+        public static int NO_OF_MINUTES_PER_HOUR = 60;
+        public static int NO_OF_HOURS_PER_DAY = 12;
+    }
+
+    public static class Patterns {
+        private Patterns() { }
+        public static String DURATION_PATTERN = "(\\d+)([a-zA-Z]+)";
+        public static String WHITESPACE_PATTERN = "\\s";
+        public static String QUERY_WITH_TIME_RANGE_PATTERN = ".*\\[(\\d+)([a-zA-Z]+)\\].*";
+    }
+
     public static final String AUTH_MOUNT_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/";
     public static final String MINIKUBE = "minikube";
     public static final String OPENSHIFT = "openshift";


### PR DESCRIPTION
The Input JSON comes with two sets of metrics `pod metrics` and `container metrics`. This PR adds the validation for metrics syntactically with the trial settings. We state it as an invalid metrics if the query has the incompatible time range with trial settings.

Signed-off-by: bharathappali <abharath@redhat.com>