### PR TITLE
Enable Metrics status

### DIFF
--- a/design/KruizePromQL.md
+++ b/design/KruizePromQL.md
@@ -21,14 +21,15 @@ To monitor the performance of these APIs, you can use the following metrics:
 
 Here are some sample metrics for the mentioned APIs which can run in Prometheus:
 
-- `kruizeAPI_seconds_count{api="createExperiment", application="Kruize", method="POST"}`: Returns the count of invocations for the `createExperiment` API.
-- `kruizeAPI_seconds_sum{api="createExperiment", application="Kruize", method="POST"}`: Returns the sum of the time taken by the `createExperiment` API.
-- `kruizeAPI_seconds_max{api="createExperiment", application="Kruize", method="POST"}`: Returns the maximum time taken by the `createExperiment` API.
+- `kruizeAPI_seconds_count{api="createExperiment", application="Kruize", method="POST", status="success"}`: Returns the count of successful invocations for the `createExperiment` API.
+- `kruizeAPI_seconds_count{api="createExperiment", application="Kruize", method="POST", status="failure"}`: Returns the count of failed invocations for the `createExperiment` API.
+- `kruizeAPI_seconds_sum{api="createExperiment", application="Kruize", method="POST", status="success"}`: Returns the sum of the time taken by the successful invocations of `createExperiment` API.
+- `kruizeAPI_seconds_max{api="createExperiment", application="Kruize", method="POST", status="success"}`: Returns the maximum time taken by the successful invocation of `createExperiment` API.
 
 By changing the value of the `api` and `method` label, you can gather metrics for other Kruize APIs such as `listRecommendations`, `listExperiments`, and `updateResults`.
 
 Here is a sample command to collect the metric through `curl`
-- `curl --silent -G -kH "Authorization: Bearer ${TOKEN}" --data-urlencode 'query=kruizeAPI_seconds_sum{api="listRecommendations", application="Kruize", method="GET"}' ${PROMETHEUS_URL} | jq` : 
+- `curl --silent -G -kH "Authorization: Bearer ${TOKEN}" --data-urlencode 'query=kruizeAPI_seconds_sum{api="listRecommendations", application="Kruize", method="GET", status="success"}' ${PROMETHEUS_URL} | jq` : 
 Returns the sum of the time taken by `listRecommendations` API.
   
 Sample Output:
@@ -84,14 +85,15 @@ To monitor the performance of these methods, you can use the following metrics:
 
 Here are some sample metrics for the mentioned DB methods which can run in Prometheus:
 
-- `kruizeDB_seconds_count{application="Kruize", method="loadAllExperiments"}`: Number of times the `loadAllExperiments` method was called.
-- `kruizeDB_seconds_sum{application="Kruize", method="loadAllExperiments"}`: Total time taken by the `loadAllExperiments` method.
-- `kruizeDB_seconds_max{application="Kruize", method="loadAllExperiments"}`: Maximum time taken by the `loadAllExperiments` method.
+- `kruizeDB_seconds_count{application="Kruize", method="loadAllExperiments", status="success"}`: Number of successful invocations of `loadAllExperiments` method.
+- `kruizeDB_seconds_count{application="Kruize", method="loadAllExperiments", status="success"}`: Number of failed invocations of `loadAllExperiments` method.
+- `kruizeDB_seconds_sum{application="Kruize", method="loadAllExperiments", status="success"}`: Total time taken by the `loadAllExperiments` method which were success.
+- `kruizeDB_seconds_max{application="Kruize", method="loadAllExperiments", status="success"}`: Maximum time taken by the `loadAllExperiments` method which were success.
 
 By changing the value of the `method` label, you can gather metrics for other KruizeDB metrics.
 
 Here is a sample command to collect the metric through `curl`
-- `curl --silent -G -kH "Authorization: Bearer ${TOKEN}" --data-urlencode 'query=kruizeDB_seconds_sum{method="loadRecommendationsByExperimentName"}' ${PROMETHEUS_URL} | jq` :
+- `curl --silent -G -kH "Authorization: Bearer ${TOKEN}" --data-urlencode 'query=kruizeDB_seconds_sum{application="Kruize", method="loadRecommendationsByExperimentName", status="success"}' ${PROMETHEUS_URL} | jq` :
   Returns the sum of the time taken by `loadRecommendationsByExperimentName` method.
 
 Sample Output:

--- a/design/KruizePromQL.md
+++ b/design/KruizePromQL.md
@@ -10,6 +10,7 @@ The following are the available Kruize APIs that you can monitor:
 - `listRecommendations` (GET): API for listing recommendations.
 - `listExperiments` (GET): API for listing experiments.
 - `updateResults` (POST): API for updating experiment results.
+- `updateRecommendations` (POST): API for updating recommendations for an experiment.
 
 ## Time taken for KruizeAPI metrics
 
@@ -65,12 +66,14 @@ Sample Output:
 
 The following are the available Kruize DB methods that you can monitor:
 
-- `addRecommendationToDB`: Method for adding a recommendation to the database.
-- `addResultsToDB`: Method for adding experiment results to the database.
 - `addExperimentToDB`: Method for adding an experiment to the database.
-- `loadResultsByExperimentName`: Method for loading experiment results by experiment name.
+- `addResultToDB`: Method for adding experiment results to the database.
+- `addBulkResultsToDBAndFetchFailedResults`: Method for adding bulk experiment results to the database and fetch the failed results.
+- `addRecommendationToDB`: Method for adding a recommendation to the database.
 - `loadExperimentByName`: Method for loading an experiment by name.
+- `loadResultsByExperimentName`: Method for loading experiment results by experiment name.
 - `loadRecommendationsByExperimentName`: Method for loading recommendations by experiment name.
+- `loadRecommendationsByExperimentNameAndDate`: Method for loading recommendations by experiment name and date.
 
 ## Time taken for KruizeDB metrics
 

--- a/design/KruizePromQL.md
+++ b/design/KruizePromQL.md
@@ -74,6 +74,9 @@ The following are the available Kruize DB methods that you can monitor:
 - `loadResultsByExperimentName`: Method for loading experiment results by experiment name.
 - `loadRecommendationsByExperimentName`: Method for loading recommendations by experiment name.
 - `loadRecommendationsByExperimentNameAndDate`: Method for loading recommendations by experiment name and date.
+- `addPerformanceProfileToDB`: Method to add performance profile to the database.
+- `loadPerformanceProfileByName`: Method to load a specific performance profile.
+- `loadAllPerformanceProfiles`: Method to load all performance profiles.
 
 ## Time taken for KruizeDB metrics
 

--- a/design/KruizePromQL.md
+++ b/design/KruizePromQL.md
@@ -67,12 +67,9 @@ The following are the available Kruize DB methods that you can monitor:
 
 - `addRecommendationToDB`: Method for adding a recommendation to the database.
 - `addResultsToDB`: Method for adding experiment results to the database.
-- `loadAllRecommendations`: Method for loading all recommendations from the database.
-- `loadAllExperiments`: Method for loading all experiments from the database.
 - `addExperimentToDB`: Method for adding an experiment to the database.
 - `loadResultsByExperimentName`: Method for loading experiment results by experiment name.
 - `loadExperimentByName`: Method for loading an experiment by name.
-- `loadAllResults`: Method for loading all experiment results from the database.
 - `loadRecommendationsByExperimentName`: Method for loading recommendations by experiment name.
 
 ## Time taken for KruizeDB metrics
@@ -85,10 +82,10 @@ To monitor the performance of these methods, you can use the following metrics:
 
 Here are some sample metrics for the mentioned DB methods which can run in Prometheus:
 
-- `kruizeDB_seconds_count{application="Kruize", method="loadAllExperiments", status="success"}`: Number of successful invocations of `loadAllExperiments` method.
-- `kruizeDB_seconds_count{application="Kruize", method="loadAllExperiments", status="success"}`: Number of failed invocations of `loadAllExperiments` method.
-- `kruizeDB_seconds_sum{application="Kruize", method="loadAllExperiments", status="success"}`: Total time taken by the `loadAllExperiments` method which were success.
-- `kruizeDB_seconds_max{application="Kruize", method="loadAllExperiments", status="success"}`: Maximum time taken by the `loadAllExperiments` method which were success.
+- `kruizeDB_seconds_count{application="Kruize", method="addExperimentToDB", status="success"}`: Number of successful invocations of `addExperimentToDB` method.
+- `kruizeDB_seconds_count{application="Kruize", method="addExperimentToDB", status="failure"}`: Number of failed invocations of `addExperimentToDB` method.
+- `kruizeDB_seconds_sum{application="Kruize", method="addExperimentToDB", status="success"}`: Total time taken by the `addExperimentToDB` method which were success.
+- `kruizeDB_seconds_max{application="Kruize", method="addExperimentToDB", status="success"}`: Maximum time taken by the `addExperimentToDB` method which were success.
 
 By changing the value of the `method` label, you can gather metrics for other KruizeDB metrics.
 

--- a/src/main/java/com/autotune/analyzer/services/CreateExperiment.java
+++ b/src/main/java/com/autotune/analyzer/services/CreateExperiment.java
@@ -80,6 +80,7 @@ public class CreateExperiment extends HttpServlet {
 
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String statusValue = "failure";
         Timer.Sample timerCreateExp = Timer.start(MetricsConfig.meterRegistry());
         Map<String, KruizeObject> mKruizeExperimentMap = new ConcurrentHashMap<String, KruizeObject>();;
         try {
@@ -112,8 +113,10 @@ public class CreateExperiment extends HttpServlet {
                         ExperimentDAO experimentDAO = new ExperimentDAOImpl();
                         addedToDB = new ExperimentDBService().addExperimentToDB(validAPIObj);
                     }
-                    if (addedToDB.isSuccess())
+                    if (addedToDB.isSuccess()) {
                         sendSuccessResponse(response, "Experiment registered successfully with Kruize.");
+                        statusValue = "success";
+                    }
                     else {
                         sendErrorResponse(response, null, HttpServletResponse.SC_BAD_REQUEST, addedToDB.getMessage());
                     }
@@ -127,7 +130,10 @@ public class CreateExperiment extends HttpServlet {
             LOGGER.error("Unknown exception caught: " + e.getMessage());
             sendErrorResponse(response, e, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Internal Server Error: " + e.getMessage());
         } finally {
-            if (null != timerCreateExp) timerCreateExp.stop(MetricsConfig.timerCreateExp);
+            if (null != timerCreateExp) {
+                MetricsConfig.timerCreateExp = MetricsConfig.timerBCreateExp.tag("status", statusValue).register(MetricsConfig.meterRegistry());
+                timerCreateExp.stop(MetricsConfig.timerCreateExp);
+            }
         }
     }
 

--- a/src/main/java/com/autotune/analyzer/services/ListExperiments.java
+++ b/src/main/java/com/autotune/analyzer/services/ListExperiments.java
@@ -102,6 +102,7 @@ public class ListExperiments extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String statusValue = "failure";
         Timer.Sample timerListExp = Timer.start(MetricsConfig.meterRegistry());
         response.setStatus(HttpServletResponse.SC_OK);
         response.setContentType(JSON_CONTENT_TYPE);

--- a/src/main/java/com/autotune/analyzer/services/ListRecommendations.java
+++ b/src/main/java/com/autotune/analyzer/services/ListRecommendations.java
@@ -73,6 +73,7 @@ public class ListRecommendations extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String statusValue = "failure";
         Timer.Sample timerListRec = Timer.start(MetricsConfig.meterRegistry());
         response.setContentType(JSON_CONTENT_TYPE);
         response.setCharacterEncoding(CHARACTER_ENCODING);
@@ -197,6 +198,7 @@ public class ListRecommendations extends HttpServlet {
                                                                             checkForTimestamp,
                                                                             monitoringEndTimestamp);
                         recommendationList.add(listRecommendationsAPIObject);
+                        statusValue = "success";
                     } catch (Exception e) {
                         LOGGER.error("Not able to generate recommendation for expName : {} due to {}", ko.getExperimentName(), e.getMessage());
                     }
@@ -233,7 +235,10 @@ public class ListRecommendations extends HttpServlet {
             e.printStackTrace();
             sendErrorResponse(response, e, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
         } finally {
-            if (null != timerListRec) timerListRec.stop(MetricsConfig.timerListRec);
+            if (null != timerListRec) {
+                MetricsConfig.timerListRec = MetricsConfig.timerBListRec.tag("status", statusValue).register(MetricsConfig.meterRegistry());
+                timerListRec.stop(MetricsConfig.timerListRec);
+            }
         }
     }
 

--- a/src/main/java/com/autotune/analyzer/services/UpdateResults.java
+++ b/src/main/java/com/autotune/analyzer/services/UpdateResults.java
@@ -65,6 +65,7 @@ public class UpdateResults extends HttpServlet {
 
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String statusValue = "failure";
         Timer.Sample timerUpdateResults = Timer.start(MetricsConfig.meterRegistry());
         Map<String, KruizeObject> mKruizeExperimentMap = new ConcurrentHashMap<String, KruizeObject>();
         try {

--- a/src/main/java/com/autotune/analyzer/services/UpdateResults.java
+++ b/src/main/java/com/autotune/analyzer/services/UpdateResults.java
@@ -88,13 +88,17 @@ public class UpdateResults extends HttpServlet {
                 sendErrorResponse(request, response, null, HttpServletResponse.SC_BAD_REQUEST, errorMessage);
             } else {
                 sendSuccessResponse(response, AnalyzerConstants.ServiceConstants.RESULT_SAVED);
+                statusValue = "success";
             }
         } catch (Exception e) {
             LOGGER.error("Exception: " + e.getMessage());
             e.printStackTrace();
             sendErrorResponse(request, response, e, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
         } finally {
-            if (null != timerUpdateResults) timerUpdateResults.stop(MetricsConfig.timerUpdateResults);
+            if (null != timerUpdateResults) {
+                MetricsConfig.timerUpdateResults = MetricsConfig.timerBUpdateResults.tag("status", statusValue).register(MetricsConfig.meterRegistry());
+                timerUpdateResults.stop(MetricsConfig.timerUpdateResults);
+            }
         }
     }
 

--- a/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
@@ -319,7 +319,7 @@ public class ExperimentDAOImpl implements ExperimentDAO {
     @Override
     public List<KruizeRecommendationEntry> loadAllRecommendations() throws Exception {
         List<KruizeRecommendationEntry> recommendationEntries = null;
-        String statusValue = "success";
+        String statusValue = "failure";
         Timer.Sample timerLoadAllRec = Timer.start(MetricsConfig.meterRegistry());
         try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
             recommendationEntries = session.createQuery(

--- a/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
@@ -37,6 +37,7 @@ public class ExperimentDAOImpl implements ExperimentDAO {
     public ValidationOutputData addExperimentToDB(KruizeExperimentEntry kruizeExperimentEntry) {
         ValidationOutputData validationOutputData = new ValidationOutputData(false, null, null);
         Transaction tx = null;
+        String statusValue = "failure";
         Timer.Sample timerAddExpDB = Timer.start(MetricsConfig.meterRegistry());
         try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
             try {
@@ -44,6 +45,7 @@ public class ExperimentDAOImpl implements ExperimentDAO {
                 session.persist(kruizeExperimentEntry);
                 tx.commit();
                 validationOutputData.setSuccess(true);
+                statusValue = "success";
             } catch (HibernateException e) {
                 LOGGER.error("Not able to save experiment due to {}", e.getMessage());
                 if (tx != null) tx.rollback();
@@ -56,7 +58,10 @@ public class ExperimentDAOImpl implements ExperimentDAO {
             LOGGER.error("Not able to save experiment due to {}", e.getMessage());
             validationOutputData.setMessage(e.getMessage());
         } finally {
-            if (null != timerAddExpDB) timerAddExpDB.stop(MetricsConfig.timerAddExpDB);
+            if (null != timerAddExpDB) {
+                MetricsConfig.timerAddExpDB = MetricsConfig.timerBAddExpDB.tag("status", statusValue).register(MetricsConfig.meterRegistry());
+                timerAddExpDB.stop(MetricsConfig.timerAddExpDB);
+            }
         }
         return validationOutputData;
     }
@@ -72,6 +77,7 @@ public class ExperimentDAOImpl implements ExperimentDAO {
                 session.persist(resultsEntry);
                 tx.commit();
                 validationOutputData.setSuccess(true);
+                statusValue = "success";
             } catch (PersistenceException ex) {
                 if (ex.getCause() instanceof org.hibernate.exception.ConstraintViolationException) {
                     validationOutputData.setSuccess(false);
@@ -92,10 +98,14 @@ public class ExperimentDAOImpl implements ExperimentDAO {
         } catch (Exception e) {
             LOGGER.error("Not able to save experiment due to {}", e.getMessage());
         } finally {
-            if (null != timerAddResultsDB) timerAddResultsDB.stop(MetricsConfig.timerAddResultsDB);
+            if (null != timerAddResultsDB) {
+                MetricsConfig.timerAddResultsDB = MetricsConfig.timerBAddResultsDB.tag("status", statusValue).register(MetricsConfig.meterRegistry());
+                timerAddResultsDB.stop(MetricsConfig.timerAddResultsDB);
+            }
         }
         return validationOutputData;
     }
+
 
     @Override
     public List<KruizeResultsEntry> addToDBAndFetchFailedResults(List<KruizeResultsEntry> kruizeResultsEntries) {
@@ -144,6 +154,7 @@ public class ExperimentDAOImpl implements ExperimentDAO {
     public ValidationOutputData addRecommendationToDB(KruizeRecommendationEntry recommendationEntry) {
         ValidationOutputData validationOutputData = new ValidationOutputData(false, null, null);
         Transaction tx = null;
+        String statusValue = "failure";
         Timer.Sample timerAddRecDB = Timer.start(MetricsConfig.meterRegistry());
         try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
             try {
@@ -159,6 +170,7 @@ public class ExperimentDAOImpl implements ExperimentDAO {
                     session.merge(existingRecommendationEntry);
                     tx.commit();
                     validationOutputData.setSuccess(true);
+                    statusValue = "success";
                 }
             } catch (Exception e) {
                 LOGGER.error("Not able to save recommendation due to {}", e.getMessage());
@@ -171,7 +183,10 @@ public class ExperimentDAOImpl implements ExperimentDAO {
         } catch (Exception e) {
             LOGGER.error("Not able to save recommendation due to {}", e.getMessage());
         } finally {
-            if (null != timerAddRecDB) timerAddRecDB.stop(MetricsConfig.timerAddRecDB);
+            if (null != timerAddRecDB) {
+                MetricsConfig.timerAddRecDB = MetricsConfig.timerBAddRecDB.tag("status", statusValue).register(MetricsConfig.meterRegistry());
+                timerAddRecDB.stop(MetricsConfig.timerAddRecDB);
+            }
         }
         return validationOutputData;
     }
@@ -262,14 +277,19 @@ public class ExperimentDAOImpl implements ExperimentDAO {
     public List<KruizeExperimentEntry> loadAllExperiments() throws Exception {
         //todo load only experimentStatus=inprogress , playback may not require completed experiments
         List<KruizeExperimentEntry> entries = null;
+        String statusValue = "failure";
         Timer.Sample timerLoadAllExp = Timer.start(MetricsConfig.meterRegistry());
         try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
             entries = session.createQuery(DBConstants.SQLQUERY.SELECT_FROM_EXPERIMENTS, KruizeExperimentEntry.class).list();
+            statusValue = "success";
         } catch (Exception e) {
             LOGGER.error("Not able to load experiment due to {}", e.getMessage());
             throw new Exception("Error while loading exsisting experiments from database due to : " + e.getMessage());
         } finally {
-            if (null != timerLoadAllExp) timerLoadAllExp.stop(MetricsConfig.timerLoadAllExp);
+            if (null != timerLoadAllExp) {
+                MetricsConfig.timerLoadAllExp = MetricsConfig.timerBLoadAllExp.tag("status", statusValue).register(MetricsConfig.meterRegistry());
+                timerLoadAllExp.stop(MetricsConfig.timerLoadAllExp);
+            }
         }
         return entries;
     }
@@ -278,14 +298,20 @@ public class ExperimentDAOImpl implements ExperimentDAO {
     public List<KruizeResultsEntry> loadAllResults() throws Exception {
         // TODO: load only experimentStatus=inProgress , playback may not require completed experiments
         List<KruizeResultsEntry> kruizeResultsEntries = null;
+        String statusValue = "failure";
         Timer.Sample timerLoadAllResults = Timer.start(MetricsConfig.meterRegistry());
         try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
             kruizeResultsEntries = session.createQuery(DBConstants.SQLQUERY.SELECT_FROM_RESULTS, KruizeResultsEntry.class).list();
+            statusValue = "success";
         } catch (Exception e) {
             LOGGER.error("Not able to load results due to: {}", e.getMessage());
             throw new Exception("Error while loading results from the database due to : " + e.getMessage());
         } finally {
-            if (null != timerLoadAllResults) timerLoadAllResults.stop(MetricsConfig.timerLoadAllResults);
+            if (null != timerLoadAllResults) {
+                MetricsConfig.timerLoadAllResults = MetricsConfig.timerBLoadAllResults.tag("status", statusValue).register(MetricsConfig.meterRegistry());
+                timerLoadAllResults.stop(MetricsConfig.timerLoadAllResults);
+            }
+
         }
         return kruizeResultsEntries;
     }
@@ -293,16 +319,21 @@ public class ExperimentDAOImpl implements ExperimentDAO {
     @Override
     public List<KruizeRecommendationEntry> loadAllRecommendations() throws Exception {
         List<KruizeRecommendationEntry> recommendationEntries = null;
+        String statusValue = "success";
         Timer.Sample timerLoadAllRec = Timer.start(MetricsConfig.meterRegistry());
         try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
             recommendationEntries = session.createQuery(
                     DBConstants.SQLQUERY.SELECT_FROM_RECOMMENDATIONS,
                     KruizeRecommendationEntry.class).list();
+            statusValue = "success";
         } catch (Exception e) {
             LOGGER.error("Not able to load recommendations due to {}", e.getMessage());
             throw new Exception("Error while loading existing recommendations from database due to : " + e.getMessage());
         } finally {
-            if (null != timerLoadAllRec) timerLoadAllRec.stop(MetricsConfig.timerLoadAllRec);
+            if (null != timerLoadAllRec) {
+                MetricsConfig.timerLoadAllRec = MetricsConfig.timerBLoadAllRec.tag("status", statusValue).register(MetricsConfig.meterRegistry());
+                timerLoadAllRec.stop(MetricsConfig.timerLoadAllRec);
+            }
         }
         return recommendationEntries;
     }
@@ -323,15 +354,21 @@ public class ExperimentDAOImpl implements ExperimentDAO {
     public List<KruizeExperimentEntry> loadExperimentByName(String experimentName) throws Exception {
         //todo load only experimentStatus=inprogress , playback may not require completed experiments
         List<KruizeExperimentEntry> entries = null;
+        String statusValue = "failure";
         Timer.Sample timerLoadExpName = Timer.start(MetricsConfig.meterRegistry());
         try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
             entries = session.createQuery(DBConstants.SQLQUERY.SELECT_FROM_EXPERIMENTS_BY_EXP_NAME, KruizeExperimentEntry.class)
                     .setParameter("experimentName", experimentName).list();
+            statusValue = "success";
         } catch (Exception e) {
             LOGGER.error("Not able to load experiment {} due to {}", experimentName, e.getMessage());
             throw new Exception("Error while loading existing experiment from database due to : " + e.getMessage());
         } finally {
-            if (null != timerLoadExpName) timerLoadExpName.stop(MetricsConfig.timerLoadExpName);
+            if (null != timerLoadExpName) {
+                MetricsConfig.timerLoadExpName = MetricsConfig.timerBLoadExpName.tag("status", statusValue).register(MetricsConfig.meterRegistry());
+                timerLoadExpName.stop(MetricsConfig.timerLoadExpName);
+            }
+
         }
         return entries;
     }
@@ -340,6 +377,7 @@ public class ExperimentDAOImpl implements ExperimentDAO {
     public List<KruizeResultsEntry> loadResultsByExperimentName(String experimentName, Timestamp interval_end_time, Integer limitRows) throws Exception {
         // TODO: load only experimentStatus=inProgress , playback may not require completed experiments
         List<KruizeResultsEntry> kruizeResultsEntries = null;
+        String statusValue = "failure";
         Timer.Sample timerLoadResultsExpName = Timer.start(MetricsConfig.meterRegistry());
         try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
             if (null != limitRows && null != interval_end_time) {
@@ -348,15 +386,20 @@ public class ExperimentDAOImpl implements ExperimentDAO {
                         .setParameter(KruizeConstants.JSONKeys.INTERVAL_END_TIME, interval_end_time)
                         .setMaxResults(limitRows)
                         .list();
+                statusValue = "success";
             } else {
                 kruizeResultsEntries = session.createQuery(DBConstants.SQLQUERY.SELECT_FROM_RESULTS_BY_EXP_NAME, KruizeResultsEntry.class)
                         .setParameter("experimentName", experimentName).list();
+                statusValue = "success";
             }
         } catch (Exception e) {
             LOGGER.error("Not able to load results due to: {}", e.getMessage());
             throw new Exception("Error while loading results from the database due to : " + e.getMessage());
         } finally {
-            if (null != timerLoadResultsExpName) timerLoadResultsExpName.stop(MetricsConfig.timerLoadResultsExpName);
+            if (null != timerLoadResultsExpName) {
+                MetricsConfig.timerLoadResultsExpName = MetricsConfig.timerBLoadResultsExpName.tag("status", statusValue).register(MetricsConfig.meterRegistry());
+                timerLoadResultsExpName.stop(MetricsConfig.timerLoadResultsExpName);
+            }
         }
         return kruizeResultsEntries;
     }
@@ -364,15 +407,20 @@ public class ExperimentDAOImpl implements ExperimentDAO {
     @Override
     public List<KruizeRecommendationEntry> loadRecommendationsByExperimentName(String experimentName) throws Exception {
         List<KruizeRecommendationEntry> recommendationEntries = null;
+        String statusValue = "failure";
         Timer.Sample timerLoadRecExpName = Timer.start(MetricsConfig.meterRegistry());
         try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
             recommendationEntries = session.createQuery(DBConstants.SQLQUERY.SELECT_FROM_RECOMMENDATIONS_BY_EXP_NAME, KruizeRecommendationEntry.class)
                     .setParameter("experimentName", experimentName).list();
+            statusValue = "success";
         } catch (Exception e) {
             LOGGER.error("Not able to load recommendations due to {}", e.getMessage());
             throw new Exception("Error while loading existing recommendations from database due to : " + e.getMessage());
         } finally {
-            if (null != timerLoadRecExpName) timerLoadRecExpName.stop(MetricsConfig.timerLoadRecExpName);
+            if (null != timerLoadRecExpName) {
+                MetricsConfig.timerLoadRecExpName = MetricsConfig.timerBLoadRecExpName.tag("status", statusValue).register(MetricsConfig.meterRegistry());
+                timerLoadRecExpName.stop(MetricsConfig.timerLoadRecExpName);
+            }
         }
         return recommendationEntries;
     }

--- a/src/main/java/com/autotune/utils/MetricsConfig.java
+++ b/src/main/java/com/autotune/utils/MetricsConfig.java
@@ -9,6 +9,7 @@ import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
+import org.eclipse.jetty.util.thread.ThreadPool;
 
 public class MetricsConfig {
 
@@ -16,31 +17,33 @@ public class MetricsConfig {
     public static Timer timerListRec, timerListExp, timerCreateExp, timerUpdateResults;
     public static Timer timerLoadRecExpName, timerLoadResultsExpName, timerLoadExpName;
     public static Timer timerLoadAllRec, timerLoadAllExp, timerLoadAllResults;
-    public static Timer timerAddRecDB, timerAddResultsDB, timerAddExpDB;
+    public static Timer timerAddRecDB , timerAddResultsDB , timerAddExpDB;
+    public static Timer.Builder timerBListRec, timerBListExp, timerBCreateExp, timerBUpdateResults;
+    public static Timer.Builder timerBLoadRecExpName, timerBLoadResultsExpName, timerBLoadExpName;
+    public static Timer.Builder timerBLoadAllRec, timerBLoadAllExp, timerBLoadAllResults;
+    public static Timer.Builder timerBAddRecDB , timerBAddResultsDB , timerBAddExpDB;
     public String API_METRIC_DESC = "Time taken for Kruize APIs";
     public String DB_METRIC_DESC = "Time taken for KruizeDB methods";
-
     public static PrometheusMeterRegistry meterRegistry;
 
-    // Private constructor to prevent instantiation
     private MetricsConfig() {
         meterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
         meterRegistry.config().commonTags("application", "Kruize");
 
-        timerListRec = Timer.builder("kruizeAPI").description(API_METRIC_DESC).tag("api","listRecommendations").tag("method","GET").register(meterRegistry);
-        timerListExp = Timer.builder("kruizeAPI").description(API_METRIC_DESC).tag("api","listExperiments").tag("method","GET").register(meterRegistry);
-        timerCreateExp = Timer.builder("kruizeAPI").description(API_METRIC_DESC).tag("api","createExperiment").tag("method","POST").register(meterRegistry);
-        timerUpdateResults = Timer.builder("kruizeAPI").description(API_METRIC_DESC).tag("api","updateResults").tag("method","POST").register(meterRegistry);
+        timerBListRec = Timer.builder("kruizeAPI").description(API_METRIC_DESC).tag("api","listRecommendations").tag("method","GET");
+        timerBListExp = Timer.builder("kruizeAPI").description(API_METRIC_DESC).tag("api","listExperiments").tag("method","GET");
+        timerBCreateExp = Timer.builder("kruizeAPI").description(API_METRIC_DESC).tag("api","createExperiment").tag("method","POST");
+        timerBUpdateResults = Timer.builder("kruizeAPI").description(API_METRIC_DESC).tag("api","updateResults").tag("method","POST");
 
-        timerLoadRecExpName = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","loadRecommendationsByExperimentName").register(meterRegistry);
-        timerLoadResultsExpName = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","loadResultsByExperimentName").register(meterRegistry);
-        timerLoadExpName = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","loadExperimentByName").register(meterRegistry);
-        timerLoadAllRec = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","loadAllRecommendations").register(meterRegistry);
-        timerLoadAllExp = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","loadAllExperiments").register(meterRegistry);
-        timerLoadAllResults = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","loadAllResults").register(meterRegistry);
-        timerAddRecDB = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","addRecommendationToDB").register(meterRegistry);
-        timerAddResultsDB = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","addResultsToDB").register(meterRegistry);
-        timerAddExpDB = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","addExperimentToDB").register(meterRegistry);
+        timerBLoadRecExpName = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","loadRecommendationsByExperimentName");
+        timerBLoadResultsExpName = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","loadResultsByExperimentName");
+        timerBLoadExpName = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","loadExperimentByName");
+        timerBLoadAllRec = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","loadAllRecommendations");
+        timerBLoadAllExp = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","loadAllExperiments");
+        timerBLoadAllResults = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","loadAllResults");
+        timerBAddRecDB = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","addRecommendationToDB");
+        timerBAddResultsDB = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","addResultsToDB");
+        timerBAddExpDB = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","addExperimentToDB");
 
         new ClassLoaderMetrics().bindTo(meterRegistry);
         new ProcessorMetrics().bindTo(meterRegistry);

--- a/src/main/java/com/autotune/utils/MetricsConfig.java
+++ b/src/main/java/com/autotune/utils/MetricsConfig.java
@@ -49,6 +49,9 @@ public class MetricsConfig {
         timerBAddResultsDB = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","addResultToDB");
         timerBAddBulkResultsDB = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","addBulkResultsToDBAndFetchFailedResults");
         timerBAddExpDB = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","addExperimentToDB");
+        timerBAddPerfProfileDB = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","addPerformanceProfileToDB");
+        timerBLoadPerfProfileName = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","loadPerformanceProfileByName");
+        timerBLoadAllPerfProfiles = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","loadAllPerformanceProfiles");
 
         new ClassLoaderMetrics().bindTo(meterRegistry);
         new ProcessorMetrics().bindTo(meterRegistry);

--- a/src/main/java/com/autotune/utils/MetricsConfig.java
+++ b/src/main/java/com/autotune/utils/MetricsConfig.java
@@ -14,14 +14,16 @@ import org.eclipse.jetty.util.thread.ThreadPool;
 public class MetricsConfig {
 
     private static MetricsConfig INSTANCE;
-    public static Timer timerListRec, timerListExp, timerCreateExp, timerUpdateResults;
-    public static Timer timerLoadRecExpName, timerLoadResultsExpName, timerLoadExpName;
+    public static Timer timerListRec, timerListExp, timerCreateExp, timerUpdateResults, timerUpdateRecomendations;
+    public static Timer timerLoadRecExpName, timerLoadResultsExpName, timerLoadExpName, timerLoadRecExpNameDate;
     public static Timer timerLoadAllRec, timerLoadAllExp, timerLoadAllResults;
-    public static Timer timerAddRecDB , timerAddResultsDB , timerAddExpDB;
-    public static Timer.Builder timerBListRec, timerBListExp, timerBCreateExp, timerBUpdateResults;
-    public static Timer.Builder timerBLoadRecExpName, timerBLoadResultsExpName, timerBLoadExpName;
+    public static Timer timerAddRecDB , timerAddResultsDB , timerAddExpDB, timerAddBulkResultsDB;
+    public static Timer timerAddPerfProfileDB , timerLoadPerfProfileName , timerLoadAllPerfProfiles;
+    public static Timer.Builder timerBListRec, timerBListExp, timerBCreateExp, timerBUpdateResults, timerBUpdateRecommendations ;
+    public static Timer.Builder timerBLoadRecExpName, timerBLoadResultsExpName, timerBLoadExpName, timerBLoadRecExpNameDate;
     public static Timer.Builder timerBLoadAllRec, timerBLoadAllExp, timerBLoadAllResults;
-    public static Timer.Builder timerBAddRecDB , timerBAddResultsDB , timerBAddExpDB;
+    public static Timer.Builder timerBAddRecDB, timerBAddResultsDB , timerBAddExpDB, timerBAddBulkResultsDB;
+    public static Timer.Builder timerBAddPerfProfileDB, timerBLoadPerfProfileName, timerBLoadAllPerfProfiles;
     public String API_METRIC_DESC = "Time taken for Kruize APIs";
     public String DB_METRIC_DESC = "Time taken for KruizeDB methods";
     public static PrometheusMeterRegistry meterRegistry;
@@ -34,15 +36,18 @@ public class MetricsConfig {
         timerBListExp = Timer.builder("kruizeAPI").description(API_METRIC_DESC).tag("api","listExperiments").tag("method","GET");
         timerBCreateExp = Timer.builder("kruizeAPI").description(API_METRIC_DESC).tag("api","createExperiment").tag("method","POST");
         timerBUpdateResults = Timer.builder("kruizeAPI").description(API_METRIC_DESC).tag("api","updateResults").tag("method","POST");
+        timerBUpdateRecommendations = Timer.builder("kruizeAPI").description(API_METRIC_DESC).tag("api","updateRecommendations").tag("method","POST");
 
         timerBLoadRecExpName = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","loadRecommendationsByExperimentName");
+        timerBLoadRecExpNameDate = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","loadRecommendationsByExperimentNameAndDate");
         timerBLoadResultsExpName = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","loadResultsByExperimentName");
         timerBLoadExpName = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","loadExperimentByName");
         timerBLoadAllRec = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","loadAllRecommendations");
         timerBLoadAllExp = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","loadAllExperiments");
         timerBLoadAllResults = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","loadAllResults");
         timerBAddRecDB = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","addRecommendationToDB");
-        timerBAddResultsDB = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","addResultsToDB");
+        timerBAddResultsDB = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","addResultToDB");
+        timerBAddBulkResultsDB = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","addBulkResultsToDBAndFetchFailedResults");
         timerBAddExpDB = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method","addExperimentToDB");
 
         new ClassLoaderMetrics().bindTo(meterRegistry);


### PR DESCRIPTION
Enable "status" for metrics of Kruize API and DB methods.
Below is one of the metric which shows both success and failure status.

```
kruizeAPI_count{api="listExperiments",application="Kruize",method="GET",status="failure",} 7.0
kruizeAPI_sum{api="listExperiments",application="Kruize",method="GET",status="failure",} 0.015359167
kruizeAPI_count{api="listExperiments",application="Kruize",method="GET",status="success",} 3.0
kruizeAPI_sum{api="listExperiments",application="Kruize",method="GET",status="success",} 0.003072515

```