### PR TITLE
Change ENV_VAR from AUTOTUNE_PORT to AUTOTUNE_SERVER_PORT

### DIFF
--- a/src/main/java/com/autotune/Autotune.java
+++ b/src/main/java/com/autotune/Autotune.java
@@ -25,15 +25,12 @@ import com.autotune.utils.AutotuneConstants;
 import io.prometheus.client.exporter.MetricsServlet;
 import io.prometheus.client.hotspot.DefaultExports;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.servlet.ErrorPageErrorHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.autotune.utils.ServerContext.*;
-
-import javax.servlet.http.HttpServletResponse;
 
 public class Autotune
 {
@@ -45,7 +42,7 @@ public class Autotune
 
 		disableServerLogging();
 
-		Server server = new Server(AUTOTUNE_PORT);
+		Server server = new Server(AUTOTUNE_SERVER_PORT);
 		context = new ServletContextHandler();
 		context.setContextPath(ServerContext.ROOT_CONTEXT);
 		context.setErrorHandler(new AutotuneErrorHandler());

--- a/src/main/java/com/autotune/utils/ServerContext.java
+++ b/src/main/java/com/autotune/utils/ServerContext.java
@@ -19,8 +19,8 @@ package com.autotune.utils;
  * Holds the server context of the dependency analyzer.
  */
 public class ServerContext {
-    public static final int AUTOTUNE_PORT = Integer.parseInt(System.getenv().getOrDefault("AUTOTUNE_PORT", "8080"));
-    public static final int HPO_PORT = 8085;
+    public static final int AUTOTUNE_SERVER_PORT = Integer.parseInt(System.getenv().getOrDefault("AUTOTUNE_SERVER_PORT", "8080"));
+    public static final int HPO_SERVER_PORT = 8085;
 
     // AnalyzerConstants end points
     public static final String ROOT_CONTEXT = "/";
@@ -39,23 +39,23 @@ public class ServerContext {
     public static final String CREATE_PERF_PROFILE = ROOT_CONTEXT + "createPerformanceProfile";
 
 
-    public static final String AUTOTUNE_SERVER_PORT = "http://localhost:" + AUTOTUNE_PORT;
-    public static final String SEARCH_SPACE_END_POINT = AUTOTUNE_SERVER_PORT + SEARCH_SPACE;
-    public static final String LIST_EXPERIMENTS_END_POINT = AUTOTUNE_SERVER_PORT + LIST_EXPERIMENTS;
-    public static final String UPDATE_RESULTS_END_POINT = AUTOTUNE_SERVER_PORT + UPDATE_RESULTS;
+    public static final String AUTOTUNE_SERVER_URL = "http://localhost:" + AUTOTUNE_SERVER_PORT;
+    public static final String SEARCH_SPACE_END_POINT = AUTOTUNE_SERVER_URL + SEARCH_SPACE;
+    public static final String LIST_EXPERIMENTS_END_POINT = AUTOTUNE_SERVER_URL + LIST_EXPERIMENTS;
+    public static final String UPDATE_RESULTS_END_POINT = AUTOTUNE_SERVER_URL + UPDATE_RESULTS;
 
     // HPO End Points
-    public static final String HPO_SERVER_PORT = "http://localhost:" + HPO_PORT;
+    public static final String HPO_SERVER_URL = "http://localhost:" + HPO_SERVER_PORT;
     public static final String HPO_TRIALS = ROOT_CONTEXT + "experiment_trials";
-    public static final String HPO_TRIALS_END_POINT = HPO_SERVER_PORT + HPO_TRIALS;
+    public static final String HPO_TRIALS_END_POINT = HPO_SERVER_URL + HPO_TRIALS;
 
-    public static final String EXPERIMENT_MANAGER_SERVER_PORT = "http://localhost:" + AUTOTUNE_PORT;
+    public static final String EXPERIMENT_MANAGER_SERVER_URL = "http://localhost:" + AUTOTUNE_SERVER_PORT;
     public static final String EXPERIMENT_MANAGER_CREATE_TRIAL = ROOT_CONTEXT + "createExperimentTrial";
-    public static final String EXPERIMENT_MANAGER_CREATE_TRIAL_END_POINT = EXPERIMENT_MANAGER_SERVER_PORT + EXPERIMENT_MANAGER_CREATE_TRIAL;
+    public static final String EXPERIMENT_MANAGER_CREATE_TRIAL_END_POINT = EXPERIMENT_MANAGER_SERVER_URL + EXPERIMENT_MANAGER_CREATE_TRIAL;
     public static final String EXPERIMENT_MANAGER_LIST_EXPERIMENT_TRIAL = ROOT_CONTEXT + "listExperimentTrial";
-    public static final String EXPERIMENT_MANAGER_LIST_EXPERIMENT_END_POINT = EXPERIMENT_MANAGER_SERVER_PORT + EXPERIMENT_MANAGER_LIST_EXPERIMENT_TRIAL;
+    public static final String EXPERIMENT_MANAGER_LIST_EXPERIMENT_END_POINT = EXPERIMENT_MANAGER_SERVER_URL + EXPERIMENT_MANAGER_LIST_EXPERIMENT_TRIAL;
     public static final String EXPERIMENT_MANAGER_LIST_TRIAL_STATUS = ROOT_CONTEXT + "listTrialStatus";
-    public static final String EXPERIMENT_MANAGER_LIST_TRIAL_STATUS_END_POINT = EXPERIMENT_MANAGER_SERVER_PORT + EXPERIMENT_MANAGER_LIST_TRIAL_STATUS;
+    public static final String EXPERIMENT_MANAGER_LIST_TRIAL_STATUS_END_POINT = EXPERIMENT_MANAGER_SERVER_URL + EXPERIMENT_MANAGER_LIST_TRIAL_STATUS;
 
     // UI support EndPoints
     public static final String QUERY_CONTEXT = ROOT_CONTEXT + "query/";


### PR DESCRIPTION
This is causing autotune to fail to come up as manifests already refer to AUTOTUNE_PORT

Signed-off-by: Dinakar Guniguntala <dgunigun@redhat.com>