### PR TITLE
Add Kruize UI manifests

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -109,32 +109,32 @@ function usage() {
 # Check if the cluster_type is one of icp or openshift
 function check_cluster_type() {
 	case "${cluster_type}" in
-	docker|minikube|openshift)
-		;;
+	docker | minikube | openshift) ;;
+
 	*)
 		echo "Error: unsupported cluster type: ${cluster_type}"
 		exit -1
+		;;
 	esac
 }
 
 # Iterate through the commandline options
-while getopts ac:d:i:k:m:n:o:p:stu:-: gopts
-do
+while getopts ac:d:i:k:m:n:o:p:stu:-: gopts; do
 	case ${gopts} in
 	-)
 		case "${OPTARG}" in
-			timeout=*)
-				timeout=${OPTARG#*=}
-				if [ -z "${timeout}" ]; then
-					usage
-				fi
-				;;
-			*)
-				if [ "${OPTERR}" == 1 ] && [ "${OPTSPEC:0:1}" != ":" ]; then
-					echo "Unknown option --${OPTARG}" >&2
-					usage
-				fi
-				;;
+		timeout=*)
+			timeout=${OPTARG#*=}
+			if [ -z "${timeout}" ]; then
+				usage
+			fi
+			;;
+		*)
+			if [ "${OPTERR}" == 1 ] && [ "${OPTSPEC:0:1}" != ":" ]; then
+				echo "Unknown option --${OPTARG}" >&2
+				usage
+			fi
+			;;
 		esac
 		;;
 	a)
@@ -153,7 +153,7 @@ do
 	k)
 		kurl="${OPTARG}"
 		;;
-  m)
+	m)
 		target="${OPTARG}"
 		;;
 	n)
@@ -168,11 +168,12 @@ do
 	t)
 		setup=0
 		;;
-  u)
-    KRUIZE_UI_DOCKER_IMAGE="${OPTARG}"
-    ;;
+	u)
+		KRUIZE_UI_DOCKER_IMAGE="${OPTARG}"
+		;;
 	[?])
 		usage
+		;;
 	esac
 done
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -46,9 +46,16 @@ KRUIZE_CRC_DEPLOY_MANIFEST_MINIKUBE="${CRC_DIR}/minikube/kruize-crc-minikube.yam
 
 AUTOTUNE_PORT="8080"
 AUTOTUNE_DOCKER_REPO="docker.io/kruize/autotune_operator"
+
 #Fetch autotune version from the pom.xml file.
 AUTOTUNE_VERSION="$(grep -A 1 "autotune" "${ROOT_DIR}"/pom.xml | grep version | awk -F '>' '{ split($2, a, "<"); print a[1] }')"
 AUTOTUNE_DOCKER_IMAGE=${AUTOTUNE_DOCKER_REPO}:${AUTOTUNE_VERSION}
+
+# Kruize UI repo
+KRUIZE_UI_REPO="quay.io/kruize/kruize-ui"
+KRUIZE_UI_VERSION="$(curl -s https://raw.githubusercontent.com/kruize/kruize-ui/main/package.json | grep -m1 '\"version\"' | tr -d ' ' | cut -d: -f2 | tr -d \" | sed 's/,$//')"
+KRUIZE_UI_DOCKER_IMAGE=${KRUIZE_UI_REPO}:${KRUIZE_UI_VERSION}
+
 HPO_DOCKER_REPO="docker.io/kruize/hpo"
 # From the kruize/hpo repo
 HPO_VERSION=0.0.2
@@ -161,6 +168,9 @@ do
 	t)
 		setup=0
 		;;
+  u)
+    KRUIZE_UI_DOCKER_IMAGE="${OPTARG}"
+    ;;
 	[?])
 		usage
 	esac

--- a/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
@@ -132,3 +132,73 @@ spec:
     - port: kruize-port
       interval: 30s
       path: /metrics
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+  namespace: monitoring
+data:
+  nginx.conf: |
+    events {}
+    http {
+      upstream kruize-api {
+        server kruize:8080;
+      }
+
+      server {
+        listen 8080;
+        server_name localhost;
+
+        root   /usr/share/nginx/html;
+    
+        location ^~ /api/ {
+          rewrite ^/api(.*)$ $1 break;
+          proxy_pass http://kruize-api;
+        }
+    
+        location / {
+          index index.html;
+          error_page 404 =200 /index.html;
+        }
+      }
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kruize-ui-nginx-service
+  namespace: monitoring
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: kruize-ui-nginx
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kruize-ui-nginx-pod
+  namespace: monitoring
+  labels:
+    app: kruize-ui-nginx
+spec:
+  containers:
+    - name: kruize-ui-nginx-container
+      image: quay.io/kruize/kruize-ui:test
+      imagePullPolicy: Always
+      env:
+        - name: KRUIZE_UI_ENV
+          value: "production"
+      volumeMounts:
+        - name: nginx-config-volume
+          mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
+  volumes:
+    - name: nginx-config-volume
+      configMap:
+        name: nginx-config
+

--- a/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
@@ -188,7 +188,7 @@ metadata:
 spec:
   containers:
     - name: kruize-ui-nginx-container
-      image: quay.io/kruize/kruize-ui:test
+      image: quay.io/kruize/kruize-ui:0.0.1
       imagePullPolicy: Always
       env:
         - name: KRUIZE_UI_ENV

--- a/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
@@ -194,7 +194,7 @@ metadata:
 spec:
   containers:
     - name: kruize-ui-nginx-container
-      image: quay.io/kruize/kruize-ui:test
+      image: quay.io/kruize/kruize-ui:0.0.1
       imagePullPolicy: Always
       env:
         - name: KRUIZE_UI_ENV

--- a/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
@@ -138,3 +138,72 @@ spec:
     - port: kruize-port
       interval: 30s
       path: /metrics
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+  namespace: openshift-tuning
+data:
+  nginx.conf: |
+    events {}
+    http {
+      upstream kruize-api {
+        server kruize:8080;
+      }
+
+      server {
+        listen 8080;
+        server_name localhost;
+
+        root   /usr/share/nginx/html;
+    
+        location ^~ /api/ {
+          rewrite ^/api(.*)$ $1 break;
+          proxy_pass http://kruize-api;
+        }
+    
+        location / {
+          index index.html;
+          error_page 404 =200 /index.html;
+        }
+      }
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kruize-ui-nginx-service
+  namespace: openshift-tuning
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: kruize-ui-nginx
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kruize-ui-nginx-pod
+  namespace: openshift-tuning
+  labels:
+    app: kruize-ui-nginx
+spec:
+  containers:
+    - name: kruize-ui-nginx-container
+      image: quay.io/kruize/kruize-ui:test
+      imagePullPolicy: Always
+      env:
+        - name: KRUIZE_UI_ENV
+          value: "production"
+      volumeMounts:
+        - name: nginx-config-volume
+          mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
+  volumes:
+    - name: nginx-config-volume
+      configMap:
+        name: nginx-config

--- a/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
@@ -210,3 +210,73 @@ spec:
     - port: kruize-port
       interval: 30s
       path: /metrics
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+  namespace: monitoring
+data:
+  nginx.conf: |
+    events {}
+    http {
+      upstream kruize-api {
+        server kruize:8080;
+      }
+
+      server {
+        listen 8080;
+        server_name localhost;
+
+        root   /usr/share/nginx/html;
+    
+        location ^~ /api/ {
+          rewrite ^/api(.*)$ $1 break;
+          proxy_pass http://kruize-api;
+        }
+    
+        location / {
+          index index.html;
+          error_page 404 =200 /index.html;
+        }
+      }
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kruize-ui-nginx-service
+  namespace: monitoring
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: kruize-ui-nginx
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kruize-ui-nginx-pod
+  namespace: monitoring
+  labels:
+    app: kruize-ui-nginx
+spec:
+  containers:
+    - name: kruize-ui-nginx-container
+      image: quay.io/kruize/kruize-ui:test
+      imagePullPolicy: Always
+      env:
+        - name: KRUIZE_UI_ENV
+          value: "production"
+      volumeMounts:
+        - name: nginx-config-volume
+          mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
+  volumes:
+    - name: nginx-config-volume
+      configMap:
+        name: nginx-config
+

--- a/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
@@ -266,7 +266,7 @@ metadata:
 spec:
   containers:
     - name: kruize-ui-nginx-container
-      image: quay.io/kruize/kruize-ui:test
+      image: quay.io/kruize/kruize-ui:0.0.1
       imagePullPolicy: Always
       env:
         - name: KRUIZE_UI_ENV

--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -255,3 +255,73 @@ spec:
     - port: kruize-port
       interval: 30s
       path: /metrics
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+  namespace: monitoring
+data:
+  nginx.conf: |
+    events {}
+    http {
+      upstream kruize-api {
+        server kruize:8080;
+      }
+
+      server {
+        listen 8080;
+        server_name localhost;
+
+        root   /usr/share/nginx/html;
+    
+        location ^~ /api/ {
+          rewrite ^/api(.*)$ $1 break;
+          proxy_pass http://kruize-api;
+        }
+    
+        location / {
+          index index.html;
+          error_page 404 =200 /index.html;
+        }
+      }
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kruize-ui-nginx-service
+  namespace: openshift-tuning
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: kruize-ui-nginx
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kruize-ui-nginx-pod
+  namespace: openshift-tuning
+  labels:
+    app: kruize-ui-nginx
+spec:
+  containers:
+    - name: kruize-ui-nginx-container
+      image: quay.io/kruize/kruize-ui:test
+      imagePullPolicy: Always
+      env:
+        - name: KRUIZE_UI_ENV
+          value: "production"
+      volumeMounts:
+        - name: nginx-config-volume
+          mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
+  volumes:
+    - name: nginx-config-volume
+      configMap:
+        name: nginx-config
+

--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -311,7 +311,7 @@ metadata:
 spec:
   containers:
     - name: kruize-ui-nginx-container
-      image: quay.io/kruize/kruize-ui:test
+      image: quay.io/kruize/kruize-ui:0.0.1
       imagePullPolicy: Always
       env:
         - name: KRUIZE_UI_ENV

--- a/scripts/common_utils.sh
+++ b/scripts/common_utils.sh
@@ -21,6 +21,7 @@ function check_running() {
 	
 	check_pod=$1
 	check_pod_ns=$2
+	ignore_pod=$3
 	kubectl_cmd="kubectl -n ${check_pod_ns}"
 
 	echo "Info: Waiting for ${check_pod} to come up....."
@@ -29,8 +30,16 @@ function check_running() {
 	while true;
 	do
 		sleep 2
-		${kubectl_cmd} get pods | grep ${check_pod}
-		pod_stat=$(${kubectl_cmd} get pods | grep ${check_pod} | awk '{ print $3 }')
+#		Check if ignore pod is sent
+		if [[ ! -z "${ignore_pod}" ]]; then
+		  ${kubectl_cmd} get pods | grep ${check_pod} | grep -v ${ignore_pod}
+      pod_stat=$(${kubectl_cmd} get pods | grep ${check_pod} | grep -v ${ignore_pod} | awk '{ print $3 }')
+    else
+      ${kubectl_cmd} get pods | grep ${check_pod}
+      pod_stat=$(${kubectl_cmd} get pods | grep ${check_pod} | awk '{ print $3 }')
+    fi
+
+
 		case "${pod_stat}" in
 			"Running")
 				echo "Info: ${check_pod} deploy succeeded: ${pod_stat}"
@@ -49,7 +58,7 @@ function check_running() {
 			*)
 				sleep 2
 				if [ $counter == 200 ]; then
-					${kubectl_cmd} describe pod ${scheck_pod}
+					${kubectl_cmd} describe pod ${check_pod}
 					echo "ERROR: Prometheus Pods failed to come up!"
 					exit -1
 				fi
@@ -85,17 +94,20 @@ kruize_crc_start() {
 	CRC_MANIFEST_FILE_OLD="${CRC_DIR}/${cluster_type}/kruize_${cluster_type}.yaml"
 
 	cp ${CRC_MANIFEST_FILE} ${CRC_MANIFEST_FILE_OLD}
-	awk -v image_name=${AUTOTUNE_DOCKER_IMAGE} '{
+	awk -v image_name=${AUTOTUNE_DOCKER_IMAGE} -v ui_image_name=${KRUIZE_UI_DOCKER_IMAGE} '{
 			if ($2=="name:") {
 				prev=$3;
 				print
 			} else if ($1=="image:" && prev=="kruize") {
 				$2=image_name;
 				printf"          %s %s\n", $1, $2;
-			} else { print }
+			} else if ($1=="image:" && prev=="kruize-ui-nginx-container") {
+        $2=ui_image_name;
+        printf"      %s %s\n", $1, $2;
+      } else { print }
 		 }' ${CRC_MANIFEST_FILE_OLD} > ${CRC_MANIFEST_FILE}
 	${kubectl_cmd} apply -f ${CRC_MANIFEST_FILE}
-	check_running kruize ${autotune_ns}
+	check_running kruize ${autotune_ns} kruize-ui
 	if [ "${err}" != "0" ]; then
 		# Indicate deploy failed on error
 		exit 1

--- a/scripts/common_utils.sh
+++ b/scripts/common_utils.sh
@@ -19,80 +19,80 @@
 
 function check_running() {
 
-  check_pod=$1
-  check_pod_ns=$2
-  ignore_pod=$3
-  kubectl_cmd="kubectl -n ${check_pod_ns}"
+	check_pod=$1
+	check_pod_ns=$2
+	ignore_pod=$3
+	kubectl_cmd="kubectl -n ${check_pod_ns}"
 
-  echo "Info: Waiting for ${check_pod} to come up....."
-  err_wait=0
-  counter=0
-  while true; do
-    sleep 2
-    #		Check if ignore pod is sent
-    if [[ ! -z "${ignore_pod}" ]]; then
-      ${kubectl_cmd} get pods | grep ${check_pod} | grep -v ${ignore_pod}
-      pod_stat=$(${kubectl_cmd} get pods | grep ${check_pod} | grep -v ${ignore_pod} | awk '{ print $3 }')
-    else
-      ${kubectl_cmd} get pods | grep ${check_pod}
-      pod_stat=$(${kubectl_cmd} get pods | grep ${check_pod} | awk '{ print $3 }')
-    fi
+	echo "Info: Waiting for ${check_pod} to come up....."
+	err_wait=0
+	counter=0
+	while true; do
+		sleep 2
+		#		Check if ignore pod is sent
+		if [[ ! -z "${ignore_pod}" ]]; then
+			${kubectl_cmd} get pods | grep ${check_pod} | grep -v ${ignore_pod}
+			pod_stat=$(${kubectl_cmd} get pods | grep ${check_pod} | grep -v ${ignore_pod} | awk '{ print $3 }')
+		else
+			${kubectl_cmd} get pods | grep ${check_pod}
+			pod_stat=$(${kubectl_cmd} get pods | grep ${check_pod} | awk '{ print $3 }')
+		fi
 
-    case "${pod_stat}" in
-    "Running")
-      echo "Info: ${check_pod} deploy succeeded: ${pod_stat}"
-      err=0
-      break
-      ;;
-    "Error")
-      # On Error, wait for 10 seconds before exiting.
-      err_wait=$((err_wait + 1))
-      if [ ${err_wait} -gt 5 ]; then
-        echo "Error: ${check_pod} deploy failed: ${pod_stat}"
-        err=-1
-        break
-      fi
-      ;;
-    *)
-      sleep 2
-      if [ $counter == 200 ]; then
-        ${kubectl_cmd} describe pod ${check_pod}
-        echo "ERROR: Prometheus Pods failed to come up!"
-        exit -1
-      fi
-      ((counter++))
-      ;;
-    esac
-  done
+		case "${pod_stat}" in
+		"Running")
+			echo "Info: ${check_pod} deploy succeeded: ${pod_stat}"
+			err=0
+			break
+			;;
+		"Error")
+			# On Error, wait for 10 seconds before exiting.
+			err_wait=$((err_wait + 1))
+			if [ ${err_wait} -gt 5 ]; then
+				echo "Error: ${check_pod} deploy failed: ${pod_stat}"
+				err=-1
+				break
+			fi
+			;;
+		*)
+			sleep 2
+			if [ $counter == 200 ]; then
+				${kubectl_cmd} describe pod ${check_pod}
+				echo "ERROR: Prometheus Pods failed to come up!"
+				exit -1
+			fi
+			((counter++))
+			;;
+		esac
+	done
 
-  ${kubectl_cmd} get pods | grep ${check_pod}
-  echo
+	${kubectl_cmd} get pods | grep ${check_pod}
+	echo
 }
 
 function check_kustomize() {
-  kubectl_tool=$(which kubectl)
-  check_err "Error: Please install the kubectl tool"
-  # Check to see if kubectl supports kustomize
-  kubectl --help | grep "kustomize" >/dev/null
-  check_err "Error: Please install a newer version of kubectl tool that supports the kustomize option (>=v1.12)"
+	kubectl_tool=$(which kubectl)
+	check_err "Error: Please install the kubectl tool"
+	# Check to see if kubectl supports kustomize
+	kubectl --help | grep "kustomize" >/dev/null
+	check_err "Error: Please install a newer version of kubectl tool that supports the kustomize option (>=v1.12)"
 }
 
 # Check error code from last command, exit on error
 check_err() {
-  err=$?
-  if [ ${err} -ne 0 ]; then
-    echo "$*"
-    exit -1
-  fi
+	err=$?
+	if [ ${err} -ne 0 ]; then
+		echo "$*"
+		exit -1
+	fi
 }
 
 # Deploy kruize in remote monitoring mode with the specified docker image
 kruize_crc_start() {
-  kubectl_cmd="kubectl -n ${autotune_ns}"
-  CRC_MANIFEST_FILE_OLD="${CRC_DIR}/${cluster_type}/kruize_${cluster_type}.yaml"
+	kubectl_cmd="kubectl -n ${autotune_ns}"
+	CRC_MANIFEST_FILE_OLD="${CRC_DIR}/${cluster_type}/kruize_${cluster_type}.yaml"
 
-  cp ${CRC_MANIFEST_FILE} ${CRC_MANIFEST_FILE_OLD}
-  awk -v image_name=${AUTOTUNE_DOCKER_IMAGE} -v ui_image_name=${KRUIZE_UI_DOCKER_IMAGE} '{
+	cp ${CRC_MANIFEST_FILE} ${CRC_MANIFEST_FILE_OLD}
+	awk -v image_name=${AUTOTUNE_DOCKER_IMAGE} -v ui_image_name=${KRUIZE_UI_DOCKER_IMAGE} '{
 			if ($2=="name:") {
 				prev=$3;
 				print
@@ -104,12 +104,12 @@ kruize_crc_start() {
         printf"      %s %s\n", $1, $2;
       } else { print }
 		 }' ${CRC_MANIFEST_FILE_OLD} >${CRC_MANIFEST_FILE}
-  ${kubectl_cmd} apply -f ${CRC_MANIFEST_FILE}
-  check_running kruize ${autotune_ns} kruize-ui
-  if [ "${err}" != "0" ]; then
-    # Indicate deploy failed on error
-    exit 1
-  fi
-  cp ${CRC_MANIFEST_FILE_OLD} ${CRC_MANIFEST_FILE}
-  rm ${CRC_MANIFEST_FILE_OLD}
+	${kubectl_cmd} apply -f ${CRC_MANIFEST_FILE}
+	check_running kruize ${autotune_ns} kruize-ui
+	if [ "${err}" != "0" ]; then
+		# Indicate deploy failed on error
+		exit 1
+	fi
+	cp ${CRC_MANIFEST_FILE_OLD} ${CRC_MANIFEST_FILE}
+	rm ${CRC_MANIFEST_FILE_OLD}
 }

--- a/scripts/common_utils.sh
+++ b/scripts/common_utils.sh
@@ -18,83 +18,81 @@
 ###############################  utilities  #################################
 
 function check_running() {
-	
-	check_pod=$1
-	check_pod_ns=$2
-	ignore_pod=$3
-	kubectl_cmd="kubectl -n ${check_pod_ns}"
 
-	echo "Info: Waiting for ${check_pod} to come up....."
-	err_wait=0
-	counter=0
-	while true;
-	do
-		sleep 2
-#		Check if ignore pod is sent
-		if [[ ! -z "${ignore_pod}" ]]; then
-		  ${kubectl_cmd} get pods | grep ${check_pod} | grep -v ${ignore_pod}
+  check_pod=$1
+  check_pod_ns=$2
+  ignore_pod=$3
+  kubectl_cmd="kubectl -n ${check_pod_ns}"
+
+  echo "Info: Waiting for ${check_pod} to come up....."
+  err_wait=0
+  counter=0
+  while true; do
+    sleep 2
+    #		Check if ignore pod is sent
+    if [[ ! -z "${ignore_pod}" ]]; then
+      ${kubectl_cmd} get pods | grep ${check_pod} | grep -v ${ignore_pod}
       pod_stat=$(${kubectl_cmd} get pods | grep ${check_pod} | grep -v ${ignore_pod} | awk '{ print $3 }')
     else
       ${kubectl_cmd} get pods | grep ${check_pod}
       pod_stat=$(${kubectl_cmd} get pods | grep ${check_pod} | awk '{ print $3 }')
     fi
 
+    case "${pod_stat}" in
+    "Running")
+      echo "Info: ${check_pod} deploy succeeded: ${pod_stat}"
+      err=0
+      break
+      ;;
+    "Error")
+      # On Error, wait for 10 seconds before exiting.
+      err_wait=$((err_wait + 1))
+      if [ ${err_wait} -gt 5 ]; then
+        echo "Error: ${check_pod} deploy failed: ${pod_stat}"
+        err=-1
+        break
+      fi
+      ;;
+    *)
+      sleep 2
+      if [ $counter == 200 ]; then
+        ${kubectl_cmd} describe pod ${check_pod}
+        echo "ERROR: Prometheus Pods failed to come up!"
+        exit -1
+      fi
+      ((counter++))
+      ;;
+    esac
+  done
 
-		case "${pod_stat}" in
-			"Running")
-				echo "Info: ${check_pod} deploy succeeded: ${pod_stat}"
-				err=0
-				break;
-				;;
-			"Error")
-				# On Error, wait for 10 seconds before exiting.
-				err_wait=$(( err_wait + 1 ))
-				if [ ${err_wait} -gt 5 ]; then
-					echo "Error: ${check_pod} deploy failed: ${pod_stat}"
-					err=-1
-					break;
-				fi
-				;;
-			*)
-				sleep 2
-				if [ $counter == 200 ]; then
-					${kubectl_cmd} describe pod ${check_pod}
-					echo "ERROR: Prometheus Pods failed to come up!"
-					exit -1
-				fi
-				((counter++))
-				;;
-		esac
-	done
-
-	${kubectl_cmd} get pods | grep ${check_pod}
-	echo
+  ${kubectl_cmd} get pods | grep ${check_pod}
+  echo
 }
 
 function check_kustomize() {
-	kubectl_tool=$(which kubectl)
-	check_err "Error: Please install the kubectl tool"
-	# Check to see if kubectl supports kustomize
-	kubectl --help | grep "kustomize" >/dev/null
-	check_err "Error: Please install a newer version of kubectl tool that supports the kustomize option (>=v1.12)"
+  kubectl_tool=$(which kubectl)
+  check_err "Error: Please install the kubectl tool"
+  # Check to see if kubectl supports kustomize
+  kubectl --help | grep "kustomize" >/dev/null
+  check_err "Error: Please install a newer version of kubectl tool that supports the kustomize option (>=v1.12)"
 }
 
 # Check error code from last command, exit on error
 check_err() {
-	err=$?
-	if [ ${err} -ne 0 ]; then
-		echo "$*"
-		exit -1
-	fi
+  err=$?
+  if [ ${err} -ne 0 ]; then
+    echo "$*"
+    exit -1
+  fi
 }
 
 # Deploy kruize in remote monitoring mode with the specified docker image
 kruize_crc_start() {
-	kubectl_cmd="kubectl -n ${autotune_ns}"
-	CRC_MANIFEST_FILE_OLD="${CRC_DIR}/${cluster_type}/kruize_${cluster_type}.yaml"
+  kubectl_cmd="kubectl -n ${autotune_ns}"
+  CRC_MANIFEST_FILE_OLD="${CRC_DIR}/${cluster_type}/kruize_${cluster_type}.yaml"
 
-	cp ${CRC_MANIFEST_FILE} ${CRC_MANIFEST_FILE_OLD}
-	awk -v image_name=${AUTOTUNE_DOCKER_IMAGE} -v ui_image_name=${KRUIZE_UI_DOCKER_IMAGE} '{
+  cp ${CRC_MANIFEST_FILE} ${CRC_MANIFEST_FILE_OLD}
+  awk -v image_name=${AUTOTUNE_DOCKER_IMAGE} -v ui_image_name=${KRUIZE_UI_DOCKER_IMAGE} '{
 			if ($2=="name:") {
 				prev=$3;
 				print
@@ -105,13 +103,13 @@ kruize_crc_start() {
         $2=ui_image_name;
         printf"      %s %s\n", $1, $2;
       } else { print }
-		 }' ${CRC_MANIFEST_FILE_OLD} > ${CRC_MANIFEST_FILE}
-	${kubectl_cmd} apply -f ${CRC_MANIFEST_FILE}
-	check_running kruize ${autotune_ns} kruize-ui
-	if [ "${err}" != "0" ]; then
-		# Indicate deploy failed on error
-		exit 1
-	fi
-	cp ${CRC_MANIFEST_FILE_OLD} ${CRC_MANIFEST_FILE}
-	rm ${CRC_MANIFEST_FILE_OLD}
+		 }' ${CRC_MANIFEST_FILE_OLD} >${CRC_MANIFEST_FILE}
+  ${kubectl_cmd} apply -f ${CRC_MANIFEST_FILE}
+  check_running kruize ${autotune_ns} kruize-ui
+  if [ "${err}" != "0" ]; then
+    # Indicate deploy failed on error
+    exit 1
+  fi
+  cp ${CRC_MANIFEST_FILE_OLD} ${CRC_MANIFEST_FILE}
+  rm ${CRC_MANIFEST_FILE_OLD}
 }

--- a/scripts/ffdc.sh
+++ b/scripts/ffdc.sh
@@ -41,7 +41,7 @@ function ffdc() {
 	pod_log="${log_dir}/kruize_pod_log.txt"
 	describe_log="${log_dir}/kruize_describe_pod_log.txt"
 
-	kruize_pod=$(kubectl get pod -n $namespace | grep $service | cut -d " " -f1)
+	kruize_pod=$(kubectl get pod -n $namespace | grep $service | grep -v "kruize-ui" | cut -d " " -f1)
 
 	kubectl describe pod ${kruize_pod} -n ${namespace} > ${describe_log} 2>&1
 	check_err "Error getting kubectl describe kruize pod log! Check ${describe_log} for details!"


### PR DESCRIPTION
This PR adds the Kruize UI related manifests

To see changes in remote monitoring demo. The deploy script need to be updated to check only for kruize api server but not kruize ui pod. 

making this PR a work in progress to fix the deploy script

The Kruize UI image should be replaced with official one in kruize repo once the  release is completed