### PR TITLE
Fix issues in Measurement_duration 

### DIFF
--- a/Dockerfile.autotune
+++ b/Dockerfile.autotune
@@ -25,7 +25,7 @@ RUN microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y jav
      && microdnf clean all 
 
 RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz https://apache.osuosl.org/maven/maven-3/3.9.0/binaries/apache-maven-3.9.0-bin.tar.gz \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz https://apache.osuosl.org/maven/maven-3/3.9.1/binaries/apache-maven-3.9.1-bin.tar.gz \
   && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
   && rm -f /tmp/apache-maven.tar.gz \
   && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn

--- a/src/main/java/com/autotune/analyzer/experiment/ExperimentResultValidation.java
+++ b/src/main/java/com/autotune/analyzer/experiment/ExperimentResultValidation.java
@@ -66,10 +66,16 @@ public class ExperimentResultValidation {
                             errorMsg = errorMsg.concat(AnalyzerErrorConstants.AutotuneObjectErrors.WRONG_TIMESTAMP);
                             resultData.setValidationOutputData(new ValidationOutputData(false, errorMsg, HttpServletResponse.SC_BAD_REQUEST));
                             break;
-                        } else if (durationInMins < Double.parseDouble(measurementDurationInMins.substring(0,measurementDurationInMins.length()-3))) {
-                            errorMsg = errorMsg.concat(AnalyzerErrorConstants.AutotuneObjectErrors.MEASUREMENT_DURATION_ERROR);
-                            resultData.setValidationOutputData(new ValidationOutputData(false, errorMsg, HttpServletResponse.SC_BAD_REQUEST));
-                            break;
+                        } else {
+                            Double parsedMeasurementDuration = Double.parseDouble(measurementDurationInMins.substring(0,measurementDurationInMins.length()-3));
+                            // Calculate the lower and upper bounds for the acceptable range i.e. +-5 seconds
+                            double lowerRange = (parsedMeasurementDuration * 60 - 5) / 60.0;
+                            double upperRange = (parsedMeasurementDuration * 60 + 5) / 60.0;
+                            if (!(durationInMins >= lowerRange && durationInMins <= upperRange)) {
+                                errorMsg = errorMsg.concat(AnalyzerErrorConstants.AutotuneObjectErrors.MEASUREMENT_DURATION_ERROR);
+                                resultData.setValidationOutputData(new ValidationOutputData(false, errorMsg, HttpServletResponse.SC_BAD_REQUEST));
+                                break;
+                            }
                         }
                         // check if resultData is present
                         boolean isExist = false;

--- a/src/main/java/com/autotune/analyzer/kruizeObject/KruizeObject.java
+++ b/src/main/java/com/autotune/analyzer/kruizeObject/KruizeObject.java
@@ -55,7 +55,6 @@ public final class KruizeObject {
     private AnalyzerConstants.ExperimentStatus status;
     @SerializedName("performance_profile")
     private String performanceProfile;
-    private String deployment_name;                                 // TODO: Need to remove this
     private TrialSettings trial_settings;
     private RecommendationSettings recommendation_settings;
     private ExperimentUseCaseType experimentUseCaseType;
@@ -179,14 +178,6 @@ public final class KruizeObject {
         this.performanceProfile = performanceProfile;
     }
 
-    public String getDeployment_name() {
-        return deployment_name;
-    }
-
-    public void setDeployment_name(String deployment_name) {
-        this.deployment_name = deployment_name;
-    }
-
     public TrialSettings getTrial_settings() {
         return trial_settings;
     }
@@ -281,7 +272,6 @@ public final class KruizeObject {
                 ", objectReference=" + objectReference +
                 ", status=" + status +
                 ", performanceProfile='" + performanceProfile + '\'' +
-                ", deployment_name='" + deployment_name + '\'' +
                 ", trial_settings=" + trial_settings +
                 ", recommendation_settings=" + recommendation_settings +
                 ", experimentUseCaseType=" + experimentUseCaseType +

--- a/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
@@ -204,8 +204,8 @@ public class Converters {
 			if (inputData != null) {
 				JSONObject jsonObject = new JSONObject(inputData);
 				String perfProfileName = jsonObject.getString(AnalyzerConstants.AutotuneObjectConstants.NAME);
-				double profileVersion = jsonObject.getDouble(AnalyzerConstants.PROFILE_VERSION);
-				String k8sType = jsonObject.getString(AnalyzerConstants.PerformanceProfileConstants.K8S_TYPE);
+				Double profileVersion = jsonObject.has(AnalyzerConstants.PROFILE_VERSION) ? jsonObject.getDouble(AnalyzerConstants.PROFILE_VERSION) : null;
+				String k8sType = jsonObject.has(AnalyzerConstants.PerformanceProfileConstants.K8S_TYPE) ? jsonObject.getString(AnalyzerConstants.PerformanceProfileConstants.K8S_TYPE) : null;
 				JSONObject sloJsonObject = jsonObject.getJSONObject(AnalyzerConstants.AutotuneObjectConstants.SLO);
 				JSONArray functionVariableArray = sloJsonObject.getJSONArray(AnalyzerConstants.AutotuneObjectConstants.FUNCTION_VARIABLES);
 				ArrayList<Metric> functionVariablesList = new ArrayList<>();
@@ -215,7 +215,7 @@ public class Converters {
 					String datasource = functionVarObj.getString(AnalyzerConstants.AutotuneObjectConstants.DATASOURCE);
 					String query = functionVarObj.has(AnalyzerConstants.AutotuneObjectConstants.QUERY) ? functionVarObj.getString(AnalyzerConstants.AutotuneObjectConstants.QUERY):null;
 					String valueType = functionVarObj.getString(AnalyzerConstants.AutotuneObjectConstants.VALUE_TYPE);
-					String kubeObject = functionVarObj.getString(AnalyzerConstants.KUBERNETES_OBJECT);
+					String kubeObject = functionVarObj.has(AnalyzerConstants.KUBERNETES_OBJECT) ? functionVarObj.getString(AnalyzerConstants.KUBERNETES_OBJECT) : null;
 					Metric metric = new Metric(name, query, datasource, valueType, kubeObject);
 					JSONArray aggrFunctionArray = functionVarObj.has(AnalyzerConstants.AGGREGATION_FUNCTIONS) ? functionVarObj.getJSONArray(AnalyzerConstants.AGGREGATION_FUNCTIONS):null;
 					for (Object innerObject : aggrFunctionArray) {
@@ -230,8 +230,8 @@ public class Converters {
 					}
 					functionVariablesList.add(metric);
 				}
-				String sloClass = sloJsonObject.get(AnalyzerConstants.AutotuneObjectConstants.SLO_CLASS).toString();
-				String direction = sloJsonObject.get(AnalyzerConstants.AutotuneObjectConstants.DIRECTION).toString();
+				String sloClass = sloJsonObject.has(AnalyzerConstants.AutotuneObjectConstants.SLO_CLASS) ? sloJsonObject.get(AnalyzerConstants.AutotuneObjectConstants.SLO_CLASS).toString() : null;
+				String direction = sloJsonObject.has(AnalyzerConstants.AutotuneObjectConstants.DIRECTION) ? sloJsonObject.get(AnalyzerConstants.AutotuneObjectConstants.DIRECTION).toString() :null;
 				ObjectiveFunction objectiveFunction = new Gson().fromJson(sloJsonObject.getJSONObject(AnalyzerConstants.AutotuneObjectConstants.OBJECTIVE_FUNCTION).toString(), ObjectiveFunction.class);
 				SloInfo sloInfo = new SloInfo(sloClass, objectiveFunction, direction, functionVariablesList);
 				performanceProfile = new PerformanceProfile(perfProfileName, profileVersion, k8sType, sloInfo);

--- a/src/main/java/com/autotune/analyzer/services/CreateExperiment.java
+++ b/src/main/java/com/autotune/analyzer/services/CreateExperiment.java
@@ -120,15 +120,18 @@ public class CreateExperiment extends HttpServlet {
     protected void doDelete(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         try {
             String inputData = request.getReader().lines().collect(Collectors.joining());
-            KruizeObject[] kruizeExpList = new Gson().fromJson(inputData, KruizeObject[].class);
-            for (KruizeObject ko : kruizeExpList) {
-                mainKruizeExperimentMap.remove(ko.getExperimentName());
-                KruizeOperator.deploymentMap.remove(ko.getExperimentName());
+            CreateExperimentAPIObject[] createExperimentAPIObjects = new Gson().fromJson(inputData, CreateExperimentAPIObject[].class);
+            for (CreateExperimentAPIObject ko : createExperimentAPIObjects) {
+                if (mainKruizeExperimentMap.containsKey(ko.getExperimentName())) {
+                    mainKruizeExperimentMap.remove(ko.getExperimentName());
+                    KruizeOperator.deploymentMap.remove(ko.getExperimentName());
+                }
+                else
+                    throw new Exception("Experiment not found!");
             }
             sendSuccessResponse(response, "Experiment deleted successfully.");
         } catch (Exception e) {
-            e.printStackTrace();
-            sendErrorResponse(response, e, HttpServletResponse.SC_BAD_REQUEST, "Validation failed: " + e.getMessage());
+            sendErrorResponse(response, e, HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
         }
     }
 

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
@@ -76,7 +76,7 @@ public class AnalyzerErrorConstants {
 		public static final String UNSUPPORTED_EXPERIMENT = "Bulk entries are currently unsupported!";
 		public static final String DUPLICATE_EXPERIMENT = "Experiment name already exists: ";
 		public static final String WRONG_TIMESTAMP = "EndTimeStamp cannot be less than StartTimeStamp!";
-		public static final String MEASUREMENT_DURATION_ERROR = "Interval duration cannot be less than measurement_duration";
+		public static final String MEASUREMENT_DURATION_ERROR = "Interval duration cannot be less than or greater than measurement_duration by more than 5 seconds";
 
 	}
 


### PR DESCRIPTION
This PR contains following changes :

- Update the check for measurement_duration to be in the range of +- 5seconds
- Update optional parameter validation failure for performance profile
- Update delete API to get data from the API object