### PR TITLE
Update List exp API to get only the experiment Names

### DIFF
--- a/src/main/java/com/autotune/analyzer/Analyzer.java
+++ b/src/main/java/com/autotune/analyzer/Analyzer.java
@@ -44,6 +44,7 @@ public class Analyzer {
         context.addServlet(ListKruizeTunables.class, ServerContext.LIST_KRUIZE_TUNABLES);
         context.addServlet(SearchSpace.class, ServerContext.SEARCH_SPACE);
         context.addServlet(ListExperiments.class, ServerContext.LIST_EXPERIMENTS);
+        context.addServlet(ListExperiments.class, ServerContext.LIST_EXPERIMENT_NAMES);
         context.addServlet(ExperimentsSummary.class, ServerContext.EXPERIMENTS_SUMMARY);
         context.addServlet(CreateExperiment.class, ServerContext.CREATE_EXPERIMENT);
         context.addServlet(UpdateResults.class, ServerContext.UPDATE_RESULTS);

--- a/src/main/java/com/autotune/analyzer/services/ListExperiments.java
+++ b/src/main/java/com/autotune/analyzer/services/ListExperiments.java
@@ -226,6 +226,8 @@ public class ListExperiments extends HttpServlet {
             if (invalidParams.isEmpty()) {
                 int page = parseIntegerOrDefault(pageStr, AnalyzerConstants.DEFAULT_PAGE_VALUE);
                 int limit = parseIntegerOrDefault(limitStr, AnalyzerConstants.DEFAULT_LIMIT_VALUE);
+                // trim the search string and remove the asterisks, if present.
+                searchString = searchString.trim().replace("*", "");
                 // Fetch experiment names data from the DB based on search string
                 kruizeExperimentsList = loadExperimentNamesFromDatabase(searchString, page, limit);
                 long count;

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -86,6 +86,8 @@ public class AnalyzerConstants {
     public static final String TARGET = "target/bin";
     public static final String MIGRATIONS = "migrations";
     public static final String DDL = "kruize_experiments_ddl.sql";
+    public static final int DEFAULT_PAGE_VALUE = 1;
+    public static final int DEFAULT_LIMIT_VALUE = 20;
 
 
     private AnalyzerConstants() {
@@ -311,6 +313,8 @@ public class AnalyzerConstants {
         public static final String LATEST = "latest";
         public static final String EXPERIMENT_REGISTERED = "Registered successfully with Kruize! View registered experiments at /listExperiments";
         public static final String RESULT_SAVED = "Results added successfully! View saved results at /listExperiments.";
+        public static final String PAGE = "page";
+        public static final String LIMIT = "limit";
 
         private ServiceConstants() {
         }

--- a/src/main/java/com/autotune/database/dao/ExperimentDAO.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAO.java
@@ -68,4 +68,9 @@ public interface ExperimentDAO {
 
     public void addPartitions(String tableName, String month, String year, int dayOfTheMonth, String partitionType) throws Exception;
 
+    List<String> loadAllExperimentNames(int page, int limit) throws Exception;
+
+    List<String> loadExperimentNamesBasedOnSearchString(String searchString, int page, int limit) throws Exception;
+
+    long getExperimentsCount(String searchString) throws Exception;
 }

--- a/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
@@ -663,4 +663,53 @@ public class ExperimentDAOImpl implements ExperimentDAO {
         yearMonth = YearMonth.of(year, month);
         return yearMonth;
     }
+
+    @Override
+    public List<String> loadAllExperimentNames(int page, int limit) throws Exception {
+        List<String> experimentNames;
+        try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
+            Query<String> query = session.createQuery(DBConstants.SQLQUERY.SELECT_EXPERIMENT_NAME_FROM_EXPERIMENTS, String.class);
+            query.setFirstResult((page - 1) * limit); // Calculate the offset
+            query.setMaxResults(limit);
+            experimentNames = query.list();
+        } catch (Exception e) {
+            LOGGER.error("Not able to load experiment names due to {}", e.getMessage());
+            throw new Exception("Error while loading experiment names from database due to : " + e.getMessage());
+        }
+        return experimentNames;
+    }
+
+    @Override
+    public List<String> loadExperimentNamesBasedOnSearchString(String searchString, int page, int limit) throws Exception {
+        List<String> experimentNames;
+        try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
+            Query<String> query = session.createQuery(DBConstants.SQLQUERY.SELECT_EXPERIMENT_NAME_FROM_EXPERIMENTS_BY_NAME, String.class);
+            query.setParameter("search", "%" + searchString + "%");
+            query.setFirstResult((page - 1) * limit); // Calculate the offset
+            query.setMaxResults(limit);
+            experimentNames = query.list();
+        } catch (Exception e) {
+            LOGGER.error("Not able to load experiment names due to {}", e.getMessage());
+            throw new Exception("Error while loading experiment names from database due to : " + e.getMessage());
+        }
+        return experimentNames;
+    }
+
+    @Override
+    public long getExperimentsCount(String searchString) throws Exception {
+        Long experimentNamesCount;
+        try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
+            if (searchString.isBlank()) {
+                experimentNamesCount = session.createQuery(DBConstants.SQLQUERY.SELECT_EXPERIMENT_NAME_COUNT, Long.class).getSingleResult();
+            } else {
+                experimentNamesCount = session.createQuery(DBConstants.SQLQUERY.SELECT_SEARCHED_EXPERIMENT_NAME_COUNT, Long.class)
+                        .setParameter("search", "%" + searchString + "%").getSingleResult();
+            }
+        } catch (Exception e) {
+            LOGGER.error("Not able to get the experiment names count due to {}", e.getMessage());
+            throw new Exception("Error while getting experiment names count from database due to : " + e.getMessage());
+        }
+        return experimentNamesCount;
+    }
+
 }

--- a/src/main/java/com/autotune/database/helper/DBConstants.java
+++ b/src/main/java/com/autotune/database/helper/DBConstants.java
@@ -44,6 +44,10 @@ public class DBConstants {
         public static final String DELETE_FROM_RESULTS_BY_EXP_NAME = "DELETE FROM KruizeResultsEntry k WHERE k.experiment_name = :experimentName";
         public static final String DELETE_FROM_RECOMMENDATIONS_BY_EXP_NAME = "DELETE FROM KruizeRecommendationEntry k WHERE k.experiment_name = :experimentName";
         public static final String DB_PARTITION_DATERANGE = "CREATE TABLE IF NOT EXISTS %s_%s%s%s PARTITION OF %s FOR VALUES FROM ('%s-%s-%s 00:00:00.000') TO ('%s-%s-%s 23:59:59');";
+        public static final String SELECT_EXPERIMENT_NAME_FROM_EXPERIMENTS = "SELECT experiment_name " + SELECT_FROM_EXPERIMENTS;
+        public static final String SELECT_EXPERIMENT_NAME_FROM_EXPERIMENTS_BY_NAME = SELECT_EXPERIMENT_NAME_FROM_EXPERIMENTS + " WHERE experiment_name LIKE :search";
+        public static final String SELECT_EXPERIMENT_NAME_COUNT = "SELECT count(k) " + SELECT_FROM_EXPERIMENTS + " k";
+        public static final String SELECT_SEARCHED_EXPERIMENT_NAME_COUNT = SELECT_EXPERIMENT_NAME_COUNT + " WHERE experiment_name LIKE :search";
     }
 
     public static final class TABLE_NAMES {

--- a/src/main/java/com/autotune/database/service/ExperimentDBService.java
+++ b/src/main/java/com/autotune/database/service/ExperimentDBService.java
@@ -362,4 +362,16 @@ public class ExperimentDBService {
         }
         return experimentResultDataList;
     }
+
+    public List<String> loadAllExperimentNames(int page, int limit) throws Exception {
+        return experimentDAO.loadAllExperimentNames(page, limit);
+    }
+
+    public List<String> loadExperimentNamesBasedOnSearchString(String searchString, int page, int limit) throws Exception {
+        return experimentDAO.loadExperimentNamesBasedOnSearchString(searchString, page, limit);
+    }
+
+    public Long getExperimentsCount(String searchString) throws Exception {
+        return experimentDAO.getExperimentsCount(searchString);
+    }
 }

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -209,6 +209,7 @@ public class KruizeConstants {
         public static final String RECOMMENDATION_TERMS = "recommendation_terms";
         public static final String RECOMMENDATION_ENGINES = "recommendation_engines";
         public static final String CONFIDENCE_LEVEL = "confidence_level";
+        public static final String SEARCH = "search";
 
         private JSONKeys() {
         }

--- a/src/main/java/com/autotune/utils/KruizeSupportedTypes.java
+++ b/src/main/java/com/autotune/utils/KruizeSupportedTypes.java
@@ -83,4 +83,7 @@ public class KruizeSupportedTypes
 	public static final Set<String> QUERY_PARAMS_SUPPORTED = new HashSet<>(Arrays.asList(
 			"experiment_name", "results", "recommendations", "latest"
 	));
+	public static final Set<String> SEARCH_PARAMS_SUPPORTED = new HashSet<>(Arrays.asList(
+			"search", "page", "limit"
+	));
 }

--- a/src/main/java/com/autotune/utils/ServerContext.java
+++ b/src/main/java/com/autotune/utils/ServerContext.java
@@ -35,6 +35,7 @@ public class ServerContext {
     public static final String LIST_STACK_TUNABLES = ROOT_CONTEXT + "listStackTunables";
     public static final String SEARCH_SPACE = ROOT_CONTEXT + "searchSpace";
     public static final String LIST_EXPERIMENTS = ROOT_CONTEXT + "listExperiments";
+    public static final String LIST_EXPERIMENT_NAMES = LIST_EXPERIMENTS + ROOT_CONTEXT + "getExperimentNames";
     public static final String EXPERIMENTS_SUMMARY = ROOT_CONTEXT + "experimentsSummary";
     public static final String CREATE_EXPERIMENT = ROOT_CONTEXT + "createExperiment";
     public static final String UPDATE_RESULTS = ROOT_CONTEXT + "updateResults";


### PR DESCRIPTION
This PR fixes #1031 

- Updated the existing list experiment API to have a variant to get only the experiment Names as a list of string.
- Endpoint : `http://127.0.0.1:8080/listExperiments/getExperimentNames?search=<search-string>&page=1&limit=20`
- By default i.e. no search-string, no page or limit,  it will return all experiment names with limit set as 20 for each page.
- Sample response:
```
{
    "experimentNames": [
        "quarkus-resteasy-autotune-min-http-response-time-db",
        "2quarkus-resteasy-autotune-min-http-response-time-db",
        "3quarkus-resteasy-autotune-min-http-response-time-db",
        "4quarkus-resteasy-autotune-min-http-response-time-db"
    ],
    "count": 4
}
```
- Here `count` represents the total no. of experiment names present in the DB corresponding to the particular search-string. It will return the total experiment names count in the absence of search-string. 
- Also, count will remain same for all the paginated results for each specific request 
