### PR TITLE
Added switch case and Recommendation sub category

### DIFF
--- a/src/main/java/com/autotune/analyzer/data/DurationBasedRecommendationSubCategory.java
+++ b/src/main/java/com/autotune/analyzer/data/DurationBasedRecommendationSubCategory.java
@@ -1,3 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
 package com.autotune.analyzer.data;
 
 import java.util.concurrent.TimeUnit;

--- a/src/main/java/com/autotune/analyzer/data/DurationBasedRecommendationSubCategory.java
+++ b/src/main/java/com/autotune/analyzer/data/DurationBasedRecommendationSubCategory.java
@@ -1,0 +1,33 @@
+package com.autotune.analyzer.data;
+
+import java.util.concurrent.TimeUnit;
+
+public class DurationBasedRecommendationSubCategory implements RecommendationSubCategory{
+    private String name;
+    private int duration;
+    private TimeUnit recommendationDurationUnits;
+
+    public DurationBasedRecommendationSubCategory(String name, int duration, TimeUnit recommendationDurationUnits) {
+        this.name = name;
+        this.duration = duration;
+        this.recommendationDurationUnits = recommendationDurationUnits;
+    }
+
+    // Adding private constructor to avoid object creation without passing any attributes
+    private DurationBasedRecommendationSubCategory() {
+
+    }
+
+    public int getDuration() {
+        return this.duration;
+    }
+
+    public TimeUnit getRecommendationDurationUnits() {
+        return this.recommendationDurationUnits;
+    }
+
+    @Override
+    public String getSubCategory() {
+        return this.name;
+    }
+}

--- a/src/main/java/com/autotune/analyzer/data/ProfileBasedRecommendationSubCategory.java
+++ b/src/main/java/com/autotune/analyzer/data/ProfileBasedRecommendationSubCategory.java
@@ -1,0 +1,9 @@
+package com.autotune.analyzer.data;
+
+public class ProfileBasedRecommendationSubCategory implements RecommendationSubCategory{
+    // TODO: Need to be implemented
+    @Override
+    public String getSubCategory() {
+        return null;
+    }
+}

--- a/src/main/java/com/autotune/analyzer/data/ProfileBasedRecommendationSubCategory.java
+++ b/src/main/java/com/autotune/analyzer/data/ProfileBasedRecommendationSubCategory.java
@@ -1,3 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
 package com.autotune.analyzer.data;
 
 public class ProfileBasedRecommendationSubCategory implements RecommendationSubCategory{

--- a/src/main/java/com/autotune/analyzer/data/RecommendationSubCategory.java
+++ b/src/main/java/com/autotune/analyzer/data/RecommendationSubCategory.java
@@ -1,0 +1,11 @@
+package com.autotune.analyzer.data;
+
+/**
+ * Interface to add the recommendation sub-category
+ *
+ * Example:
+ * Duration Based recommendations has sub categories like `short term`, `medium term`, `long term`
+ */
+public interface RecommendationSubCategory {
+    public String getSubCategory();
+}

--- a/src/main/java/com/autotune/analyzer/data/RecommendationSubCategory.java
+++ b/src/main/java/com/autotune/analyzer/data/RecommendationSubCategory.java
@@ -1,3 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
 package com.autotune.analyzer.data;
 
 /**

--- a/src/main/java/com/autotune/analyzer/utils/GenerateRecommendation.java
+++ b/src/main/java/com/autotune/analyzer/utils/GenerateRecommendation.java
@@ -62,13 +62,10 @@ public class GenerateRecommendation {
                                     monitorStartDate = addDays(monitorEndDate, -1 * days);
                                     if (monitorStartDate.compareTo(minDate) >= 0 || days == 1) {
                                         Timestamp finalMonitorStartDate = monitorStartDate;
-                                        System.out.println(finalMonitorStartDate);
-                                        System.out.println(monitorEndDate);
                                         Map<Timestamp, StartEndTimeStampResults> filteredResultsMap = containerObject.getResults().entrySet().stream()
                                                 .filter((x -> ((x.getKey().compareTo(finalMonitorStartDate) >= 0)
                                                         && (x.getKey().compareTo(monitorEndDate) <= 0))))
                                                 .collect((Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-                                        System.out.println(filteredResultsMap);
                                         Recommendation recommendation = new Recommendation(monitorStartDate, monitorEndDate);
                                         HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> config = new HashMap<>();
                                         HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> requestsMap = new HashMap<>();
@@ -106,7 +103,6 @@ public class GenerateRecommendation {
                         containerRecommendationMap = new HashMap<>();
                     containerRecommendationMap.put(monitorEndDate, recCatMap);
                     containerObject.setRecommendations(containerRecommendationMap);
-                    System.out.println(containerRecommendationMap);
                 }
             }
         } catch (Exception e) {

--- a/src/main/java/com/autotune/analyzer/utils/GenerateRecommendation.java
+++ b/src/main/java/com/autotune/analyzer/utils/GenerateRecommendation.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package com.autotune.analyzer.utils;
 
+import com.autotune.analyzer.data.DurationBasedRecommendationSubCategory;
+import com.autotune.analyzer.data.RecommendationSubCategory;
 import com.autotune.common.data.result.Recommendation;
 import com.autotune.common.data.result.RecommendationConfigItem;
 import com.autotune.common.data.result.RecommendationNotification;
@@ -38,19 +40,11 @@ import java.util.stream.Collectors;
 public class GenerateRecommendation {
     private static final Logger LOGGER = LoggerFactory.getLogger(GenerateRecommendation.class);
 
-    private static Map<String, Integer> recommendation_periods = new HashMap<>();
-
-
     public static void generateRecommendation(KruizeObject kruizeObject) {
         try {
-            recommendation_periods.put(AutotuneConstants.JSONKeys.SHORT_TERM, 1);
-            recommendation_periods.put(AutotuneConstants.JSONKeys.MEDIUM_TERM, 7);
-            recommendation_periods.put(AutotuneConstants.JSONKeys.LONG_TERM, 15);
-
             for (String dName : kruizeObject.getDeployments().keySet()) {
                 DeploymentObject deploymentObj = kruizeObject.getDeployments().get(dName);
                 for (String cName : deploymentObj.getContainers().keySet()) {
-                    System.out.println(cName);
                     ContainerObject containerObject = deploymentObj.getContainers().get(cName);
                     Timestamp monitorEndDate = containerObject.getResults().keySet().stream().max(Timestamp::compareTo).get();
                     Timestamp minDate = containerObject.getResults().keySet().stream().min(Timestamp::compareTo).get();
@@ -58,48 +52,53 @@ public class GenerateRecommendation {
                     HashMap<String,HashMap<String, Recommendation>> recCatMap = new HashMap<String, HashMap<String, Recommendation>>();
                     for (AnalyzerConstants.RecommendationCategory recommendationCategory : AnalyzerConstants.RecommendationCategory.values()) {
                         HashMap<String, Recommendation> recommendationPeriodMap = new HashMap<>();
-                        // TODO: add appropriate sub functions and call via switch case
-                        if (recommendationCategory.getName().equalsIgnoreCase(AutotuneConstants.JSONKeys.DURATION_BASED)) {
-                            for (String recPeriod : recommendation_periods.keySet()) {
-                                int days = recommendation_periods.get(recPeriod);
-                                monitorStartDate = addDays(monitorEndDate, -1 * days);
-                                if (monitorStartDate.compareTo(minDate) >= 0 || days == 1) {
-                                    Timestamp finalMonitorStartDate = monitorStartDate;
-                                    System.out.println(finalMonitorStartDate);
-                                    System.out.println(monitorEndDate);
-                                    Map<Timestamp, StartEndTimeStampResults> filteredResultsMap = containerObject.getResults().entrySet().stream()
-                                            .filter((x -> ((x.getKey().compareTo(finalMonitorStartDate) >= 0)
-                                                    && (x.getKey().compareTo(monitorEndDate) <= 0))))
-                                            .collect((Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-                                    System.out.println(filteredResultsMap);
-                                    Recommendation recommendation = new Recommendation(monitorStartDate, monitorEndDate);
-                                    HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> config = new HashMap<>();
-                                    HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> requestsMap = new HashMap<>();
-                                    requestsMap.put(AnalyzerConstants.RecommendationItem.cpu, getCPUCapacityRecommendation(filteredResultsMap));
-                                    requestsMap.put(AnalyzerConstants.RecommendationItem.memory, getMemoryCapacityRecommendation(filteredResultsMap));
-                                    config.put(AnalyzerConstants.ResourceSetting.requests, requestsMap);
-                                    HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> limitsMap = new HashMap<>();
-                                    limitsMap.put(AnalyzerConstants.RecommendationItem.cpu, getCPUMaxRecommendation(filteredResultsMap));
-                                    limitsMap.put(AnalyzerConstants.RecommendationItem.memory, getMemoryMaxRecommendation(filteredResultsMap));
-                                    config.put(AnalyzerConstants.ResourceSetting.limits, limitsMap);
-                                    Double hours = filteredResultsMap.values().stream().map((x) -> (x.getDurationInMinutes()))
-                                            .collect(Collectors.toList())
-                                            .stream()
-                                            .mapToDouble(f -> f.doubleValue()).sum() / 60;
-                                    recommendation.setDuration_in_hours(hours);
-                                    recommendation.setConfig(config);
-                                    recommendationPeriodMap.put(recPeriod, recommendation);
-                                } else {
-                                    RecommendationNotification notification = new RecommendationNotification(
-                                            AnalyzerConstants.RecommendationNotificationTypes.INFO.getName(),
-                                            AnalyzerConstants.RecommendationNotificationMsgConstant.NOT_ENOUGH_DATA);
-                                    recommendationPeriodMap.put(recPeriod, new Recommendation(notification));
+                        // TODO: Add all possible cases which are added in RecommendationCategory
+                        switch (recommendationCategory) {
+                            case DURATION_BASED:
+                                for (RecommendationSubCategory recommendationSubCategory : recommendationCategory.getRecommendationSubCategories()) {
+                                    DurationBasedRecommendationSubCategory durationBasedRecommendationSubCategory = (DurationBasedRecommendationSubCategory) recommendationSubCategory;
+                                    String recPeriod = durationBasedRecommendationSubCategory.getSubCategory();
+                                    int days = durationBasedRecommendationSubCategory.getDuration();
+                                    monitorStartDate = addDays(monitorEndDate, -1 * days);
+                                    if (monitorStartDate.compareTo(minDate) >= 0 || days == 1) {
+                                        Timestamp finalMonitorStartDate = monitorStartDate;
+                                        System.out.println(finalMonitorStartDate);
+                                        System.out.println(monitorEndDate);
+                                        Map<Timestamp, StartEndTimeStampResults> filteredResultsMap = containerObject.getResults().entrySet().stream()
+                                                .filter((x -> ((x.getKey().compareTo(finalMonitorStartDate) >= 0)
+                                                        && (x.getKey().compareTo(monitorEndDate) <= 0))))
+                                                .collect((Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+                                        System.out.println(filteredResultsMap);
+                                        Recommendation recommendation = new Recommendation(monitorStartDate, monitorEndDate);
+                                        HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> config = new HashMap<>();
+                                        HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> requestsMap = new HashMap<>();
+                                        requestsMap.put(AnalyzerConstants.RecommendationItem.cpu, getCPUCapacityRecommendation(filteredResultsMap));
+                                        requestsMap.put(AnalyzerConstants.RecommendationItem.memory, getMemoryCapacityRecommendation(filteredResultsMap));
+                                        config.put(AnalyzerConstants.ResourceSetting.requests, requestsMap);
+                                        HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> limitsMap = new HashMap<>();
+                                        limitsMap.put(AnalyzerConstants.RecommendationItem.cpu, getCPUMaxRecommendation(filteredResultsMap));
+                                        limitsMap.put(AnalyzerConstants.RecommendationItem.memory, getMemoryMaxRecommendation(filteredResultsMap));
+                                        config.put(AnalyzerConstants.ResourceSetting.limits, limitsMap);
+                                        Double hours = filteredResultsMap.values().stream().map((x) -> (x.getDurationInMinutes()))
+                                                .collect(Collectors.toList())
+                                                .stream()
+                                                .mapToDouble(f -> f.doubleValue()).sum() / 60;
+                                        recommendation.setDuration_in_hours(hours);
+                                        recommendation.setConfig(config);
+                                        recommendationPeriodMap.put(recPeriod, recommendation);
+                                    } else {
+                                        RecommendationNotification notification = new RecommendationNotification(
+                                                AnalyzerConstants.RecommendationNotificationTypes.INFO.getName(),
+                                                AnalyzerConstants.RecommendationNotificationMsgConstant.NOT_ENOUGH_DATA);
+                                        recommendationPeriodMap.put(recPeriod, new Recommendation(notification));
+                                    }
                                 }
-                            }
-                            // This needs to be moved to common area after implementing other categories of recommedations
-                            recCatMap.put(recommendationCategory.getName(), recommendationPeriodMap);
-                        } else if (recommendationCategory.getName().equalsIgnoreCase(AutotuneConstants.JSONKeys.PROFILE_BASED)) {
-                            // TODO: Needs to be implemented
+                                // This needs to be moved to common area after implementing other categories of recommedations
+                                recCatMap.put(recommendationCategory.getName(), recommendationPeriodMap);
+                                break;
+                            case PROFILE_BASED:
+                                // Need to be implemented
+                                break;
                         }
                     }
                     HashMap<Timestamp, HashMap<String,HashMap<String, Recommendation>>>  containerRecommendationMap = containerObject.getRecommendations();

--- a/src/main/java/com/autotune/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/utils/AnalyzerConstants.java
@@ -15,7 +15,12 @@
  *******************************************************************************/
 package com.autotune.utils;
 
+import com.autotune.analyzer.data.DurationBasedRecommendationSubCategory;
+import com.autotune.analyzer.data.ProfileBasedRecommendationSubCategory;
+import com.autotune.analyzer.data.RecommendationSubCategory;
+
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 /**
@@ -148,16 +153,43 @@ public class AnalyzerConstants {
     }
 
     public enum RecommendationCategory {
-        DURATION_BASED(AutotuneConstants.JSONKeys.DURATION_BASED),
-        PROFILE_BASED(AutotuneConstants.JSONKeys.PROFILE_BASED);
+        DURATION_BASED(
+                AutotuneConstants.JSONKeys.DURATION_BASED,
+                new DurationBasedRecommendationSubCategory[]{
+                        new DurationBasedRecommendationSubCategory(
+                                AutotuneConstants.JSONKeys.SHORT_TERM,
+                                1,
+                                TimeUnit.DAYS
+                        ),
+                        new DurationBasedRecommendationSubCategory(
+                                AutotuneConstants.JSONKeys.MEDIUM_TERM,
+                                7,
+                                TimeUnit.DAYS
+                        ),
+                        new DurationBasedRecommendationSubCategory(
+                                AutotuneConstants.JSONKeys.LONG_TERM,
+                                15,
+                                TimeUnit.DAYS
+                        ),
+                }
+        ),
+        // Need to update with profile based sub categories
+        PROFILE_BASED(AutotuneConstants.JSONKeys.PROFILE_BASED, null);
 
         private String name;
-        private RecommendationCategory(String name) {
+        private RecommendationSubCategory[] recommendationSubCategories;
+
+        private RecommendationCategory(String name, RecommendationSubCategory[] recommendationSubCategories) {
             this.name = name;
+            this.recommendationSubCategories = recommendationSubCategories;
         }
 
         public String getName() {
             return this.name;
+        }
+
+        public RecommendationSubCategory[] getRecommendationSubCategories() {
+            return this.recommendationSubCategories;
         }
     }
 


### PR DESCRIPTION
@dinogun This PR adds `RecommendationSubCategory` which is extendable to any other category which we may add in future. Currently `getSubCategory` is the only common function in the interface expecting that not all type of categories might have duration given. So instead of using plain strings we can use objects extending this interface and add category specific contents in them. eg : `DurationBasedRecommedationSubCategory` has `duration` and `timeunits` as attributes which are specific to duration based recommendations.

I would like to request you to review this PR. Thanks in advance!