### PR TITLE
Add changes to fix DB retrival issues with Jackson

### DIFF
--- a/src/main/java/com/autotune/analyzer/serviceObjects/ContainerAPIObject.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/ContainerAPIObject.java
@@ -3,6 +3,7 @@ package com.autotune.analyzer.serviceObjects;
 import com.autotune.analyzer.recommendations.ContainerRecommendations;
 import com.autotune.common.data.metrics.Metric;
 import com.autotune.utils.KruizeConstants;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.List;
@@ -36,6 +37,7 @@ public class ContainerAPIObject {
         return container_name;
     }
 
+    @JsonProperty(KruizeConstants.JSONKeys.RECOMMENDATIONS)
     public ContainerRecommendations getContainerRecommendations() {
         return containerRecommendations;
     }

--- a/src/main/java/com/autotune/analyzer/serviceObjects/KubernetesAPIObject.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/KubernetesAPIObject.java
@@ -16,6 +16,7 @@
 package com.autotune.analyzer.serviceObjects;
 
 import com.autotune.utils.KruizeConstants;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.List;
@@ -54,6 +55,7 @@ public class KubernetesAPIObject {
         return namespace;
     }
 
+    @JsonProperty(KruizeConstants.JSONKeys.CONTAINERS)
     public List<ContainerAPIObject> getContainerAPIObjects() {
         return containerAPIObjects;
     }

--- a/src/main/java/com/autotune/common/data/metrics/Metric.java
+++ b/src/main/java/com/autotune/common/data/metrics/Metric.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package com.autotune.common.data.metrics;
 
+import com.autotune.utils.KruizeConstants;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.HashMap;
@@ -76,6 +78,7 @@ public final class Metric {
         return valueType;
     }
 
+    @JsonProperty(KruizeConstants.JSONKeys.RESULTS)
     public MetricResults getMetricResult() {
         return metricResults;
     }

--- a/src/main/java/com/autotune/common/data/metrics/MetricResults.java
+++ b/src/main/java/com/autotune/common/data/metrics/MetricResults.java
@@ -17,14 +17,15 @@ package com.autotune.common.data.metrics;
 
 import com.autotune.experimentManager.exceptions.IncompatibleInputJSONException;
 import com.autotune.utils.KruizeConstants;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.SerializedName;
 import org.json.JSONObject;
 
 public class MetricResults {
     private String name;
-    @SerializedName("aggregation_info")
+    @SerializedName(KruizeConstants.JSONKeys.AGGREGATION_INFO)
     private MetricAggregationInfoResults metricAggregationInfoResults;
-    @SerializedName("percentile_info")
+    @SerializedName(KruizeConstants.JSONKeys.PERCENTILE_INFO)
     private MetricPercentileResults metricPercentileResults;
     private Double value;
     private String format;
@@ -51,13 +52,15 @@ public class MetricResults {
         return isPercentileResultsAvailable;
     }
 
-    public void setPercentileResultsAvailable(boolean percentileResultsAvailable) {
-        isPercentileResultsAvailable = percentileResultsAvailable;
+    public void setIsPercentileResultsAvailable(boolean isPercentileResultsAvailable) {
+        isPercentileResultsAvailable = isPercentileResultsAvailable;
     }
+    @JsonProperty(KruizeConstants.JSONKeys.AGGREGATION_INFO)
     public MetricAggregationInfoResults getAggregationInfoResult() {
         return metricAggregationInfoResults;
     }
 
+    @JsonProperty(KruizeConstants.JSONKeys.PERCENTILE_INFO)
     public MetricPercentileResults getMetricPercentileResults() {
         return metricPercentileResults;
     }

--- a/src/main/java/com/autotune/common/k8sObjects/K8sObject.java
+++ b/src/main/java/com/autotune/common/k8sObjects/K8sObject.java
@@ -3,6 +3,7 @@ package com.autotune.common.k8sObjects;
 import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.common.data.result.ContainerData;
 import com.autotune.utils.KruizeConstants;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.HashMap;
@@ -45,6 +46,7 @@ public class K8sObject {
         this.namespace = namespace;
     }
 
+    @JsonProperty(KruizeConstants.JSONKeys.CONTAINERS)
     public HashMap<String, ContainerData> getContainerDataMap() {
         return containerDataMap;
     }

--- a/src/main/java/com/autotune/database/helper/DBHelpers.java
+++ b/src/main/java/com/autotune/database/helper/DBHelpers.java
@@ -316,8 +316,6 @@ public class DBHelpers {
                         kruizeResultsEntry.getMeta_data();
                         JsonNode extendedDataNode = kruizeResultsEntry.getExtended_data();
                         JsonNode k8sObjectsNode = extendedDataNode.get(KruizeConstants.JSONKeys.KUBERNETES_OBJECTS);
-//                        List<K8sObject> k8sObjectList = mapper.readValue(mapper.writeValueAsString(k8sObjectsNode), new TypeReference<>() {
-//                        });
                         List<K8sObject> k8sObjectList = new ArrayList<K8sObject>();
                         if (k8sObjectsNode.isArray()) {
                             for (JsonNode node: k8sObjectsNode) {
@@ -325,7 +323,7 @@ public class DBHelpers {
                                 if (null != k8sObject) {
                                     k8sObjectList.add(k8sObject);
                                 } else {
-                                    System.out.println("\n\n\n\n Its null, cant convert, check DB results \n\n\n\n");
+                                    LOGGER.debug("GSON failed to convert the DB Json object in convertResultEntryToUpdateResultsAPIObject");
                                 }
                             }
                         }
@@ -409,7 +407,7 @@ public class DBHelpers {
                                 if (null != kubernetesAPIObject) {
                                     kubernetesAPIObjectList.add(kubernetesAPIObject);
                                 } else {
-                                    System.out.println("\n\n\n\n Its null, cant convert, check DB recommendations \n\n\n\n");
+                                    LOGGER.debug("GSON failed to convert the DB Json object in convertRecommendationEntryToRecommendationAPIObject");
                                 }
                             }
                         }

--- a/src/main/java/com/autotune/database/helper/DBHelpers.java
+++ b/src/main/java/com/autotune/database/helper/DBHelpers.java
@@ -40,6 +40,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.json.JSONObject;
@@ -118,6 +119,7 @@ public class DBHelpers {
                         .disableHtmlEscaping()
                         .setPrettyPrinting()
                         .enableComplexMapKeySerialization()
+                        .setDateFormat(KruizeConstants.DateFormats.STANDARD_JSON_DATE_FORMAT)
                         .registerTypeAdapter(Date.class, new GsonUTCDateAdapter())
                         .create();
                 try {
@@ -222,6 +224,7 @@ public class DBHelpers {
                         .disableHtmlEscaping()
                         .setPrettyPrinting()
                         .enableComplexMapKeySerialization()
+                        .setDateFormat(KruizeConstants.DateFormats.STANDARD_JSON_DATE_FORMAT)
                         .registerTypeAdapter(Date.class, new GsonUTCDateAdapter())
                         .create();
                 try {
@@ -294,6 +297,15 @@ public class DBHelpers {
 
             public static List<UpdateResultsAPIObject> convertResultEntryToUpdateResultsAPIObject(List<KruizeResultsEntry> kruizeResultsEntries) throws JsonProcessingException {
                 ObjectMapper mapper = new ObjectMapper();
+                DateFormat df = new SimpleDateFormat(KruizeConstants.DateFormats.STANDARD_JSON_DATE_FORMAT);
+                mapper.setDateFormat(df);
+                Gson gson = new GsonBuilder()
+                        .disableHtmlEscaping()
+                        .setPrettyPrinting()
+                        .enableComplexMapKeySerialization()
+                        .setDateFormat(KruizeConstants.DateFormats.STANDARD_JSON_DATE_FORMAT)
+                        .registerTypeAdapter(Date.class, new GsonUTCDateAdapter())
+                        .create();
                 List<UpdateResultsAPIObject> updateResultsAPIObjects = new ArrayList<>();
                 for (KruizeResultsEntry kruizeResultsEntry : kruizeResultsEntries) {
                     try {
@@ -304,13 +316,25 @@ public class DBHelpers {
                         kruizeResultsEntry.getMeta_data();
                         JsonNode extendedDataNode = kruizeResultsEntry.getExtended_data();
                         JsonNode k8sObjectsNode = extendedDataNode.get(KruizeConstants.JSONKeys.KUBERNETES_OBJECTS);
-                        List<K8sObject> k8sObjectList = mapper.readValue(k8sObjectsNode.toString(), new TypeReference<>() {
-                        });
+//                        List<K8sObject> k8sObjectList = mapper.readValue(mapper.writeValueAsString(k8sObjectsNode), new TypeReference<>() {
+//                        });
+                        List<K8sObject> k8sObjectList = new ArrayList<K8sObject>();
+                        if (k8sObjectsNode.isArray()) {
+                            for (JsonNode node: k8sObjectsNode) {
+                                K8sObject k8sObject = gson.fromJson(mapper.writeValueAsString(node), K8sObject.class);
+                                if (null != k8sObject) {
+                                    k8sObjectList.add(k8sObject);
+                                } else {
+                                    System.out.println("\n\n\n\n Its null, cant convert, check DB results \n\n\n\n");
+                                }
+                            }
+                        }
                         List<KubernetesAPIObject> kubernetesAPIObjectList = convertK8sObjectListToKubernetesAPIObjectList(k8sObjectList);
                         updateResultsAPIObject.setKubernetesObjects(kubernetesAPIObjectList);
                         updateResultsAPIObjects.add(updateResultsAPIObject);
                     } catch (Exception e) {
                         LOGGER.error("Exception occurred while updating local storage: {}", e.getMessage());
+                        e.printStackTrace();
                     }
                 }
                 return updateResultsAPIObjects;
@@ -348,6 +372,13 @@ public class DBHelpers {
                     return null;
                 if (kruizeRecommendationEntryList.size() == 0)
                     return null;
+                Gson gson = new GsonBuilder()
+                        .disableHtmlEscaping()
+                        .setPrettyPrinting()
+                        .enableComplexMapKeySerialization()
+                        .setDateFormat(KruizeConstants.DateFormats.STANDARD_JSON_DATE_FORMAT)
+                        .registerTypeAdapter(Date.class, new GsonUTCDateAdapter())
+                        .create();
                 List<ListRecommendationsAPIObject> listRecommendationsAPIObjectList = new ArrayList<ListRecommendationsAPIObject>();
                 for (KruizeRecommendationEntry kruizeRecommendationEntry : kruizeRecommendationEntryList) {
                     // Check if instance of KruizeRecommendationEntry is null
@@ -362,7 +393,7 @@ public class DBHelpers {
                     }
                     // Create an Object Mapper to extract value from JSON Node
                     ObjectMapper objectMapper = new ObjectMapper();
-                    DateFormat df = new SimpleDateFormat(KruizeConstants.DateFormats.DB_EXTRACTION_FORMAT);
+                    DateFormat df = new SimpleDateFormat(KruizeConstants.DateFormats.STANDARD_JSON_DATE_FORMAT);
                     objectMapper.setDateFormat(df);
                     // Create a holder for recommendation object to save the result from object mapper
                     ListRecommendationsAPIObject listRecommendationsAPIObject = null;
@@ -371,8 +402,17 @@ public class DBHelpers {
                         continue;
                     try {
                         // If successful, the object mapper returns the list recommendation API Object
-                        List<KubernetesAPIObject> kubernetesAPIObjectList = objectMapper.readValue(extendedData.toString(),
-                                new TypeReference<>(){});
+                        List<KubernetesAPIObject> kubernetesAPIObjectList = new ArrayList<KubernetesAPIObject>();
+                        if (extendedData.isArray()) {
+                            for (JsonNode node: extendedData) {
+                                KubernetesAPIObject kubernetesAPIObject = gson.fromJson(objectMapper.writeValueAsString(node), KubernetesAPIObject.class);
+                                if (null != kubernetesAPIObject) {
+                                    kubernetesAPIObjectList.add(kubernetesAPIObject);
+                                } else {
+                                    System.out.println("\n\n\n\n Its null, cant convert, check DB recommendations \n\n\n\n");
+                                }
+                            }
+                        }
                         if (null != kubernetesAPIObjectList) {
                             listRecommendationsAPIObject = new ListRecommendationsAPIObject();
                             listRecommendationsAPIObject.setKubernetesObjects(kubernetesAPIObjectList);


### PR DESCRIPTION
Recent changes for preserving timestamp with precision by GSON lib (Ref #793) has introduced new issues where the JSON read from DB cannot be parsed due to the below issues

```
com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "containers" (class com.autotune.analyzer.serviceObjects.KubernetesAPIObject), not marked as ignorable (4 known properties: "type", "name", "namespace", "containerAPIObjects"])
 at [Source: (String)"[{"name":"tfb-qrh-deployment_0","type":"deployment","namespace":"default_0","containers":[{"container_name":"tfb-server-1","recommendations":{"data":{"2023-04-02T13:30:00.680Z":{"duration_based":{"long_term":{"pods_count":0,"notifications":[{"type":"info","message":"There is not enough data available to generate a recommendation."}],"confidence_level":0.0},"short_term":{"config":{"limits":{"cpu":{"amount":0.9299999999999999,"format":"cores"},"memory":{"amount":238.2,"format":"MiB"}},"requests":{"[truncated 819 chars]; line: 1, column: 91] (through reference chain: java.util.ArrayList[0]->com.autotune.analyzer.serviceObjects.KubernetesAPIObject["containers"])
	at com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException.from(UnrecognizedPropertyException.java:61)
	at com.fasterxml.jackson.databind.DeserializationContext.handleUnknownProperty(DeserializationContext.java:987)
	at com.fasterxml.jackson.databind.deser.std.StdDeserializer.handleUnknownProperty(StdDeserializer.java:1974)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.handleUnknownProperty(BeanDeserializerBase.java:1701)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.handleUnknownVanilla(BeanDeserializerBase.java:1679)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:330)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:187)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer._deserializeFromArray(CollectionDeserializer.java:355)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:244)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:28)
	at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:322)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4593)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3548)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3531)
```

This PR fixes the above issues and also other similar issues which have came up when kruize trying to populate it's map from DB.

@dinogun Can I please have your review?