### PR TITLE
Fix cors issue for UI to access the API's

### DIFF
--- a/src/main/java/com/autotune/analyzer/services/CreateExperiment.java
+++ b/src/main/java/com/autotune/analyzer/services/CreateExperiment.java
@@ -76,6 +76,8 @@ public class CreateExperiment extends HttpServlet {
 
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        // Adding CORS headers as this API is accessed by UI
+        Utils.addCORSHeaders(response);
         try {
             String inputData = request.getReader().lines().collect(Collectors.joining());
             List<CreateExperimentSO> experimentSOList = Arrays.asList(new Gson().fromJson(inputData, CreateExperimentSO[].class));

--- a/src/main/java/com/autotune/analyzer/services/ListDeploymentsInNamespace.java
+++ b/src/main/java/com/autotune/analyzer/services/ListDeploymentsInNamespace.java
@@ -18,6 +18,7 @@ package com.autotune.analyzer.services;
 import com.autotune.common.target.kubernetes.service.KubernetesServices;
 import com.autotune.common.target.kubernetes.service.impl.KubernetesServicesImpl;
 import com.autotune.utils.AutotuneConstants;
+import com.autotune.utils.Utils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -29,13 +30,10 @@ import java.util.stream.Collectors;
 public class ListDeploymentsInNamespace extends HttpServlet {
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) {
+        // Adding CORS headers as this API is accessed by UI
+        Utils.addCORSHeaders(response);
         KubernetesServices kubernetesServices = null;
         try {
-            // Add headers to avoid CORS
-            response.addHeader("Access-Control-Allow-Origin", "*");
-            response.addHeader("Access-Control-Allow-Methods", "POST, GET");
-            response.addHeader("Access-Control-Allow-Headers", "X-PINGOTHER, Origin, X-Requested-With, Content-Type, Accept");
-            response.addHeader("Access-Control-Max-Age", "1728000");
             // Set content type
             response.setContentType("application/json");
             // Set encoding

--- a/src/main/java/com/autotune/analyzer/services/ListExperiments.java
+++ b/src/main/java/com/autotune/analyzer/services/ListExperiments.java
@@ -27,6 +27,7 @@ import com.autotune.common.target.kubernetes.service.KubernetesServices;
 import com.autotune.experimentManager.exceptions.IncompatibleInputJSONException;
 import com.autotune.utils.AnalyzerConstants;
 import com.autotune.utils.TrialHelpers;
+import com.autotune.utils.Utils;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.json.JSONArray;
@@ -64,6 +65,8 @@ public class ListExperiments extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        // Adding CORS headers as this API is accessed by UI
+        Utils.addCORSHeaders(response);
         response.setStatus(HttpServletResponse.SC_OK);
         response.setContentType(JSON_CONTENT_TYPE);
         response.setCharacterEncoding(CHARACTER_ENCODING);
@@ -96,6 +99,8 @@ public class ListExperiments extends HttpServlet {
     //TODO this function no more used.
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        // Adding CORS headers as this API is accessed by UI
+        Utils.addCORSHeaders(response);
         response.setStatus(HttpServletResponse.SC_OK);
         response.setContentType(JSON_CONTENT_TYPE);
         response.setCharacterEncoding(CHARACTER_ENCODING);

--- a/src/main/java/com/autotune/analyzer/services/ListNamespaces.java
+++ b/src/main/java/com/autotune/analyzer/services/ListNamespaces.java
@@ -18,6 +18,7 @@ package com.autotune.analyzer.services;
 import com.autotune.common.target.kubernetes.service.KubernetesServices;
 import com.autotune.common.target.kubernetes.service.impl.KubernetesServicesImpl;
 import com.autotune.utils.AutotuneConstants;
+import com.autotune.utils.Utils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -28,15 +29,12 @@ import javax.servlet.http.HttpServletResponse;
 public class ListNamespaces extends HttpServlet {
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) {
+        // Adding CORS headers as this API is accessed by UI
+        Utils.addCORSHeaders(response);
         KubernetesServices kubernetesServices = null;
         try {
             // Initialising the kubernetes service
             kubernetesServices = new KubernetesServicesImpl();
-            // Set response headers
-            response.addHeader("Access-Control-Allow-Origin", "*");
-            response.addHeader("Access-Control-Allow-Methods", "POST, GET");
-            response.addHeader("Access-Control-Allow-Headers", "X-PINGOTHER, Origin, X-Requested-With, Content-Type, Accept");
-            response.addHeader("Access-Control-Max-Age", "1728000");
             JSONObject returnJson = new JSONObject();
             JSONObject dataJson = new JSONObject();
             JSONArray namespacesList = new JSONArray();

--- a/src/main/java/com/autotune/analyzer/services/ListRecommendation.java
+++ b/src/main/java/com/autotune/analyzer/services/ListRecommendation.java
@@ -63,6 +63,8 @@ public class ListRecommendation extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        // Adding CORS headers as this API is accessed by UI
+        Utils.addCORSHeaders(response);
         response.setContentType(JSON_CONTENT_TYPE);
         response.setCharacterEncoding(CHARACTER_ENCODING);
         response.setStatus(HttpServletResponse.SC_OK);

--- a/src/main/java/com/autotune/analyzer/services/ListStackLayers.java
+++ b/src/main/java/com/autotune/analyzer/services/ListStackLayers.java
@@ -21,6 +21,7 @@ import com.autotune.analyzer.deployment.KruizeDeployment;
 import com.autotune.common.k8sObjects.AutotuneConfig;
 import com.autotune.common.k8sObjects.KruizeObject;
 import com.autotune.utils.AnalyzerConstants;
+import com.autotune.utils.Utils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -134,6 +135,8 @@ public class ListStackLayers extends HttpServlet {
      */
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        // Adding CORS headers as this API is accessed by UI
+        Utils.addCORSHeaders(response);
         response.setStatus(HttpServletResponse.SC_OK);
         response.setContentType(JSON_CONTENT_TYPE);
         response.setCharacterEncoding(CHARACTER_ENCODING);

--- a/src/main/java/com/autotune/analyzer/services/PerformanceProfileService.java
+++ b/src/main/java/com/autotune/analyzer/services/PerformanceProfileService.java
@@ -24,6 +24,7 @@ import com.autotune.common.performanceProfiles.PerformanceProfile;
 import com.autotune.common.performanceProfiles.PerformanceProfileInterface.PerfProfileImpl;
 import com.autotune.utils.AnalyzerConstants;
 import com.autotune.utils.AnalyzerErrorConstants;
+import com.autotune.utils.Utils;
 import com.google.gson.ExclusionStrategy;
 import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
@@ -77,6 +78,8 @@ public class PerformanceProfileService extends HttpServlet {
 
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        // Adding CORS headers as this API is accessed by UI
+        Utils.addCORSHeaders(response);
         try {
             String inputData = request.getReader().lines().collect(Collectors.joining());
             PerformanceProfile performanceProfile = new Gson().fromJson(inputData, PerformanceProfile.class);
@@ -102,6 +105,8 @@ public class PerformanceProfileService extends HttpServlet {
      */
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse response) throws ServletException, IOException {
+        // Adding CORS headers as this API is accessed by UI
+        Utils.addCORSHeaders(response);
         response.setContentType(JSON_CONTENT_TYPE);
         response.setCharacterEncoding(CHARACTER_ENCODING);
         response.setStatus(HttpServletResponse.SC_OK);
@@ -144,6 +149,8 @@ public class PerformanceProfileService extends HttpServlet {
      */
     @Override
     protected void doPut(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        // Adding CORS headers as this API is accessed by UI
+        Utils.addCORSHeaders(resp);
         super.doPut(req, resp);
     }
 
@@ -156,6 +163,8 @@ public class PerformanceProfileService extends HttpServlet {
      */
     @Override
     protected void doDelete(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        // Adding CORS headers as this API is accessed by UI
+        Utils.addCORSHeaders(resp);
         super.doDelete(req, resp);
     }
 

--- a/src/main/java/com/autotune/analyzer/services/UpdateResults.java
+++ b/src/main/java/com/autotune/analyzer/services/UpdateResults.java
@@ -63,6 +63,8 @@ public class UpdateResults extends HttpServlet {
 
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        // Adding CORS headers as this API is accessed by UI
+        Utils.addCORSHeaders(response);
         try {
             String inputData = request.getReader().lines().collect(Collectors.joining());
             List<ExperimentResultData> experimentResultDataList = new ArrayList<ExperimentResultData>();

--- a/src/main/java/com/autotune/utils/Utils.java
+++ b/src/main/java/com/autotune/utils/Utils.java
@@ -25,6 +25,7 @@ import com.autotune.common.k8sObjects.DeploymentObject;
 import com.autotune.common.k8sObjects.K8sObject;
 import com.autotune.common.k8sObjects.KruizeObject;
 
+import javax.servlet.http.HttpServletResponse;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.ArrayList;
@@ -141,6 +142,15 @@ public class Utils
 			return AnalyzerConstants.MetricName.memoryRSS;
 
 		return null;
+	}
+
+	public static void addCORSHeaders(HttpServletResponse response) {
+		if (null != response) {
+			response.addHeader("Access-Control-Allow-Origin", "*");
+			response.addHeader("Access-Control-Allow-Methods", "POST, GET");
+			response.addHeader("Access-Control-Allow-Headers", "X-PINGOTHER, Origin, X-Requested-With, Content-Type, Accept");
+			response.addHeader("Access-Control-Max-Age", "1728000");
+		}
 	}
 
 	public static class Converters {

--- a/src/main/java/com/autotune/utils/Utils.java
+++ b/src/main/java/com/autotune/utils/Utils.java
@@ -144,6 +144,8 @@ public class Utils
 		return null;
 	}
 
+	// TODO: Ideally CORS should be added as web filter but for a quick fix we are adding headers
+	// Need to add CORSFilter in xml in future when moving to web filter way of fixing cors, this method should not be used after that change
 	public static void addCORSHeaders(HttpServletResponse response) {
 		if (null != response) {
 			response.addHeader("Access-Control-Allow-Origin", "*");


### PR DESCRIPTION
@dinogun Currently the UI is not able to access these API's as UI and kruize are running on different domains. This is a temporary change as we need to move towards a web filter model once we finalise API scope (which API are internal and which are client facing or external).

I have added todos mentioning this current patch should not be used after implementing a web filter.

I'm currently making it draft as I would like to get feedback from bhanvi upon testing it with front end.