### PR TITLE
Use GSON registerTypeAdapter to set the Date adapter to convert to JSON before writing to DB

### DIFF
--- a/src/main/java/com/autotune/database/helper/DBHelpers.java
+++ b/src/main/java/com/autotune/database/helper/DBHelpers.java
@@ -114,6 +114,12 @@ public class DBHelpers {
              */
             public static KruizeResultsEntry convertExperimentResultToExperimentResultsTable(ExperimentResultData experimentResultData) {
                 KruizeResultsEntry kruizeResultsEntry = null;
+                Gson gson = new GsonBuilder()
+                        .disableHtmlEscaping()
+                        .setPrettyPrinting()
+                        .enableComplexMapKeySerialization()
+                        .registerTypeAdapter(Date.class, new GsonUTCDateAdapter())
+                        .create();
                 try {
                     kruizeResultsEntry = new KruizeResultsEntry();
                     kruizeResultsEntry.setExperiment_name(experimentResultData.getExperiment_name());
@@ -123,13 +129,13 @@ public class DBHelpers {
                             Double.valueOf((experimentResultData.getIntervalEndTime().getTime() -
                                     experimentResultData.getIntervalStartTime().getTime()) / (60 * 1000))
                     );
-                    JSONObject jsonObject = new JSONObject();
-                    jsonObject.put(KruizeConstants.JSONKeys.KUBERNETES_OBJECTS, experimentResultData.getKubernetes_objects());
+                    Map k8sObjectsMap = Map.of(KruizeConstants.JSONKeys.KUBERNETES_OBJECTS, experimentResultData.getKubernetes_objects());
+                    String k8sObjectString = gson.toJson(k8sObjectsMap);
                     ObjectMapper objectMapper = new ObjectMapper();
                     try {
                         kruizeResultsEntry.setExtended_data(
                                 objectMapper.readTree(
-                                        jsonObject.toString()
+                                        k8sObjectString
                                 )
                         );
                     } catch (JsonProcessingException e) {


### PR DESCRIPTION
As we are seeing inconsistencies with milliseconds in `monitoring_end_timestamp` as

```
"2023-04-02T13:30:00.680Z": {
                  "duration_based": {
                    "short_term": {
                      "monitoring_start_time": "2023-04-01T12:00:00.000Z",
                      "monitoring_end_time": "2023-04-02T13:30:00.068Z",
```

This PR removes the usage of plain JSONObject and uses Gson's registerTypeAdapter to set the GsonUTCdateAdapter to strictly preserve the precision of the date.

Results:

```
"data": {
                                "2023-04-02T13:30:00.680Z": {
                                    "duration_based": {
                                        "short_term": {
                                            "monitoring_start_time": "2023-04-01T12:00:00.000Z",
                                            "monitoring_end_time": "2023-04-02T13:30:00.680Z",
                                            "duration_in_hours": 24.0,
                                            "pods_count": 27,
                                            "confidence_level": 0.0,
```

@dinogun Can I please have your review on this? Thanks in advance.