### PR TITLE
Set Allow private network to true

### DIFF
--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -331,6 +331,15 @@ public class KruizeConstants {
         public static final String ALLOWED_METHODS = "POST, GET";
         public static final String ALLOWED_HEADERS = "X-PINGOTHER, Origin, X-Requested-With, Content-Type, Accept";
         public static final String MAX_AGE = "1728000";
+        public static final String ALLOW_PRIVATE_NETWORKS = "true";
+
+        public static class FilterParam {
+
+            public static final String ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK = "Access-Control-Allow-Private-Network";
+            private FilterParam() {
+
+            }
+        }
 
         private CORSConstants() {
 

--- a/src/main/java/com/autotune/utils/filter/KruizeCORSFilter.java
+++ b/src/main/java/com/autotune/utils/filter/KruizeCORSFilter.java
@@ -55,6 +55,10 @@ public class KruizeCORSFilter {
                     CrossOriginFilter.ACCESS_CONTROL_MAX_AGE_HEADER,
                     KruizeConstants.CORSConstants.MAX_AGE
             );
+            filterParams.put(
+                    KruizeConstants.CORSConstants.FilterParam.ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK,
+                    KruizeConstants.CORSConstants.ALLOW_PRIVATE_NETWORKS
+            );
             filterHolder.setInitParameters(filterParams);
         }
         return filterHolder;


### PR DESCRIPTION
Kruize UI is facing issues with private network

```
Access to fetch at 'http://192.168.39.141:30487/listRecommendations?experiment_name=quarkus-resteasy-kruize-min-http-response-time-db_0&latest=false' from origin 'http://0.0.0.0:8080/' has been blocked by CORS policy: The request client is not a secure context and the resource is in more-private address space `private`.
```

Added a response header `Access-Control-Allow-Private-Network` and setting it to `true`