### PR TITLE
Reverting to requests and limits

### DIFF
--- a/design/MonitoringModeAPI.md
+++ b/design/MonitoringModeAPI.md
@@ -351,7 +351,7 @@ List recommendations output JSON as follows. Some parameters like CPU limit , EN
                                     "pods_count": 0,
                                     "confidence_level": 0.0,
                                     "config": {
-                                        "max": {
+                                        "limits": {
                                             "memory": {
                                                 "amount": 982.5997506234414,
                                                 "format": ""
@@ -361,7 +361,7 @@ List recommendations output JSON as follows. Some parameters like CPU limit , EN
                                                 "format": ""
                                             }
                                         },
-                                        "capacity": {
+                                        "requests": {
                                             "memory": {
                                                 "amount": 123.6,
                                                 "format": ""
@@ -398,7 +398,7 @@ List recommendations output JSON as follows. Some parameters like CPU limit , EN
                                     "pods_count": 0,
                                     "confidence_level": 0.0,
                                     "config": {
-                                        "max": {
+                                        "limits": {
                                             "memory": {
                                                 "amount": 982.5997506234414,
                                                 "format": ""
@@ -408,7 +408,7 @@ List recommendations output JSON as follows. Some parameters like CPU limit , EN
                                                 "format": ""
                                             }
                                         },
-                                        "capacity": {
+                                        "requests": {
                                             "memory": {
                                                 "amount": 123.6,
                                                 "format": ""

--- a/src/main/java/com/autotune/analyzer/utils/GenerateRecommendation.java
+++ b/src/main/java/com/autotune/analyzer/utils/GenerateRecommendation.java
@@ -68,15 +68,15 @@ public class GenerateRecommendation {
                                     .collect((Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
                             System.out.println(filteredResultsMap);
                             Recommendation recommendation = new Recommendation(monitorStartDate, monitorEndDate);
-                            HashMap<AnalyzerConstants.CapacityMax, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> config = new HashMap<>();
-                            HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> capacityMap = new HashMap<>();
-                            capacityMap.put(AnalyzerConstants.RecommendationItem.cpu, getCPUCapacityRecommendation(filteredResultsMap));
-                            capacityMap.put(AnalyzerConstants.RecommendationItem.memory, getMemoryCapacityRecommendation(filteredResultsMap));
-                            config.put(AnalyzerConstants.CapacityMax.capacity, capacityMap);
-                            HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> maxMap = new HashMap<>();
-                            maxMap.put(AnalyzerConstants.RecommendationItem.cpu, getCPUMaxRecommendation(filteredResultsMap));
-                            maxMap.put(AnalyzerConstants.RecommendationItem.memory, getMemoryMaxRecommendation(filteredResultsMap));
-                            config.put(AnalyzerConstants.CapacityMax.max, maxMap);
+                            HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> config = new HashMap<>();
+                            HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> requestsMap = new HashMap<>();
+                            requestsMap.put(AnalyzerConstants.RecommendationItem.cpu, getCPUCapacityRecommendation(filteredResultsMap));
+                            requestsMap.put(AnalyzerConstants.RecommendationItem.memory, getMemoryCapacityRecommendation(filteredResultsMap));
+                            config.put(AnalyzerConstants.ResourceSetting.requests, requestsMap);
+                            HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> limitsMap = new HashMap<>();
+                            limitsMap.put(AnalyzerConstants.RecommendationItem.cpu, getCPUMaxRecommendation(filteredResultsMap));
+                            limitsMap.put(AnalyzerConstants.RecommendationItem.memory, getMemoryMaxRecommendation(filteredResultsMap));
+                            config.put(AnalyzerConstants.ResourceSetting.limits, limitsMap);
                             Double hours = filteredResultsMap.values().stream().map((x) -> (x.getDurationInMinutes()))
                                     .collect(Collectors.toList())
                                     .stream()

--- a/src/main/java/com/autotune/common/data/result/Recommendation.java
+++ b/src/main/java/com/autotune/common/data/result/Recommendation.java
@@ -38,7 +38,7 @@ public class Recommendation {
     @SerializedName(AutotuneConstants.JSONKeys.ERROR_MSG)
     private String errorMessage;
 
-    private HashMap<AnalyzerConstants.CapacityMax, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> config;
+    private HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> config;
 
     public Recommendation(Timestamp monitoringStartTime, Timestamp monitoringEndTime) {
         this.monitoringStartTime = monitoringStartTime;
@@ -89,11 +89,11 @@ public class Recommendation {
         this.confidence_level = confidence_level;
     }
 
-    public HashMap<AnalyzerConstants.CapacityMax, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> getConfig() {
+    public HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> getConfig() {
         return config;
     }
 
-    public void setConfig(HashMap<AnalyzerConstants.CapacityMax, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> config) {
+    public void setConfig(HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> config) {
         this.config = config;
     }
 

--- a/src/main/java/com/autotune/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/utils/AnalyzerConstants.java
@@ -129,6 +129,11 @@ public class AnalyzerConstants {
         max
     }
 
+    public enum ResourceSetting {
+        requests,
+        limits
+    }
+
     public enum MetricName {
         cpuRequest,
         cpuLimit,


### PR DESCRIPTION
This change reverts back the changes for `resource settings`

`capacity` -> `requests`
`max` -> `limits`