### PR TITLE
CRD updates for mode and targetCluster

### DIFF
--- a/examples/app-autotune.yaml
+++ b/examples/app-autotune.yaml
@@ -14,7 +14,8 @@ spec:
       query: "application_org_acme_microprofile_metrics_PrimeNumberChecker_checksTimer_mean_seconds"
       datasource: "prometheus"
       value_type: "double"
-  mode: "show"
+  mode: "experiment"
+  targetCluster: "local"
   selector:
     matchLabel: "app.kubernetes.io/name"
     matchLabelValue: "petclinic-deployment"

--- a/manifests/autotune-operator-crd.yaml
+++ b/manifests/autotune-operator-crd.yaml
@@ -47,7 +47,7 @@ spec:
                       type: object
                       properties:
                         name:
-                          description: 'name of the varialbe used in objective_function'
+                          description: 'name of the variable used in objective_function'
                           type: string
                         query:
                           description: 'query expression for respective datasource'
@@ -71,18 +71,22 @@ spec:
                 - function_variables
                 type: object
               mode:
-                description: 'provide an options to either try, show or apply the recommendation'
+                description: 'Mode for this experiment. Supported modes: experiment (default), monitor'
                 type: string
-                default: "show"
+                default: 'experiment'
+              targetCluster:
+                description: 'Target cluster where the experiments are performed. Supported targets: local (default), remote'
+                type: string
+                default: 'local'
               selector:
                 description: 'test'
                 type: object
                 properties:
                   matchLabel:
-                    description: 'match lable is may be the name of the applications where recommendation system apply'
+                    description: 'match label is may be the name of the applications where recommendation system apply'
                     type: string
                   matchLabelValue:
-                    description: 'match lable value'
+                    description: 'match label value'
                     type: string
                   matchRoute:
                     description: 'test'
@@ -94,7 +98,7 @@ spec:
                     description: 'test'
                     type: string
               datasource:
-                description: 'name of the applicaton which is going to monitor the cluster and
+                description: 'name of the application which is going to monitor the cluster and
                               provide the data e.g prometheus etc'
                 properties:
                   name:

--- a/src/main/java/com/autotune/analyzer/deployment/AutotuneDeployment.java
+++ b/src/main/java/com/autotune/analyzer/deployment/AutotuneDeployment.java
@@ -337,6 +337,7 @@ public class AutotuneDeployment
 
 			String name;
 			String mode;
+			String targetCluster;
 			SloInfo sloInfo;
 			String namespace;
 			SelectorInfo selectorInfo;
@@ -352,7 +353,8 @@ public class AutotuneDeployment
 				sloJson = specJson.optJSONObject(AnalyzerConstants.AutotuneObjectConstants.SLO);
 				slo_class = sloJson.optString(AnalyzerConstants.AutotuneObjectConstants.SLO_CLASS);
 				direction = sloJson.optString(AnalyzerConstants.AutotuneObjectConstants.DIRECTION);
-				hpoAlgoImpl = sloJson.optString(AnalyzerConstants.AutotuneObjectConstants.HPO_ALGO_IMPL);
+				hpoAlgoImpl = sloJson.optString(AnalyzerConstants.AutotuneObjectConstants.HPO_ALGO_IMPL,
+						AnalyzerConstants.AutotuneObjectConstants.DEFAULT_HPO_ALGO_IMPL);
 				objectiveFunction = sloJson.optString(AnalyzerConstants.AutotuneObjectConstants.OBJECTIVE_FUNCTION);
 			}
 
@@ -375,11 +377,6 @@ public class AutotuneDeployment
 						valueType);
 
 				metricArrayList.add(metric);
-			}
-
-			// If the user has not specified hpoAlgoImpl, we use the default one.
-			if (hpoAlgoImpl == null || hpoAlgoImpl.isEmpty()) {
-				hpoAlgoImpl = AnalyzerConstants.AutotuneObjectConstants.DEFAULT_HPO_ALGO_IMPL;
 			}
 
 			sloInfo = new SloInfo(slo_class,
@@ -406,7 +403,10 @@ public class AutotuneDeployment
 					matchURI,
 					matchService);
 
-			mode = specJson.optString(AnalyzerConstants.AutotuneObjectConstants.MODE);
+			mode = specJson.optString(AnalyzerConstants.AutotuneObjectConstants.MODE,
+					AnalyzerConstants.AutotuneObjectConstants.DEFAULT_MODE);
+			targetCluster = specJson.optString(AnalyzerConstants.AutotuneObjectConstants.TARGET_CLUSTER,
+					AnalyzerConstants.AutotuneObjectConstants.DEFAULT_TARGET_CLUSTER);
 			name = metadataJson.optString(AnalyzerConstants.AutotuneObjectConstants.NAME);
 			namespace = metadataJson.optString(AnalyzerConstants.AutotuneObjectConstants.NAMESPACE);
 
@@ -426,6 +426,7 @@ public class AutotuneDeployment
 			return new AutotuneObject(name,
 					namespace,
 					mode,
+					targetCluster,
 					sloInfo,
 					selectorInfo,
 					objectReference

--- a/src/main/java/com/autotune/common/experiments/ExperimentSettings.java
+++ b/src/main/java/com/autotune/common/experiments/ExperimentSettings.java
@@ -45,17 +45,21 @@ public class ExperimentSettings {
     private final TrialSettings trialSettings;
     @SerializedName("deployment_settings")
     private final DeploymentSettings deploymentSettings;
-    @SerializedName("do_experiments")
-    private final boolean do_experiments;
+    @SerializedName("do_experiment")
+    private final boolean do_experiment;
     @SerializedName("do_monitoring")
     private final boolean do_monitoring;
     @SerializedName("wait_for_load")
     private final boolean wait_for_load;
 
-    public ExperimentSettings(TrialSettings trialSettings, DeploymentSettings deploymentSettings, boolean do_experiments, boolean do_monitoring, boolean wait_for_load) {
+    public ExperimentSettings(TrialSettings trialSettings,
+                              DeploymentSettings deploymentSettings,
+                              boolean do_experiment,
+                              boolean do_monitoring,
+                              boolean wait_for_load) {
         this.trialSettings = trialSettings;
         this.deploymentSettings = deploymentSettings;
-        this.do_experiments = do_experiments;
+        this.do_experiment = do_experiment;
         this.do_monitoring = do_monitoring;
         this.wait_for_load = wait_for_load;
     }
@@ -68,8 +72,8 @@ public class ExperimentSettings {
         return deploymentSettings;
     }
 
-    public boolean isDo_experiments() {
-        return do_experiments;
+    public boolean isDo_experiment() {
+        return do_experiment;
     }
 
     public boolean isDo_monitoring() {

--- a/src/main/java/com/autotune/common/experiments/ExperimentTrial.java
+++ b/src/main/java/com/autotune/common/experiments/ExperimentTrial.java
@@ -40,13 +40,6 @@ public class ExperimentTrial {
     @SerializedName("mode")
     private final String mode;
     /**
-     * Environment is used to indicate QA or PROD
-     * By default PRODUCTION environed doest not wait for load to applied
-     * Whereas in QA environment EM waits for USER to apply load.
-     */
-    @SerializedName("environment")
-    private final String environment;
-    /**
      * Namespace and Deployment Name will be mentioned here.
      */
     @SerializedName("resource")
@@ -127,13 +120,16 @@ public class ExperimentTrial {
     private ExperimentMetaData experimentMetaData;
 
     public ExperimentTrial(String experimentName,
-                           String mode, String environment, ResourceDetails resourceDetails, String experimentId,
-                           HashMap<String, Metric> podMetricsHashMap, HashMap<String, HashMap<String, Metric>> containerMetricsHashMap, TrialInfo trialInfo,
+                           String mode,
+                           ResourceDetails resourceDetails,
+                           String experimentId,
+                           HashMap<String, Metric> podMetricsHashMap,
+                           HashMap<String, HashMap<String, Metric>> containerMetricsHashMap,
+                           TrialInfo trialInfo,
                            HashMap<String, DatasourceInfo> datasourceInfoHashMap,
                            ExperimentSettings experimentSettings,
                            HashMap<String, TrialDetails> trialDetails) {
         this.mode = mode;
-        this.environment = environment;
         this.resourceDetails = resourceDetails;
         this.experimentId = experimentId;
         this.experimentName = experimentName;
@@ -209,10 +205,6 @@ public class ExperimentTrial {
         return mode;
     }
 
-    public String getEnvironment() {
-        return environment;
-    }
-
     public HashMap<EMUtil.EMFlowFlags, Boolean> getFlagsMap() {
         if (!this.flagInitCheck) {
             this.initialiseFlags();
@@ -237,25 +229,6 @@ public class ExperimentTrial {
         this.status = status;
     }
 
-    @Override
-    public String toString() {
-        return "ExperimentTrial{" +
-                "experimentName='" + experimentName + '\'' +
-                ", mode='" + mode + '\'' +
-                ", environment='" + environment + '\'' +
-                ", resourceDetails=" + resourceDetails +
-                ", experimentId='" + experimentId + '\'' +
-                ", podMetricsHashMap=" + podMetricsHashMap +
-                ", containerMetricsHashMap=" + containerMetricsHashMap +
-                ", trialDetails=" + trialDetails +
-                ", trialInfo=" + trialInfo +
-                ", datasourceInfoHashMap=" + datasourceInfoHashMap +
-                ", experimentSettings=" + experimentSettings +
-                '}';
-    }
-
-
-
     public ExperimentMetaData getExperimentMetaData() {
         return experimentMetaData;
     }
@@ -271,7 +244,20 @@ public class ExperimentTrial {
     public void setTrialResultURL(String trialResultURL) {
         this.trialResultURL = trialResultURL;
     }
+
+    @Override
+    public String toString() {
+        return "ExperimentTrial{" +
+                "experimentName='" + experimentName + '\'' +
+                ", mode='" + mode + '\'' +
+                ", resourceDetails=" + resourceDetails +
+                ", experimentId='" + experimentId + '\'' +
+                ", podMetricsHashMap=" + podMetricsHashMap +
+                ", containerMetricsHashMap=" + containerMetricsHashMap +
+                ", trialDetails=" + trialDetails +
+                ", trialInfo=" + trialInfo +
+                ", datasourceInfoHashMap=" + datasourceInfoHashMap +
+                ", experimentSettings=" + experimentSettings +
+                '}';
+    }
 }
-
-
-

--- a/src/main/java/com/autotune/common/k8sObjects/AutotuneObject.java
+++ b/src/main/java/com/autotune/common/k8sObjects/AutotuneObject.java
@@ -33,6 +33,7 @@ public final class AutotuneObject
 	private final String experimentName;
 	private final String namespace;
 	private final String mode;
+	private final String targetCluster;
 	private final SloInfo sloInfo;
 	private final SelectorInfo selectorInfo;
 	private final ObjectReference objectReference;
@@ -40,6 +41,7 @@ public final class AutotuneObject
 	public AutotuneObject(String experimentName,
 						  String namespace,
 						  String mode,
+						  String targetCluster,
 						  SloInfo sloInfo,
 						  SelectorInfo selectorInfo,
 						  ObjectReference objectReference) throws InvalidValueException {
@@ -48,6 +50,7 @@ public final class AutotuneObject
 		map.put(AnalyzerConstants.AutotuneObjectConstants.NAME, experimentName);
 		map.put(AnalyzerConstants.AutotuneObjectConstants.NAMESPACE, namespace);
 		map.put(AnalyzerConstants.AutotuneObjectConstants.MODE, mode);
+		map.put(AnalyzerConstants.AutotuneObjectConstants.TARGET_CLUSTER, targetCluster);
 		map.put(AnalyzerConstants.AutotuneObjectConstants.SLO, sloInfo);
 		map.put(AnalyzerConstants.AutotuneObjectConstants.SELECTOR, selectorInfo);
 
@@ -56,6 +59,7 @@ public final class AutotuneObject
 			this.experimentName = experimentName;
 			this.namespace = namespace;
 			this.mode = mode;
+			this.targetCluster = targetCluster;
 			this.sloInfo = sloInfo;
 			this.selectorInfo = selectorInfo;
 			this.experimentId = Utils.generateID(toString());
@@ -81,6 +85,10 @@ public final class AutotuneObject
 		return mode;
 	}
 
+	public String getTargetCluster() {
+		return targetCluster;
+	}
+
 	public String getNamespace() {
 		return namespace;
 	}
@@ -99,7 +107,8 @@ public final class AutotuneObject
 				"name='" + experimentName + '\'' +
 				", namespace='" + namespace + '\'' +
 				", mode='" + mode + '\'' +
-				", sloInfo=" + sloInfo +
+				", targetCluster='" + targetCluster + '\'' +
+				", sloInfo=" + sloInfo + '\'' +
 				", selectorInfo=" + selectorInfo +
 				'}';
 	}

--- a/src/main/java/com/autotune/common/k8sObjects/ValidateAutotuneObject.java
+++ b/src/main/java/com/autotune/common/k8sObjects/ValidateAutotuneObject.java
@@ -44,7 +44,13 @@ public class ValidateAutotuneObject
 
 		// Check if mode is supported
 		if (!AutotuneSupportedTypes.MODES_SUPPORTED.contains((String)map.get(AnalyzerConstants.AutotuneObjectConstants.MODE))) {
+			errorString.append("Mode: " + map.get(AnalyzerConstants.AutotuneObjectConstants.MODE) + " ");
 			errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.MODE_NOT_SUPPORTED);
+		}
+
+		// Check if targetCluster is supported
+		if (!AutotuneSupportedTypes.TARGET_CLUSTERS_SUPPORTED.contains((String)map.get(AnalyzerConstants.AutotuneObjectConstants.TARGET_CLUSTER))) {
+			errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.TARGET_CLUSTER_NOT_SUPPORTED);
 		}
 
 		// Check if matching label is set to a valid value (not null or only whitespace)

--- a/src/main/java/com/autotune/experimentManager/data/result/AutoTuneWorkFlow.java
+++ b/src/main/java/com/autotune/experimentManager/data/result/AutoTuneWorkFlow.java
@@ -33,16 +33,16 @@ public class AutoTuneWorkFlow {
     private final LinkedHashMap<String, String> iterationWorkflowMap;
     private final LinkedHashMap<String, String> trialWorkflowMap;
 
-    public AutoTuneWorkFlow(boolean do_experiments, boolean do_monitoring, boolean wait_for_load, String trialResultURL) throws Exception {
-        LOGGER.debug("Do_experiments : {} , Do_monitoring : {}", do_experiments, do_monitoring);
+    public AutoTuneWorkFlow(boolean do_experiment, boolean do_monitoring, boolean wait_for_load, String trialResultURL) throws Exception {
+        LOGGER.debug("Do_experiment : {} , Do_monitoring : {}", do_experiment, do_monitoring);
         this.wait_for_load = wait_for_load;
         iterationWorkflowMap = new LinkedHashMap<String, String>();
 
-        if (!do_experiments && !do_monitoring){
+        if (!do_experiment && !do_monitoring){
             throw new Exception("Workflow not defined");
         }
         iterationWorkflowMap.put(PreValidationHandler.class.getSimpleName().replace("Handler", ""), PreValidationHandler.class.getName());
-        if (do_experiments == true) {
+        if (do_experiment == true) {
             iterationWorkflowMap.put(DeploymentHandler.class.getSimpleName().replace("Handler", ""), DeploymentHandler.class.getName());
             iterationWorkflowMap.put(PostValidationHandler.class.getSimpleName().replace("Handler", ""), PostValidationHandler.class.getName());
         }

--- a/src/main/java/com/autotune/experimentManager/workerimpl/IterationManager.java
+++ b/src/main/java/com/autotune/experimentManager/workerimpl/IterationManager.java
@@ -141,7 +141,7 @@ public class IterationManager implements AutotuneWorker {
             ExperimentMetaData experimentMetaData = experimentTrial.getExperimentMetaData();
             AutoTuneWorkFlow autoTuneWorkFlow = experimentMetaData.getAutoTuneWorkFlow();
             if (null == autoTuneWorkFlow) {
-                autoTuneWorkFlow = new AutoTuneWorkFlow(experimentTrial.getExperimentSettings().isDo_experiments(),
+                autoTuneWorkFlow = new AutoTuneWorkFlow(experimentTrial.getExperimentSettings().isDo_experiment(),
                         experimentTrial.getExperimentSettings().isDo_monitoring(),
                         experimentTrial.getExperimentSettings().isWait_for_load(),
                         experimentTrial.getTrialResultURL());     //Check Workflow is Experiment or Monitoring Workflow

--- a/src/main/java/com/autotune/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/utils/AnalyzerConstants.java
@@ -101,6 +101,11 @@ public class AnalyzerConstants {
 		public static final String MATCH_SERVICE = "matchService";
 
 		public static final String MODE = "mode";
+		public static final String DEFAULT_MODE = "experiment";
+
+		public static final String TARGET_CLUSTER = "targetCluster";
+		public static final String DEFAULT_TARGET_CLUSTER = "local";
+
 		public static final String METADATA = "metadata";
 		public static final String NAMESPACE = "namespace";
 		public static final String EXPERIMENT_ID = "experiment_id";

--- a/src/main/java/com/autotune/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/utils/AnalyzerErrorConstants.java
@@ -51,6 +51,7 @@ public class AnalyzerErrorConstants {
 		public static final String FUNCTION_VARIABLES_EMPTY = "function_variables is empty\n";
 		public static final String OBJECTIVE_FUNCTION_MISSING = "objective_function missing\n";
 		public static final String MODE_NOT_SUPPORTED = "Autotune object mode not supported\n";
+		public static final String TARGET_CLUSTER_NOT_SUPPORTED = "Autotune object targetCluster not supported\n";
 		public static final String HPO_ALGO_NOT_SUPPORTED = "HPO algorithm not supported\n";
 		public static final String INVALID_OBJECTIVE_FUNCTION = "objective_function improperly formatted\n";
 		public static final String OBJECTIVE_FUNCTION_MAP_MISSING = "objective_function_map is missing or empty\n";

--- a/src/main/java/com/autotune/utils/AutotuneSupportedTypes.java
+++ b/src/main/java/com/autotune/utils/AutotuneSupportedTypes.java
@@ -33,7 +33,10 @@ public class AutotuneSupportedTypes
 			new HashSet<>(Arrays.asList("prometheus"));
 
 	public static final Set<String> MODES_SUPPORTED =
-			new HashSet<>(Arrays.asList("show", "try", "apply"));
+			new HashSet<>(Arrays.asList("experiment", "monitor"));
+
+	public static final Set<String> TARGET_CLUSTERS_SUPPORTED =
+			new HashSet<>(Arrays.asList("local", "remote"));
 
 	public static final Set<String> PRESENCE_SUPPORTED =
 			new HashSet<>(Arrays.asList("always", "", null));


### PR DESCRIPTION
1. mode will now be used to determine whether autotune will run an experiment or just do monitoring
2. targetCluster will indicate whether we are dealing with a local or a remote cluster.

Signed-off-by: Dinakar Guniguntala <dgunigun@redhat.com>