### PR TITLE
Change the namespace from monitoring to openshift-tuning

### DIFF
--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -260,7 +260,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: nginx-config
-  namespace: monitoring
+  namespace: openshift-tuning
 data:
   nginx.conf: |
     events {}


### PR DESCRIPTION
This PR changes the `namespace` from `monitoring` to `openshift-tuning` in the CRC yaml's

@dinogun Can I please have your review on this change. Would like to have it in `0.0.18`