### PR TITLE
Fix variation object

### DIFF
--- a/src/main/java/com/autotune/analyzer/recommendations/engine/DurationBasedRecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/DurationBasedRecommendationEngine.java
@@ -199,7 +199,8 @@ public class DurationBasedRecommendationEngine implements KruizeRecommendationEn
                 }
 
                 // Set Request variation map
-                variation.put(AnalyzerConstants.ResourceSetting.requests, requestsVariationMap);
+                if (!requestsVariationMap.isEmpty())
+                    variation.put(AnalyzerConstants.ResourceSetting.requests, requestsVariationMap);
 
                 // Create a new map for storing variation in limits
                 HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> limitsVariationMap = new HashMap<>();
@@ -207,9 +208,17 @@ public class DurationBasedRecommendationEngine implements KruizeRecommendationEn
                 // Calling requests on limits as we are maintaining limits and requests as same
                 // Maintaining different flow for both of them even though if they are same as in future we might have
                 // a different implementation for both and this avoids confusion
-                Double currentCpuLimit = currentCpuRequest;
-                Double currentMemLimit = currentMemRequest;
+                Double currentCpuLimit = getCurrentValue(   filteredResultsMap,
+                                                            timestampToExtract,
+                                                            AnalyzerConstants.ResourceSetting.limits,
+                                                            AnalyzerConstants.RecommendationItem.cpu);;
+                Double currentMemLimit = getCurrentValue(   filteredResultsMap,
+                                                            timestampToExtract,
+                                                            AnalyzerConstants.ResourceSetting.limits,
+                                                            AnalyzerConstants.RecommendationItem.memory);
 
+                // No notification if CPU limit not set
+                // Check if currentCpuLimit is not null and
                 if (null != currentCpuLimit
                         && null != generatedCpuLimit
                         && null != generatedCpuLimitFormat) {
@@ -231,8 +240,12 @@ public class DurationBasedRecommendationEngine implements KruizeRecommendationEn
                 }
 
                 // Set Limits variation map
-                variation.put(AnalyzerConstants.ResourceSetting.limits, limitsVariationMap);
-                recommendation.setVariation(variation);
+                if (!limitsVariationMap.isEmpty())
+                    variation.put(AnalyzerConstants.ResourceSetting.limits, limitsVariationMap);
+
+                // Set Variation Map
+                if (!variation.isEmpty())
+                    recommendation.setVariation(variation);
 
                 // Set Recommendations
                 resultRecommendation.put(recPeriod, recommendation);


### PR DESCRIPTION
The current implementation of variation needs to be like

![variation_object](https://user-images.githubusercontent.com/14173012/235438338-2801a766-535f-4c17-a890-365e403a4f24.png)


But we have changed the `currentCPULimits` to `currentCPURequest` and `currentMemLimits` to `currentMemRequest` at the time of setting the limit values of recommendation same as requests. This causes issue like showing Limits and Request not set notifications to appear in the case only where request are set but limits exist. And some times this allows empty variation object to be added.

This PR checks if map is not empty before adding and also extracts the current limits and requests for calculating variation