### PR TITLE
Bump jetty package to fix CVE-2023-36479 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <fabric8-version>4.13.0</fabric8-version>
         <org-json-version>20201115</org-json-version>
-        <jetty-version>9.4.44.v20210927</jetty-version>
+        <jetty-version>9.4.53.v20231009</jetty-version>
         <slf4j-version>2.17.1</slf4j-version>
         <java-version>17</java-version>
         <prometheus-simpleclient>0.14.1</prometheus-simpleclient>


### PR DESCRIPTION
Security issue - [CVE-2023-36479](https://access.redhat.com/security/cve/CVE-2023-36479)

This PR added the required version updates to fix the security issue. Although the latest available version is `12.0.3` for jetty, we are moving to nearest stable version to avoid any major integration issues. Would highly recommend to test the latest version and proceed to update to the latest.

NOTE: This is a quick fix.