### PR TITLE
Moved capturing ffdc logs into a separate step

### DIFF
--- a/.github/workflows/test-on-pr.yaml
+++ b/.github/workflows/test-on-pr.yaml
@@ -50,6 +50,8 @@ jobs:
           echo "***************************************************************"
           ./deploy.sh -c minikube -i autotune_operator:test
           sleep 20
+      - name: Capture ffdc logs
+        run: |
           ./scripts/ffdc.sh -d ${GITHUB_WORKSPACE}
       - name: Archive results
         if: always()
@@ -102,7 +104,8 @@ jobs:
 
           cd tests
           ./test_autotune.sh -c minikube -i autotune_operator:test --testsuite=remote_monitoring_tests --testcase=test_e2e --resultsdir=${GITHUB_WORKSPACE}
-          cd ..
+      - name: Capture ffdc logs
+        run: |
           ./scripts/ffdc.sh -m crc -d ${GITHUB_WORKSPACE}/kruize_test_results
       - name: Archive results
         if: always()

--- a/.github/workflows/test-on-push.yaml
+++ b/.github/workflows/test-on-push.yaml
@@ -65,6 +65,8 @@ jobs:
           echo Deploy Kruize in experiment mode
           ./deploy.sh -c minikube -i kruize/autotune_operator:test      
           sleep 20
+      - name: Capture ffdc logs
+        run: |
           ./scripts/ffdc.sh -d ${GITHUB_WORKSPACE}
       - name: Archive results
         if: always()
@@ -111,7 +113,8 @@ jobs:
           cat ./manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
           cd tests
           ./test_autotune.sh -c minikube -i kruize/autotune_operator:test --testsuite=remote_monitoring_tests --testcase=test_e2e --resultsdir=${GITHUB_WORKSPACE}
-          cd ..
+      - name: Capture ffdc logs
+        run: |
           ./scripts/ffdc.sh -m crc -d ${GITHUB_WORKSPACE}/kruize_test_results
       - name: Archive results
         if: always()


### PR DESCRIPTION
Moved capturing ffdc logs into a separate step as it is not executed when the deploy script fails