### PR TITLE
Adds service to list the supported k8s object types

### DIFF
--- a/src/main/java/com/autotune/analyzer/Analyzer.java
+++ b/src/main/java/com/autotune/analyzer/Analyzer.java
@@ -65,5 +65,6 @@ public class Analyzer {
         // Adding UI support API's
         context.addServlet(ListNamespaces.class, ServerContext.LIST_NAMESPACES);
         context.addServlet(ListDeploymentsInNamespace.class, ServerContext.LIST_DEPLOYMENTS);
+        context.addServlet(ListSupportedK8sObjects.class, ServerContext.LIST_K8S_OBJECTS);
     }
 }

--- a/src/main/java/com/autotune/analyzer/serviceObjects/ListSupportedK8sObjectsSO.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/ListSupportedK8sObjectsSO.java
@@ -1,0 +1,20 @@
+package com.autotune.analyzer.serviceObjects;
+
+import com.autotune.utils.AutotuneConstants;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ListSupportedK8sObjectsSO {
+    @SerializedName(AutotuneConstants.JSONKeys.KUBERNETES_OBJECTS)
+    private List<String> kubernetesObjects;
+
+    public ListSupportedK8sObjectsSO() {
+        kubernetesObjects = new ArrayList<String>();
+    }
+
+    public void addSupportedK8sObject(String k8sObject) {
+        kubernetesObjects.add(k8sObject);
+    }
+}

--- a/src/main/java/com/autotune/analyzer/serviceObjects/ListSupportedK8sObjectsSO.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/ListSupportedK8sObjectsSO.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
 package com.autotune.analyzer.serviceObjects;
 
 import com.autotune.utils.AutotuneConstants;

--- a/src/main/java/com/autotune/analyzer/services/ListSupportedK8sObjects.java
+++ b/src/main/java/com/autotune/analyzer/services/ListSupportedK8sObjects.java
@@ -1,0 +1,64 @@
+package com.autotune.analyzer.services;
+
+import com.autotune.analyzer.exceptions.AutotuneResponse;
+import com.autotune.analyzer.serviceObjects.ListSupportedK8sObjectsSO;
+import com.autotune.analyzer.utils.GsonUTCDateAdapter;
+import com.autotune.utils.AnalyzerConstants;
+import com.autotune.utils.Utils;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Date;
+
+import static com.autotune.utils.AnalyzerConstants.ServiceConstants.CHARACTER_ENCODING;
+import static com.autotune.utils.AnalyzerConstants.ServiceConstants.JSON_CONTENT_TYPE;
+
+@WebServlet(asyncSupported = true)
+public class ListSupportedK8sObjects extends HttpServlet {
+    private static final long serialVersionUID = 1L;
+    private static final Logger LOGGER = LoggerFactory.getLogger(ListSupportedK8sObjects.class);
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        // Create the Service Object for the List Supported K8S Objects endpoint
+        ListSupportedK8sObjectsSO listSupportedK8sObjectsSO =  new ListSupportedK8sObjectsSO();
+        // Iterate over the supported Kubernetes Object type supported by Kruize
+        for (AnalyzerConstants.K8S_OBJECT_TYPES k8SObjectType : AnalyzerConstants.K8S_OBJECT_TYPES.values()) {
+            // Get the String value of the K8S object types
+            String k8sObjectTypeString = Utils.getAppropriateK8sObjectTypeString(k8SObjectType);
+            // Check for null and if it's not null add to the list of K8S objects in the Service Object
+            if (null != k8sObjectTypeString) {
+                listSupportedK8sObjectsSO.addSupportedK8sObject(k8sObjectTypeString);
+            }
+        }
+        String responseGSONString = "";
+        // Create a GSON builder
+        Gson gsonObj = new GsonBuilder()
+                .disableHtmlEscaping()
+                .setPrettyPrinting()
+                .enableComplexMapKeySerialization()
+                .registerTypeAdapter(Date.class, new GsonUTCDateAdapter())
+                .create();
+        // Convert the Service object to JSON
+        responseGSONString = gsonObj.toJson(listSupportedK8sObjectsSO);
+
+        // Write the JSON to Response and close the writer
+        response.getWriter().println(responseGSONString);
+        response.getWriter().close();
+    }
+
+    // Redirect the Get request to the POST handler
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        doPost(request, response);
+    }
+}

--- a/src/main/java/com/autotune/analyzer/services/ListSupportedK8sObjects.java
+++ b/src/main/java/com/autotune/analyzer/services/ListSupportedK8sObjects.java
@@ -1,6 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
 package com.autotune.analyzer.services;
 
-import com.autotune.analyzer.exceptions.AutotuneResponse;
 import com.autotune.analyzer.serviceObjects.ListSupportedK8sObjectsSO;
 import com.autotune.analyzer.utils.GsonUTCDateAdapter;
 import com.autotune.utils.AnalyzerConstants;
@@ -16,11 +30,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.util.Date;
-
-import static com.autotune.utils.AnalyzerConstants.ServiceConstants.CHARACTER_ENCODING;
-import static com.autotune.utils.AnalyzerConstants.ServiceConstants.JSON_CONTENT_TYPE;
 
 @WebServlet(asyncSupported = true)
 public class ListSupportedK8sObjects extends HttpServlet {

--- a/src/main/java/com/autotune/utils/ServerContext.java
+++ b/src/main/java/com/autotune/utils/ServerContext.java
@@ -63,4 +63,5 @@ public class ServerContext {
     public static final String QUERY_CONTEXT = ROOT_CONTEXT + "query/";
     public static final String LIST_NAMESPACES = QUERY_CONTEXT + "listNamespaces";
     public static final String LIST_DEPLOYMENTS = QUERY_CONTEXT + "listDeployments";
+    public static final String LIST_K8S_OBJECTS = QUERY_CONTEXT + "listK8sObjects";
 }


### PR DESCRIPTION
Adds a service to list the supported K8S object types by kruize

Resolves the first item mentioned in #591 (`One API to get k8s object corresponding to a namespace selected`)