### PR TITLE
Fixed db persist issue with openshift.

### DIFF
--- a/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: monitoring
 spec:
   capacity:
-    storage: 1Gi
+    storage: 20Gi
   accessModes:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
@@ -22,7 +22,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 1Gi
+      storage: 20Gi
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -3,33 +3,6 @@ kind: Namespace
 metadata:
   name: openshift-tuning
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: kruize-sa
-  namespace: openshift-tuning
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: autotune-scc-crb
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:openshift:scc:anyuid
-subjects:
-  - kind: ServiceAccount
-    name: kruize-sa
-    namespace: openshift-tuning
----
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: manual
-provisioner: kubernetes.io/no-provisioner
-reclaimPolicy: Retain
-volumeBindingMode: Immediate
----
 kind: PersistentVolume
 apiVersion: v1
 metadata:
@@ -41,7 +14,7 @@ metadata:
 spec:
   storageClassName: manual
   capacity:
-    storage: 1Gi # Sets PV Volume
+    storage: 20Gi # Sets PV Volume
   accessModes:
     - ReadWriteMany
   hostPath:
@@ -60,7 +33,7 @@ spec:
     - ReadWriteMany  # Sets read and write access
   resources:
     requests:
-      storage: 1Gi  # Sets volume size
+      storage: 20Gi  # Sets volume size
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -95,7 +68,7 @@ data:
         "dialect": "org.hibernate.dialect.PostgreSQLDialect",
         "driver": "org.postgresql.Driver",
         "c3p0minsize": 2,
-        "c3p0maxsize": 5,
+        "c3p0maxsize": 50,
         "c3p0timeout": 300,
         "c3p0maxstatements": 50,
         "hbm2ddlauto": "update",
@@ -121,25 +94,22 @@ spec:
       labels:
         app: postgres
     spec:
-      serviceAccountName: kruize-sa
       containers:
         - name: postgres
-          image: postgres:15.2
+          image: image-registry.openshift-image-registry.svc:5000/openshift/postgresql
           imagePullPolicy: IfNotPresent
           env:
-            - name: POSTGRES_PASSWORD
-              value: admin
-            - name: POSTGRES_USER
-              value: admin
-            - name: POSTGRES_DB
+            - name: POSTGRESQL_DATABASE
               value: kruizeDB
-            - name: PGDATA
-              value: /var/lib/pg_data
+            - name: POSTGRESQL_PASSWORD
+              value: admin
+            - name: POSTGRESQL_USER
+              value: admin
           ports:
             - containerPort: 5432
           volumeMounts:
             - name: postgres-storage
-              mountPath: /var/lib/pgsql/data
+              mountPath: /home/pgdata
       volumes:
         - name: postgres-storage
           persistentVolumeClaim:
@@ -179,7 +149,6 @@ spec:
         app: kruize
         name: kruize
     spec:
-      serviceAccountName: kruize-sa
       containers:
         - name: kruize
           image: kruize/autotune_operator:0.0.13_rm

--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -3,6 +3,14 @@ kind: Namespace
 metadata:
   name: openshift-tuning
 ---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: manual
+provisioner: kubernetes.io/no-provisioner
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+---
 kind: PersistentVolume
 apiVersion: v1
 metadata:
@@ -77,6 +85,16 @@ data:
       }
     }
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-config
+  namespace: openshift-tuning
+data:
+  POSTGRESQL_USER: admin
+  POSTGRESQL_PASSWORD: admin
+  POSTGRESQL_DATABASE: kruizeDB
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -98,13 +116,9 @@ spec:
         - name: postgres
           image: image-registry.openshift-image-registry.svc:5000/openshift/postgresql
           imagePullPolicy: IfNotPresent
-          env:
-            - name: POSTGRESQL_DATABASE
-              value: kruizeDB
-            - name: POSTGRESQL_PASSWORD
-              value: admin
-            - name: POSTGRESQL_USER
-              value: admin
+          envFrom:
+            - configMapRef:
+                name: postgres-config
           ports:
             - containerPort: 5432
           volumeMounts:


### PR DESCRIPTION
The default deployment of the docker.in/Postgres image on OpenShift runs as a root user, which is restricted. Therefore, the OpenShift Postgres image is utilized instead, and the SCC role is removed. Consequently, Postgres can now be deployed without SCC:anyUid, resolving the issue of data playback in case of a Postgres pod restart.