### PR TITLE
Fix- Removes repeated error messages for tunable stepValue zero

### DIFF
--- a/src/main/java/com/autotune/analyzer/application/Tunable.java
+++ b/src/main/java/com/autotune/analyzer/application/Tunable.java
@@ -142,7 +142,6 @@ public class Tunable {
                    String lowerBound
     ) throws InvalidBoundsException {
         setCommonTunableParameters(queries, name, valueType, sloClassList, layerName);
-        this.step = Objects.requireNonNull(step, ZERO_STEP);
         /* Parse the value for the bounds from the strings passed in */
         Double upperBoundValue = Double.parseDouble(BOUND_CHARS.matcher(upperBound).replaceAll(""));
         Double lowerBoundValue = Double.parseDouble(BOUND_CHARS.matcher(lowerBound).replaceAll(""));

--- a/src/main/java/com/autotune/analyzer/kruizeLayer/ValidateKruizeLayer.java
+++ b/src/main/java/com/autotune/analyzer/kruizeLayer/ValidateKruizeLayer.java
@@ -82,13 +82,13 @@ public class ValidateKruizeLayer
 				if (tunable.getName().trim().isEmpty()) {
 					errorString.append(AnalyzerErrorConstants.AutotuneConfigErrors.TUNABLE_NAME_EMPTY);
 				}
+				// Check if tunable step value is zero
+				if (!tunable.getValueType().equals(CATEGORICAL_TYPE) && tunable.getStep() == 0) {
+					errorString.append(AnalyzerErrorConstants.AutotuneConfigErrors.ZERO_STEP);
+				}
 				for (String slo_class : tunable.getSloClassList()) {
 					if (!KruizeSupportedTypes.SLO_CLASSES_SUPPORTED.contains(slo_class)) {
 						errorString.append(AnalyzerErrorConstants.AutotuneConfigErrors.INVALID_SLO_CLASS).append(tunable.getName()).append("\n");
-					}
-
-					if (!tunable.getValueType().equals(CATEGORICAL_TYPE) && tunable.getStep() == 0) {
-						errorString.append(AnalyzerErrorConstants.AutotuneConfigErrors.ZERO_STEP);
 					}
 				}
 			}


### PR DESCRIPTION
This PR fixes the issue #255
Attaching the test file zero-step-autotune.log and zip folder for `--testsuite=kruize_layer_yaml_tests` `--testcase=step`
[zero-step-autotune.log](https://github.com/kruize/autotune/files/11135963/zero-step-autotune.log)
[testcase_step.zip](https://github.com/kruize/autotune/files/11135949/testcase_step.zip)
