### PR TITLE
Tuneables Upper Lower bound validation

### DIFF
--- a/src/main/java/com/autotune/analyzer/application/Tunable.java
+++ b/src/main/java/com/autotune/analyzer/application/Tunable.java
@@ -17,11 +17,11 @@ package com.autotune.analyzer.application;
 
 import com.autotune.analyzer.exceptions.InvalidBoundsException;
 import com.autotune.utils.KruizeSupportedTypes;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+
 
 import static com.autotune.analyzer.utils.AnalyzerConstants.AutotuneConfigConstants.*;
 import static com.autotune.analyzer.utils.AnalyzerErrorConstants.AutotuneConfigErrors.*;
@@ -86,6 +86,7 @@ public class Tunable {
          * upperBound has to be greater than lowerBound.
          * step has to be lesser than or equal to the difference between the two bounds.
          */
+
         if (upperBoundValue < 0 ||
                 lowerBoundValue < 0 ||
                 lowerBoundValue >= upperBoundValue ||
@@ -143,10 +144,20 @@ public class Tunable {
     ) throws InvalidBoundsException {
         setCommonTunableParameters(queries, name, valueType, sloClassList, layerName);
         this.step = Objects.requireNonNull(step, ZERO_STEP);
-        /* Parse the value for the bounds from the strings passed in */
-        Double upperBoundValue = Double.parseDouble(BOUND_CHARS.matcher(upperBound).replaceAll(""));
-        Double lowerBoundValue = Double.parseDouble(BOUND_CHARS.matcher(lowerBound).replaceAll(""));
+        Double upperBoundValue;
+        Double lowerBoundValue;
 
+        /* Parse the value for the bounds from the strings passed in */
+        try {
+            upperBoundValue = Double.parseDouble(BOUND_CHARS.matcher(upperBound).replaceAll(""));
+        } catch (Exception e) {
+            throw new InvalidBoundsException("Error: Upper bound value is not a valid number");
+        }
+        try {
+            lowerBoundValue = Double.parseDouble(BOUND_CHARS.matcher(lowerBound).replaceAll(""));
+        } catch (Exception e) {
+            throw new InvalidBoundsException("Error: Lower bound value is not a valid number");
+        }
         /* Parse the bound units from the strings passed in and make sure they are the same */
         String upperBoundUnits = BOUND_DIGITS.matcher(upperBound).replaceAll("");
         String lowerBoundUnits = BOUND_DIGITS.matcher(lowerBound).replaceAll("");

--- a/src/main/java/com/autotune/operator/KruizeOperator.java
+++ b/src/main/java/com/autotune/operator/KruizeOperator.java
@@ -570,6 +570,10 @@ public class KruizeOperator {
                     } else {
                         upperBound = tunableJson.optString(AnalyzerConstants.AutotuneConfigConstants.UPPER_BOUND);
                         lowerBound = tunableJson.optString(AnalyzerConstants.AutotuneConfigConstants.LOWER_BOUND);
+                        if (upperBound.isEmpty() && tunableJson.isNull(AnalyzerConstants.AutotuneConfigConstants.UPPER_BOUND) || upperBound.isBlank() && tunableJson.isNull(AnalyzerConstants.AutotuneConfigConstants.UPPER_BOUND) || lowerBound.isEmpty() && tunableJson.isNull(AnalyzerConstants.AutotuneConfigConstants.LOWER_BOUND) || lowerBound.isBlank()  && tunableJson.isNull(AnalyzerConstants.AutotuneConfigConstants.LOWER_BOUND))
+                            throw new InvalidBoundsException("Bounds value(s) cannot be null");
+                        if (upperBound.isEmpty() && !tunableJson.isNull(AnalyzerConstants.AutotuneConfigConstants.UPPER_BOUND) || upperBound.isBlank() && !tunableJson.isNull(AnalyzerConstants.AutotuneConfigConstants.UPPER_BOUND) || lowerBound.isEmpty() && !tunableJson.isNull(AnalyzerConstants.AutotuneConfigConstants.LOWER_BOUND) || lowerBound.isBlank()  && !tunableJson.isNull(AnalyzerConstants.AutotuneConfigConstants.LOWER_BOUND))
+                            throw new InvalidBoundsException("Bounds value(s) are empty");
                         // Read in step from the tunable, set it to '1' if not specified.
                         step = tunableJson.optDouble(AutotuneConfigConstants.STEP, 1);
                         tunable = new Tunable(tunableName, tunableValueType, queriesMap, sloClassList, layerName, step, upperBound, lowerBound);

--- a/tests/autotune_test_yamls/manifests/da/kruize_layer_yaml/tunable_lower_bound/char-tunable-lower-bound.yaml
+++ b/tests/autotune_test_yamls/manifests/da/kruize_layer_yaml/tunable_lower_bound/char-tunable-lower-bound.yaml
@@ -12,7 +12,7 @@ tunables:
   - name: memoryRequest
     value_type: double
     upper_bound: '300 Mi'
-    lower_bound: GM
+    lower_bound: 'G'
     queries:
     - datasource: 'prometheus'
       query: 'container_memory_working_set_bytes{$CONTAINER_LABEL$="", $POD_LABEL$="$POD$"}'

--- a/tests/autotune_test_yamls/manifests/da/kruize_layer_yaml/tunable_lower_bound/integer-tunable-lower-bound.yaml
+++ b/tests/autotune_test_yamls/manifests/da/kruize_layer_yaml/tunable_lower_bound/integer-tunable-lower-bound.yaml
@@ -1,7 +1,7 @@
 apiVersion: "recommender.com/v1"
 kind: "KruizeLayer"
 metadata:
-  name: "invalid-tunable-upper-bound"
+  name: "integer-tunable-lower-bound"
 layer_name: container
 layer_level: 0
 details: generic container tunables
@@ -11,8 +11,8 @@ layer_presence:
 tunables:
   - name: memoryRequest
     value_type: double
-    upper_bound: -100
-    lower_bound: '150 Mi'
+    upper_bound: '150 Mi'
+    lower_bound: 00
     queries:
     - datasource: 'prometheus'
       query: 'container_memory_working_set_bytes{$CONTAINER_LABEL$="", $POD_LABEL$="$POD$"}'
@@ -23,7 +23,7 @@ tunables:
 
   - name: cpuRequest
     value_type: double
-    upper_bound: '4.0'
+    upper_bound: '3.0'
     lower_bound: '1.0'
     queries:
     - datasource: 'prometheus'

--- a/tests/autotune_test_yamls/manifests/da/kruize_layer_yaml/tunable_lower_bound/no-tunable-lower-bound-value.yaml
+++ b/tests/autotune_test_yamls/manifests/da/kruize_layer_yaml/tunable_lower_bound/no-tunable-lower-bound-value.yaml
@@ -1,7 +1,7 @@
 apiVersion: "recommender.com/v1"
 kind: "KruizeLayer"
 metadata:
-  name: "no-tunable-lower-bound-val"
+  name: "no-tunable-lower-bound-value"
 layer_name: container
 layer_level: 0
 details: generic container tunables

--- a/tests/autotune_test_yamls/manifests/da/kruize_layer_yaml/tunable_lower_bound/zero-tunable-lower-bound.yaml
+++ b/tests/autotune_test_yamls/manifests/da/kruize_layer_yaml/tunable_lower_bound/zero-tunable-lower-bound.yaml
@@ -12,7 +12,7 @@ tunables:
   - name: memoryRequest
     value_type: double
     upper_bound: '300 Mi'
-    lower_bound: 00
+    lower_bound: '00'
     queries:
     - datasource: 'prometheus'
       query: 'container_memory_working_set_bytes{$CONTAINER_LABEL$="", $POD_LABEL$="$POD$"}'

--- a/tests/autotune_test_yamls/manifests/da/kruize_layer_yaml/tunable_upper_bound/blank-tunable-upper-bound.yaml
+++ b/tests/autotune_test_yamls/manifests/da/kruize_layer_yaml/tunable_upper_bound/blank-tunable-upper-bound.yaml
@@ -11,8 +11,8 @@ layer_presence:
 tunables:
   - name: memoryRequest
     value_type: double
-    upper_bound: ' '
-    lower_bound: '150 Mi'
+    upper_bound: ''
+    lower_bound: '160 Mi'
     queries:
     - datasource: 'prometheus'
       query: 'container_memory_working_set_bytes{$CONTAINER_LABEL$="", $POD_LABEL$="$POD$"}'

--- a/tests/autotune_test_yamls/manifests/da/kruize_layer_yaml/tunable_upper_bound/char-tunable-upper-bound.yaml
+++ b/tests/autotune_test_yamls/manifests/da/kruize_layer_yaml/tunable_upper_bound/char-tunable-upper-bound.yaml
@@ -11,7 +11,7 @@ layer_presence:
 tunables:
   - name: memoryRequest
     value_type: double
-    upper_bound: GM
+    upper_bound: 'A'
     lower_bound: '150 Mi'
     queries:
     - datasource: 'prometheus'

--- a/tests/autotune_test_yamls/manifests/da/kruize_layer_yaml/tunable_upper_bound/integer-tunable-upper-bound.yaml
+++ b/tests/autotune_test_yamls/manifests/da/kruize_layer_yaml/tunable_upper_bound/integer-tunable-upper-bound.yaml
@@ -1,7 +1,7 @@
 apiVersion: "recommender.com/v1"
 kind: "KruizeLayer"
 metadata:
-  name: "invalid-tunable-upper-bound"
+  name: "integer-tunable-upper-bound"
 layer_name: container
 layer_level: 0
 details: generic container tunables
@@ -11,7 +11,7 @@ layer_presence:
 tunables:
   - name: memoryRequest
     value_type: double
-    upper_bound: -100
+    upper_bound: 00
     lower_bound: '150 Mi'
     queries:
     - datasource: 'prometheus'
@@ -23,7 +23,7 @@ tunables:
 
   - name: cpuRequest
     value_type: double
-    upper_bound: '4.0'
+    upper_bound: '3.0'
     lower_bound: '1.0'
     queries:
     - datasource: 'prometheus'

--- a/tests/autotune_test_yamls/manifests/da/kruize_layer_yaml/tunable_upper_bound/no-tunable-upper-bound-value.yaml
+++ b/tests/autotune_test_yamls/manifests/da/kruize_layer_yaml/tunable_upper_bound/no-tunable-upper-bound-value.yaml
@@ -1,7 +1,7 @@
 apiVersion: "recommender.com/v1"
 kind: "KruizeLayer"
 metadata:
-  name: "no-tunable-upper-bound-val"
+  name: "no-tunable-upper-bound-value"
 layer_name: container
 layer_level: 0
 details: generic container tunables

--- a/tests/autotune_test_yamls/manifests/da/kruize_layer_yaml/tunable_upper_bound/zero-tunable-upper-bound.yaml
+++ b/tests/autotune_test_yamls/manifests/da/kruize_layer_yaml/tunable_upper_bound/zero-tunable-upper-bound.yaml
@@ -11,7 +11,7 @@ layer_presence:
 tunables:
   - name: memoryRequest
     value_type: double
-    upper_bound: 00
+    upper_bound: '00'
     lower_bound: '150 Mi'
     queries:
     - datasource: 'prometheus'

--- a/tests/scripts/da/constants/kruize_layer_constants.sh
+++ b/tests/scripts/da/constants/kruize_layer_constants.sh
@@ -156,6 +156,7 @@ tunable_upper_bound_testcases=("blank-tunable-upper-bound"
 "null-tunable-upper-bound"
 "char-tunable-upper-bound"
 "zero-tunable-upper-bound"
+"integer-tunable-upper-bound"
 "valid-tunable-upper-bound")
 
 # tests for tunable lower bound
@@ -166,6 +167,7 @@ tunable_lower_bound_testcases=("blank-tunable-lower-bound"
 "null-tunable-lower-bound"
 "char-tunable-lower-bound"
 "zero-tunable-lower-bound"
+"integer-tunable-lower-bound"
 "valid-tunable-lower-bound")
 
 # tests for step
@@ -452,53 +454,63 @@ tunable_value_type_expected_log_msgs=([blank-tunable-value-type]='Validation fro
 
 # Expected autotune object for tunable upper bound
 declare -A tunable_upper_bound_autotune_objects
-tunable_upper_bound_autotune_objects=([blank-tunable-upper-bound]='false'
-[invalid-tunable-upper-bound]='true'
-[no-tunable-upper-bound]='false'
-[no-tunable-upper-bound-value]='false'
-[null-tunable-upper-bound]='false'
-[char-tunable-upper-bound]='false'
+tunable_upper_bound_autotune_objects=([blank-tunable-upper-bound]='true'
+[invalid-tunable-upper-bound]='false'
+[no-tunable-upper-bound]='true'
+[no-tunable-upper-bound-value]='true'
+[null-tunable-upper-bound]='true'
+[char-tunable-upper-bound]='true'
 [zero-tunable-upper-bound]='true'
+[integer-tunable-upper-bound]='false'
 [valid-tunable-upper-bound]='true')
+
 
 # Expected log message for tunable-upper-bound
 declare -A tunable_upper_bound_expected_log_msgs
+memory_tuneable="memoryRequest"
 tunable_upper_bound_yaml_path="${yaml_path}/${kruize_layer_tests[11]}"
 tunable_upper_bound_kubectl_error=': error validating data: ValidationError(KruizeLayer.tunables\[0\]): missing required field "upper_bound" in com.recommender.v1.KruizeLayer.tunables; if you choose to ignore these errors, turn validation off with --validate=false'
-invalid_upper_bound_error=': error validating data: ValidationError(KruizeLayer.tunables\[0\].upper_bound): invalid type for com.recommender.v1.KruizeLayer.tunables.upper_bound: got "string", expected "number"; if you choose to ignore these errors, turn validation off with --validate=false'
-tunable_upper_bound_expected_log_msgs=([blank-tunable-upper-bound]='error: error validating "'${tunable_upper_bound_yaml_path}/blank-tunable-upper-bound.yaml'"'${invalid_upper_bound_error}''
-[invalid-tunable-upper-bound]=''${invalid_bound_exception}''
-[no-tunable-upper-bound]='error: error validating "'${tunable_upper_bound_yaml_path}/no-tunable-upper-bound.yaml'"'${tunable_upper_bound_kubectl_error}''
-[no-tunable-upper-bound-value]='error: error validating "'${tunable_upper_bound_yaml_path}/no-tunable-upper-bound-value.yaml'"'${tunable_upper_bound_kubectl_error}''
-[null-tunable-upper-bound]='error: error validating "'${tunable_upper_bound_yaml_path}/null-tunable-upper-bound.yaml'"'${tunable_upper_bound_kubectl_error}''
-[char-tunable-upper-bound]='error: error validating "'${tunable_upper_bound_yaml_path}/char-tunable-upper-bound.yaml'"'${invalid_upper_bound_error}''
-[zero-tunable-upper-bound]=''${invalid_bound_exception}''
-[valid-tunable-upper-bound]=''${kruize_layer_obj_create_msg}' valid-tunable-upper-bound')
+invalid_upper_bound_error='The KruizeLayer "invalid-tunable-upper-bound" is invalid:'
+tunable_upper_bound_expected_log_msgs=([blank-tunable-upper-bound]=''${invalid_bound_exception}': Bounds value(s) are empty'
+[invalid-tunable-upper-bound]=''${invalid_upper_bound_error}''
+[no-tunable-upper-bound]=''${invalid_bound_exception}': Bounds value(s) cannot be null'
+[integer-tunable-upper-bound]='The KruizeLayer "integer-tunable-upper-bound" is invalid:'
+[no-tunable-upper-bound-value]=''${invalid_bound_exception}': Bounds value(s) cannot be null'
+[null-tunable-upper-bound]=''${invalid_bound_exception}': Bounds value(s) cannot be null'
+[char-tunable-upper-bound]=''${invalid_bound_exception}': Error: Upper bound value is not a valid number'
+[zero-tunable-upper-bound]=''${invalid_bound_exception}': ERROR: Tunable: '${memory_tuneable}' has invalid bounds;'
+[valid-tunable-upper-bound]='Added autotuneconfig valid-tunable-upper-bound')
+
 
 # Expected autotune object for tunable lower bound
 declare -A tunable_lower_bound_autotune_objects
-tunable_lower_bound_autotune_objects=([blank-tunable-lower-bound]='false'
-[invalid-tunable-lower-bound]='true'
-[no-tunable-lower-bound]='false'
-[no-tunable-lower-bound-value]='false'
-[null-tunable-lower-bound]='false'
-[char-tunable-lower-bound]='false'
+invalid_lower_bound_error='The KruizeLayer "invalid-tunable-lower-bound" is invalid:'
+tunable_lower_bound_autotune_objects=([blank-tunable-lower-bound]='true'
+[invalid-tunable-lower-bound]='false'
+[no-tunable-lower-bound]='true'
+[no-tunable-lower-bound-value]='true'
+[null-tunable-lower-bound]='true'
+[char-tunable-lower-bound]='true'
 [zero-tunable-lower-bound]='true'
+[integer-tunable-lower-bound]='false'
+[zero-tunable-nonstring-lower-bound]='true'
 [valid-tunable-lower-bound]='true')
 
 # Expected log message for tunable-lower-bound
 declare -A tunable_lower_bound_expected_log_msgs
+memory_tuneable="memoryRequest"
 tunable_lower_bound_yaml_path="${yaml_path}/${kruize_layer_tests[12]}"
 tunable_lower_bound_kubectl_error=': error validating data: ValidationError(KruizeLayer.tunables\[0\]): missing required field "lower_bound" in com.recommender.v1.KruizeLayer.tunables; if you choose to ignore these errors, turn validation off with --validate=false'
-invalid_lower_bound_error=': error validating data: ValidationError(KruizeLayer.tunables\[0\].lower_bound): invalid type for com.recommender.v1.KruizeLayer.tunables.lower_bound: got "string", expected "number"; if you choose to ignore these errors, turn validation off with --validate=false'
-tunable_lower_bound_expected_log_msgs=([blank-tunable-lower-bound]='error: error validating "'${tunable_lower_bound_yaml_path}/blank-tunable-lower-bound.yaml'"'${invalid_lower_bound_error}''
-[invalid-tunable-lower-bound]=''${invalid_bound_exception}''
-[no-tunable-lower-bound]='error: error validating "'${tunable_lower_bound_yaml_path}/no-tunable-lower-bound.yaml'"'${tunable_lower_bound_kubectl_error}''
-[no-tunable-lower-bound-value]='error: error validating "'${tunable_lower_bound_yaml_path}/no-tunable-lower-bound-value.yaml'"'${tunable_lower_bound_kubectl_error}''
-[null-tunable-lower-bound]='error: error validating "'${tunable_lower_bound_yaml_path}/null-tunable-lower-bound.yaml'"'${tunable_lower_bound_kubectl_error}''
-[char-tunable-lower-bound]='error: error validating "'${tunable_lower_bound_yaml_path}/char-tunable-lower-bound.yaml'"'${invalid_lower_bound_error}''
-[zero-tunable-lower-bound]=''${kruize_layer_obj_create_msg}' zero-tunable-lower-bound'
-[valid-tunable-lower-bound]=''${kruize_layer_obj_create_msg}' valid-tunable-lower-bound')
+invalid_lower_bound_error='The KruizeLayer "invalid-tunable-lower-bound" is invalid:'
+tunable_lower_bound_expected_log_msgs=([blank-tunable-lower-bound]=''${invalid_bound_exception}': Bounds value(s) are empty'
+[invalid-tunable-lower-bound]=''${invalid_lower_bound_error}''
+[no-tunable-lower-bound]=''${invalid_bound_exception}': Bounds value(s) cannot be null'
+[no-tunable-lower-bound-value]=''${invalid_bound_exception}': Bounds value(s) cannot be null'
+[null-tunable-lower-bound]=''${invalid_bound_exception}': Bounds value(s) cannot be null'
+[char-tunable-lower-bound]=''${invalid_bound_exception}': Error: Lower bound value is not a valid number'
+[zero-tunable-lower-bound]='Test yet to be decided'
+[integer-tunable-lower-bound]='The KruizeLayer "integer-tunable-lower-bound" is invalid:'
+[valid-tunable-lower-bound]='Added autotuneconfig valid-tunable-lower-bound')
 
 # Expected autotune object for step
 declare -A step_autotune_objects


### PR DESCRIPTION
Summary:
This Pr aims to fix all the test cases included in upper_bound and lower_bound test suite. 

Notes:
The logic for testing zero-tunable-lower-bound case is ambiguous and needs to be discussed as for some of the case the value of lowerbound for a tuneable can be zero.

While fixing the tests when provided with ambiguous bound values for tunables. A loop was getting triggered which was spawning multiple threads and was resulting in memory crash. Preventive measures are taken in try catch blocks to avoid this loop. 

closes #103 
closes #104 
closes #143 