### PR TITLE
Use a separate naming tag for CRC container images

### DIFF
--- a/manifests/crc/kruize-crc-minikube.yaml
+++ b/manifests/crc/kruize-crc-minikube.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: kruize
-        image: "kruize/autotune_operator:0.0.9_mvp"
+        image: "kruize/autotune_operator:0.0.8_rm"
         imagePullPolicy: Always
         env:
           - name: CLUSTER_TYPE

--- a/manifests/crc/kruize-crc-openshift.yaml
+++ b/manifests/crc/kruize-crc-openshift.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: kruize
-        image: "kruize/autotune_operator:0.0.9_mvp"
+        image: "kruize/autotune_operator:0.0.8_rm"
         imagePullPolicy: Always
         env:
           - name: CLUSTER_TYPE


### PR DESCRIPTION
This ensures that they do not get overwritten during regular build/test cycles.