### PR TITLE
Set Kruize CPU and Mem request and Java Heap Size

### DIFF
--- a/.github/workflows/test-on-pr.yaml
+++ b/.github/workflows/test-on-pr.yaml
@@ -22,10 +22,13 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.3.0
+        id: minikube
+        uses: medyagh/setup-minikube@latest
         with:
-          minikube version: 'v1.16.0'
-          kubernetes version: 'v1.19.2'
+          minikube-version: 1.16.0
+          kubernetes-version: v1.19.2
+          cpus: 4
+          memory: 8000m
       - name: Build autotune
         run: |
           echo Build autotune

--- a/.github/workflows/test-on-pr.yaml
+++ b/.github/workflows/test-on-pr.yaml
@@ -1,6 +1,6 @@
 name: Test on Pull Request
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   pull_request:
     paths-ignore:
@@ -28,12 +28,12 @@ jobs:
           minikube-version: 1.16.0
           kubernetes-version: v1.19.2
           cpus: 4
-          memory: 8000m
+          memory: 6000m
       - name: Build autotune
         run: |
           echo Build autotune
           ./build.sh -i autotune_operator:test
-          docker images | grep autotune     
+          docker images | grep autotune
       - name: Check cluster info on minikube
         run: |
           kubectl cluster-info
@@ -79,10 +79,13 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.3.0
+        id: minikube
+        uses: medyagh/setup-minikube@latest
         with:
-          minikube version: 'v1.16.0'
-          kubernetes version: 'v1.19.2'
+          minikube-version: 1.16.0
+          kubernetes-version: v1.19.2
+          cpus: 4
+          memory: 6000m
       - name: Build crc
         run: |
           echo Build crc
@@ -123,4 +126,3 @@ jobs:
           name: crc-results
           path: ./crc_results.tar
           retention-days: 2
-

--- a/.github/workflows/test-on-pr.yaml
+++ b/.github/workflows/test-on-pr.yaml
@@ -1,6 +1,6 @@
 name: Test on Pull Request
 
-# Controls when the action will run.
+# Controls when the action will run. 
 on:
   pull_request:
     paths-ignore:
@@ -22,18 +22,15 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
       - name: Setup Minikube
-        id: minikube
-        uses: medyagh/setup-minikube@latest
+        uses: manusa/actions-setup-minikube@v2.3.0
         with:
-          minikube-version: 1.16.0
-          kubernetes-version: v1.19.2
-          cpus: 4
-          memory: 6000m
+          minikube version: 'v1.16.0'
+          kubernetes version: 'v1.19.2'
       - name: Build autotune
         run: |
           echo Build autotune
           ./build.sh -i autotune_operator:test
-          docker images | grep autotune
+          docker images | grep autotune     
       - name: Check cluster info on minikube
         run: |
           kubectl cluster-info
@@ -79,13 +76,10 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
       - name: Setup Minikube
-        id: minikube
-        uses: medyagh/setup-minikube@latest
+        uses: manusa/actions-setup-minikube@v2.3.0
         with:
-          minikube-version: 1.16.0
-          kubernetes-version: v1.19.2
-          cpus: 4
-          memory: 6000m
+          minikube version: 'v1.16.0'
+          kubernetes version: 'v1.19.2'
       - name: Build crc
         run: |
           echo Build crc
@@ -126,3 +120,4 @@ jobs:
           name: crc-results
           path: ./crc_results.tar
           retention-days: 2
+

--- a/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
@@ -79,6 +79,14 @@ spec:
               value: "/etc/config/dbconfigjson"
             - name: KRUIZE_CONFIG_FILE
               value: "/etc/config/kruizeconfigjson"
+            - name: JAVA_OPTIONS
+              value: " -server -XX:MaxRAMPercentage=90"
+          resources:
+            requests:
+              memory: "4Gi"
+              cpu: "2"
+            limits:
+              memory: "4Gi"
           ports:
             - name: kruize-port
               containerPort: 8080

--- a/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
@@ -83,10 +83,10 @@ spec:
               value: " -server -XX:MaxRAMPercentage=90"
           resources:
             requests:
-              memory: "2Gi"
-              cpu: "1"
+              memory: "500m"
+              cpu: "0.5"
             limits:
-              memory: "2Gi"
+              memory: "500m"
           ports:
             - name: kruize-port
               containerPort: 8080

--- a/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
@@ -79,8 +79,8 @@ spec:
               value: "/etc/config/dbconfigjson"
             - name: KRUIZE_CONFIG_FILE
               value: "/etc/config/kruizeconfigjson"
-            - name: JAVA_OPTIONS
-              value: " -server -XX:MaxRAMPercentage=90"
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=80"
           ports:
             - name: kruize-port
               containerPort: 8080

--- a/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
@@ -81,12 +81,6 @@ spec:
               value: "/etc/config/kruizeconfigjson"
             - name: JAVA_OPTIONS
               value: " -server -XX:MaxRAMPercentage=90"
-          resources:
-            requests:
-              memory: "500m"
-              cpu: "0.5"
-            limits:
-              memory: "500m"
           ports:
             - name: kruize-port
               containerPort: 8080

--- a/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
@@ -83,10 +83,10 @@ spec:
               value: " -server -XX:MaxRAMPercentage=90"
           resources:
             requests:
-              memory: "4Gi"
-              cpu: "2"
+              memory: "2Gi"
+              cpu: "1"
             limits:
-              memory: "4Gi"
+              memory: "2Gi"
           ports:
             - name: kruize-port
               containerPort: 8080

--- a/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
@@ -79,6 +79,14 @@ spec:
               value: "/etc/config/dbconfigjson"
             - name: KRUIZE_CONFIG_FILE
               value: "/etc/config/kruizeconfigjson"
+            - name: JAVA_OPTIONS
+              value: " -server -XX:MaxRAMPercentage=90"
+          resources:
+            requests:
+              memory: "4Gi"
+              cpu: "2"
+            limits:
+              memory: "4Gi"
           ports:
             - name: kruize-port
               containerPort: 8080

--- a/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
@@ -79,12 +79,12 @@ spec:
               value: "/etc/config/dbconfigjson"
             - name: KRUIZE_CONFIG_FILE
               value: "/etc/config/kruizeconfigjson"
-            - name: JAVA_OPTIONS
-              value: " -server -XX:MaxRAMPercentage=90"
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=80"
           resources:
             requests:
               memory: "4Gi"
-              cpu: "2"
+              cpu: "4"
             limits:
               memory: "4Gi"
           ports:

--- a/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
@@ -157,8 +157,8 @@ spec:
               value: "/etc/config/dbconfigjson"
             - name: KRUIZE_CONFIG_FILE
               value: "/etc/config/kruizeconfigjson"
-            - name: JAVA_OPTIONS
-              value: " -server -XX:MaxRAMPercentage=90"
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=80"
           ports:
             - name: kruize-port
               containerPort: 8080

--- a/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
@@ -159,12 +159,6 @@ spec:
               value: "/etc/config/kruizeconfigjson"
             - name: JAVA_OPTIONS
               value: " -server -XX:MaxRAMPercentage=90"
-          resources:
-            requests:
-              memory: "500m"
-              cpu: "0.5"
-            limits:
-              memory: "500m"
           ports:
             - name: kruize-port
               containerPort: 8080

--- a/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
@@ -161,10 +161,10 @@ spec:
               value: " -server -XX:MaxRAMPercentage=90"
           resources:
             requests:
-              memory: "4Gi"
-              cpu: "2"
+              memory: "2Gi"
+              cpu: "1"
             limits:
-              memory: "4Gi"
+              memory: "2Gi"
           ports:
             - name: kruize-port
               containerPort: 8080

--- a/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
@@ -161,10 +161,10 @@ spec:
               value: " -server -XX:MaxRAMPercentage=90"
           resources:
             requests:
-              memory: "2Gi"
-              cpu: "1"
+              memory: "500m"
+              cpu: "0.5"
             limits:
-              memory: "2Gi"
+              memory: "500m"
           ports:
             - name: kruize-port
               containerPort: 8080

--- a/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
@@ -157,6 +157,14 @@ spec:
               value: "/etc/config/dbconfigjson"
             - name: KRUIZE_CONFIG_FILE
               value: "/etc/config/kruizeconfigjson"
+            - name: JAVA_OPTIONS
+              value: " -server -XX:MaxRAMPercentage=90"
+          resources:
+            requests:
+              memory: "4Gi"
+              cpu: "2"
+            limits:
+              memory: "4Gi"
           ports:
             - name: kruize-port
               containerPort: 8080

--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -196,12 +196,12 @@ spec:
               value: "/etc/config/dbconfigjson"
             - name: KRUIZE_CONFIG_FILE
               value: "/etc/config/kruizeconfigjson"
-            - name: JAVA_OPTIONS
-              value: " -server -XX:MaxRAMPercentage=90"
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=80"
           resources:
             requests:
               memory: "4Gi"
-              cpu: "2"
+              cpu: "4"
             limits:
               memory: "4Gi"
           ports:

--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -196,6 +196,14 @@ spec:
               value: "/etc/config/dbconfigjson"
             - name: KRUIZE_CONFIG_FILE
               value: "/etc/config/kruizeconfigjson"
+            - name: JAVA_OPTIONS
+              value: " -server -XX:MaxRAMPercentage=90"
+          resources:
+            requests:
+              memory: "4Gi"
+              cpu: "2"
+            limits:
+              memory: "4Gi"
           ports:
             - name: kruize-port
               containerPort: 8080


### PR DESCRIPTION
Set Kruize Requests and Limits as follows (OpenShift only)
- CPU = 4 cores
- Mem = 4Gi
- Java Heap = -XX:MaxRAMPercentage=80  
```
# This means  Heap Size = 80% 4Gi = 3.2Gi
# Native mem = 819Mi
```
Not setting any config for minikube as it is needed to be run in constrained environments