### PR TITLE
add index to recommendations and results table

### DIFF
--- a/design/KruizeDatabaseDesign.md
+++ b/design/KruizeDatabaseDesign.md
@@ -361,12 +361,10 @@ GROUP BY id;
 
 ---
 
-
 The entity called Kruize_results is used to store the metric results of a previously created experiment, and this data
 is either sent through an external system or retrieved from a data source such as Prometheus or Thanos in order to
 generate recommendations. The columns in this entity include the version, experiment name, start and end timestamps for
 monitoring, duration in minutes, extended data, and metadata.
-
 
 <table>
   <tr>
@@ -442,6 +440,12 @@ monitoring, duration in minutes, extended data, and metadata.
    </td>
   </tr>
 </table>
+
+Following index added
+
+```
+CREATE INDEX idx_result_experiment_name ON public.kruize_results USING btree (experiment_name)
+```
 
 ### Experiment_results API
 
@@ -617,7 +621,6 @@ Where r.experiment_name = e.experiment_name
 The purpose of this entity is to store the recommendations generated for each experiment, with the Kubernetes objects
 tree stored in the extended_data column, where the recommendations are stored on a per-container basis
 
-
 <table>
   <tr>
    <td><strong>Attribute</strong>
@@ -668,6 +671,14 @@ tree stored in the extended_data column, where the recommendations are stored on
    </td>
   </tr>
 </table>
+
+Following index added
+
+```
+CREATE INDEX idx_recommendation_cluster_name ON public.kruize_recommendations USING btree (cluster_name)
+CREATE INDEX idx_recommendation_experiment_name ON public.kruize_recommendations USING btree (experiment_name)
+CREATE INDEX idx_recommendation_interval_end_time ON public.kruize_recommendations USING btree (interval_end_time)
+```
 
 ### Recommendation API
 

--- a/src/main/java/com/autotune/database/table/KruizeRecommendationEntry.java
+++ b/src/main/java/com/autotune/database/table/KruizeRecommendationEntry.java
@@ -8,7 +8,20 @@ import org.hibernate.type.SqlTypes;
 import java.sql.Timestamp;
 
 @Entity
-@Table(name = "kruize_recommendations")
+@Table(name = "kruize_recommendations", indexes = {
+        @Index(
+                name = "idx_recommendation_experiment_name",
+                columnList = "experiment_name",
+                unique = false),
+        @Index(
+                name = "idx_recommendation_cluster_name",
+                columnList = "cluster_name",
+                unique = false),
+        @Index(
+                name = "idx_recommendation_interval_end_time",
+                columnList = "interval_end_time",
+                unique = false)
+})
 public class KruizeRecommendationEntry {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/autotune/database/table/KruizeResultsEntry.java
+++ b/src/main/java/com/autotune/database/table/KruizeResultsEntry.java
@@ -28,7 +28,11 @@ import java.sql.Timestamp;
  */
 @Entity
 @Table(name = "kruize_results",
-        uniqueConstraints = {@UniqueConstraint(columnNames = {"experiment_name", "interval_start_time", "interval_end_time"})})
+        uniqueConstraints = {@UniqueConstraint(columnNames = {"experiment_name", "interval_start_time", "interval_end_time"})},
+        indexes = @Index(
+                name = "idx_result_experiment_name",
+                columnList = "experiment_name",
+                unique = false))
 public class KruizeResultsEntry {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
Following index added 

1.   "CREATE INDEX idx_recommendation_cluster_name ON public.kruize_recommendations USING btree (cluster_name)"
2.  "CREATE INDEX idx_recommendation_experiment_name ON public.kruize_recommendations USING btree (experiment_name)"
3.  "CREATE INDEX idx_recommendation_interval_end_time ON public.kruize_recommendations USING btree (interval_end_time)"
4.  "CREATE INDEX idx_result_experiment_name ON public.kruize_results USING btree (experiment_name)"


this index will  avoid Parallel Seq Scan as shown in this example

```
kruize=> explain analyse select k1_0.recommendation_id,k1_0.cluster_name,k1_0.experiment_name,k1_0.extended_data,k1_0.interval_end_time from kruize_recommendations k1_0 where k1_0.experiment_name='abc';

                                                                      QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------
 Gather  (cost=1000.00..189912.25 rows=280 width=2039) (actual time=95641.540..95654.199 rows=0 loops=1)
   Workers Planned: 2
   Workers Launched: 1
   ->  Parallel Seq Scan on kruize_recommendations k1_0  (cost=0.00..188884.25 rows=117 width=2039) (actual time=95639.423..95639.424 rows=0 loops=2)
         Filter: ((experiment_name)::text = 'abc'::text)
         Rows Removed by Filter: 451688
 Planning Time: 249.098 ms
 Execution Time: 95654.246 ms
(8 rows)
```


In Hibernate, there is no direct way to specify the NOINDEX option for a primary key column. By default, Hibernate will create an index on the primary key column when generating the database schema. 
When we move to migration sql we can explicitly avoid/remove index on primary key.

