### PR TITLE
Fix monitoring start time issue causing PR check failure

### DIFF
--- a/src/main/java/com/autotune/common/data/result/IntervalResults.java
+++ b/src/main/java/com/autotune/common/data/result/IntervalResults.java
@@ -65,6 +65,10 @@ public class IntervalResults {
         this.metricResultsMap = metricResultsMap;
     }
 
+    public Timestamp getIntervalStartTime() {
+        return intervalStartTime;
+    }
+
     @Override
     public String toString() {
         return "IntervalResults{" +


### PR DESCRIPTION
This PR fixes the test failure in PR check post #770 merge. 

**Issue** : `monitoring_start_time` mismatch in `listRecommendations`. Test expects the `monitoring_start_time` for short term to be 1 day less than the `monitoring_end_time`.

```
test_e2e_workflow.py::test_list_recommendations_multiple_exps_from_diff_json_files - AssertionError: actual = 2023-05-26T18:19:14.407Z expected = 2023-05-26T18:04:14.407Z
```
[test_e2e.zip](https://github.com/kruize/autotune/files/11610608/test_e2e.zip)


After fixing, ran the end to end test. (Attached test report)