### PR TITLE
Readme Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,27 @@ Tracking down performance issues in a dynamic microservices environment can be c
 
 ##Usecases
 Kruize will support the following use cases
-Use Case 1: Autotune - Config Recommendation for a User Provided Performance Objective
+Use Case 1: Autotune - Config Recommendation for a User Provided Performance Objective 
+In this use case, the user provides a deployment name and a performance objective. The performance objective consists of metrics that either needs to be maximized or minimized.
+
+The goal is to find the config supplied by HPO that best optimizes the user provided objective. The config can consist of both resource requests and limits and Runtime parameters. A config recommendation will be provided at the end of the experiment.
+
+
 Use Case 2: Hyper Parameter Optimization as a Service - Performance
+In this use case, provide HPO as an independent entity that can be used outside of Kubernetes. This is very useful for arriving at OS tuning (RHEL Performance Profiles, TuneD and NTO), Tuning OpenShift itself, Thresholds for perf tests in CI/CD pipelines etc (as part of Integrated Performance Threshold Testing - IPT)
+
+
 Use Case 3: Monitor a deployment over a long term and provide recommendations to help reduce cost (Production scenario with no experiment trials)
-Remote (ROS)
-Local (ACM)
+1.Remote (ROS)
+2.Local (ACM)
+In this use case, the SRE will provide a deployment that needs to be monitored over a long period of time. The intention is to better understand the variance of the incoming load conditions and provide recommendations on the container and heap sizing in an effort to reduce costs.
+
+
 Use Case 4: Provide tooling for automating performance regressions instead of manual testing (A/B/n testing as part of the build pipeline)
+In this use case, the user provides a deployment name, two docker images and metrics to be monitored during the course of the experiment. The goal is to deploy the docker images in two separate trials respectively, one after the other.
+
+It will monitor the given metrics during both the trials and report the results at the end of each trial. The results from each of the trials can then be used to compare the two trials and determine if there has been a variation in the performance objective and the quantum of the same.
+
 
 
 ## How do I start ?

--- a/README.md
+++ b/README.md
@@ -17,30 +17,34 @@ Consider an Flight Booking Application as shown in the figure. It consists of a 
 
 Tracking down performance issues in a dynamic microservices environment can be challenging and more often than not, stack or runtime specific optimizations are written off as too complex. This is because runtime optimization is a very involved effort and requires deep expertise. Common fixes are mostly limited to increasing pod resources, fixing application logic to make it more optimal or increasing horizontal pod auto-scaling. 
 
-##Usecases
+## Usecases
 Kruize will support the following use cases
-Use Case 1: Autotune - Config Recommendation for a User Provided Performance Objective 
+
+**Use Case 1:** **Autotune - Config Recommendation for a User Provided Performance Objective** 
+
 In this use case, the user provides a deployment name and a performance objective. The performance objective consists of metrics that either needs to be maximized or minimized.
 
 The goal is to find the config supplied by HPO that best optimizes the user provided objective. The config can consist of both resource requests and limits and Runtime parameters. A config recommendation will be provided at the end of the experiment.
 
+**Use Case 2:** **Hyper Parameter Optimization as a Service - Performance**
 
-Use Case 2: Hyper Parameter Optimization as a Service - Performance
 In this use case, provide HPO as an independent entity that can be used outside of Kubernetes. This is very useful for arriving at OS tuning (RHEL Performance Profiles, TuneD and NTO), Tuning OpenShift itself, Thresholds for perf tests in CI/CD pipelines etc (as part of Integrated Performance Threshold Testing - IPT)
 
+**Use Case 3:** **Monitor a deployment over a long term and provide recommendations to help reduce cost (Production scenario with no experiment trials)** 
 
-Use Case 3: Monitor a deployment over a long term and provide recommendations to help reduce cost (Production scenario with no experiment trials)
-1.Remote (ROS)
-2.Local (ACM)
+1.Remote 
+
+2.Local 
+
 In this use case, the SRE will provide a deployment that needs to be monitored over a long period of time. The intention is to better understand the variance of the incoming load conditions and provide recommendations on the container and heap sizing in an effort to reduce costs.
 
+**Use Case 4:** **Provide tooling for automating performance regressions instead of manual testing (A/B/n testing as part of the build pipeline)**
 
-Use Case 4: Provide tooling for automating performance regressions instead of manual testing (A/B/n testing as part of the build pipeline)
 In this use case, the user provides a deployment name, two docker images and metrics to be monitored during the course of the experiment. The goal is to deploy the docker images in two separate trials respectively, one after the other.
 
 It will monitor the given metrics during both the trials and report the results at the end of each trial. The results from each of the trials can then be used to compare the two trials and determine if there has been a variation in the performance objective and the quantum of the same.
 
-
+For more information refer the file [USECASES](USECASES.md)
 
 ## How do I start ?
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ Consider an Flight Booking Application as shown in the figure. It consists of a 
 
 Tracking down performance issues in a dynamic microservices environment can be challenging and more often than not, stack or runtime specific optimizations are written off as too complex. This is because runtime optimization is a very involved effort and requires deep expertise. Common fixes are mostly limited to increasing pod resources, fixing application logic to make it more optimal or increasing horizontal pod auto-scaling. 
 
+##Usecases
+Kruize will support the following use cases
+Use Case 1: Autotune - Config Recommendation for a User Provided Performance Objective
+Use Case 2: Hyper Parameter Optimization as a Service - Performance
+Use Case 3: Monitor a deployment over a long term and provide recommendations to help reduce cost (Production scenario with no experiment trials)
+Remote (ROS)
+Local (ACM)
+Use Case 4: Provide tooling for automating performance regressions instead of manual testing (A/B/n testing as part of the build pipeline)
+
+
 ## How do I start ?
 
 Autotune helps to capture your performance tuning needs in a comprehensive way and runs experiments to provide recommendations that help achieve your slo goals. So how does it do it ? We recommend you check out the [kruize-demos](https://github.com/kruize/kruize-demos) repo for a quick start !

--- a/USECASES.md
+++ b/USECASES.md
@@ -1,0 +1,58 @@
+## Usecases
+
+****Use Case 1**: Autotune - Config Recommendation for a User Provided Performance Objective**
+
+Provide container sizing recommendations to customer applications that are being run in customer OpenShift clusters and being monitored through the 
+ROS OpenShift Insights framework. The overall goal is to reduce costs for the customer by providing container recommendations that aim to right size 
+containers.
+
+**Workflow**
+
+The Proposed work flow will be as follows
+1.The ROS-OCP-backend will invoke the Kruize createExperiment API for each deployment + namespace that ROS is monitoring.
+
+2.ROS-OCP-backend will then call the updateResults API for each deployment + namespace as and when it gets new data from the target clusters. 
+This can happen multiple times in a day
+
+3.The ROS-OCP-backend will then call the listRecommendations API for each deployment + namespace after a predetermined amount of time 
+has elapsed from the first call to updateResults to obtain the recommendations for that specific deployment + namespace combination.
+
+**Queries**
+
+This includes the Prometheus Queries that will need to be run against the target clusters for each deployment that is being monitored.
+
+**The queries assume the following**
+
+1.Data is gathered for 15 min intervals
+
+2.The data unless specified needs to be gathered at the Container granularity
+
+**Use Case 2: Hyper Parameter Optimization as a Service - Performance**
+
+Provide Kruize Hyper Parameter Optimization (HPO) to choose the optimal values for hyperparameters provided by the user for any model.
+
+Hyperparameter optimization(HPO) is choosing a set of optimal hyperparameters that yields an optimal performance based on the 
+predefined objective function.
+
+The current architecture of Kruize HPO consists of a thin abstraction layer that provides a common REST API and gRPC 
+interface. It provides an interface for integrating with Open Source projects / modules that provide HPO functionality. Currently it only supports the Optuna OSS Project. It provides a simple HTTP server through which the REST APIs can be accessed.
+
+Kruize HPO supports the following ways of deployment:
+
+1. Bare Metal
+
+2. Container
+
+3. Kubernetes (Minikube / Openshift)
+
+**Use Case 3: Monitor a deployment over a long term and provide recommendations to help reduce cost (Production scenario with no experiment trials)**
+
+1.Remote (RH Insights Resource Optimization Service for OpenShift)
+
+
+
+2.Local (Advanced Cluster Management)
+
+
+**Use Case 4: Provide tooling for automating performance regressions instead of manual testing (A/B/n testing as part of the build pipeline)**
+

--- a/USECASES.md
+++ b/USECASES.md
@@ -1,40 +1,45 @@
 ## Usecases
 
-****Use Case 1**: Autotune - Config Recommendation for a User Provided Performance Objective**
+Kruize usecases include Autotune, Remote Monitoring and Local Monitoring
 
-Provide container sizing recommendations to customer applications that are being run in customer OpenShift clusters and being monitored through the 
-ROS OpenShift Insights framework. The overall goal is to reduce costs for the customer by providing container recommendations that aim to right size 
-containers.
+**Autotune**
 
-**Workflow**
+Autotune accepts a user provided "slo" goal to optimize application performance. It uses Prometheus to identify "layers" of an application that it is monitoring and matches tunables from those layers to the user provided slo. It then runs experiments with the help of a hyperparameter optimization framework to arrive at the most optimal values for the identified set of tunables to get a better result for the user provided slo.
+The trials provided by the HPO is fed to the Experiment Manager which deploys it to the application and then monitors the pods. After all the trials are completed, EM reports the result and generates the recommendation.
 
-The Proposed work flow will be as follows
-1.The ROS-OCP-backend will invoke the Kruize createExperiment API for each deployment + namespace that ROS is monitoring.
+**Remote Monitoring**
 
-2.ROS-OCP-backend will then call the updateResults API for each deployment + namespace as and when it gets new data from the target clusters. 
-This can happen multiple times in a day
+In this, an experiment is created using mode as monitor and targetted cluster as remote. This usecases uses the REST APIs instead of the kubernetes yaml to create experiment. In this, external agents are involved in monitoring the pods and reporting the result, using which the recommendations are generated and provided as a response by the listRecommendations API.
 
-3.The ROS-OCP-backend will then call the listRecommendations API for each deployment + namespace after a predetermined amount of time 
-has elapsed from the first call to updateResults to obtain the recommendations for that specific deployment + namespace combination.
+**Local Monitoring**
 
-**Queries**
+This is a planned usecase which is under active development. In this, the targetted cluster will be local and it will make use of experiment manager to monitor the pods and providing the results to generated recommendations.
 
-This includes the Prometheus Queries that will need to be run against the target clusters for each deployment that is being monitored.
 
-**The queries assume the following**
+# ****Use Case 1**: Autotune - Config Recommendation for a User Provided Performance Objective**
 
-1.Data is gathered for 15 min intervals
+**1.Using Bayesian Optimization to tune the OS**
 
-2.The data unless specified needs to be gathered at the Container granularity
+OS tuning settings are improved using Bayesian optimisation. Using the Node Tuning Operator, OpenShift enables the establishment of performance profiles for
+specific nodes or containers. For subsequent OS versions, the present OS tunables, which were manually created on RHEL 7, need to be updated. Although it is
+still in development, Autotune seeks to optimise microservices inside of containers and might be modified for OS tweaking. Objective function definition, the addition of an OS layer, the creation of a Tuned YAML file, and synchronisation with benchmark load generation scripts are among the changes made. For executing these actions, technology and automation are essential.
+
+**2.Using Autotune to tune nodes and schedule appropriate microservices onto them**
+
+Autotune is used to improve the performance of a group of microservices, which includes a database. Through a series of experiments, Autotune determines the
+best configuration for the given objective function. Based on OS performance profiles, Autotune categorises the microservices and objective functions and
+offers the best profiles to apply to the nodes. By doing this, resource usage is maximised and the microservices are able to reach their performance goals
+from the OS layer to the runtime framework
+
 
 **Use Case 2: Hyper Parameter Optimization as a Service - Performance**
 
 Provide Kruize Hyper Parameter Optimization (HPO) to choose the optimal values for hyperparameters provided by the user for any model.
 
-Hyperparameter optimization(HPO) is choosing a set of optimal hyperparameters that yields an optimal performance based on the 
+Hyperparameter optimization(HPO) is choosing a set of optimal hyperparameters that yields an optimal performance based on the
 predefined objective function.
 
-The current architecture of Kruize HPO consists of a thin abstraction layer that provides a common REST API and gRPC 
+The current architecture of Kruize HPO consists of a thin abstraction layer that provides a common REST API and gRPC
 interface. It provides an interface for integrating with Open Source projects / modules that provide HPO functionality. Currently it only supports the Optuna OSS Project. It provides a simple HTTP server through which the REST APIs can be accessed.
 
 Kruize HPO supports the following ways of deployment:
@@ -47,12 +52,32 @@ Kruize HPO supports the following ways of deployment:
 
 **Use Case 3: Monitor a deployment over a long term and provide recommendations to help reduce cost (Production scenario with no experiment trials)**
 
-1.Remote (RH Insights Resource Optimization Service for OpenShift)
+Provide recommendations on container sizing for customer apps running in their OpenShift clusters. By offering container suggestions that focus on the
+proper size containers, the overarching objective is to lower expenses for the customer
 
+**1.Remote (RH Insights Resource Optimization Service for OpenShift)**
 
+**Workflow**
 
-2.Local (Advanced Cluster Management)
+1.The client backend will invoke the Kruize createExperiment API for each deployment + namespace that it is monitoring.
+
+2.It will then call the Kruize updateResults API for each deployment + namespace as and when it gets new data from the target clusters. This can happen
+multiple times in a day.
+
+3.After that it will call the listRecommendations API for each deployment + namespace after a predetermined amount of time has elapsed from the first call to
+updateResults to obtain the recommendations for that specific deployment + namespace combination.
+
+**Queries**
+
+This includes the Prometheus Queries that will need to be run against the target clusters for each deployment that is being monitored.
+
+**The queries assume the following**
+
+1.Data is gathered for a fixed interval. For e.g: It can be 15min, 30min or 60min etc.
+
+2.The data unless specified needs to be gathered at the Container granularity
+
+**2.Local (Advanced Cluster Management)**
 
 
 **Use Case 4: Provide tooling for automating performance regressions instead of manual testing (A/B/n testing as part of the build pipeline)**
-

--- a/USECASES.md
+++ b/USECASES.md
@@ -18,6 +18,9 @@ This is a planned usecase which is under active development. In this, the target
 
 # ****Use Case 1**: Autotune - Config Recommendation for a User Provided Performance Objective**
 
+Autotune accepts a user provided "slo" goal to optimize application performance. It uses Prometheus to identify "layers" of an application that it is monitoring and matches tunables from those layers to the user provided slo. It then runs experiments with the help of a hyperparameter optimization framework to arrive at the most optimal values for the identified set of tunables to get a better result for the user provided slo.
+The trials provided by the HPO is fed to the Experiment Manager which deploys it to the application and then monitors the pods. After all the trials are completed, EM reports the result and generates the recommendation.
+
 **1.Using Bayesian Optimization to tune the OS**
 
 OS tuning settings are improved using Bayesian optimisation. Using the Node Tuning Operator, OpenShift enables the establishment of performance profiles for


### PR DESCRIPTION
This PR fixes the issue #808 

Added the brief about following Usescases :
Use Case 1: Autotune - Config Recommendation for a User Provided Performance Objective
Use Case 2: Hyper Parameter Optimization as a Service - Performance
Use Case 3: Monitor a deployment over a long term and provide recommendations to help reduce cost (Production scenario with no experiment trials)
Remote (ROS)
Local (ACM)
Use Case 4: Provide tooling for automating performance regressions instead of manual testing (A/B/n testing as part of the build pipeline)
