### PR TITLE
Adds threshold for limit rows 

### DIFF
--- a/src/main/java/com/autotune/analyzer/recommendations/utils/RecommendationUtils.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/utils/RecommendationUtils.java
@@ -160,4 +160,12 @@ public class RecommendationUtils {
         }
         return recommendationNotification;
     }
+
+    public static int getThreshold(int value, int failoverPercentage, boolean direction) {
+        if (direction) {
+            return Math.round(value + value * (failoverPercentage / 100.0f));
+        } else {
+            return Math.round(value - value * (failoverPercentage / 100.0f));
+        }
+    }
 }


### PR DESCRIPTION
This PR adds threshold for `limit rows` to make sure duration in mins is covered for all terms.