### PR TITLE
Layer presence label value validation

### DIFF
--- a/src/main/java/com/autotune/analyzer/kruizeLayer/KruizeLayer.java
+++ b/src/main/java/com/autotune/analyzer/kruizeLayer/KruizeLayer.java
@@ -20,9 +20,9 @@ import com.autotune.analyzer.exceptions.InvalidValueException;
 import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.utils.Utils;
 import io.fabric8.kubernetes.api.model.ObjectReference;
-
 import java.util.ArrayList;
 import java.util.HashMap;
+
 
 /**
  * Container class for the KruizeLayer kubernetes kind, which is used to tune

--- a/src/main/java/com/autotune/analyzer/kruizeLayer/ValidateKruizeLayer.java
+++ b/src/main/java/com/autotune/analyzer/kruizeLayer/ValidateKruizeLayer.java
@@ -16,12 +16,12 @@
 package com.autotune.analyzer.kruizeLayer;
 
 import com.autotune.analyzer.application.Tunable;
-import com.autotune.utils.KruizeSupportedTypes;
 import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.analyzer.utils.AnalyzerErrorConstants;
-
+import com.autotune.utils.KruizeSupportedTypes;
 import java.util.ArrayList;
 import java.util.HashMap;
+
 
 import static com.autotune.analyzer.utils.AnalyzerConstants.AutotuneConfigConstants.CATEGORICAL_TYPE;
 
@@ -45,7 +45,7 @@ public class ValidateKruizeLayer
 				|| ((String)map.get(AnalyzerConstants.AutotuneConfigConstants.NAME)).isEmpty()) {
 			errorString.append(AnalyzerErrorConstants.AutotuneConfigErrors.AUTOTUNE_CONFIG_NAME_NULL);
 		}
-
+        
 		// Check if either presence, layerPresenceQuery or layerPresenceLabel are set. presence field has highest priority.
 		if (map.get(AnalyzerConstants.AutotuneConfigConstants.PRESENCE) == null ||
 				!map.get(AnalyzerConstants.AutotuneConfigConstants.PRESENCE).equals(AnalyzerConstants.PRESENCE_ALWAYS)) {
@@ -56,6 +56,14 @@ public class ValidateKruizeLayer
 					&& ((ArrayList<LayerPresenceQuery>)map.get(AnalyzerConstants.AutotuneConfigConstants.LAYER_PRESENCE_QUERIES)).isEmpty()))) {
 				errorString.append(AnalyzerErrorConstants.AutotuneConfigErrors.LAYER_PRESENCE_MISSING);
 			}
+		}
+        
+		// Check if Label Presence value is blank
+		String layer_presence_label_value = (String)map.get(AnalyzerConstants.AutotuneConfigConstants.LAYER_PRESENCE_LABEL_VALUE);
+		String layer_presence_label_name = (String)map.get(AnalyzerConstants.AutotuneConfigConstants.LAYER_PRESENCE_LABEL);
+
+		if (layer_presence_label_name != null && (layer_presence_label_value.isBlank() || layer_presence_label_value.isEmpty())) {
+			errorString.append(AnalyzerErrorConstants.AutotuneConfigErrors.LAYER_PRESENCE_LABEL_VALUE_BLANK_NULL_MISSING);
 		}
 
 		// Check if both layerPresenceQuery and layerPresenceLabel are set

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
@@ -37,6 +37,8 @@ public class AnalyzerErrorConstants {
 		public static final String VALUE_TYPE_NULL = "value_type cannot be null";
 		public static final String ZERO_STEP = "Tunable step cannot be 0 or null";
 		public static final String INVALID_TUNABLE_CHOICE = "Invalid categorical choice for tunable ";
+		public static final String LAYER_PRESENCE_LABEL_VALUE_BLANK_NULL_MISSING = "layer presence label value cannot be blank/null/missing";
+		
 	}
 
 	public static final class AutotuneObjectErrors {

--- a/tests/autotune_test_yamls/manifests/da/kruize_layer_yaml/layer_presence_labelvalue/blank-layer-presence-labelvalue.yaml
+++ b/tests/autotune_test_yamls/manifests/da/kruize_layer_yaml/layer_presence_labelvalue/blank-layer-presence-labelvalue.yaml
@@ -8,7 +8,7 @@ details: quarkus tunables
 layer_presence:
   label:
   - name: app.kubernetes.io/layer
-    value: ' '
+    value: ''
 tunables:
 - name: quarkus.thread-pool.core-threads
   description: 'The core thread pool size. This number of threads will always be kept alive.'

--- a/tests/scripts/da/constants/kruize_layer_constants.sh
+++ b/tests/scripts/da/constants/kruize_layer_constants.sh
@@ -367,22 +367,23 @@ layer_presence_label_name_expected_log_msgs=([blank-layer-presence-label-name]='
 declare -A layer_presence_labelvalue_autotune_objects
 layer_presence_labelvalue_autotune_objects=([blank-layer-presence-labelvalue]='true'
 [invalid-layer-presence-labelvalue]='true'
-[no-layer-presence-labelvalue]='false'
-[no-layer-presence-labelvalue-value]='false'
-[null-layer-presence-labelvalue]='false'
+[no-layer-presence-labelvalue]='true' # These objects are expected to be created as validation at CRD level is not possible (due to the reason either one of presence/queries/label should be present and this is not a strict validation)
+[no-layer-presence-labelvalue-value]='true'
+[null-layer-presence-labelvalue]='true'
 [numerical-layer-presence-labelvalue]='false'
 [valid-layer-presence-labelvalue]='true')
 
 # Expected log message for layer-presence-labelvalue
 declare -A layer_presence_labelvalue_expected_log_msgs
 layer_presence_labelvalue_error=': layerPresence.label.value in body must be of type string:'
-layer_presence_labelvalue_expected_log_msgs=([blank-layer-presence-labelvalue]='Validation from da'
+layer_presence_labelvalue_expected_log_msgs=([blank-layer-presence-labelvalue]='layer presence label value cannot be blank/null/missing'
 [invalid-layer-presence-labelvalue]='validation from da'
-[no-layer-presence-labelvalue]='validation from crd'
-[no-layer-presence-labelvalue-value]='The KruizeLayer "no-layer-presence-labelvalue-value" is invalid: layerPresence.label.value: Invalid value: "null"'${layer_presence_labelvalue_error}' "null"'
-[null-layer-presence-labelvalue]='The KruizeLayer "null-layer-presence-labelvalue" is invalid: layerPresence.label.value: Invalid value: "null"'${layer_presence_labelvalue_error}' "null"'
-[numerical-layer-presence-labelvalue]='The KruizeLayer "numerical-layer-presence-labelvalue" is invalid: layerPresence.label.value: Invalid value: "integer"'${layer_presence_labelvalue_error}' "integer"'
-[valid-layer-presence-labelvalue]=''${kruize_layer_obj_create_msg}' valid-layer-presence-labelvalue')
+
+[no-layer-presence-labelvalue]='layer presence label value cannot be blank/null/missing'
+[no-layer-presence-labelvalue-value]='layer presence label value cannot be blank/null/missing'
+[null-layer-presence-labelvalue]='layer presence label value cannot be blank/null/missing'
+[numerical-layer-presence-labelvalue]='The AutotuneConfig "numerical-layer-presence-labelvalue" is invalid: layerPresence.label.value: Invalid value: "integer"'${layer_presence_labelvalue_error}' "integer"'
+[valid-layer-presence-labelvalue]=''${autotune_config_obj_create_msg}' valid-layer-presence-labelvalue')
 
 # Expected autotune object for layer presence
 declare -A layer_presence_autotune_objects


### PR DESCRIPTION
Added Validation For layer_presence_label_value (WIP)

Changes:
The PR is assuming that the validation for the label_value being not present or NULL cannot be done in CRD validation as either one of the keys i.e (presence/queries/label should be present and this type of validation is not possible in CRD itself).

Concerns:
For all the three yaml test cases:
no-layer-presence-labelvalue
no-layer-presence-labelvalue-value
null-layer-presence-labelvalue

Value returned for extracting the string "layer_presence_label_value" comes out to be blank or empty. Which is not expected logically. The value string never comes out to be null but blank for every negative test cases.

@dinogun Can you please guide on what should be considered valid and invalid for the invalid-layer-presence-labelvalue case?
