### PR TITLE
[WIP] Adds cluster_name parameter to listRecommendations API

### DIFF
--- a/migrations/kruize_experiments_ddl.sql
+++ b/migrations/kruize_experiments_ddl.sql
@@ -5,5 +5,6 @@ create table IF NOT EXISTS kruize_results (interval_start_time timestamp(6) not 
 alter table if exists kruize_experiments add constraint UK_experiment_name unique (experiment_name);
 create index IF NOT EXISTS idx_recommendation_experiment_name on kruize_recommendations (experiment_name);
 create index IF NOT EXISTS idx_recommendation_interval_end_time on kruize_recommendations (interval_end_time);
+create index IF NOT EXISTS idx_recommendation_cluster_name on kruize_recommendations (cluster_name);
 create index IF NOT EXISTS idx_result_experiment_name on kruize_results (experiment_name);
 create index IF NOT EXISTS idx_result_interval_end_time on kruize_results (interval_end_time);

--- a/src/main/java/com/autotune/analyzer/services/ListRecommendations.java
+++ b/src/main/java/com/autotune/analyzer/services/ListRecommendations.java
@@ -151,7 +151,7 @@ public class ListRecommendations extends HttpServlet {
                 try {
                     new ExperimentDBService().loadExperimentsAndRecommendationsFromDBByClusterName(mKruizeExperimentMap, clusterName);
                 } catch (Exception e) {
-                    LOGGER.error("Loading saved cluster {} failed: {} ", clusterName, e.getMessage());
+                    LOGGER.error("Loading experiments and recommendations based on cluster {} failed: {} ", clusterName, e.getMessage());
                 }
                 // Check if cluster exists
                 if (!mKruizeExperimentMap.isEmpty()) {

--- a/src/main/java/com/autotune/analyzer/services/ListRecommendations.java
+++ b/src/main/java/com/autotune/analyzer/services/ListRecommendations.java
@@ -149,7 +149,7 @@ public class ListRecommendations extends HttpServlet {
                 }
             }else if(null != clusterName){
                 try {
-                    new ExperimentDBService().loadExperimentAndRecommendationsFromDBByClusterName(mKruizeExperimentMap, clusterName);
+                    new ExperimentDBService().loadExperimentsAndRecommendationsFromDBByClusterName(mKruizeExperimentMap, clusterName);
                 } catch (Exception e) {
                     LOGGER.error("Loading saved cluster {} failed: {} ", clusterName, e.getMessage());
                 }

--- a/src/main/java/com/autotune/analyzer/services/ListRecommendations.java
+++ b/src/main/java/com/autotune/analyzer/services/ListRecommendations.java
@@ -147,7 +147,7 @@ public class ListRecommendations extends HttpServlet {
                             String.format(AnalyzerErrorConstants.APIErrors.ListRecommendationsAPI.INVALID_EXPERIMENT_NAME_MSG, experimentName)
                     );
                 }
-            }else if(null != clusterName){
+            } else if (null != clusterName) {
                 try {
                     new ExperimentDBService().loadExperimentsAndRecommendationsFromDBByClusterName(mKruizeExperimentMap, clusterName);
                 } catch (Exception e) {
@@ -200,7 +200,7 @@ public class ListRecommendations extends HttpServlet {
                             String.format(AnalyzerErrorConstants.APIErrors.ListRecommendationsAPI.INVALID_CLUSTER_NAME_MSG, clusterName)
                     );
                 }
-            }else {
+            } else {
                 try {
                     new ExperimentDBService().loadAllExperimentsAndRecommendations(mKruizeExperimentMap);
                 } catch (Exception e) {

--- a/src/main/java/com/autotune/analyzer/services/ListRecommendations.java
+++ b/src/main/java/com/autotune/analyzer/services/ListRecommendations.java
@@ -79,6 +79,7 @@ public class ListRecommendations extends HttpServlet {
         // Set the character encoding of the request to UTF-8
         request.setCharacterEncoding(CHARACTER_ENCODING);
         String experimentName = request.getParameter(AnalyzerConstants.ServiceConstants.EXPERIMENT_NAME);
+        String clusterName = request.getParameter(KruizeConstants.JSONKeys.CLUSTER_NAME);
         String latestRecommendation = request.getParameter(AnalyzerConstants.ServiceConstants.LATEST);
         String monitoringEndTime = request.getParameter(KruizeConstants.JSONKeys.MONITORING_END_TIME);
         Timestamp monitoringEndTimestamp = null;
@@ -146,7 +147,13 @@ public class ListRecommendations extends HttpServlet {
                             String.format(AnalyzerErrorConstants.APIErrors.ListRecommendationsAPI.INVALID_EXPERIMENT_NAME_MSG, experimentName)
                     );
                 }
-            } else {
+            }else if(null != clusterName){
+                try {
+                    new ExperimentDBService().loadExperimentAndRecommendationsFromDBByClusterName(mKruizeExperimentMap, clusterName);
+                } catch (Exception e) {
+                    LOGGER.error("Loading saved cluster {} failed: {} ", clusterName, e.getMessage());
+                }
+            }else {
                 try {
                     new ExperimentDBService().loadAllExperimentsAndRecommendations(mKruizeExperimentMap);
                 } catch (Exception e) {

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
@@ -144,6 +144,8 @@ public class AnalyzerErrorConstants {
             public static final String INVALID_EXPERIMENT_NAME_MSG = "Given experiment name - \" %s \" is not valid";
             public static final String INVALID_QUERY_PARAM = "The query param(s) - \" %s \" is/are invalid";
             public static final String INVALID_QUERY_PARAM_VALUE = "The query param value(s) is/are invalid";
+            public static final String INVALID_CLUSTER_NAME_EXCPTN = "Invalid Cluster Name";
+            public static final String INVALID_CLUSTER_NAME_MSG = "Given cluster name - \" %s \" is not valid";
 
             private ListRecommendationsAPI() {
 

--- a/src/main/java/com/autotune/database/dao/ExperimentDAO.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAO.java
@@ -54,9 +54,6 @@ public interface ExperimentDAO {
     // Load all results for a particular experimentName
     List<KruizeResultsEntry> loadResultsByExperimentName(String experimentName, String cluster_name, Timestamp interval_start_time, Timestamp interval_end_time) throws Exception;
 
-    // Load all results for a particular clusterName
-    List<KruizeResultsEntry> loadResultsByClusterName(String clusterName, Timestamp interval_start_time, Integer limitRows) throws Exception;
-
     // Load all recommendations of a particular experiment
     List<KruizeRecommendationEntry> loadRecommendationsByExperimentName(String experimentName) throws Exception;
     // Load all recommendations of a particular cluster

--- a/src/main/java/com/autotune/database/dao/ExperimentDAO.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAO.java
@@ -56,7 +56,8 @@ public interface ExperimentDAO {
 
     // Load all recommendations of a particular experiment
     List<KruizeRecommendationEntry> loadRecommendationsByExperimentName(String experimentName) throws Exception;
-
+    // Load all recommendations of a particular cluster
+    List<KruizeRecommendationEntry> loadRecommendationsByClusterName(String clusterName) throws Exception;
 
     // Load a single Performance Profile based on name
     List<KruizePerformanceProfileEntry> loadPerformanceProfileByName(String performanceProfileName) throws Exception;

--- a/src/main/java/com/autotune/database/dao/ExperimentDAO.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAO.java
@@ -48,8 +48,10 @@ public interface ExperimentDAO {
     // Load a single experiment based on experimentName
     List<KruizeExperimentEntry> loadExperimentByName(String experimentName) throws Exception;
 
-    // Load all results for a particular experimentName
+    //Load all experiments of a particular clusterName
+    List<KruizeExperimentEntry> loadExperimentsByClusterName(String clusterName) throws Exception;
 
+    // Load all results for a particular experimentName
     List<KruizeResultsEntry> loadResultsByExperimentName(String experimentName, String cluster_name, Timestamp interval_start_time, Timestamp interval_end_time) throws Exception;
 
     // Load all recommendations of a particular experiment

--- a/src/main/java/com/autotune/database/dao/ExperimentDAO.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAO.java
@@ -54,6 +54,9 @@ public interface ExperimentDAO {
     // Load all results for a particular experimentName
     List<KruizeResultsEntry> loadResultsByExperimentName(String experimentName, String cluster_name, Timestamp interval_start_time, Timestamp interval_end_time) throws Exception;
 
+    // Load all results for a particular clusterName
+    List<KruizeResultsEntry> loadResultsByClusterName(String clusterName, Timestamp interval_start_time, Integer limitRows) throws Exception;
+
     // Load all recommendations of a particular experiment
     List<KruizeRecommendationEntry> loadRecommendationsByExperimentName(String experimentName) throws Exception;
     // Load all recommendations of a particular cluster

--- a/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
@@ -583,6 +583,26 @@ public class ExperimentDAOImpl implements ExperimentDAO {
         return recommendationEntries;
     }
 
+    public List<KruizeRecommendationEntry> loadRecommendationsByClusterName(String clusterName) throws Exception {
+        List<KruizeRecommendationEntry> recommendationEntries = null;
+        String statusValue = "failure";
+        Timer.Sample timerLoadRecExpName = Timer.start(MetricsConfig.meterRegistry());
+        try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
+            recommendationEntries = session.createQuery(DBConstants.SQLQUERY.SELECT_FROM_RECOMMENDATIONS_BY_CLUSTER_NAME, KruizeRecommendationEntry.class)
+                    .setParameter("clusterName", clusterName).list();
+            statusValue = "success";
+        } catch (Exception e) {
+            LOGGER.error("Not able to load recommendations due to {}", e.getMessage());
+            throw new Exception("Error while loading existing recommendations from database due to : " + e.getMessage());
+        } finally {
+            if (null != timerLoadRecExpName) {
+                MetricsConfig.timerLoadRecExpName = MetricsConfig.timerBLoadRecExpName.tag("status", statusValue).register(MetricsConfig.meterRegistry());
+                timerLoadRecExpName.stop(MetricsConfig.timerLoadRecExpName);
+            }
+        }
+        return recommendationEntries;
+    }
+
     @Override
     public KruizeRecommendationEntry loadRecommendationsByExperimentNameAndDate(String experimentName, String cluster_name, Timestamp interval_end_time) throws Exception {
         KruizeRecommendationEntry recommendationEntries = null;

--- a/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
@@ -511,7 +511,7 @@ public class ExperimentDAOImpl implements ExperimentDAO {
                     .setParameter("clusterName", clusterName).list();
             statusValue = "success";
         } catch (Exception e) {
-            LOGGER.error("Not able to load cluster {} due to {}", clusterName, e.getMessage());
+            LOGGER.error("Not able to load experiments of cluster {} due to {}", clusterName, e.getMessage());
             throw new Exception("Error while loading existing experiments of specified cluster from database due to : " + e.getMessage());
         } finally {
             if (null != timerLoadExpName) {

--- a/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
@@ -561,36 +561,6 @@ public class ExperimentDAOImpl implements ExperimentDAO {
         }
         return kruizeResultsEntries;
     }
-    @Override
-    public List<KruizeResultsEntry> loadResultsByClusterName(String clusterName, Timestamp interval_end_time, Integer limitRows) throws Exception {
-        // TODO: load only experimentStatus=inProgress , playback may not require completed experiments
-        List<KruizeResultsEntry> kruizeResultsEntries = null;
-        String statusValue = "failure";
-        Timer.Sample timerLoadResultsExpName = Timer.start(MetricsConfig.meterRegistry());
-        try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
-            if (null != limitRows && null != interval_end_time) {
-                kruizeResultsEntries = session.createQuery(DBConstants.SQLQUERY.SELECT_FROM_RESULTS_BY_CLUSTER_NAME_AND_DATE_RANGE, KruizeResultsEntry.class)
-                        .setParameter(KruizeConstants.JSONKeys.CLUSTER_NAME, clusterName)
-                        .setParameter(KruizeConstants.JSONKeys.INTERVAL_END_TIME, interval_end_time)
-                        .setMaxResults(limitRows)
-                        .list();
-                statusValue = "success";
-            } else {
-                kruizeResultsEntries = session.createQuery(DBConstants.SQLQUERY.SELECT_FROM_RESULTS_BY_CLUSTER_NAME, KruizeResultsEntry.class)
-                        .setParameter("clsuterName", clusterName).list();
-                statusValue = "success";
-            }
-        } catch (Exception e) {
-            LOGGER.error("Not able to load results due to: {}", e.getMessage());
-            throw new Exception("Error while loading results from the database due to : " + e.getMessage());
-        } finally {
-            if (null != timerLoadResultsExpName) {
-                MetricsConfig.timerLoadResultsExpName = MetricsConfig.timerBLoadResultsExpName.tag("status", statusValue).register(MetricsConfig.meterRegistry());
-                timerLoadResultsExpName.stop(MetricsConfig.timerLoadResultsExpName);
-            }
-        }
-        return kruizeResultsEntries;
-    }
 
     @Override
     public List<KruizeRecommendationEntry> loadRecommendationsByExperimentName(String experimentName) throws Exception {

--- a/src/main/java/com/autotune/database/helper/DBConstants.java
+++ b/src/main/java/com/autotune/database/helper/DBConstants.java
@@ -7,6 +7,7 @@ public class DBConstants {
     public static final class SQLQUERY {
         public static final String SELECT_FROM_EXPERIMENTS = "from KruizeExperimentEntry";
         public static final String SELECT_FROM_EXPERIMENTS_BY_EXP_NAME = "from KruizeExperimentEntry k WHERE k.experiment_name = :experimentName";
+        public static final String SELECT_FROM_EXPERIMENTS_BY_CLUSTER_NAME = "from KruizeExperimentEntry k WHERE k.cluster_name = :clusterName";
         public static final String SELECT_FROM_RESULTS = "from KruizeResultsEntry";
         public static final String SELECT_FROM_RESULTS_BY_EXP_NAME = "from KruizeResultsEntry k WHERE k.experiment_name = :experimentName";
         public static final String SELECT_FROM_RESULTS_BY_EXP_NAME_AND_DATE_RANGE_AND_LIMIT =

--- a/src/main/java/com/autotune/database/helper/DBConstants.java
+++ b/src/main/java/com/autotune/database/helper/DBConstants.java
@@ -19,19 +19,21 @@ public class DBConstants {
                         KruizeConstants.JSONKeys.CALCULATED_START_TIME,
                         KruizeConstants.JSONKeys.INTERVAL_END_TIME);
         public static final String SELECT_FROM_RESULTS_BY_EXP_NAME_AND_START_END_TIME = String.format("from KruizeResultsEntry k " +
-                        "WHERE k.experiment_name = :%s and k.interval_start_time >= :%s and " +
+                        "WHERE k.cluster_name = :%s k.experiment_name = :%s and k.interval_start_time >= :%s and " +
                         "k.interval_end_time <= :%s ",
-                KruizeConstants.JSONKeys.EXPERIMENT_NAME, KruizeConstants.JSONKeys.INTERVAL_START_TIME, KruizeConstants.JSONKeys.INTERVAL_END_TIME);
+                KruizeConstants.JSONKeys.CLUSTER_NAME, KruizeConstants.JSONKeys.EXPERIMENT_NAME, KruizeConstants.JSONKeys.INTERVAL_START_TIME, KruizeConstants.JSONKeys.INTERVAL_END_TIME);
         public static final String SELECT_FROM_RESULTS_BY_EXP_NAME_AND_END_TIME = String.format(
                 "from KruizeResultsEntry k WHERE " +
+                        "k.cluster_name = :%s and " +
                         "k.experiment_name = :%s " +
                         "and k.interval_end_time = :%s ",
-                KruizeConstants.JSONKeys.EXPERIMENT_NAME, KruizeConstants.JSONKeys.INTERVAL_END_TIME);
+                KruizeConstants.JSONKeys.CLUSTER_NAME, KruizeConstants.JSONKeys.EXPERIMENT_NAME, KruizeConstants.JSONKeys.INTERVAL_END_TIME);
         public static final String SELECT_FROM_RESULTS_BY_EXP_NAME_AND_MAX_END_TIME = String.format(
                 "from KruizeResultsEntry k WHERE " +
+                        "k.cluster_name = :%s and " +
                         "k.experiment_name = :%s and " +
                         "k.interval_end_time = (SELECT MAX(e.interval_end_time) FROM KruizeResultsEntry e  where e.experiment_name = :%s ) ",
-                KruizeConstants.JSONKeys.EXPERIMENT_NAME, KruizeConstants.JSONKeys.EXPERIMENT_NAME);
+                KruizeConstants.JSONKeys.CLUSTER_NAME, KruizeConstants.JSONKeys.EXPERIMENT_NAME, KruizeConstants.JSONKeys.EXPERIMENT_NAME);
         public static final String SELECT_FROM_RECOMMENDATIONS_BY_EXP_NAME = String.format("from KruizeRecommendationEntry k WHERE k.experiment_name = :experimentName");
         public static final String SELECT_FROM_RECOMMENDATIONS_BY_EXP_NAME_AND_END_TIME = String.format("from KruizeRecommendationEntry k WHERE k.cluster_name= :%s and k.experiment_name = :%s and k.interval_end_time= :%s", KruizeConstants.JSONKeys.CLUSTER_NAME, KruizeConstants.JSONKeys.EXPERIMENT_NAME, KruizeConstants.JSONKeys.INTERVAL_END_TIME);
         public static final String SELECT_FROM_RECOMMENDATIONS_BY_CLUSTER_NAME = "from KruizeRecommendationEntry k WHERE k.cluster_name = :clusterName";

--- a/src/main/java/com/autotune/database/helper/DBConstants.java
+++ b/src/main/java/com/autotune/database/helper/DBConstants.java
@@ -33,11 +33,8 @@ public class DBConstants {
                         "k.interval_end_time = (SELECT MAX(e.interval_end_time) FROM KruizeResultsEntry e  where e.experiment_name = :%s ) ",
                 KruizeConstants.JSONKeys.EXPERIMENT_NAME, KruizeConstants.JSONKeys.EXPERIMENT_NAME);
         public static final String SELECT_FROM_RECOMMENDATIONS_BY_EXP_NAME = String.format("from KruizeRecommendationEntry k WHERE k.experiment_name = :experimentName");
-        public static final String SELECT_FROM_RECOMMENDATIONS_BY_EXP_NAME_AND_END_TIME = String.format(
-                "from KruizeRecommendationEntry k WHERE " +
-                        "k.experiment_name = :%s and " +
-                        "k.interval_end_time= :%s ",
-                KruizeConstants.JSONKeys.EXPERIMENT_NAME, KruizeConstants.JSONKeys.INTERVAL_END_TIME);
+        public static final String SELECT_FROM_RECOMMENDATIONS_BY_EXP_NAME_AND_END_TIME = String.format("from KruizeRecommendationEntry k WHERE k.cluster_name= :%s and k.experiment_name = :%s and k.interval_end_time= :%s", KruizeConstants.JSONKeys.CLUSTER_NAME, KruizeConstants.JSONKeys.EXPERIMENT_NAME, KruizeConstants.JSONKeys.INTERVAL_END_TIME);
+        public static final String SELECT_FROM_RECOMMENDATIONS_BY_CLUSTER_NAME = "from KruizeRecommendationEntry k WHERE k.cluster_name = :clusterName";
         public static final String SELECT_FROM_RECOMMENDATIONS = "from KruizeRecommendationEntry";
         public static final String SELECT_FROM_PERFORMANCE_PROFILE = "from KruizePerformanceProfileEntry";
         public static final String SELECT_FROM_PERFORMANCE_PROFILE_BY_NAME = "from KruizePerformanceProfileEntry k WHERE k.name = :name";

--- a/src/main/java/com/autotune/database/service/ExperimentDBService.java
+++ b/src/main/java/com/autotune/database/service/ExperimentDBService.java
@@ -319,6 +319,11 @@ public class ExperimentDBService {
         loadRecommendationsFromDBByName(mainKruizeExperimentMap, experimentName);
     }
 
+    public void loadExperimentAndRecommendationsFromDBByClusterName(Map<String, KruizeObject> mainKruizeExperimentMap, String clusterName) throws Exception{
+        loadExperimentFromDBByClusterName(mainKruizeExperimentMap, clusterName);
+        loadRecommendationsFromDBByClusterName(mainKruizeExperimentMap, clusterName);
+    }
+
     public void loadPerformanceProfileFromDBByName(Map<String, PerformanceProfile> performanceProfileMap, String performanceProfileName) throws Exception {
         List<KruizePerformanceProfileEntry> entries = experimentDAO.loadPerformanceProfileByName(performanceProfileName);
         if (null != entries && !entries.isEmpty()) {

--- a/src/main/java/com/autotune/database/service/ExperimentDBService.java
+++ b/src/main/java/com/autotune/database/service/ExperimentDBService.java
@@ -190,32 +190,7 @@ public class ExperimentDBService {
             }
         }
     }
-    // Todo - confirm if experimentResultData to be changed to clusterResultData
-    public void loadResultsFromDBByClusterName(Map<String, KruizeObject> mainKruizeExperimentMap, String clusterName, Timestamp interval_end_time, Integer limitRows) throws Exception {
-        ExperimentInterface experimentInterface = new ExperimentInterfaceImpl();
-        // Load results from the DB and save to local
-        List<KruizeResultsEntry> kruizeResultsEntries = experimentDAO.loadResultsByClusterName(clusterName, interval_end_time, limitRows);
-        if (null != kruizeResultsEntries && !kruizeResultsEntries.isEmpty()) {
-            List<UpdateResultsAPIObject> updateResultsAPIObjects = DBHelpers.Converters.KruizeObjectConverters.convertResultEntryToUpdateResultsAPIObject(kruizeResultsEntries);
-            if (null != updateResultsAPIObjects && !updateResultsAPIObjects.isEmpty()) {
-                List<ExperimentResultData> resultDataList = new ArrayList<>();
-                for (UpdateResultsAPIObject updateResultsAPIObject : updateResultsAPIObjects) {
-                    try {
-                        ExperimentResultData experimentResultData = Converters.KruizeObjectConverters.convertUpdateResultsAPIObjToExperimentResultData(updateResultsAPIObject);
-                        if (experimentResultData != null)
-                            resultDataList.add(experimentResultData);
-                        else
-                            LOGGER.warn("Converted experimentResultData is null");
-                    } catch (IllegalArgumentException e) {
-                        LOGGER.error("Failed to convert DB data to local: {}", e.getMessage());
-                    } catch (Exception e) {
-                        LOGGER.error("Unexpected error: {}", e.getMessage());
-                    }
-                }
-                experimentInterface.addResultsToLocalStorage(mainKruizeExperimentMap, resultDataList);
-            }
-        }
-    }
+
     public void loadRecommendationsFromDBByClusterName(Map<String, KruizeObject> mainKruizeExperimentMap, String clusterName) throws Exception {
         ExperimentInterface experimentInterface = new ExperimentInterfaceImpl();
         // Load Recommendations from DB and save to local
@@ -394,11 +369,6 @@ public class ExperimentDBService {
         loadRecommendationsFromDBByName(mainKruizeExperimentMap, experimentName);
     }
 
-    public void loadExperimentsAndResultsFromDBByClusterName(Map<String, KruizeObject> mainKruizeExperimentMap, String clusterName) throws Exception {
-
-        loadExperimentsFromDBByClusterName(mainKruizeExperimentMap, clusterName);
-        loadResultsFromDBByClusterName(mainKruizeExperimentMap, clusterName, null, null);
-    }
     public void loadExperimentsAndRecommendationsFromDBByClusterName(Map<String, KruizeObject> mainKruizeExperimentMap, String clusterName) throws Exception {
         loadExperimentsFromDBByClusterName(mainKruizeExperimentMap, clusterName);
         loadRecommendationsFromDBByClusterName(mainKruizeExperimentMap, clusterName);

--- a/src/main/java/com/autotune/database/service/ExperimentDBService.java
+++ b/src/main/java/com/autotune/database/service/ExperimentDBService.java
@@ -399,7 +399,7 @@ public class ExperimentDBService {
         loadExperimentsFromDBByClusterName(mainKruizeExperimentMap, clusterName);
         loadResultsFromDBByClusterName(mainKruizeExperimentMap, clusterName, null, null);
     }
-    public void loadExperimentsAndRecommendationsFromDBByClusterName(Map<String, KruizeObject> mainKruizeExperimentMap, String clusterName) throws Exception{
+    public void loadExperimentsAndRecommendationsFromDBByClusterName(Map<String, KruizeObject> mainKruizeExperimentMap, String clusterName) throws Exception {
         loadExperimentsFromDBByClusterName(mainKruizeExperimentMap, clusterName);
         loadRecommendationsFromDBByClusterName(mainKruizeExperimentMap, clusterName);
     }

--- a/src/main/java/com/autotune/database/service/ExperimentDBService.java
+++ b/src/main/java/com/autotune/database/service/ExperimentDBService.java
@@ -190,7 +190,32 @@ public class ExperimentDBService {
             }
         }
     }
-    ///
+    // Todo - confirm if experimentResultData to be changed to clusterResultData
+    public void loadResultsFromDBByClusterName(Map<String, KruizeObject> mainKruizeExperimentMap, String clusterName, Timestamp interval_end_time, Integer limitRows) throws Exception {
+        ExperimentInterface experimentInterface = new ExperimentInterfaceImpl();
+        // Load results from the DB and save to local
+        List<KruizeResultsEntry> kruizeResultsEntries = experimentDAO.loadResultsByClusterName(clusterName, interval_end_time, limitRows);
+        if (null != kruizeResultsEntries && !kruizeResultsEntries.isEmpty()) {
+            List<UpdateResultsAPIObject> updateResultsAPIObjects = DBHelpers.Converters.KruizeObjectConverters.convertResultEntryToUpdateResultsAPIObject(kruizeResultsEntries);
+            if (null != updateResultsAPIObjects && !updateResultsAPIObjects.isEmpty()) {
+                List<ExperimentResultData> resultDataList = new ArrayList<>();
+                for (UpdateResultsAPIObject updateResultsAPIObject : updateResultsAPIObjects) {
+                    try {
+                        ExperimentResultData experimentResultData = Converters.KruizeObjectConverters.convertUpdateResultsAPIObjToExperimentResultData(updateResultsAPIObject);
+                        if (experimentResultData != null)
+                            resultDataList.add(experimentResultData);
+                        else
+                            LOGGER.warn("Converted experimentResultData is null");
+                    } catch (IllegalArgumentException e) {
+                        LOGGER.error("Failed to convert DB data to local: {}", e.getMessage());
+                    } catch (Exception e) {
+                        LOGGER.error("Unexpected error: {}", e.getMessage());
+                    }
+                }
+                experimentInterface.addResultsToLocalStorage(mainKruizeExperimentMap, resultDataList);
+            }
+        }
+    }
     public void loadRecommendationsFromDBByClusterName(Map<String, KruizeObject> mainKruizeExperimentMap, String clusterName) throws Exception {
         ExperimentInterface experimentInterface = new ExperimentInterfaceImpl();
         // Load Recommendations from DB and save to local
@@ -369,6 +394,11 @@ public class ExperimentDBService {
         loadRecommendationsFromDBByName(mainKruizeExperimentMap, experimentName);
     }
 
+    public void loadExperimentsAndResultsFromDBByClusterName(Map<String, KruizeObject> mainKruizeExperimentMap, String clusterName) throws Exception {
+
+        loadExperimentsFromDBByClusterName(mainKruizeExperimentMap, clusterName);
+        loadResultsFromDBByClusterName(mainKruizeExperimentMap, clusterName, null, null);
+    }
     public void loadExperimentsAndRecommendationsFromDBByClusterName(Map<String, KruizeObject> mainKruizeExperimentMap, String clusterName) throws Exception{
         loadExperimentsFromDBByClusterName(mainKruizeExperimentMap, clusterName);
         loadRecommendationsFromDBByClusterName(mainKruizeExperimentMap, clusterName);

--- a/src/main/java/com/autotune/database/service/ExperimentDBService.java
+++ b/src/main/java/com/autotune/database/service/ExperimentDBService.java
@@ -303,6 +303,33 @@ public class ExperimentDBService {
             }
         }
     }
+    public void loadExperimentsFromDBByClusterName(Map<String, KruizeObject> mainKruizeExperimentMap, String clusterName) throws Exception {
+        ExperimentInterface experimentInterface = new ExperimentInterfaceImpl();
+        List<KruizeExperimentEntry> entries = experimentDAO.loadExperimentsByClusterName(clusterName);
+        if (null != entries && !entries.isEmpty()) {
+            List<CreateExperimentAPIObject> createExperimentAPIObjects = DBHelpers.Converters.KruizeObjectConverters.convertExperimentEntryToCreateExperimentAPIObject(entries);
+            if (null != createExperimentAPIObjects && !createExperimentAPIObjects.isEmpty()) {
+                List<KruizeObject> kruizeExpList = new ArrayList<>();
+
+                int failureThreshHold = createExperimentAPIObjects.size();
+                int failureCount = 0;
+                for (CreateExperimentAPIObject createExperimentAPIObject : createExperimentAPIObjects) {
+                    KruizeObject kruizeObject = Converters.KruizeObjectConverters.convertCreateExperimentAPIObjToKruizeObject(createExperimentAPIObject);
+                    if (null != kruizeObject) {
+                        kruizeExpList.add(kruizeObject);
+                    } else {
+                        failureCount++;
+                    }
+                }
+                if (failureThreshHold > 0 && failureCount == failureThreshHold) {
+                    throw new Exception("Experiments of cluster " + clusterName + " unable to load from DB.");
+                }
+                experimentInterface.addExperimentToLocalStorage(mainKruizeExperimentMap, kruizeExpList);
+            }
+        }
+    }
+
+
 
 
     public void loadExperimentAndResultsFromDBByName(Map<String, KruizeObject> mainKruizeExperimentMap, String experimentName) throws Exception {
@@ -319,8 +346,8 @@ public class ExperimentDBService {
         loadRecommendationsFromDBByName(mainKruizeExperimentMap, experimentName);
     }
 
-    public void loadExperimentAndRecommendationsFromDBByClusterName(Map<String, KruizeObject> mainKruizeExperimentMap, String clusterName) throws Exception{
-        loadExperimentFromDBByClusterName(mainKruizeExperimentMap, clusterName);
+    public void loadExperimentsAndRecommendationsFromDBByClusterName(Map<String, KruizeObject> mainKruizeExperimentMap, String clusterName) throws Exception{
+        loadExperimentsFromDBByClusterName(mainKruizeExperimentMap, clusterName);
         loadRecommendationsFromDBByClusterName(mainKruizeExperimentMap, clusterName);
     }
 

--- a/src/main/java/com/autotune/database/service/ExperimentDBService.java
+++ b/src/main/java/com/autotune/database/service/ExperimentDBService.java
@@ -190,6 +190,28 @@ public class ExperimentDBService {
             }
         }
     }
+    ///
+    public void loadRecommendationsFromDBByClusterName(Map<String, KruizeObject> mainKruizeExperimentMap, String clusterName) throws Exception {
+        ExperimentInterface experimentInterface = new ExperimentInterfaceImpl();
+        // Load Recommendations from DB and save to local
+        List<KruizeRecommendationEntry> recommendationEntries = experimentDAO.loadRecommendationsByClusterName(clusterName);
+        if (null != recommendationEntries && !recommendationEntries.isEmpty()) {
+            List<ListRecommendationsAPIObject> recommendationsAPIObjects
+                    = null;
+            try {
+                recommendationsAPIObjects = DBHelpers.Converters.KruizeObjectConverters
+                        .convertRecommendationEntryToRecommendationAPIObject(recommendationEntries);
+            } catch (InvalidConversionOfRecommendationEntryException e) {
+                e.printStackTrace();
+            }
+            if (null != recommendationsAPIObjects && !recommendationsAPIObjects.isEmpty()) {
+                experimentInterface.addRecommendationsToLocalStorage(mainKruizeExperimentMap,
+                        recommendationsAPIObjects,
+                        true);
+            }
+        }
+    }
+
 
     public ValidationOutputData addExperimentToDB(CreateExperimentAPIObject createExperimentAPIObject) {
         ValidationOutputData validationOutputData = new ValidationOutputData(false, null, null);
@@ -328,6 +350,7 @@ public class ExperimentDBService {
             }
         }
     }
+
 
 
 

--- a/src/main/java/com/autotune/database/service/ExperimentDBService.java
+++ b/src/main/java/com/autotune/database/service/ExperimentDBService.java
@@ -344,7 +344,7 @@ public class ExperimentDBService {
                     }
                 }
                 if (failureThreshHold > 0 && failureCount == failureThreshHold) {
-                    throw new Exception("Experiments of cluster " + clusterName + " unable to load from DB.");
+                    throw new Exception("Failed to load experiments for cluster " + clusterName + " from the database. No valid experiments found.");
                 }
                 experimentInterface.addExperimentToLocalStorage(mainKruizeExperimentMap, kruizeExpList);
             }


### PR DESCRIPTION
This PR fixes #940 

-  Enhancement of `/listRecommendations` API by adding `cluster_name` query parameter to retrieve recommendations for a specific cluster based on its name  

