### PR TITLE
Fix variation for limits

### DIFF
--- a/src/main/java/com/autotune/analyzer/recommendations/engine/DurationBasedRecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/DurationBasedRecommendationEngine.java
@@ -231,7 +231,7 @@ public class DurationBasedRecommendationEngine implements KruizeRecommendationEn
                 }
 
                 // Set Limits variation map
-                variation.put(AnalyzerConstants.ResourceSetting.limits, limitsMap);
+                variation.put(AnalyzerConstants.ResourceSetting.limits, limitsVariationMap);
                 recommendation.setVariation(variation);
 
                 // Set Recommendations


### PR DESCRIPTION
The current limits are set same in variation due to variable change. This PR sets the correct variables to be placed.