### PR TITLE
Added support for additional units for the metric values

### DIFF
--- a/src/main/java/com/autotune/analyzer/performanceProfiles/utils/PerformanceProfileUtil.java
+++ b/src/main/java/com/autotune/analyzer/performanceProfiles/utils/PerformanceProfileUtil.java
@@ -218,6 +218,7 @@ public class PerformanceProfileUtil {
                 if (value instanceof String) {
                     stringValue = (String) value;
                 }
+                // TODO: handle the conversions for additional supported formats
                 if (!KruizeSupportedTypes.SUPPORTED_FORMATS.contains(stringValue)) {
                     LOGGER.error(AnalyzerErrorConstants.AutotuneObjectErrors.UNSUPPORTED_FORMAT);
                     errorMsg = errorMsg.concat(AnalyzerErrorConstants.AutotuneObjectErrors.UNSUPPORTED_FORMAT);

--- a/src/main/java/com/autotune/utils/KruizeSupportedTypes.java
+++ b/src/main/java/com/autotune/utils/KruizeSupportedTypes.java
@@ -78,7 +78,7 @@ public class KruizeSupportedTypes
 			new HashSet<>(Arrays.asList("deployment", "pod", "container"));
 	
   public static final Set<String> SUPPORTED_FORMATS =
-			new HashSet<>(Arrays.asList("cores", "MiB"));
+			new HashSet<>(Arrays.asList("cores", "m", "Bytes", "bytes", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "kB", "KB", "MB", "GB", "TB", "PB", "EB", "K", "k", "M", "G", "T", "P", "E"));
 
 	public static final Set<String> QUERY_PARAMS_SUPPORTED = new HashSet<>(Arrays.asList(
 			"experiment_name", "results", "recommendations", "latest"


### PR DESCRIPTION
This PR solves Issue https://github.com/kruize/autotune/issues/1036

- Currently Kruize supports only MiB unit for the metric values. We added support for different memory units like Bytes, KiB, MiB, GiB, TiB, PiB, EiB