### PR TITLE
Add null check before isEmpty check

### DIFF
--- a/design/MonitoringModeAPI.md
+++ b/design/MonitoringModeAPI.md
@@ -857,7 +857,7 @@ Returns the recommendation at a particular timestamp if it exists
 ]
 ```
 
-###Invalid Scenarios:
+### Invalid Scenarios:
 
 **Invalid experiment name**
 

--- a/design/MonitoringModeAPI.md
+++ b/design/MonitoringModeAPI.md
@@ -404,7 +404,7 @@ If no parameter is passed API returns all the latest recommendations available f
                             "notifications": [
                                 {
                                     "type": "info",
-                                    "message": "Duration Based recommendations available"
+                                    "message": "Duration Based Recommendations Available"
                                 }
                             ],
                             "data": {
@@ -513,7 +513,7 @@ Returns the latest result of that experiment
                             "notifications": [
                                 {
                                     "type": "info",
-                                    "message": "Duration Based recommendations available"
+                                    "message": "Duration Based Recommendations Available"
                                 }
                             ],
                             "data": {
@@ -623,7 +623,7 @@ Returns all the results of that experiment
                             "notifications": [
                                 {
                                     "type": "info",
-                                    "message": "Duration Based recommendations available"
+                                    "message": "Duration Based Recommendations Available"
                                 }
                             ],
                             "data": {
@@ -787,7 +787,7 @@ Returns the recommendation at a particular timestamp if it exists
                             "notifications": [
                                 {
                                     "type": "info",
-                                    "message": "Duration Based recommendations available"
+                                    "message": "Duration Based Recommendations Available"
                                 }
                             ],
                             "data": {

--- a/design/MonitoringModeAPI.md
+++ b/design/MonitoringModeAPI.md
@@ -760,7 +760,7 @@ Returns all the results of that experiment
 ]
 ```
 
-**Request with experiment name parameter and monitoing end time set to a valid timestamo**
+**Request with experiment name parameter and monitoing end time set to a valid timestamp**
 
 `GET /listRecommendations`
 
@@ -857,7 +857,7 @@ Returns the recommendation at a particular timestamp if it exists
 ]
 ```
 
-###Invalid Scenerios:
+###Invalid Scenarios:
 
 **Invalid experiment name**
 

--- a/src/main/java/com/autotune/analyzer/performanceProfiles/PerformanceProfileInterface/PerfProfileImpl.java
+++ b/src/main/java/com/autotune/analyzer/performanceProfiles/PerformanceProfileInterface/PerfProfileImpl.java
@@ -114,7 +114,7 @@ public class PerfProfileImpl implements PerfProfileInterface {
                     }
                     // check if the 'value' is present in the result JSON
                     if (null == funcVar.getValue().get("results").getValue()) {
-                        LOGGER.warn(AnalyzerErrorConstants.AutotuneObjectErrors.MISSING_VALUE.concat(funcVar.getKey().toString()));
+                        LOGGER.debug(AnalyzerErrorConstants.AutotuneObjectErrors.MISSING_VALUE.concat(funcVar.getKey().toString()));
                     }
                 }
             }

--- a/src/main/java/com/autotune/analyzer/recommendations/GenerateRecommendation.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/GenerateRecommendation.java
@@ -42,9 +42,10 @@ public class GenerateRecommendation {
                 DeploymentObject deploymentObj = kruizeObject.getDeployments().get(dName);
                 for (String cName : deploymentObj.getContainers().keySet()) {
                     ContainerObject containerObject = deploymentObj.getContainers().get(cName);
-                    if (containerObject.getResults().isEmpty()) {
+                    if (null == containerObject.getResults())
                         continue;
-                    }
+                    if (containerObject.getResults().isEmpty())
+                        continue;
                     Timestamp monitorEndDate = containerObject.getResults().keySet().stream().max(Timestamp::compareTo).get();
                     Timestamp minDate = containerObject.getResults().keySet().stream().min(Timestamp::compareTo).get();
                     Timestamp monitorStartDate;


### PR DESCRIPTION
Autotune is getting a null pointer exception in `GenerateRecommendation.java` as mentioned by @dinogun 

Issue:
```
2023-03-2310:52:34.243 ERROR [pool-7-thread-36][GenerateRecommendation.java(122)]-Unable to get recommendation for : quarkus-resteasy-kruize-min-http-response-time-db_0 : Cannot invoke "java.util.HashMap.isEmpty()" because the return value of "com.autotune.common.k8sObjects.ContainerObject.getResults()" is null
```