### PR TITLE
Included pytest html version for consistent html format

### DIFF
--- a/tests/scripts/remote_monitoring_tests/requirements.txt
+++ b/tests/scripts/remote_monitoring_tests/requirements.txt
@@ -1,4 +1,4 @@
 pytest
 requests
 jinja2
-pytest-html
+pytest-html==3.2.0


### PR DESCRIPTION
Included pytest html version for consistent html format as the processing of the test report html failed in the PR check 

/home/runner/work/autotune/autotune/tests/scripts/remote_monitoring_tests/remote_monitoring_tests.sh: line 124: 0 + : syntax error: operand expected (error token is "+ ")
https://github.com/kruize/autotune/actions/runs/6194788501/job/16818325464?pr=946

