### PR TITLE
enhanced error response for updateResults API

### DIFF
--- a/src/main/java/com/autotune/analyzer/serviceObjects/FailedUpdateResultsAPIObject.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/FailedUpdateResultsAPIObject.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.autotune.analyzer.serviceObjects;
+
+import com.autotune.analyzer.exceptions.KruizeResponse;
+import com.autotune.utils.KruizeConstants;
+import com.google.gson.annotations.SerializedName;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+public class FailedUpdateResultsAPIObject extends BaseSO {
+    @SerializedName(KruizeConstants.JSONKeys.INTERVAL_START_TIME)
+    public Timestamp startTimestamp;
+
+    @SerializedName(KruizeConstants.JSONKeys.INTERVAL_END_TIME)
+    public Timestamp endTimestamp;
+
+    private List<KruizeResponse> errors;
+
+    public FailedUpdateResultsAPIObject(String version, String experiment_name, Timestamp startTimestamp, Timestamp endTimestamp, List<KruizeResponse> errors) {
+        this.setApiVersion(version);
+        this.setExperimentName(experiment_name);
+        this.startTimestamp = startTimestamp;
+        this.endTimestamp = endTimestamp;
+        this.errors = errors;
+    }
+}


### PR DESCRIPTION
Standardized the error message format for `updateResults` API for bulk records
```
{
  "message": "Out of a total of 3 records, 3 failed to save",
  "httpcode": 400,
  "documentationLink": "",
  "status": "ERROR",
  "data": [
    {
      "interval_start_time": "Jan 1, 2024, 5:30:00 AM",
      "interval_end_time": "Jan 1, 2024, 5:45:00 AM",
      "errors": [
        {
          "message": "experiment_name: may not be empty , version: may not be empty",
          "httpcode": 400,
          "documentationLink": "",
          "status": "ERROR"
        }
      ]
    },
    {
      "interval_start_time": "Jan 1, 2023, 5:45:00 AM",
      "interval_end_time": "Jan 1, 2023, 6:00:00 AM",
      "errors": [
        {
          "message": "An entry for this record already exists!",
          "httpcode": 409,
          "documentationLink": "",
          "status": "ERROR"
        }
      ],
      "version": "3.0",
      "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db_1_1"
    },
    {
      "interval_start_time": "Jan 1, 2023, 6:00:00 AM",
      "interval_end_time": "Jan 1, 2023, 6:15:00 AM",
      "errors": [
        {
          "message": "An entry for this record already exists!",
          "httpcode": 409,
          "documentationLink": "",
          "status": "ERROR"
        }
      ],
      "version": "3.0",
      "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db_1_1"
    }
  ]
}
```