### PR TITLE
Fix term threshold

### DIFF
--- a/src/main/java/com/autotune/analyzer/recommendations/RecommendationConstants.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/RecommendationConstants.java
@@ -654,6 +654,10 @@ public class RecommendationConstants {
         public static final Double MEM_SPIKE_BUFFER_DECIMAL = 0.05;
         public static final Double DEFAULT_CPU_THRESHOLD = 0.1;
         public static final Double DEFAULT_MEMORY_THRESHOLD = 0.1;
+
+        public static final int THRESHOLD_HRS_SHORT_TERM = 6;
+        public static final int THRESHOLD_HRS_MEDIUM_TERM = 6;
+        public static final int THRESHOLD_HRS_LONG_TERM = 6;
     }
 
     public static final class RecommendationNotificationMsgConstant {


### PR DESCRIPTION
n order to enhance the recommendation generation process, this PR builds upon the existing logic outlined in [PR #968](https://github.com/kruize/autotune/pull/968). The primary objective is to introduce the concept of maximum data thresholds for each term, where the threshold is defined as the TERM_DURATION plus an additional 6 hours of data.

To achieve this, the proposed modification focuses on optimizing the monitoringStartTime function. Instead of simply retrieving a list of timestamps until the monitoring start time (Calculated based on sum of duration in mins value), the function has been adjusted to provide a value that aligns with the defined data thresholds. This adjustment ensures that the recommendation generation process remains consistent while accommodating the new data threshold requirements.

PS: This PR is built on top of #968 so it should be merged before merging this PR.
