### PR TITLE
Fix the duplicate record issue in update results API

### DIFF
--- a/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
@@ -163,8 +163,8 @@ public class ExperimentDAOImpl implements ExperimentDAO {
         String statusValue = "failure";
         Timer.Sample timerAddBulkResultsDB = Timer.start(MetricsConfig.meterRegistry());
         try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
-            tx = session.beginTransaction();
             for (KruizeResultsEntry entry : kruizeResultsEntries) {
+                tx = session.beginTransaction();
                 try {
                     session.persist(entry);
                     session.flush();
@@ -199,16 +199,13 @@ public class ExperimentDAOImpl implements ExperimentDAO {
                         entry.setErrorReasons(List.of(e.getMessage()));
                         failedResultsEntries.add(entry);
                     }
-                    tx.commit();
-                    tx = session.beginTransaction();
                 } catch (Exception e) {
                     entry.setErrorReasons(List.of(e.getMessage()));
                     failedResultsEntries.add(entry);
+                } finally {
                     tx.commit();
-                    tx = session.beginTransaction();
                 }
             }
-            tx.commit();
             statusValue = "success";
         } catch (Exception e) {
             LOGGER.error("Not able to save experiment due to {}", e.getMessage());

--- a/tests/scripts/remote_monitoring_tests/fault_tolerant_tests/kruize_pod_restart_test.py
+++ b/tests/scripts/remote_monitoring_tests/fault_tolerant_tests/kruize_pod_restart_test.py
@@ -133,7 +133,12 @@ def main(argv):
 
         # Fetch listExperiments
         list_exp_json_file_before = list_exp_json_dir + "/list_exp_json_before_" + str(i) + ".json"
-        response = list_experiments()
+        # assign params to be passed in listExp
+        results = "true"
+        recommendations = "true"
+        latest = "false"
+        experiment_name = None
+        response = list_experiments(results, recommendations, latest, experiment_name)
         if response.status_code == SUCCESS_200_STATUS_CODE:
            list_exp_json = response.json()
         else:
@@ -173,7 +178,11 @@ def main(argv):
 
         # Fetch listExperiments
         list_exp_json_file_after = list_exp_json_dir + "/list_exp_json_after_" + str(i) + ".json"
-        response = list_experiments()
+        results = "true"
+        recommendations = "true"
+        latest = "false"
+        experiment_name = None
+        response = list_experiments(results, recommendations, latest, experiment_name)
         if response.status_code == SUCCESS_200_STATUS_CODE:
             list_exp_json = response.json()
         else:

--- a/tests/scripts/remote_monitoring_tests/helpers/kruize.py
+++ b/tests/scripts/remote_monitoring_tests/helpers/kruize.py
@@ -216,13 +216,25 @@ def create_performance_profile(perf_profile_json_file):
 
 # Description: This function obtains the experiments from Kruize Autotune using listExperiments API
 # Input Parameters: None
-def list_experiments():
-    PARAMS = {'results': "true", 'recommendations': "true", "latest": "false"}
+def list_experiments(results=None, recommendations=None, latest=None, experiment_name=None):
     print("\nListing the experiments...")
+    query_params = {}
+
+    if experiment_name is not None:
+        query_params['experiment_name'] = experiment_name
+    if latest is not None:
+        query_params['latest'] = latest
+    if results is not None:
+        query_params['results'] = results
+    if recommendations is not None:
+        query_params['recommendations'] = recommendations
+
+    query_string = "&".join(f"{key}={value}" for key, value in query_params.items())
+
     url = URL + "/listExperiments"
+    if query_string:
+        url += "?" + query_string
     print("URL = ", url)
-
-    response = requests.get(url=url, params=PARAMS)
-
+    response = requests.get(url)
     print("Response status code = ", response.status_code)
     return response

--- a/tests/scripts/remote_monitoring_tests/json_files/multiple_duplicate_results_single_exp.json
+++ b/tests/scripts/remote_monitoring_tests/json_files/multiple_duplicate_results_single_exp.json
@@ -1,0 +1,20102 @@
+[
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-13T23:29:20.982Z",
+    "interval_end_time": "2023-04-13T23:44:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.04609118991037,
+                    "min": 2.34309635937407,
+                    "max": 3.88964089192222,
+                    "avg": 3.01536372997012,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 229.984375,
+                    "max": 314.703125,
+                    "sum": 828.3160282258062,
+                    "avg": 276.1053427419357,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 225.0703125,
+                    "max": 307.4921875,
+                    "sum": 799.6636844758062,
+                    "avg": 266.5545614919357,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.04609118991037,
+                    "min": 2.34309635937407,
+                    "max": 3.88964089192222,
+                    "avg": 3.01536372997012,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 229.984375,
+                    "max": 314.703125,
+                    "sum": 828.3160282258062,
+                    "avg": 276.1053427419357,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 225.0703125,
+                    "max": 307.4921875,
+                    "sum": 799.6636844758062,
+                    "avg": 266.5545614919357,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T01:59:20.982Z",
+    "interval_end_time": "2023-04-14T02:14:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 13.0997042618841,
+                    "min": 3.50427849813703,
+                    "max": 5.33515178196666,
+                    "avg": 4.36656808729469,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 481.91796875,
+                    "max": 559.76953125,
+                    "sum": 1563.6571320564556,
+                    "avg": 521.2190440188169,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 475.24609375,
+                    "max": 540.44140625,
+                    "sum": 1520.0132308467769,
+                    "avg": 506.671076948925,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 13.0997042618841,
+                    "min": 3.50427849813703,
+                    "max": 5.33515178196666,
+                    "avg": 4.36656808729469,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 481.91796875,
+                    "max": 559.76953125,
+                    "sum": 1563.6571320564556,
+                    "avg": 521.2190440188169,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 475.24609375,
+                    "max": 540.44140625,
+                    "sum": 1520.0132308467769,
+                    "avg": 506.671076948925,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T13:44:20.982Z",
+    "interval_end_time": "2023-04-14T13:59:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.458832859871,
+                    "min": 3.0186840297333,
+                    "max": 3.90330548338146,
+                    "avg": 3.486277619957,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 586.48828125,
+                    "max": 706.55859375,
+                    "sum": 1953.346270161295,
+                    "avg": 651.1154233870964,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 579.7734375,
+                    "max": 696.05859375,
+                    "sum": 1921.781754032259,
+                    "avg": 640.5939180107526,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.458832859871,
+                    "min": 3.0186840297333,
+                    "max": 3.90330548338146,
+                    "avg": 3.486277619957,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 586.48828125,
+                    "max": 706.55859375,
+                    "sum": 1953.346270161295,
+                    "avg": 651.1154233870964,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 579.7734375,
+                    "max": 696.05859375,
+                    "sum": 1921.781754032259,
+                    "avg": 640.5939180107526,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-13T22:59:20.982Z",
+    "interval_end_time": "2023-04-13T23:14:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.008612013913388,
+                    "min": 0.000361107147235,
+                    "max": 0.003050324185815,
+                    "avg": 0.001435335652231,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 0.0,
+                    "max": 1330.0234375,
+                    "sum": 3606.66143465909,
+                    "avg": 601.110239109849,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 0.0,
+                    "max": 1320.109375,
+                    "sum": 3502.236328125,
+                    "avg": 583.7060546875,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.008612013913388,
+                    "min": 0.000361107147235,
+                    "max": 0.003050324185815,
+                    "avg": 0.001435335652231,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 0.0,
+                    "max": 1330.0234375,
+                    "sum": 3606.66143465909,
+                    "avg": 601.110239109849,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 0.0,
+                    "max": 1320.109375,
+                    "sum": 3502.236328125,
+                    "avg": 583.7060546875,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-13T23:14:20.982Z",
+    "interval_end_time": "2023-04-13T23:29:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.00125369576092,
+                    "max": 0.00125369576092,
+                    "avg": 0.000417898586973,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.23642774156611,
+                    "min": 0.122641301400588,
+                    "max": 4.05884393815185,
+                    "avg": 3.0788092471887,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 194.62890625,
+                    "max": 290.046875,
+                    "sum": 730.8758820564518,
+                    "avg": 243.62529401881696,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 187.2265625,
+                    "max": 281.9921875,
+                    "sum": 701.5254536290321,
+                    "avg": 233.84181787634373,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.00125369576092,
+                    "max": 0.00125369576092,
+                    "avg": 0.000417898586973,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.23642774156611,
+                    "min": 0.122641301400588,
+                    "max": 4.05884393815185,
+                    "avg": 3.0788092471887,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 194.62890625,
+                    "max": 290.046875,
+                    "sum": 730.8758820564518,
+                    "avg": 243.62529401881696,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 187.2265625,
+                    "max": 281.9921875,
+                    "sum": 701.5254536290321,
+                    "avg": 233.84181787634373,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-13T23:29:20.982Z",
+    "interval_end_time": "2023-04-13T23:44:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.04609118991037,
+                    "min": 2.34309635937407,
+                    "max": 3.88964089192222,
+                    "avg": 3.01536372997012,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 229.984375,
+                    "max": 314.703125,
+                    "sum": 828.3160282258062,
+                    "avg": 276.1053427419357,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 225.0703125,
+                    "max": 307.4921875,
+                    "sum": 799.6636844758062,
+                    "avg": 266.5545614919357,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.04609118991037,
+                    "min": 2.34309635937407,
+                    "max": 3.88964089192222,
+                    "avg": 3.01536372997012,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 229.984375,
+                    "max": 314.703125,
+                    "sum": 828.3160282258062,
+                    "avg": 276.1053427419357,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 225.0703125,
+                    "max": 307.4921875,
+                    "sum": 799.6636844758062,
+                    "avg": 266.5545614919357,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-13T23:44:20.982Z",
+    "interval_end_time": "2023-04-13T23:59:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.112328922496552,
+                    "max": 0.085147492862069,
+                    "avg": 0.037442974165517,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.46914730046654,
+                    "min": 2.30112868885926,
+                    "max": 4.58010182155185,
+                    "avg": 2.82304910015551,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 251.234375,
+                    "max": 346.984375,
+                    "sum": 890.1745211693544,
+                    "avg": 296.7248403897848,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 246.47265625,
+                    "max": 335.62109375,
+                    "sum": 859.1034526209679,
+                    "avg": 286.3678175403223,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.112328922496552,
+                    "max": 0.085147492862069,
+                    "avg": 0.037442974165517,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.46914730046654,
+                    "min": 2.30112868885926,
+                    "max": 4.58010182155185,
+                    "avg": 2.82304910015551,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 251.234375,
+                    "max": 346.984375,
+                    "sum": 890.1745211693544,
+                    "avg": 296.7248403897848,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 246.47265625,
+                    "max": 335.62109375,
+                    "sum": 859.1034526209679,
+                    "avg": 286.3678175403223,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-13T23:59:20.982Z",
+    "interval_end_time": "2023-04-14T00:14:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 13.2376485156556,
+                    "min": 3.91502781582593,
+                    "max": 4.85605234033704,
+                    "avg": 4.41254950521852,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 271.42578125,
+                    "max": 347.83984375,
+                    "sum": 952.2685231854839,
+                    "avg": 317.4228410618277,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 265.5390625,
+                    "max": 338.46875,
+                    "sum": 918.4469506048393,
+                    "avg": 306.14898353494647,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 13.2376485156556,
+                    "min": 3.91502781582593,
+                    "max": 4.85605234033704,
+                    "avg": 4.41254950521852,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 271.42578125,
+                    "max": 347.83984375,
+                    "sum": 952.2685231854839,
+                    "avg": 317.4228410618277,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 265.5390625,
+                    "max": 338.46875,
+                    "sum": 918.4469506048393,
+                    "avg": 306.14898353494647,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T00:14:20.982Z",
+    "interval_end_time": "2023-04-14T00:29:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 11.3112178759358,
+                    "min": 3.33503295274444,
+                    "max": 4.81386723182222,
+                    "avg": 3.77040595864527,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 271.59375,
+                    "max": 356.5390625,
+                    "sum": 989.438004032259,
+                    "avg": 329.8126680107527,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 265.66796875,
+                    "max": 348.39453125,
+                    "sum": 956.612777217741,
+                    "avg": 318.8709257392473,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 11.3112178759358,
+                    "min": 3.33503295274444,
+                    "max": 4.81386723182222,
+                    "avg": 3.77040595864527,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 271.59375,
+                    "max": 356.5390625,
+                    "sum": 989.438004032259,
+                    "avg": 329.8126680107527,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 265.66796875,
+                    "max": 348.39453125,
+                    "sum": 956.612777217741,
+                    "avg": 318.8709257392473,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T00:29:20.982Z",
+    "interval_end_time": "2023-04-14T00:44:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.23973705240321,
+                    "min": 2.23026164174074,
+                    "max": 3.92129674667037,
+                    "avg": 3.07991235080107,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 290.625,
+                    "max": 359.1015625,
+                    "sum": 1001.7091733870983,
+                    "avg": 333.9030577956991,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 286.27734375,
+                    "max": 350.00390625,
+                    "sum": 970.1455393145179,
+                    "avg": 323.3818464381723,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.23973705240321,
+                    "min": 2.23026164174074,
+                    "max": 3.92129674667037,
+                    "avg": 3.07991235080107,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 290.625,
+                    "max": 359.1015625,
+                    "sum": 1001.7091733870983,
+                    "avg": 333.9030577956991,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 286.27734375,
+                    "max": 350.00390625,
+                    "sum": 970.1455393145179,
+                    "avg": 323.3818464381723,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T00:44:20.982Z",
+    "interval_end_time": "2023-04-14T00:59:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.004116689491954,
+                    "max": 0.002598697606897,
+                    "avg": 0.001372229830651,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 7.87229159665284,
+                    "min": 2.21689067767037,
+                    "max": 3.59979932507037,
+                    "avg": 2.62409719888428,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 295.34765625,
+                    "max": 398.4921875,
+                    "sum": 1034.1706149193574,
+                    "avg": 344.7235383064518,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 291.51953125,
+                    "max": 380.515625,
+                    "sum": 1001.016129032259,
+                    "avg": 333.6720430107527,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.004116689491954,
+                    "max": 0.002598697606897,
+                    "avg": 0.001372229830651,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 7.87229159665284,
+                    "min": 2.21689067767037,
+                    "max": 3.59979932507037,
+                    "avg": 2.62409719888428,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 295.34765625,
+                    "max": 398.4921875,
+                    "sum": 1034.1706149193574,
+                    "avg": 344.7235383064518,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 291.51953125,
+                    "max": 380.515625,
+                    "sum": 1001.016129032259,
+                    "avg": 333.6720430107527,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T00:59:20.982Z",
+    "interval_end_time": "2023-04-14T01:14:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.6005743048741,
+                    "min": 3.21516195458148,
+                    "max": 3.92478116602223,
+                    "avg": 3.53352476829136,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 329.65625,
+                    "max": 390.6953125,
+                    "sum": 1104.1881300403213,
+                    "avg": 368.06271001344106,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 322.6484375,
+                    "max": 382.08203125,
+                    "sum": 1068.776839717741,
+                    "avg": 356.2589465725803,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.6005743048741,
+                    "min": 3.21516195458148,
+                    "max": 3.92478116602223,
+                    "avg": 3.53352476829136,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 329.65625,
+                    "max": 390.6953125,
+                    "sum": 1104.1881300403213,
+                    "avg": 368.06271001344106,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 322.6484375,
+                    "max": 382.08203125,
+                    "sum": 1068.776839717741,
+                    "avg": 356.2589465725803,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T01:14:20.982Z",
+    "interval_end_time": "2023-04-14T01:29:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.9410424960665,
+                    "min": 3.18957297767777,
+                    "max": 4.02861094841482,
+                    "avg": 3.64701416535551,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 329.8359375,
+                    "max": 446.5625,
+                    "sum": 1225.6387348790358,
+                    "avg": 408.5462449596777,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 323.28125,
+                    "max": 431.42578125,
+                    "sum": 1183.387726814518,
+                    "avg": 394.4625756048384,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.9410424960665,
+                    "min": 3.18957297767777,
+                    "max": 4.02861094841482,
+                    "avg": 3.64701416535551,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 329.8359375,
+                    "max": 446.5625,
+                    "sum": 1225.6387348790358,
+                    "avg": 408.5462449596777,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 323.28125,
+                    "max": 431.42578125,
+                    "sum": 1183.387726814518,
+                    "avg": 394.4625756048384,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T01:29:20.982Z",
+    "interval_end_time": "2023-04-14T01:44:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.18851521172901,
+                    "min": 2.23911712425925,
+                    "max": 3.99740168404445,
+                    "avg": 2.72950507057634,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 417.515625,
+                    "max": 472.35546875,
+                    "sum": 1332.7711693548392,
+                    "avg": 444.25705645161344,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 410.34765625,
+                    "max": 461.05078125,
+                    "sum": 1294.0414566532231,
+                    "avg": 431.34715221774195,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.18851521172901,
+                    "min": 2.23911712425925,
+                    "max": 3.99740168404445,
+                    "avg": 2.72950507057634,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 417.515625,
+                    "max": 472.35546875,
+                    "sum": 1332.7711693548392,
+                    "avg": 444.25705645161344,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 410.34765625,
+                    "max": 461.05078125,
+                    "sum": 1294.0414566532231,
+                    "avg": 431.34715221774195,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T01:44:20.982Z",
+    "interval_end_time": "2023-04-14T01:59:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 12.5538705072991,
+                    "min": 2.32747479522221,
+                    "max": 5.24432858166296,
+                    "avg": 4.18462350243305,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 447.375,
+                    "max": 521.5546875,
+                    "sum": 1467.8884828629016,
+                    "avg": 489.2961609543009,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 438.125,
+                    "max": 510.3046875,
+                    "sum": 1426.0090725806426,
+                    "avg": 475.3363575268822,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 12.5538705072991,
+                    "min": 2.32747479522221,
+                    "max": 5.24432858166296,
+                    "avg": 4.18462350243305,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 447.375,
+                    "max": 521.5546875,
+                    "sum": 1467.8884828629016,
+                    "avg": 489.2961609543009,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 438.125,
+                    "max": 510.3046875,
+                    "sum": 1426.0090725806426,
+                    "avg": 475.3363575268822,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T01:59:20.982Z",
+    "interval_end_time": "2023-04-14T02:14:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 13.0997042618841,
+                    "min": 3.50427849813703,
+                    "max": 5.33515178196666,
+                    "avg": 4.36656808729469,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 481.91796875,
+                    "max": 559.76953125,
+                    "sum": 1563.6571320564556,
+                    "avg": 521.2190440188169,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 475.24609375,
+                    "max": 540.44140625,
+                    "sum": 1520.0132308467769,
+                    "avg": 506.671076948925,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 13.0997042618841,
+                    "min": 3.50427849813703,
+                    "max": 5.33515178196666,
+                    "avg": 4.36656808729469,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 481.91796875,
+                    "max": 559.76953125,
+                    "sum": 1563.6571320564556,
+                    "avg": 521.2190440188169,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 475.24609375,
+                    "max": 540.44140625,
+                    "sum": 1520.0132308467769,
+                    "avg": 506.671076948925,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T02:14:20.982Z",
+    "interval_end_time": "2023-04-14T02:29:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 11.0524067195789,
+                    "min": 2.66358841466294,
+                    "max": 4.19660716037036,
+                    "avg": 3.68413557319296,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 483.8046875,
+                    "max": 557.84765625,
+                    "sum": 1591.0030241935444,
+                    "avg": 530.3343413978491,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 478.68359375,
+                    "max": 540.7109375,
+                    "sum": 1553.057207661295,
+                    "avg": 517.6857358870964,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 11.0524067195789,
+                    "min": 2.66358841466294,
+                    "max": 4.19660716037036,
+                    "avg": 3.68413557319296,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 483.8046875,
+                    "max": 557.84765625,
+                    "sum": 1591.0030241935444,
+                    "avg": 530.3343413978491,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 478.68359375,
+                    "max": 540.7109375,
+                    "sum": 1553.057207661295,
+                    "avg": 517.6857358870964,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T02:29:20.982Z",
+    "interval_end_time": "2023-04-14T02:44:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 7.11427328335358,
+                    "min": 2.13855924275925,
+                    "max": 2.74692213271852,
+                    "avg": 2.37142442778453,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 483.82421875,
+                    "max": 546.765625,
+                    "sum": 1567.1585181451608,
+                    "avg": 522.3861727150536,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 477.94140625,
+                    "max": 533.4296875,
+                    "sum": 1537.9644657258034,
+                    "avg": 512.6548219086018,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 7.11427328335358,
+                    "min": 2.13855924275925,
+                    "max": 2.74692213271852,
+                    "avg": 2.37142442778453,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 483.82421875,
+                    "max": 546.765625,
+                    "sum": 1567.1585181451608,
+                    "avg": 522.3861727150536,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 477.94140625,
+                    "max": 533.4296875,
+                    "sum": 1537.9644657258034,
+                    "avg": 512.6548219086018,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T02:44:20.982Z",
+    "interval_end_time": "2023-04-14T02:59:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 7.40207558177333,
+                    "min": 2.17771477021481,
+                    "max": 3.22089857927408,
+                    "avg": 2.46735852725778,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 484.3359375,
+                    "max": 630.69140625,
+                    "sum": 1610.2723034274197,
+                    "avg": 536.7574344758062,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 478.125,
+                    "max": 615.4375,
+                    "sum": 1576.3912550403213,
+                    "avg": 525.4637516801071,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 7.40207558177333,
+                    "min": 2.17771477021481,
+                    "max": 3.22089857927408,
+                    "avg": 2.46735852725778,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 484.3359375,
+                    "max": 630.69140625,
+                    "sum": 1610.2723034274197,
+                    "avg": 536.7574344758062,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 478.125,
+                    "max": 615.4375,
+                    "sum": 1576.3912550403213,
+                    "avg": 525.4637516801071,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T02:59:20.982Z",
+    "interval_end_time": "2023-04-14T03:14:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.8811287533044,
+                    "min": 3.06415491851111,
+                    "max": 3.97339506212593,
+                    "avg": 3.62704291776815,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 501.6328125,
+                    "max": 630.84765625,
+                    "sum": 1724.2982610887145,
+                    "avg": 574.7660870295696,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 492.3828125,
+                    "max": 616.39453125,
+                    "sum": 1684.5724546370984,
+                    "avg": 561.5241515456992,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.8811287533044,
+                    "min": 3.06415491851111,
+                    "max": 3.97339506212593,
+                    "avg": 3.62704291776815,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 501.6328125,
+                    "max": 630.84765625,
+                    "sum": 1724.2982610887145,
+                    "avg": 574.7660870295696,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 492.3828125,
+                    "max": 616.39453125,
+                    "sum": 1684.5724546370984,
+                    "avg": 561.5241515456992,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T03:14:20.982Z",
+    "interval_end_time": "2023-04-14T03:29:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.4764962408307,
+                    "min": 3.01007331396298,
+                    "max": 3.90357787986297,
+                    "avg": 3.49216541361025,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 486.8984375,
+                    "max": 627.91015625,
+                    "sum": 1686.097152217741,
+                    "avg": 562.0323840725804,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 481.13671875,
+                    "max": 615.5625,
+                    "sum": 1656.9078881048392,
+                    "avg": 552.3026293682794,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.4764962408307,
+                    "min": 3.01007331396298,
+                    "max": 3.90357787986297,
+                    "avg": 3.49216541361025,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 486.8984375,
+                    "max": 627.91015625,
+                    "sum": 1686.097152217741,
+                    "avg": 562.0323840725804,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 481.13671875,
+                    "max": 615.5625,
+                    "sum": 1656.9078881048392,
+                    "avg": 552.3026293682794,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T03:29:20.982Z",
+    "interval_end_time": "2023-04-14T03:44:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.21048489802543,
+                    "min": 2.1600138799926,
+                    "max": 3.76924492766295,
+                    "avg": 3.07016163267514,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 486.4453125,
+                    "max": 614.93359375,
+                    "sum": 1675.7011088709642,
+                    "avg": 558.5670362903223,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 481.06640625,
+                    "max": 605.23046875,
+                    "sum": 1647.626386088705,
+                    "avg": 549.2087953629036,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.21048489802543,
+                    "min": 2.1600138799926,
+                    "max": 3.76924492766295,
+                    "avg": 3.07016163267514,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 486.4453125,
+                    "max": 614.93359375,
+                    "sum": 1675.7011088709642,
+                    "avg": 558.5670362903223,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 481.06640625,
+                    "max": 605.23046875,
+                    "sum": 1647.626386088705,
+                    "avg": 549.2087953629036,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T03:44:20.982Z",
+    "interval_end_time": "2023-04-14T03:59:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 7.74138200375716,
+                    "min": 2.16799914465185,
+                    "max": 3.54586913627777,
+                    "avg": 2.58046066791905,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 486.5078125,
+                    "max": 637.21484375,
+                    "sum": 1694.0756048387145,
+                    "avg": 564.6918682795696,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 480.9765625,
+                    "max": 626.53125,
+                    "sum": 1664.540070564518,
+                    "avg": 554.8466901881724,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 7.74138200375716,
+                    "min": 2.16799914465185,
+                    "max": 3.54586913627777,
+                    "avg": 2.58046066791905,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 486.5078125,
+                    "max": 637.21484375,
+                    "sum": 1694.0756048387145,
+                    "avg": 564.6918682795696,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 480.9765625,
+                    "max": 626.53125,
+                    "sum": 1664.540070564518,
+                    "avg": 554.8466901881724,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T03:59:20.982Z",
+    "interval_end_time": "2023-04-14T04:14:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 12.8251170955222,
+                    "min": 3.23395848808149,
+                    "max": 4.77055224205558,
+                    "avg": 4.27503903184074,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 494.55078125,
+                    "max": 650.2578125,
+                    "sum": 1736.034652217741,
+                    "avg": 578.6782174059143,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 488.2265625,
+                    "max": 640.46875,
+                    "sum": 1704.3125,
+                    "avg": 568.104166666667,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 12.8251170955222,
+                    "min": 3.23395848808149,
+                    "max": 4.77055224205558,
+                    "avg": 4.27503903184074,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 494.55078125,
+                    "max": 650.2578125,
+                    "sum": 1736.034652217741,
+                    "avg": 578.6782174059143,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 488.2265625,
+                    "max": 640.46875,
+                    "sum": 1704.3125,
+                    "avg": 568.104166666667,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T04:14:20.982Z",
+    "interval_end_time": "2023-04-14T04:29:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 11.3903337685619,
+                    "min": 3.16656801385557,
+                    "max": 4.66166533206296,
+                    "avg": 3.79677792285395,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 494.70703125,
+                    "max": 659.1328125,
+                    "sum": 1749.0136088709642,
+                    "avg": 583.0045362903223,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 488.70703125,
+                    "max": 649.44921875,
+                    "sum": 1718.802167338705,
+                    "avg": 572.9340557795696,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 11.3903337685619,
+                    "min": 3.16656801385557,
+                    "max": 4.66166533206296,
+                    "avg": 3.79677792285395,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 494.70703125,
+                    "max": 659.1328125,
+                    "sum": 1749.0136088709642,
+                    "avg": 583.0045362903223,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 488.70703125,
+                    "max": 649.44921875,
+                    "sum": 1718.802167338705,
+                    "avg": 572.9340557795696,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T04:29:20.982Z",
+    "interval_end_time": "2023-04-14T04:44:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.5014342027542,
+                    "min": 2.23111050125557,
+                    "max": 3.90711991666672,
+                    "avg": 3.1671447342514,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 493.90234375,
+                    "max": 664.98046875,
+                    "sum": 1755.2971270161247,
+                    "avg": 585.0990423387099,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 488.5078125,
+                    "max": 655.546875,
+                    "sum": 1726.4992439516163,
+                    "avg": 575.4997479838714,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.5014342027542,
+                    "min": 2.23111050125557,
+                    "max": 3.90711991666672,
+                    "avg": 3.1671447342514,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 493.90234375,
+                    "max": 664.98046875,
+                    "sum": 1755.2971270161247,
+                    "avg": 585.0990423387099,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 488.5078125,
+                    "max": 655.546875,
+                    "sum": 1726.4992439516163,
+                    "avg": 575.4997479838714,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T04:44:20.982Z",
+    "interval_end_time": "2023-04-14T04:59:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 7.43306912187407,
+                    "min": 2.07185424824816,
+                    "max": 3.06512188040366,
+                    "avg": 2.47768970729136,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 494.13671875,
+                    "max": 676.08203125,
+                    "sum": 1764.3756300403213,
+                    "avg": 588.1252100134411,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 488.59765625,
+                    "max": 665.80859375,
+                    "sum": 1735.278351814518,
+                    "avg": 578.4261172715054,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 7.43306912187407,
+                    "min": 2.07185424824816,
+                    "max": 3.06512188040366,
+                    "avg": 2.47768970729136,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 494.13671875,
+                    "max": 676.08203125,
+                    "sum": 1764.3756300403213,
+                    "avg": 588.1252100134411,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 488.59765625,
+                    "max": 665.80859375,
+                    "sum": 1735.278351814518,
+                    "avg": 578.4261172715054,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T04:59:20.982Z",
+    "interval_end_time": "2023-04-14T05:14:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.1357935901567,
+                    "min": 2.66977707079261,
+                    "max": 3.78942297675185,
+                    "avg": 3.37859786338556,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 503.1796875,
+                    "max": 676.015625,
+                    "sum": 1782.6373487903213,
+                    "avg": 594.2124495967741,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 496.76171875,
+                    "max": 666.15234375,
+                    "sum": 1752.6008064516163,
+                    "avg": 584.2002688172045,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.1357935901567,
+                    "min": 2.66977707079261,
+                    "max": 3.78942297675185,
+                    "avg": 3.37859786338556,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 503.1796875,
+                    "max": 676.015625,
+                    "sum": 1782.6373487903213,
+                    "avg": 594.2124495967741,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 496.76171875,
+                    "max": 666.15234375,
+                    "sum": 1752.6008064516163,
+                    "avg": 584.2002688172045,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T05:14:20.982Z",
+    "interval_end_time": "2023-04-14T05:29:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.55468554314938,
+                    "min": 2.74066107575183,
+                    "max": 3.66097612442962,
+                    "avg": 3.18489518104979,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 510.5390625,
+                    "max": 676.0078125,
+                    "sum": 1790.8097278225803,
+                    "avg": 596.9365759408598,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 504.8125,
+                    "max": 666.078125,
+                    "sum": 1760.911542338705,
+                    "avg": 586.9705141129036,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.55468554314938,
+                    "min": 2.74066107575183,
+                    "max": 3.66097612442962,
+                    "avg": 3.18489518104979,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 510.5390625,
+                    "max": 676.0078125,
+                    "sum": 1790.8097278225803,
+                    "avg": 596.9365759408598,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 504.8125,
+                    "max": 666.078125,
+                    "sum": 1760.911542338705,
+                    "avg": 586.9705141129036,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T05:29:20.982Z",
+    "interval_end_time": "2023-04-14T05:44:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.07138111892988,
+                    "min": 2.23248651319257,
+                    "max": 3.29872863727775,
+                    "avg": 2.69046037297663,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 516.2109375,
+                    "max": 675.546875,
+                    "sum": 1792.684097782259,
+                    "avg": 597.5613659274196,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 510.23828125,
+                    "max": 665.9296875,
+                    "sum": 1763.5529233870984,
+                    "avg": 587.8509744623651,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.07138111892988,
+                    "min": 2.23248651319257,
+                    "max": 3.29872863727775,
+                    "avg": 2.69046037297663,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 516.2109375,
+                    "max": 675.546875,
+                    "sum": 1792.684097782259,
+                    "avg": 597.5613659274196,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 510.23828125,
+                    "max": 665.9296875,
+                    "sum": 1763.5529233870984,
+                    "avg": 587.8509744623651,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T05:44:20.982Z",
+    "interval_end_time": "2023-04-14T05:59:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 11.4579040636927,
+                    "min": 2.27507910785185,
+                    "max": 5.21721080437036,
+                    "avg": 3.81930135456424,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 516.3515625,
+                    "max": 680.54296875,
+                    "sum": 1805.8592489919376,
+                    "avg": 601.9530829973116,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 510.53125,
+                    "max": 668.9296875,
+                    "sum": 1772.4647177419376,
+                    "avg": 590.8215725806446,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 11.4579040636927,
+                    "min": 2.27507910785185,
+                    "max": 5.21721080437036,
+                    "avg": 3.81930135456424,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 516.3515625,
+                    "max": 680.54296875,
+                    "sum": 1805.8592489919376,
+                    "avg": 601.9530829973116,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 510.53125,
+                    "max": 668.9296875,
+                    "sum": 1772.4647177419376,
+                    "avg": 590.8215725806446,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T05:59:20.982Z",
+    "interval_end_time": "2023-04-14T06:14:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 12.1769354107975,
+                    "min": 3.25358324688886,
+                    "max": 5.20446525337778,
+                    "avg": 4.05897847026584,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 525.13671875,
+                    "max": 684.7109375,
+                    "sum": 1818.7581905241966,
+                    "avg": 606.2527301747313,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 518.140625,
+                    "max": 671.2890625,
+                    "sum": 1779.1058467741966,
+                    "avg": 593.0352822580643,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 12.1769354107975,
+                    "min": 3.25358324688886,
+                    "max": 5.20446525337778,
+                    "avg": 4.05897847026584,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 525.13671875,
+                    "max": 684.7109375,
+                    "sum": 1818.7581905241966,
+                    "avg": 606.2527301747313,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 518.140625,
+                    "max": 671.2890625,
+                    "sum": 1779.1058467741966,
+                    "avg": 593.0352822580643,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T06:14:20.982Z",
+    "interval_end_time": "2023-04-14T06:29:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.73707889392692,
+                    "min": 2.14165028458147,
+                    "max": 3.99961398575925,
+                    "avg": 2.91235963130897,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 523.6953125,
+                    "max": 684.37890625,
+                    "sum": 1812.4635836693574,
+                    "avg": 604.1545278897848,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 517.6015625,
+                    "max": 671.7265625,
+                    "sum": 1779.0907258064556,
+                    "avg": 593.0302419354839,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.73707889392692,
+                    "min": 2.14165028458147,
+                    "max": 3.99961398575925,
+                    "avg": 2.91235963130897,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 523.6953125,
+                    "max": 684.37890625,
+                    "sum": 1812.4635836693574,
+                    "avg": 604.1545278897848,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 517.6015625,
+                    "max": 671.7265625,
+                    "sum": 1779.0907258064556,
+                    "avg": 593.0302419354839,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T06:29:20.982Z",
+    "interval_end_time": "2023-04-14T06:44:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.9635417955321,
+                    "min": 2.21280712303705,
+                    "max": 3.70458764186667,
+                    "avg": 2.98784726517737,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 523.375,
+                    "max": 681.06640625,
+                    "sum": 1809.6016213037585,
+                    "avg": 603.2005404345874,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 517.6015625,
+                    "max": 670.62890625,
+                    "sum": 1778.884551411295,
+                    "avg": 592.9615171370964,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.9635417955321,
+                    "min": 2.21280712303705,
+                    "max": 3.70458764186667,
+                    "avg": 2.98784726517737,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 523.375,
+                    "max": 681.06640625,
+                    "sum": 1809.6016213037585,
+                    "avg": 603.2005404345874,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 517.6015625,
+                    "max": 670.62890625,
+                    "sum": 1778.884551411295,
+                    "avg": 592.9615171370964,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T06:44:20.982Z",
+    "interval_end_time": "2023-04-14T06:59:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.22226443660519,
+                    "min": 2.47049967477409,
+                    "max": 3.71793174642592,
+                    "avg": 3.07408814553506,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 522.8359375,
+                    "max": 680.8046875,
+                    "sum": 1807.053301411295,
+                    "avg": 602.3511004704304,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 517.3671875,
+                    "max": 670.48046875,
+                    "sum": 1778.7809979838753,
+                    "avg": 592.9269993279571,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.22226443660519,
+                    "min": 2.47049967477409,
+                    "max": 3.71793174642592,
+                    "avg": 3.07408814553506,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 522.8359375,
+                    "max": 680.8046875,
+                    "sum": 1807.053301411295,
+                    "avg": 602.3511004704304,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 517.3671875,
+                    "max": 670.48046875,
+                    "sum": 1778.7809979838753,
+                    "avg": 592.9269993279571,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T06:59:20.982Z",
+    "interval_end_time": "2023-04-14T07:14:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.05406900328592,
+                    "min": 2.46702676600738,
+                    "max": 3.79059665009258,
+                    "avg": 3.01802300109531,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 523.20703125,
+                    "max": 686.9296875,
+                    "sum": 1812.3484122983837,
+                    "avg": 604.1161374327955,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 517.2734375,
+                    "max": 673.3125,
+                    "sum": 1780.4061239919376,
+                    "avg": 593.4687079973116,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.05406900328592,
+                    "min": 2.46702676600738,
+                    "max": 3.79059665009258,
+                    "avg": 3.01802300109531,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 523.20703125,
+                    "max": 686.9296875,
+                    "sum": 1812.3484122983837,
+                    "avg": 604.1161374327955,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 517.2734375,
+                    "max": 673.3125,
+                    "sum": 1780.4061239919376,
+                    "avg": 593.4687079973116,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T07:14:20.982Z",
+    "interval_end_time": "2023-04-14T07:29:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.748921211987,
+                    "min": 3.13011860182963,
+                    "max": 3.97355685707039,
+                    "avg": 3.58297373732901,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 529.19921875,
+                    "max": 689.15625,
+                    "sum": 1825.0662802419376,
+                    "avg": 608.3554267473116,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 521.55859375,
+                    "max": 675.6953125,
+                    "sum": 1788.46875,
+                    "avg": 596.15625,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.748921211987,
+                    "min": 3.13011860182963,
+                    "max": 3.97355685707039,
+                    "avg": 3.58297373732901,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 529.19921875,
+                    "max": 689.15625,
+                    "sum": 1825.0662802419376,
+                    "avg": 608.3554267473116,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 521.55859375,
+                    "max": 675.6953125,
+                    "sum": 1788.46875,
+                    "avg": 596.15625,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T07:29:20.982Z",
+    "interval_end_time": "2023-04-14T07:44:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.6526740209126,
+                    "min": 3.10204645853336,
+                    "max": 3.9707105071963,
+                    "avg": 3.5508913403042,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 529.12109375,
+                    "max": 691.828125,
+                    "sum": 1828.6769153225803,
+                    "avg": 609.5589717741938,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 521.30078125,
+                    "max": 677.484375,
+                    "sum": 1792.1616683467769,
+                    "avg": 597.387222782258,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.6526740209126,
+                    "min": 3.10204645853336,
+                    "max": 3.9707105071963,
+                    "avg": 3.5508913403042,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 529.12109375,
+                    "max": 691.828125,
+                    "sum": 1828.6769153225803,
+                    "avg": 609.5589717741938,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 521.30078125,
+                    "max": 677.484375,
+                    "sum": 1792.1616683467769,
+                    "avg": 597.387222782258,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T07:44:20.982Z",
+    "interval_end_time": "2023-04-14T07:59:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.7631599491053,
+                    "min": 3.18491469815555,
+                    "max": 3.99021273118889,
+                    "avg": 3.5877199830351,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 531.23046875,
+                    "max": 690.40234375,
+                    "sum": 1829.9347278225803,
+                    "avg": 609.9782426075268,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 523.36328125,
+                    "max": 678.2890625,
+                    "sum": 1794.4102822580624,
+                    "avg": 598.1367607526884,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.7631599491053,
+                    "min": 3.18491469815555,
+                    "max": 3.99021273118889,
+                    "avg": 3.5877199830351,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 531.23046875,
+                    "max": 690.40234375,
+                    "sum": 1829.9347278225803,
+                    "avg": 609.9782426075268,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 523.36328125,
+                    "max": 678.2890625,
+                    "sum": 1794.4102822580624,
+                    "avg": 598.1367607526884,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T07:59:20.982Z",
+    "interval_end_time": "2023-04-14T08:14:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.7310224917078,
+                    "min": 3.13325848021853,
+                    "max": 3.96387228262223,
+                    "avg": 3.57700749723593,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 531.50390625,
+                    "max": 696.03515625,
+                    "sum": 1838.799395161295,
+                    "avg": 612.9331317204304,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 523.4921875,
+                    "max": 679.8125,
+                    "sum": 1802.1993447580624,
+                    "avg": 600.7331149193554,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.7310224917078,
+                    "min": 3.13325848021853,
+                    "max": 3.96387228262223,
+                    "avg": 3.57700749723593,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 531.50390625,
+                    "max": 696.03515625,
+                    "sum": 1838.799395161295,
+                    "avg": 612.9331317204304,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 523.4921875,
+                    "max": 679.8125,
+                    "sum": 1802.1993447580624,
+                    "avg": 600.7331149193554,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T08:14:20.982Z",
+    "interval_end_time": "2023-04-14T08:29:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.62329535628198,
+                    "min": 2.05688880096293,
+                    "max": 3.86548729112595,
+                    "avg": 2.87443178542733,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 540.66015625,
+                    "max": 691.59765625,
+                    "sum": 1844.354964717741,
+                    "avg": 614.7849882392474,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 535.3828125,
+                    "max": 679.9375,
+                    "sum": 1814.6233618951608,
+                    "avg": 604.8744539650536,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.62329535628198,
+                    "min": 2.05688880096293,
+                    "max": 3.86548729112595,
+                    "avg": 2.87443178542733,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 540.66015625,
+                    "max": 691.59765625,
+                    "sum": 1844.354964717741,
+                    "avg": 614.7849882392474,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 535.3828125,
+                    "max": 679.9375,
+                    "sum": 1814.6233618951608,
+                    "avg": 604.8744539650536,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T08:29:20.982Z",
+    "interval_end_time": "2023-04-14T08:44:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.15722079557728,
+                    "min": 2.03335331438149,
+                    "max": 4.14853096777041,
+                    "avg": 3.0524069318591,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 540.64453125,
+                    "max": 695.4140625,
+                    "sum": 1876.40625,
+                    "avg": 625.46875,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 535.25390625,
+                    "max": 681.609375,
+                    "sum": 1837.198714717741,
+                    "avg": 612.3995715725804,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.15722079557728,
+                    "min": 2.03335331438149,
+                    "max": 4.14853096777041,
+                    "avg": 3.0524069318591,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 540.64453125,
+                    "max": 695.4140625,
+                    "sum": 1876.40625,
+                    "avg": 625.46875,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 535.25390625,
+                    "max": 681.609375,
+                    "sum": 1837.198714717741,
+                    "avg": 612.3995715725804,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T08:44:20.982Z",
+    "interval_end_time": "2023-04-14T08:59:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.16009550522592,
+                    "min": 2.21267326740371,
+                    "max": 4.09413172910001,
+                    "avg": 3.05336516840864,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 544.80859375,
+                    "max": 696.21875,
+                    "sum": 1883.3708417338753,
+                    "avg": 627.7902805779571,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 540.265625,
+                    "max": 682.17578125,
+                    "sum": 1851.9214969758034,
+                    "avg": 617.3071656586018,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.16009550522592,
+                    "min": 2.21267326740371,
+                    "max": 4.09413172910001,
+                    "avg": 3.05336516840864,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 544.80859375,
+                    "max": 696.21875,
+                    "sum": 1883.3708417338753,
+                    "avg": 627.7902805779571,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 540.265625,
+                    "max": 682.17578125,
+                    "sum": 1851.9214969758034,
+                    "avg": 617.3071656586018,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T08:59:20.982Z",
+    "interval_end_time": "2023-04-14T09:14:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.05982423239408,
+                    "min": 2.24615530672966,
+                    "max": 3.9812969362333,
+                    "avg": 3.01994141079803,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 544.61328125,
+                    "max": 695.73828125,
+                    "sum": 1886.9499747983837,
+                    "avg": 628.9833249327955,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 539.75390625,
+                    "max": 681.4375,
+                    "sum": 1851.157636088705,
+                    "avg": 617.0525453629026,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.05982423239408,
+                    "min": 2.24615530672966,
+                    "max": 3.9812969362333,
+                    "avg": 3.01994141079803,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 544.61328125,
+                    "max": 695.73828125,
+                    "sum": 1886.9499747983837,
+                    "avg": 628.9833249327955,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 539.75390625,
+                    "max": 681.4375,
+                    "sum": 1851.157636088705,
+                    "avg": 617.0525453629026,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T09:14:20.982Z",
+    "interval_end_time": "2023-04-14T09:29:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.9071274727203,
+                    "min": 3.25862739362966,
+                    "max": 4.04602333235186,
+                    "avg": 3.63570915757342,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 556.9765625,
+                    "max": 698.71875,
+                    "sum": 1915.0883316532231,
+                    "avg": 638.362777217742,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 548.3828125,
+                    "max": 684.76953125,
+                    "sum": 1875.245589717741,
+                    "avg": 625.0818632392474,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.9071274727203,
+                    "min": 3.25862739362966,
+                    "max": 4.04602333235186,
+                    "avg": 3.63570915757342,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 556.9765625,
+                    "max": 698.71875,
+                    "sum": 1915.0883316532231,
+                    "avg": 638.362777217742,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 548.3828125,
+                    "max": 684.76953125,
+                    "sum": 1875.245589717741,
+                    "avg": 625.0818632392474,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T09:29:20.982Z",
+    "interval_end_time": "2023-04-14T09:44:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.913451177673,
+                    "min": 3.20804799411481,
+                    "max": 4.07098015567414,
+                    "avg": 3.63781705922432,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 583.68359375,
+                    "max": 709.1015625,
+                    "sum": 1937.9122983870984,
+                    "avg": 645.9707661290321,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 574.48046875,
+                    "max": 691.66015625,
+                    "sum": 1897.7899445564556,
+                    "avg": 632.5966481854839,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.913451177673,
+                    "min": 3.20804799411481,
+                    "max": 4.07098015567414,
+                    "avg": 3.63781705922432,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 583.68359375,
+                    "max": 709.1015625,
+                    "sum": 1937.9122983870984,
+                    "avg": 645.9707661290321,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 574.48046875,
+                    "max": 691.66015625,
+                    "sum": 1897.7899445564556,
+                    "avg": 632.5966481854839,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T09:44:20.982Z",
+    "interval_end_time": "2023-04-14T09:59:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.5137791759659,
+                    "min": 2.9830304468333,
+                    "max": 4.03336992185192,
+                    "avg": 3.50459305865531,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 581.28515625,
+                    "max": 714.05859375,
+                    "sum": 1934.5202872983837,
+                    "avg": 644.8400957661295,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 575.6640625,
+                    "max": 697.23828125,
+                    "sum": 1901.7436995967769,
+                    "avg": 633.914566532258,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.5137791759659,
+                    "min": 2.9830304468333,
+                    "max": 4.03336992185192,
+                    "avg": 3.50459305865531,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 581.28515625,
+                    "max": 714.05859375,
+                    "sum": 1934.5202872983837,
+                    "avg": 644.8400957661295,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 575.6640625,
+                    "max": 697.23828125,
+                    "sum": 1901.7436995967769,
+                    "avg": 633.914566532258,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T09:59:20.982Z",
+    "interval_end_time": "2023-04-14T10:14:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.334772011927,
+                    "min": 3.01208016822595,
+                    "max": 3.83399587318892,
+                    "avg": 3.44492400397568,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 581.36328125,
+                    "max": 700.55078125,
+                    "sum": 1927.2738155241966,
+                    "avg": 642.4246051747313,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 575.53515625,
+                    "max": 691.76171875,
+                    "sum": 1898.2774697580624,
+                    "avg": 632.7591565860214,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.334772011927,
+                    "min": 3.01208016822595,
+                    "max": 3.83399587318892,
+                    "avg": 3.44492400397568,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 581.36328125,
+                    "max": 700.55078125,
+                    "sum": 1927.2738155241966,
+                    "avg": 642.4246051747313,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 575.53515625,
+                    "max": 691.76171875,
+                    "sum": 1898.2774697580624,
+                    "avg": 632.7591565860214,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T10:14:20.982Z",
+    "interval_end_time": "2023-04-14T10:29:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.2373047261481,
+                    "min": 3.0129144124704,
+                    "max": 3.8386583563074,
+                    "avg": 3.41243490871605,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 581.45703125,
+                    "max": 699.578125,
+                    "sum": 1926.7009828629016,
+                    "avg": 642.2336609543008,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 575.43359375,
+                    "max": 690.1796875,
+                    "sum": 1897.559601814518,
+                    "avg": 632.5198672715054,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.2373047261481,
+                    "min": 3.0129144124704,
+                    "max": 3.8386583563074,
+                    "avg": 3.41243490871605,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 581.45703125,
+                    "max": 699.578125,
+                    "sum": 1926.7009828629016,
+                    "avg": 642.2336609543008,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 575.43359375,
+                    "max": 690.1796875,
+                    "sum": 1897.559601814518,
+                    "avg": 632.5198672715054,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T10:29:20.982Z",
+    "interval_end_time": "2023-04-14T10:44:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.3677284877604,
+                    "min": 2.96829540441853,
+                    "max": 3.84416734849629,
+                    "avg": 3.45590949592013,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 581.33203125,
+                    "max": 699.671875,
+                    "sum": 1927.2884324596787,
+                    "avg": 642.4294774865589,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 575.35546875,
+                    "max": 689.9140625,
+                    "sum": 1896.942414314518,
+                    "avg": 632.3141381048383,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.3677284877604,
+                    "min": 2.96829540441853,
+                    "max": 3.84416734849629,
+                    "avg": 3.45590949592013,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 581.33203125,
+                    "max": 699.671875,
+                    "sum": 1927.2884324596787,
+                    "avg": 642.4294774865589,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 575.35546875,
+                    "max": 689.9140625,
+                    "sum": 1896.942414314518,
+                    "avg": 632.3141381048383,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T10:44:20.982Z",
+    "interval_end_time": "2023-04-14T10:59:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.4170744901365,
+                    "min": 3.07377479822969,
+                    "max": 3.87213772268884,
+                    "avg": 3.47235816337885,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 581.66015625,
+                    "max": 700.13671875,
+                    "sum": 1929.4209929435444,
+                    "avg": 643.1403309811831,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 575.45703125,
+                    "max": 689.4296875,
+                    "sum": 1897.0625,
+                    "avg": 632.354166666667,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.4170744901365,
+                    "min": 3.07377479822969,
+                    "max": 3.87213772268884,
+                    "avg": 3.47235816337885,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 581.66015625,
+                    "max": 700.13671875,
+                    "sum": 1929.4209929435444,
+                    "avg": 643.1403309811831,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 575.45703125,
+                    "max": 689.4296875,
+                    "sum": 1897.0625,
+                    "avg": 632.354166666667,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T10:59:20.982Z",
+    "interval_end_time": "2023-04-14T11:14:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.00094267493246,
+                    "min": 2.1490613836407,
+                    "max": 3.84200228375557,
+                    "avg": 2.66698089164415,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 582.34375,
+                    "max": 701.4453125,
+                    "sum": 1929.3668094758034,
+                    "avg": 643.1222698252687,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 575.66796875,
+                    "max": 689.4453125,
+                    "sum": 1897.686113911295,
+                    "avg": 632.5620379704304,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.00094267493246,
+                    "min": 2.1490613836407,
+                    "max": 3.84200228375557,
+                    "avg": 2.66698089164415,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 582.34375,
+                    "max": 701.4453125,
+                    "sum": 1929.3668094758034,
+                    "avg": 643.1222698252687,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 575.66796875,
+                    "max": 689.4453125,
+                    "sum": 1897.686113911295,
+                    "avg": 632.5620379704304,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T11:14:20.982Z",
+    "interval_end_time": "2023-04-14T11:29:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 12.0856279078068,
+                    "min": 2.21310629708891,
+                    "max": 5.00496882604817,
+                    "avg": 4.0285426359356,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 583.0078125,
+                    "max": 703.1796875,
+                    "sum": 1940.4615675403213,
+                    "avg": 646.8205225134411,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 575.81640625,
+                    "max": 690.0546875,
+                    "sum": 1905.545866935482,
+                    "avg": 635.1819556451617,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 12.0856279078068,
+                    "min": 2.21310629708891,
+                    "max": 5.00496882604817,
+                    "avg": 4.0285426359356,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 583.0078125,
+                    "max": 703.1796875,
+                    "sum": 1940.4615675403213,
+                    "avg": 646.8205225134411,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 575.81640625,
+                    "max": 690.0546875,
+                    "sum": 1905.545866935482,
+                    "avg": 635.1819556451617,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T11:29:20.982Z",
+    "interval_end_time": "2023-04-14T11:44:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 11.1477041407654,
+                    "min": 3.15427694251121,
+                    "max": 4.71658542189258,
+                    "avg": 3.71590138025515,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 584.46875,
+                    "max": 700.734375,
+                    "sum": 1941.6325604838753,
+                    "avg": 647.2108534946242,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 576.7578125,
+                    "max": 690.6171875,
+                    "sum": 1909.1512096774197,
+                    "avg": 636.3837365591402,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 11.1477041407654,
+                    "min": 3.15427694251121,
+                    "max": 4.71658542189258,
+                    "avg": 3.71590138025515,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 584.46875,
+                    "max": 700.734375,
+                    "sum": 1941.6325604838753,
+                    "avg": 647.2108534946242,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 576.7578125,
+                    "max": 690.6171875,
+                    "sum": 1909.1512096774197,
+                    "avg": 636.3837365591402,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T11:44:20.982Z",
+    "interval_end_time": "2023-04-14T11:59:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.08913062436407,
+                    "min": 2.1663344800704,
+                    "max": 3.80971794644806,
+                    "avg": 2.69637687478802,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 583.7109375,
+                    "max": 700.2890625,
+                    "sum": 1940.0672883064556,
+                    "avg": 646.68909610215,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 577.4140625,
+                    "max": 690.5859375,
+                    "sum": 1910.522933467741,
+                    "avg": 636.8409778225804,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.08913062436407,
+                    "min": 2.1663344800704,
+                    "max": 3.80971794644806,
+                    "avg": 2.69637687478802,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 583.7109375,
+                    "max": 700.2890625,
+                    "sum": 1940.0672883064556,
+                    "avg": 646.68909610215,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 577.4140625,
+                    "max": 690.5859375,
+                    "sum": 1910.522933467741,
+                    "avg": 636.8409778225804,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T11:59:20.982Z",
+    "interval_end_time": "2023-04-14T12:14:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.4725226309758,
+                    "min": 2.1357842092814,
+                    "max": 3.76223526866665,
+                    "avg": 3.1575075436586,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 583.9921875,
+                    "max": 701.73046875,
+                    "sum": 1944.325226814518,
+                    "avg": 648.1084089381724,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 577.46875,
+                    "max": 691.046875,
+                    "sum": 1911.3967993951608,
+                    "avg": 637.1322664650536,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.4725226309758,
+                    "min": 2.1357842092814,
+                    "max": 3.76223526866665,
+                    "avg": 3.1575075436586,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 583.9921875,
+                    "max": 701.73046875,
+                    "sum": 1944.325226814518,
+                    "avg": 648.1084089381724,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 577.46875,
+                    "max": 691.046875,
+                    "sum": 1911.3967993951608,
+                    "avg": 637.1322664650536,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T12:14:20.982Z",
+    "interval_end_time": "2023-04-14T12:29:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.0524877211616,
+                    "min": 2.87703812444449,
+                    "max": 3.7929688102556,
+                    "avg": 3.3508292403872,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 584.29296875,
+                    "max": 701.9296875,
+                    "sum": 1943.7375252016163,
+                    "avg": 647.9125084005375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 578.1796875,
+                    "max": 691.27734375,
+                    "sum": 1912.4357358870984,
+                    "avg": 637.4785786290321,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.0524877211616,
+                    "min": 2.87703812444449,
+                    "max": 3.7929688102556,
+                    "avg": 3.3508292403872,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 584.29296875,
+                    "max": 701.9296875,
+                    "sum": 1943.7375252016163,
+                    "avg": 647.9125084005375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 578.1796875,
+                    "max": 691.27734375,
+                    "sum": 1912.4357358870984,
+                    "avg": 637.4785786290321,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T12:29:20.982Z",
+    "interval_end_time": "2023-04-14T12:44:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 7.90843343750581,
+                    "min": 2.14200564715181,
+                    "max": 3.52121458107409,
+                    "avg": 2.6361444791686,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 584.1796875,
+                    "max": 701.68359375,
+                    "sum": 1942.852066532259,
+                    "avg": 647.6173555107526,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 578.23046875,
+                    "max": 691.83203125,
+                    "sum": 1912.8453881048392,
+                    "avg": 637.6151293682794,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 7.90843343750581,
+                    "min": 2.14200564715181,
+                    "max": 3.52121458107409,
+                    "avg": 2.6361444791686,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 584.1796875,
+                    "max": 701.68359375,
+                    "sum": 1942.852066532259,
+                    "avg": 647.6173555107526,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 578.23046875,
+                    "max": 691.83203125,
+                    "sum": 1912.8453881048392,
+                    "avg": 637.6151293682794,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T12:44:20.982Z",
+    "interval_end_time": "2023-04-14T12:59:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.71381415422864,
+                    "min": 2.15790548954812,
+                    "max": 3.97823024805931,
+                    "avg": 3.23793805140955,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 584.921875,
+                    "max": 703.92578125,
+                    "sum": 1945.9642137096787,
+                    "avg": 648.6547379032259,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 578.3046875,
+                    "max": 692.7421875,
+                    "sum": 1914.073210685482,
+                    "avg": 638.0244035618276,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.71381415422864,
+                    "min": 2.15790548954812,
+                    "max": 3.97823024805931,
+                    "avg": 3.23793805140955,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 584.921875,
+                    "max": 703.92578125,
+                    "sum": 1945.9642137096787,
+                    "avg": 648.6547379032259,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 578.3046875,
+                    "max": 692.7421875,
+                    "sum": 1914.073210685482,
+                    "avg": 638.0244035618276,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T12:59:20.982Z",
+    "interval_end_time": "2023-04-14T13:14:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.5451647607294,
+                    "min": 3.12512637135558,
+                    "max": 3.86204776687783,
+                    "avg": 3.51505492024313,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 585.3515625,
+                    "max": 703.87890625,
+                    "sum": 1947.2176159274197,
+                    "avg": 649.0725386424732,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 578.6171875,
+                    "max": 693.7890625,
+                    "sum": 1915.7574344758034,
+                    "avg": 638.5858114919357,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.5451647607294,
+                    "min": 3.12512637135558,
+                    "max": 3.86204776687783,
+                    "avg": 3.51505492024313,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 585.3515625,
+                    "max": 703.87890625,
+                    "sum": 1947.2176159274197,
+                    "avg": 649.0725386424732,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 578.6171875,
+                    "max": 693.7890625,
+                    "sum": 1915.7574344758034,
+                    "avg": 638.5858114919357,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T13:14:20.982Z",
+    "interval_end_time": "2023-04-14T13:29:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.03849701442754,
+                    "min": 2.03413861009262,
+                    "max": 3.90778873488512,
+                    "avg": 2.67949900480918,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 585.10546875,
+                    "max": 705.7734375,
+                    "sum": 1948.2381552419376,
+                    "avg": 649.4127184139786,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 578.625,
+                    "max": 695.53515625,
+                    "sum": 1917.475176411295,
+                    "avg": 639.1583921370974,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.03849701442754,
+                    "min": 2.03413861009262,
+                    "max": 3.90778873488512,
+                    "avg": 2.67949900480918,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 585.10546875,
+                    "max": 705.7734375,
+                    "sum": 1948.2381552419376,
+                    "avg": 649.4127184139786,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 578.625,
+                    "max": 695.53515625,
+                    "sum": 1917.475176411295,
+                    "avg": 639.1583921370974,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T13:29:20.982Z",
+    "interval_end_time": "2023-04-14T13:44:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.16431375389765,
+                    "min": 2.01623494006667,
+                    "max": 3.70945589486294,
+                    "avg": 3.05477125129922,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 585.0703125,
+                    "max": 706.13671875,
+                    "sum": 1952.1539818548392,
+                    "avg": 650.7179939516125,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 578.94921875,
+                    "max": 696.1328125,
+                    "sum": 1920.5725806451608,
+                    "avg": 640.1908602150536,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.16431375389765,
+                    "min": 2.01623494006667,
+                    "max": 3.70945589486294,
+                    "avg": 3.05477125129922,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 585.0703125,
+                    "max": 706.13671875,
+                    "sum": 1952.1539818548392,
+                    "avg": 650.7179939516125,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 578.94921875,
+                    "max": 696.1328125,
+                    "sum": 1920.5725806451608,
+                    "avg": 640.1908602150536,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T13:44:20.982Z",
+    "interval_end_time": "2023-04-14T13:59:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.458832859871,
+                    "min": 3.0186840297333,
+                    "max": 3.90330548338146,
+                    "avg": 3.486277619957,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 586.48828125,
+                    "max": 706.55859375,
+                    "sum": 1953.346270161295,
+                    "avg": 651.1154233870964,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 579.7734375,
+                    "max": 696.05859375,
+                    "sum": 1921.781754032259,
+                    "avg": 640.5939180107526,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.458832859871,
+                    "min": 3.0186840297333,
+                    "max": 3.90330548338146,
+                    "avg": 3.486277619957,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 586.48828125,
+                    "max": 706.55859375,
+                    "sum": 1953.346270161295,
+                    "avg": 651.1154233870964,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 579.7734375,
+                    "max": 696.05859375,
+                    "sum": 1921.781754032259,
+                    "avg": 640.5939180107526,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T13:59:20.982Z",
+    "interval_end_time": "2023-04-14T14:14:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.53227033687927,
+                    "min": 2.23295641035182,
+                    "max": 3.90809862530743,
+                    "avg": 2.84409011229309,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 585.78515625,
+                    "max": 705.85546875,
+                    "sum": 1951.542464717741,
+                    "avg": 650.5141549059143,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 579.4765625,
+                    "max": 695.55859375,
+                    "sum": 1920.9435483870984,
+                    "avg": 640.3145161290321,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.53227033687927,
+                    "min": 2.23295641035182,
+                    "max": 3.90809862530743,
+                    "avg": 2.84409011229309,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 585.78515625,
+                    "max": 705.85546875,
+                    "sum": 1951.542464717741,
+                    "avg": 650.5141549059143,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 579.4765625,
+                    "max": 695.55859375,
+                    "sum": 1920.9435483870984,
+                    "avg": 640.3145161290321,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T14:14:20.982Z",
+    "interval_end_time": "2023-04-14T14:29:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 11.3105670961746,
+                    "min": 2.28138709989251,
+                    "max": 4.91107536171481,
+                    "avg": 3.77018903205819,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 586.0625,
+                    "max": 706.8671875,
+                    "sum": 1953.272051411295,
+                    "avg": 651.0906838037633,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 579.4765625,
+                    "max": 695.734375,
+                    "sum": 1920.9940776209642,
+                    "avg": 640.3313592069893,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 11.3105670961746,
+                    "min": 2.28138709989251,
+                    "max": 4.91107536171481,
+                    "avg": 3.77018903205819,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 586.0625,
+                    "max": 706.8671875,
+                    "sum": 1953.272051411295,
+                    "avg": 651.0906838037633,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 579.4765625,
+                    "max": 695.734375,
+                    "sum": 1920.9940776209642,
+                    "avg": 640.3313592069893,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T14:29:20.982Z",
+    "interval_end_time": "2023-04-14T14:44:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 11.6351519346616,
+                    "min": 3.29073386108891,
+                    "max": 5.0519409623481,
+                    "avg": 3.87838397822053,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 586.80859375,
+                    "max": 706.3984375,
+                    "sum": 1953.6118951612855,
+                    "avg": 651.2039650537633,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 579.51171875,
+                    "max": 695.9765625,
+                    "sum": 1921.8780241935444,
+                    "avg": 640.6260080645161,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 11.6351519346616,
+                    "min": 3.29073386108891,
+                    "max": 5.0519409623481,
+                    "avg": 3.87838397822053,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 586.80859375,
+                    "max": 706.3984375,
+                    "sum": 1953.6118951612855,
+                    "avg": 651.2039650537633,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 579.51171875,
+                    "max": 695.9765625,
+                    "sum": 1921.8780241935444,
+                    "avg": 640.6260080645161,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T14:44:20.982Z",
+    "interval_end_time": "2023-04-14T14:59:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.47149154645631,
+                    "min": 2.11797208714081,
+                    "max": 3.87644002308155,
+                    "avg": 2.82383051548544,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 586.94140625,
+                    "max": 706.625,
+                    "sum": 1953.4712701612855,
+                    "avg": 651.1570900537633,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 579.8984375,
+                    "max": 696.015625,
+                    "sum": 1922.2391633064556,
+                    "avg": 640.7463877688169,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.47149154645631,
+                    "min": 2.11797208714081,
+                    "max": 3.87644002308155,
+                    "avg": 2.82383051548544,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 586.94140625,
+                    "max": 706.625,
+                    "sum": 1953.4712701612855,
+                    "avg": 651.1570900537633,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 579.8984375,
+                    "max": 696.015625,
+                    "sum": 1922.2391633064556,
+                    "avg": 640.7463877688169,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T14:59:20.982Z",
+    "interval_end_time": "2023-04-14T15:14:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.21809724495517,
+                    "min": 2.26505906991111,
+                    "max": 3.68395089868152,
+                    "avg": 3.07269908165172,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 587.91796875,
+                    "max": 712.33203125,
+                    "sum": 1958.6911542338753,
+                    "avg": 652.8970514112901,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 581.1015625,
+                    "max": 699.13671875,
+                    "sum": 1925.9162046370984,
+                    "avg": 641.9720682123661,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.21809724495517,
+                    "min": 2.26505906991111,
+                    "max": 3.68395089868152,
+                    "avg": 3.07269908165172,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 587.91796875,
+                    "max": 712.33203125,
+                    "sum": 1958.6911542338753,
+                    "avg": 652.8970514112901,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 581.1015625,
+                    "max": 699.13671875,
+                    "sum": 1925.9162046370984,
+                    "avg": 641.9720682123661,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T15:14:20.982Z",
+    "interval_end_time": "2023-04-14T15:29:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.5926810157483,
+                    "min": 3.15093494377043,
+                    "max": 4.04325676777031,
+                    "avg": 3.53089367191609,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 588.98828125,
+                    "max": 711.62109375,
+                    "sum": 1965.8360635080624,
+                    "avg": 655.2786878360214,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 582.46484375,
+                    "max": 699.5234375,
+                    "sum": 1930.1082409274197,
+                    "avg": 643.3694136424732,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.5926810157483,
+                    "min": 3.15093494377043,
+                    "max": 4.04325676777031,
+                    "avg": 3.53089367191609,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 588.98828125,
+                    "max": 711.62109375,
+                    "sum": 1965.8360635080624,
+                    "avg": 655.2786878360214,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 582.46484375,
+                    "max": 699.5234375,
+                    "sum": 1930.1082409274197,
+                    "avg": 643.3694136424732,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T15:29:20.982Z",
+    "interval_end_time": "2023-04-14T15:44:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.64368714286926,
+                    "min": 2.24967557978525,
+                    "max": 3.9592644776112,
+                    "avg": 2.88122904762309,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 589.7578125,
+                    "max": 711.3125,
+                    "sum": 1963.3489163306426,
+                    "avg": 654.4496387768812,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 583.875,
+                    "max": 699.796875,
+                    "sum": 1932.0260836693574,
+                    "avg": 644.0086945564518,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.64368714286926,
+                    "min": 2.24967557978525,
+                    "max": 3.9592644776112,
+                    "avg": 2.88122904762309,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 589.7578125,
+                    "max": 711.3125,
+                    "sum": 1963.3489163306426,
+                    "avg": 654.4496387768812,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 583.875,
+                    "max": 699.796875,
+                    "sum": 1932.0260836693574,
+                    "avg": 644.0086945564518,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T15:44:20.982Z",
+    "interval_end_time": "2023-04-14T15:59:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 11.4050785602907,
+                    "min": 2.22315159918896,
+                    "max": 5.22983893591488,
+                    "avg": 3.80169285343025,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 589.23828125,
+                    "max": 713.2890625,
+                    "sum": 1964.893523185482,
+                    "avg": 654.9645077284946,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 583.0234375,
+                    "max": 700.1640625,
+                    "sum": 1931.3766381048392,
+                    "avg": 643.7922127016134,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 11.4050785602907,
+                    "min": 2.22315159918896,
+                    "max": 5.22983893591488,
+                    "avg": 3.80169285343025,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 589.23828125,
+                    "max": 713.2890625,
+                    "sum": 1964.893523185482,
+                    "avg": 654.9645077284946,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 583.0234375,
+                    "max": 700.1640625,
+                    "sum": 1931.3766381048392,
+                    "avg": 643.7922127016134,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T15:59:20.982Z",
+    "interval_end_time": "2023-04-14T16:14:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 12.2353137862839,
+                    "min": 3.43897659853694,
+                    "max": 5.12842233671119,
+                    "avg": 4.07843792876132,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 590.56640625,
+                    "max": 712.30078125,
+                    "sum": 1969.35546875,
+                    "avg": 656.451822916667,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 583.15234375,
+                    "max": 700.79296875,
+                    "sum": 1934.6273941532231,
+                    "avg": 644.875798051075,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 12.2353137862839,
+                    "min": 3.43897659853694,
+                    "max": 5.12842233671119,
+                    "avg": 4.07843792876132,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 590.56640625,
+                    "max": 712.30078125,
+                    "sum": 1969.35546875,
+                    "avg": 656.451822916667,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 583.15234375,
+                    "max": 700.79296875,
+                    "sum": 1934.6273941532231,
+                    "avg": 644.875798051075,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T16:14:20.982Z",
+    "interval_end_time": "2023-04-14T16:29:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.7793188497863,
+                    "min": 2.16661255676299,
+                    "max": 3.87875162170741,
+                    "avg": 2.92643961659543,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 591.5859375,
+                    "max": 711.890625,
+                    "sum": 1966.4546370967769,
+                    "avg": 655.484879032258,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 585.54296875,
+                    "max": 700.8203125,
+                    "sum": 1935.6321824596787,
+                    "avg": 645.2107274865589,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.7793188497863,
+                    "min": 2.16661255676299,
+                    "max": 3.87875162170741,
+                    "avg": 2.92643961659543,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 591.5859375,
+                    "max": 711.890625,
+                    "sum": 1966.4546370967769,
+                    "avg": 655.484879032258,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 585.54296875,
+                    "max": 700.8203125,
+                    "sum": 1935.6321824596787,
+                    "avg": 645.2107274865589,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T16:29:20.982Z",
+    "interval_end_time": "2023-04-14T16:44:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.04291315149839,
+                    "min": 2.20755518967409,
+                    "max": 3.75499438936294,
+                    "avg": 3.0143043838328,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 591.69140625,
+                    "max": 719.515625,
+                    "sum": 1974.7953629032231,
+                    "avg": 658.265120967742,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 585.56640625,
+                    "max": 703.546875,
+                    "sum": 1939.3046875,
+                    "avg": 646.434895833333,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.04291315149839,
+                    "min": 2.20755518967409,
+                    "max": 3.75499438936294,
+                    "avg": 3.0143043838328,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 591.69140625,
+                    "max": 719.515625,
+                    "sum": 1974.7953629032231,
+                    "avg": 658.265120967742,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 585.56640625,
+                    "max": 703.546875,
+                    "sum": 1939.3046875,
+                    "avg": 646.434895833333,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T16:44:20.982Z",
+    "interval_end_time": "2023-04-14T16:59:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.5671862739724,
+                    "min": 3.08753737648151,
+                    "max": 3.88855943243338,
+                    "avg": 3.52239542465745,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 596.3359375,
+                    "max": 715.51171875,
+                    "sum": 1977.8702116935444,
+                    "avg": 659.2900705645161,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 589.1484375,
+                    "max": 703.3359375,
+                    "sum": 1942.8647933467769,
+                    "avg": 647.621597782258,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.5671862739724,
+                    "min": 3.08753737648151,
+                    "max": 3.88855943243338,
+                    "avg": 3.52239542465745,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 596.3359375,
+                    "max": 715.51171875,
+                    "sum": 1977.8702116935444,
+                    "avg": 659.2900705645161,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 589.1484375,
+                    "max": 703.3359375,
+                    "sum": 1942.8647933467769,
+                    "avg": 647.621597782258,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T16:59:20.982Z",
+    "interval_end_time": "2023-04-14T17:14:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.77283014256012,
+                    "min": 2.22594466240747,
+                    "max": 3.91171864267036,
+                    "avg": 2.92427671418671,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 595.09375,
+                    "max": 714.77734375,
+                    "sum": 1973.9478326612855,
+                    "avg": 657.9826108870964,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 588.890625,
+                    "max": 703.39453125,
+                    "sum": 1942.2434475806426,
+                    "avg": 647.4144825268821,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.77283014256012,
+                    "min": 2.22594466240747,
+                    "max": 3.91171864267036,
+                    "avg": 2.92427671418671,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 595.09375,
+                    "max": 714.77734375,
+                    "sum": 1973.9478326612855,
+                    "avg": 657.9826108870964,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 588.890625,
+                    "max": 703.39453125,
+                    "sum": 1942.2434475806426,
+                    "avg": 647.4144825268821,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T17:14:20.982Z",
+    "interval_end_time": "2023-04-14T17:29:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.8640609704824,
+                    "min": 2.24353211339999,
+                    "max": 5.06897459706665,
+                    "avg": 3.62135365682745,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 595.0859375,
+                    "max": 716.28125,
+                    "sum": 1979.0505292338753,
+                    "avg": 659.6835097446242,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 588.92578125,
+                    "max": 703.24609375,
+                    "sum": 1945.008316532259,
+                    "avg": 648.3361055107526,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.8640609704824,
+                    "min": 2.24353211339999,
+                    "max": 5.06897459706665,
+                    "avg": 3.62135365682745,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 595.0859375,
+                    "max": 716.28125,
+                    "sum": 1979.0505292338753,
+                    "avg": 659.6835097446242,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 588.92578125,
+                    "max": 703.24609375,
+                    "sum": 1945.008316532259,
+                    "avg": 648.3361055107526,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T17:29:20.982Z",
+    "interval_end_time": "2023-04-14T17:44:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 12.303771608827,
+                    "min": 3.19303099134812,
+                    "max": 5.27164915240741,
+                    "avg": 4.10125720294234,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 600.7890625,
+                    "max": 720.25390625,
+                    "sum": 1983.504410282259,
+                    "avg": 661.1681367607526,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 593.32421875,
+                    "max": 704.83203125,
+                    "sum": 1948.3068296370984,
+                    "avg": 649.4356098790321,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 12.303771608827,
+                    "min": 3.19303099134812,
+                    "max": 5.27164915240741,
+                    "avg": 4.10125720294234,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 600.7890625,
+                    "max": 720.25390625,
+                    "sum": 1983.504410282259,
+                    "avg": 661.1681367607526,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 593.32421875,
+                    "max": 704.83203125,
+                    "sum": 1948.3068296370984,
+                    "avg": 649.4356098790321,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T17:44:20.982Z",
+    "interval_end_time": "2023-04-14T17:59:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.88046177254543,
+                    "min": 2.21091980862957,
+                    "max": 3.79593948783704,
+                    "avg": 2.96015392418181,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 600.9609375,
+                    "max": 717.27734375,
+                    "sum": 1981.827116935482,
+                    "avg": 660.6090389784946,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 593.61328125,
+                    "max": 705.05859375,
+                    "sum": 1949.7668850806426,
+                    "avg": 649.9222950268821,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.88046177254543,
+                    "min": 2.21091980862957,
+                    "max": 3.79593948783704,
+                    "avg": 2.96015392418181,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 600.9609375,
+                    "max": 717.27734375,
+                    "sum": 1981.827116935482,
+                    "avg": 660.6090389784946,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 593.61328125,
+                    "max": 705.05859375,
+                    "sum": 1949.7668850806426,
+                    "avg": 649.9222950268821,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T17:59:20.982Z",
+    "interval_end_time": "2023-04-14T18:14:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.94958328393977,
+                    "min": 2.24761090759259,
+                    "max": 3.8150791290186,
+                    "avg": 2.98319442797992,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 601.1875,
+                    "max": 717.3984375,
+                    "sum": 1986.6217237903213,
+                    "avg": 662.2072412634411,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 595.171875,
+                    "max": 705.0859375,
+                    "sum": 1951.9397681451608,
+                    "avg": 650.6465893817206,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.94958328393977,
+                    "min": 2.24761090759259,
+                    "max": 3.8150791290186,
+                    "avg": 2.98319442797992,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 601.1875,
+                    "max": 717.3984375,
+                    "sum": 1986.6217237903213,
+                    "avg": 662.2072412634411,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 595.171875,
+                    "max": 705.0859375,
+                    "sum": 1951.9397681451608,
+                    "avg": 650.6465893817206,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T18:14:20.982Z",
+    "interval_end_time": "2023-04-14T18:29:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.6959422357652,
+                    "min": 3.16705717062588,
+                    "max": 4.00928962749259,
+                    "avg": 3.56531407858839,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 606.0234375,
+                    "max": 718.52734375,
+                    "sum": 1993.9778225806426,
+                    "avg": 664.6592741935482,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 597.96875,
+                    "max": 705.609375,
+                    "sum": 1956.986895161295,
+                    "avg": 652.3289650537633,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.6959422357652,
+                    "min": 3.16705717062588,
+                    "max": 4.00928962749259,
+                    "avg": 3.56531407858839,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 606.0234375,
+                    "max": 718.52734375,
+                    "sum": 1993.9778225806426,
+                    "avg": 664.6592741935482,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 597.96875,
+                    "max": 705.609375,
+                    "sum": 1956.986895161295,
+                    "avg": 652.3289650537633,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T18:29:20.982Z",
+    "interval_end_time": "2023-04-14T18:44:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.18414829603026,
+                    "min": 2.21657201254436,
+                    "max": 3.96953617514077,
+                    "avg": 3.06138276534342,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 605.34375,
+                    "max": 718.76953125,
+                    "sum": 1990.8679435483837,
+                    "avg": 663.6226478494625,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 599.55859375,
+                    "max": 705.64453125,
+                    "sum": 1957.7373991935444,
+                    "avg": 652.5791330645161,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.18414829603026,
+                    "min": 2.21657201254436,
+                    "max": 3.96953617514077,
+                    "avg": 3.06138276534342,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 605.34375,
+                    "max": 718.76953125,
+                    "sum": 1990.8679435483837,
+                    "avg": 663.6226478494625,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 599.55859375,
+                    "max": 705.64453125,
+                    "sum": 1957.7373991935444,
+                    "avg": 652.5791330645161,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T18:44:20.982Z",
+    "interval_end_time": "2023-04-14T18:59:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.4773938469727,
+                    "min": 2.22080172608882,
+                    "max": 5.07865683601477,
+                    "avg": 3.49246461565757,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 605.7578125,
+                    "max": 723.578125,
+                    "sum": 1999.2072832661247,
+                    "avg": 666.4024277553768,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 599.40234375,
+                    "max": 707.52734375,
+                    "sum": 1963.6956905241966,
+                    "avg": 654.5652301747313,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.4773938469727,
+                    "min": 2.22080172608882,
+                    "max": 5.07865683601477,
+                    "avg": 3.49246461565757,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 605.7578125,
+                    "max": 723.578125,
+                    "sum": 1999.2072832661247,
+                    "avg": 666.4024277553768,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 599.40234375,
+                    "max": 707.52734375,
+                    "sum": 1963.6956905241966,
+                    "avg": 654.5652301747313,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T18:59:20.982Z",
+    "interval_end_time": "2023-04-14T19:14:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 12.8896534244778,
+                    "min": 3.47680979265187,
+                    "max": 5.1807445324371,
+                    "avg": 4.2965511414926,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 614.703125,
+                    "max": 722.19140625,
+                    "sum": 2010.5089465725803,
+                    "avg": 670.1696488575268,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 606.5078125,
+                    "max": 708.6484375,
+                    "sum": 1970.5293598790358,
+                    "avg": 656.8431199596777,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 12.8896534244778,
+                    "min": 3.47680979265187,
+                    "max": 5.1807445324371,
+                    "avg": 4.2965511414926,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 614.703125,
+                    "max": 722.19140625,
+                    "sum": 2010.5089465725803,
+                    "avg": 670.1696488575268,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 606.5078125,
+                    "max": 708.6484375,
+                    "sum": 1970.5293598790358,
+                    "avg": 656.8431199596777,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T19:14:20.982Z",
+    "interval_end_time": "2023-04-14T19:29:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.50028536230247,
+                    "min": 2.17673640065563,
+                    "max": 4.18001101019262,
+                    "avg": 3.16676178743416,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 611.86328125,
+                    "max": 722.64453125,
+                    "sum": 2003.563004032259,
+                    "avg": 667.8543346774196,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 606.41015625,
+                    "max": 708.66796875,
+                    "sum": 1969.5727066532231,
+                    "avg": 656.524235551075,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.50028536230247,
+                    "min": 2.17673640065563,
+                    "max": 4.18001101019262,
+                    "avg": 3.16676178743416,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 611.86328125,
+                    "max": 722.64453125,
+                    "sum": 2003.563004032259,
+                    "avg": 667.8543346774196,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 606.41015625,
+                    "max": 708.66796875,
+                    "sum": 1969.5727066532231,
+                    "avg": 656.524235551075,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T19:29:20.982Z",
+    "interval_end_time": "2023-04-14T19:44:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.008612013913388,
+                    "min": 0.000361107147235,
+                    "max": 0.003050324185815,
+                    "avg": 0.001435335652231,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 0.0,
+                    "max": 1330.0234375,
+                    "sum": 3606.66143465909,
+                    "avg": 601.110239109849,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 0.0,
+                    "max": 1320.109375,
+                    "sum": 3502.236328125,
+                    "avg": 583.7060546875,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.008612013913388,
+                    "min": 0.000361107147235,
+                    "max": 0.003050324185815,
+                    "avg": 0.001435335652231,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 0.0,
+                    "max": 1330.0234375,
+                    "sum": 3606.66143465909,
+                    "avg": 601.110239109849,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 0.0,
+                    "max": 1320.109375,
+                    "sum": 3502.236328125,
+                    "avg": 583.7060546875,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T19:44:20.982Z",
+    "interval_end_time": "2023-04-14T19:59:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.00125369576092,
+                    "max": 0.00125369576092,
+                    "avg": 0.000417898586973,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.23642774156611,
+                    "min": 0.122641301400588,
+                    "max": 4.05884393815185,
+                    "avg": 3.0788092471887,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 194.62890625,
+                    "max": 290.046875,
+                    "sum": 730.8758820564518,
+                    "avg": 243.62529401881696,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 187.2265625,
+                    "max": 281.9921875,
+                    "sum": 701.5254536290321,
+                    "avg": 233.84181787634373,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.00125369576092,
+                    "max": 0.00125369576092,
+                    "avg": 0.000417898586973,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.23642774156611,
+                    "min": 0.122641301400588,
+                    "max": 4.05884393815185,
+                    "avg": 3.0788092471887,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 194.62890625,
+                    "max": 290.046875,
+                    "sum": 730.8758820564518,
+                    "avg": 243.62529401881696,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 187.2265625,
+                    "max": 281.9921875,
+                    "sum": 701.5254536290321,
+                    "avg": 233.84181787634373,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T19:59:20.982Z",
+    "interval_end_time": "2023-04-14T20:14:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.04609118991037,
+                    "min": 2.34309635937407,
+                    "max": 3.88964089192222,
+                    "avg": 3.01536372997012,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 229.984375,
+                    "max": 314.703125,
+                    "sum": 828.3160282258062,
+                    "avg": 276.1053427419357,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 225.0703125,
+                    "max": 307.4921875,
+                    "sum": 799.6636844758062,
+                    "avg": 266.5545614919357,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.04609118991037,
+                    "min": 2.34309635937407,
+                    "max": 3.88964089192222,
+                    "avg": 3.01536372997012,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 229.984375,
+                    "max": 314.703125,
+                    "sum": 828.3160282258062,
+                    "avg": 276.1053427419357,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 225.0703125,
+                    "max": 307.4921875,
+                    "sum": 799.6636844758062,
+                    "avg": 266.5545614919357,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T20:14:20.982Z",
+    "interval_end_time": "2023-04-14T20:29:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.112328922496552,
+                    "max": 0.085147492862069,
+                    "avg": 0.037442974165517,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.46914730046654,
+                    "min": 2.30112868885926,
+                    "max": 4.58010182155185,
+                    "avg": 2.82304910015551,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 251.234375,
+                    "max": 346.984375,
+                    "sum": 890.1745211693544,
+                    "avg": 296.7248403897848,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 246.47265625,
+                    "max": 335.62109375,
+                    "sum": 859.1034526209679,
+                    "avg": 286.3678175403223,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.112328922496552,
+                    "max": 0.085147492862069,
+                    "avg": 0.037442974165517,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 8.46914730046654,
+                    "min": 2.30112868885926,
+                    "max": 4.58010182155185,
+                    "avg": 2.82304910015551,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 251.234375,
+                    "max": 346.984375,
+                    "sum": 890.1745211693544,
+                    "avg": 296.7248403897848,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 246.47265625,
+                    "max": 335.62109375,
+                    "sum": 859.1034526209679,
+                    "avg": 286.3678175403223,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T20:29:20.982Z",
+    "interval_end_time": "2023-04-14T20:44:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 13.2376485156556,
+                    "min": 3.91502781582593,
+                    "max": 4.85605234033704,
+                    "avg": 4.41254950521852,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 271.42578125,
+                    "max": 347.83984375,
+                    "sum": 952.2685231854839,
+                    "avg": 317.4228410618277,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 265.5390625,
+                    "max": 338.46875,
+                    "sum": 918.4469506048393,
+                    "avg": 306.14898353494647,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 13.2376485156556,
+                    "min": 3.91502781582593,
+                    "max": 4.85605234033704,
+                    "avg": 4.41254950521852,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 271.42578125,
+                    "max": 347.83984375,
+                    "sum": 952.2685231854839,
+                    "avg": 317.4228410618277,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 265.5390625,
+                    "max": 338.46875,
+                    "sum": 918.4469506048393,
+                    "avg": 306.14898353494647,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T20:44:20.982Z",
+    "interval_end_time": "2023-04-14T20:59:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 11.3112178759358,
+                    "min": 3.33503295274444,
+                    "max": 4.81386723182222,
+                    "avg": 3.77040595864527,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 271.59375,
+                    "max": 356.5390625,
+                    "sum": 989.438004032259,
+                    "avg": 329.8126680107527,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 265.66796875,
+                    "max": 348.39453125,
+                    "sum": 956.612777217741,
+                    "avg": 318.8709257392473,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 11.3112178759358,
+                    "min": 3.33503295274444,
+                    "max": 4.81386723182222,
+                    "avg": 3.77040595864527,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 271.59375,
+                    "max": 356.5390625,
+                    "sum": 989.438004032259,
+                    "avg": 329.8126680107527,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 265.66796875,
+                    "max": 348.39453125,
+                    "sum": 956.612777217741,
+                    "avg": 318.8709257392473,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T20:59:20.982Z",
+    "interval_end_time": "2023-04-14T21:14:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.23973705240321,
+                    "min": 2.23026164174074,
+                    "max": 3.92129674667037,
+                    "avg": 3.07991235080107,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 290.625,
+                    "max": 359.1015625,
+                    "sum": 1001.7091733870983,
+                    "avg": 333.9030577956991,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 286.27734375,
+                    "max": 350.00390625,
+                    "sum": 970.1455393145179,
+                    "avg": 323.3818464381723,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 9.23973705240321,
+                    "min": 2.23026164174074,
+                    "max": 3.92129674667037,
+                    "avg": 3.07991235080107,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 290.625,
+                    "max": 359.1015625,
+                    "sum": 1001.7091733870983,
+                    "avg": 333.9030577956991,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 286.27734375,
+                    "max": 350.00390625,
+                    "sum": 970.1455393145179,
+                    "avg": 323.3818464381723,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T21:14:20.982Z",
+    "interval_end_time": "2023-04-14T21:29:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.004116689491954,
+                    "max": 0.002598697606897,
+                    "avg": 0.001372229830651,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 7.87229159665284,
+                    "min": 2.21689067767037,
+                    "max": 3.59979932507037,
+                    "avg": 2.62409719888428,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 295.34765625,
+                    "max": 398.4921875,
+                    "sum": 1034.1706149193574,
+                    "avg": 344.7235383064518,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 291.51953125,
+                    "max": 380.515625,
+                    "sum": 1001.016129032259,
+                    "avg": 333.6720430107527,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.004116689491954,
+                    "max": 0.002598697606897,
+                    "avg": 0.001372229830651,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 7.87229159665284,
+                    "min": 2.21689067767037,
+                    "max": 3.59979932507037,
+                    "avg": 2.62409719888428,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 295.34765625,
+                    "max": 398.4921875,
+                    "sum": 1034.1706149193574,
+                    "avg": 344.7235383064518,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 291.51953125,
+                    "max": 380.515625,
+                    "sum": 1001.016129032259,
+                    "avg": 333.6720430107527,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T22:44:20.982Z",
+    "interval_end_time": "2023-04-14T22:59:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 11.0524067195789,
+                    "min": 2.66358841466294,
+                    "max": 4.19660716037036,
+                    "avg": 3.68413557319296,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 483.8046875,
+                    "max": 557.84765625,
+                    "sum": 1591.0030241935444,
+                    "avg": 530.3343413978491,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 478.68359375,
+                    "max": 540.7109375,
+                    "sum": 1553.057207661295,
+                    "avg": 517.6857358870964,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 11.0524067195789,
+                    "min": 2.66358841466294,
+                    "max": 4.19660716037036,
+                    "avg": 3.68413557319296,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 483.8046875,
+                    "max": 557.84765625,
+                    "sum": 1591.0030241935444,
+                    "avg": 530.3343413978491,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 478.68359375,
+                    "max": 540.7109375,
+                    "sum": 1553.057207661295,
+                    "avg": 517.6857358870964,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T22:59:20.982Z",
+    "interval_end_time": "2023-04-14T23:14:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 7.11427328335358,
+                    "min": 2.13855924275925,
+                    "max": 2.74692213271852,
+                    "avg": 2.37142442778453,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 483.82421875,
+                    "max": 546.765625,
+                    "sum": 1567.1585181451608,
+                    "avg": 522.3861727150536,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 477.94140625,
+                    "max": 533.4296875,
+                    "sum": 1537.9644657258034,
+                    "avg": 512.6548219086018,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 7.11427328335358,
+                    "min": 2.13855924275925,
+                    "max": 2.74692213271852,
+                    "avg": 2.37142442778453,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 483.82421875,
+                    "max": 546.765625,
+                    "sum": 1567.1585181451608,
+                    "avg": 522.3861727150536,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 477.94140625,
+                    "max": 533.4296875,
+                    "sum": 1537.9644657258034,
+                    "avg": 512.6548219086018,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T23:14:20.982Z",
+    "interval_end_time": "2023-04-14T23:29:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 7.40207558177333,
+                    "min": 2.17771477021481,
+                    "max": 3.22089857927408,
+                    "avg": 2.46735852725778,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 484.3359375,
+                    "max": 630.69140625,
+                    "sum": 1610.2723034274197,
+                    "avg": 536.7574344758062,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 478.125,
+                    "max": 615.4375,
+                    "sum": 1576.3912550403213,
+                    "avg": 525.4637516801071,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 7.40207558177333,
+                    "min": 2.17771477021481,
+                    "max": 3.22089857927408,
+                    "avg": 2.46735852725778,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 484.3359375,
+                    "max": 630.69140625,
+                    "sum": 1610.2723034274197,
+                    "avg": 536.7574344758062,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 478.125,
+                    "max": 615.4375,
+                    "sum": 1576.3912550403213,
+                    "avg": 525.4637516801071,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T23:29:20.982Z",
+    "interval_end_time": "2023-04-14T23:44:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.8811287533044,
+                    "min": 3.06415491851111,
+                    "max": 3.97339506212593,
+                    "avg": 3.62704291776815,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 501.6328125,
+                    "max": 630.84765625,
+                    "sum": 1724.2982610887145,
+                    "avg": 574.7660870295696,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 492.3828125,
+                    "max": 616.39453125,
+                    "sum": 1684.5724546370984,
+                    "avg": 561.5241515456992,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.8811287533044,
+                    "min": 3.06415491851111,
+                    "max": 3.97339506212593,
+                    "avg": 3.62704291776815,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 501.6328125,
+                    "max": 630.84765625,
+                    "sum": 1724.2982610887145,
+                    "avg": 574.7660870295696,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 492.3828125,
+                    "max": 616.39453125,
+                    "sum": 1684.5724546370984,
+                    "avg": 561.5241515456992,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T23:44:20.982Z",
+    "interval_end_time": "2023-04-14T23:59:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.4764962408307,
+                    "min": 3.01007331396298,
+                    "max": 3.90357787986297,
+                    "avg": 3.49216541361025,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 486.8984375,
+                    "max": 627.91015625,
+                    "sum": 1686.097152217741,
+                    "avg": 562.0323840725804,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 481.13671875,
+                    "max": 615.5625,
+                    "sum": 1656.9078881048392,
+                    "avg": 552.3026293682794,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 10.4764962408307,
+                    "min": 3.01007331396298,
+                    "max": 3.90357787986297,
+                    "avg": 3.49216541361025,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 486.8984375,
+                    "max": 627.91015625,
+                    "sum": 1686.097152217741,
+                    "avg": 562.0323840725804,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 481.13671875,
+                    "max": 615.5625,
+                    "sum": 1656.9078881048392,
+                    "avg": 552.3026293682794,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T17:29:20.982Z",
+    "interval_end_time": "2023-04-14T17:44:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 12.303771608827,
+                    "min": 3.19303099134812,
+                    "max": 5.27164915240741,
+                    "avg": 4.10125720294234,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 600.7890625,
+                    "max": 720.25390625,
+                    "sum": 1983.504410282259,
+                    "avg": 661.1681367607526,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 593.32421875,
+                    "max": 704.83203125,
+                    "sum": 1948.3068296370984,
+                    "avg": 649.4356098790321,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 12.303771608827,
+                    "min": 3.19303099134812,
+                    "max": 5.27164915240741,
+                    "avg": 4.10125720294234,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 600.7890625,
+                    "max": 720.25390625,
+                    "sum": 1983.504410282259,
+                    "avg": 661.1681367607526,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 593.32421875,
+                    "max": 704.83203125,
+                    "sum": 1948.3068296370984,
+                    "avg": 649.4356098790321,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db",
+    "interval_start_time": "2023-04-14T20:44:20.982Z",
+    "interval_end_time": "2023-04-14T20:59:20.982Z",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 11.3112178759358,
+                    "min": 3.33503295274444,
+                    "max": 4.81386723182222,
+                    "avg": 3.77040595864527,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 271.59375,
+                    "max": 356.5390625,
+                    "sum": 989.438004032259,
+                    "avg": 329.8126680107527,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 265.66796875,
+                    "max": 348.39453125,
+                    "sum": 956.612777217741,
+                    "avg": 318.8709257392473,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "metrics": [
+              {
+                "name": "cpuRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 16.11,
+                    "avg": 5.37,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 24.0,
+                    "avg": 8.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuThrottle",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 0.0,
+                    "max": 0.0,
+                    "avg": 0.0,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "cpuUsage",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 11.3112178759358,
+                    "min": 3.33503295274444,
+                    "max": 4.81386723182222,
+                    "avg": 3.77040595864527,
+                    "format": "cores"
+                  }
+                }
+              },
+              {
+                "name": "memoryRequest",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 3413.2003784179688,
+                    "avg": 1137.7334594726562,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryLimit",
+                "results": {
+                  "aggregation_info": {
+                    "sum": 4291.534423828125,
+                    "avg": 1430.511474609375,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryUsage",
+                "results": {
+                  "aggregation_info": {
+                    "min": 271.59375,
+                    "max": 356.5390625,
+                    "sum": 989.438004032259,
+                    "avg": 329.8126680107527,
+                    "format": "MiB"
+                  }
+                }
+              },
+              {
+                "name": "memoryRSS",
+                "results": {
+                  "aggregation_info": {
+                    "min": 265.66796875,
+                    "max": 348.39453125,
+                    "sum": 956.612777217741,
+                    "avg": 318.8709257392473,
+                    "format": "MiB"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This PR fixes the duplicate record mismatch issue after hitting the updateResults API. We were seeing a difference in the number of records getting saved in the DB.

Note: Created this separate PR against the 0.0.19 branch. PR #1051 was raised against master.