### PR TITLE
Adding Support For Default DataSource and Removing Monitoring Agent

### DIFF
--- a/src/main/java/com/autotune/Autotune.java
+++ b/src/main/java/com/autotune/Autotune.java
@@ -16,10 +16,10 @@
 package com.autotune;
 
 import com.autotune.analyzer.Analyzer;
+import com.autotune.analyzer.exceptions.DefaultDataSourceNotFoundException;
 import com.autotune.analyzer.exceptions.K8sTypeNotSupportedException;
 import com.autotune.analyzer.exceptions.KruizeErrorHandler;
-import com.autotune.analyzer.exceptions.MonitoringAgentNotFoundException;
-import com.autotune.analyzer.exceptions.MonitoringAgentNotSupportedException;
+import com.autotune.analyzer.exceptions.DefaultDataSourceNotFoundException;
 import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.database.helper.DBConstants;
 import com.autotune.database.init.KruizeHibernateUtil;
@@ -102,8 +102,8 @@ public class Autotune {
             InitializeDeployment.setup_deployment_info();
             // Read and execute the DDLs here
             executeDDLs();
-        } catch (Exception | K8sTypeNotSupportedException | MonitoringAgentNotSupportedException |
-                 MonitoringAgentNotFoundException e) {
+        } catch (Exception | K8sTypeNotSupportedException |
+                 DefaultDataSourceNotFoundException e) {
             e.printStackTrace();
             System.exit(1);
         }

--- a/src/main/java/com/autotune/analyzer/exceptions/DefaultDataSourceNotFoundException.java
+++ b/src/main/java/com/autotune/analyzer/exceptions/DefaultDataSourceNotFoundException.java
@@ -15,12 +15,12 @@
  *******************************************************************************/
 package com.autotune.analyzer.exceptions;
 
-public class MonitoringAgentNotFoundException extends Throwable
+public class DefaultDataSourceNotFoundException extends Throwable
 {
-	public MonitoringAgentNotFoundException() {
+	public DefaultDataSourceNotFoundException() {
 	}
 
-	public MonitoringAgentNotFoundException(String message) {
+	public DefaultDataSourceNotFoundException(String message) {
 		super(message);
 	}
 }

--- a/src/main/java/com/autotune/analyzer/kruizeLayer/LayerPresenceQuery.java
+++ b/src/main/java/com/autotune/analyzer/kruizeLayer/LayerPresenceQuery.java
@@ -31,7 +31,7 @@ public class LayerPresenceQuery {
 							  String layerPresenceQuery,
 							  String layerPresenceKey) throws MonitoringAgentNotSupportedException {
 
-		if (KruizeSupportedTypes.MONITORING_AGENTS_SUPPORTED.contains(datasource)) {
+		if (KruizeSupportedTypes.DATASOURCES_SUPPORTED.contains(datasource)) {
 			this.dataSource = datasource;
 		} else {
 			throw new MonitoringAgentNotSupportedException();

--- a/src/main/java/com/autotune/analyzer/performanceProfiles/PerformanceProfileValidation.java
+++ b/src/main/java/com/autotune/analyzer/performanceProfiles/PerformanceProfileValidation.java
@@ -144,7 +144,7 @@ public class PerformanceProfileValidation {
             String expression = null;
             for (Metric functionVariable : sloInfo.getFunctionVariables()) {
                 // Check if datasource is supported
-                if (!KruizeSupportedTypes.MONITORING_AGENTS_SUPPORTED.contains(functionVariable.getDatasource().toLowerCase())) {
+                if (!KruizeSupportedTypes.DATASOURCES_SUPPORTED.contains(functionVariable.getDatasource().toLowerCase())) {
                     errorString.append(AnalyzerConstants.AutotuneObjectConstants.FUNCTION_VARIABLE)
                             .append(functionVariable.getName())
                             .append(AnalyzerErrorConstants.AutotuneObjectErrors.DATASOURCE_NOT_SUPPORTED);

--- a/src/main/java/com/autotune/analyzer/utils/ServiceHelpers.java
+++ b/src/main/java/com/autotune/analyzer/utils/ServiceHelpers.java
@@ -143,7 +143,7 @@ public class ServiceHelpers {
             if (sloClass == null || tunable.sloClassList.contains(sloClass)) {
                 JSONObject tunableJson = new JSONObject();
                 addTunable(tunableJson, tunable);
-                String tunableQuery = tunable.getQueries().get(KruizeDeploymentInfo.monitoring_agent);
+                String tunableQuery = tunable.getQueries().get(KruizeDeploymentInfo.defaultDataSource.getProvider());
                 String query = AnalyzerConstants.NONE;
                 if (tunableQuery != null && !tunableQuery.isEmpty()) {
                     query = tunableQuery;

--- a/src/main/java/com/autotune/common/datasource/DataSourceCollection.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceCollection.java
@@ -62,6 +62,31 @@ public class DataSourceCollection {
     }
 
     /**
+     * Returns the object of default dataSource
+     * @return DataSourceInfo object
+     */
+    public DataSourceInfo getDefaultDataSource() {
+        return dataSourceCollection.get(KruizeConstants.DataSourceConstants.DEFAULT_DATASOURCE_NAME);
+    }
+
+    /**
+     * Set or update the default dataSource
+     * @param dataSource dataSourceInfo object containing the details of default datasource
+     */
+    public void setDefaultDataSource(DataSourceInfo dataSource) {
+        if (dataSourceCollection.containsKey(KruizeConstants.DataSourceConstants.DEFAULT_DATASOURCE_NAME)) {
+            updateDataSource(KruizeConstants.DataSourceConstants.DEFAULT_DATASOURCE_NAME, dataSource);
+        } else {
+            if (!dataSource.getName().equalsIgnoreCase(KruizeConstants.DataSourceConstants.DEFAULT_DATASOURCE_NAME)) {
+                addDataSource(dataSource);
+            } else {
+                LOGGER.error(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.INVALID_DEFAULT_DATASOURCE_NAME);
+            }
+
+        }
+    }
+
+    /**
      * Adds datasource to collection
      * @param datasource DataSourceInfo object containing details of datasource
      */

--- a/src/main/java/com/autotune/common/datasource/DataSourceOperatorImpl.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceOperatorImpl.java
@@ -1,6 +1,6 @@
 package com.autotune.common.datasource;
 
-import com.autotune.analyzer.exceptions.MonitoringAgentNotFoundException;
+import com.autotune.analyzer.exceptions.DefaultDataSourceNotFoundException;
 import com.autotune.analyzer.exceptions.TooManyRecursiveCallsException;
 import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.common.datasource.prometheus.PrometheusDataOperatorImpl;
@@ -147,33 +147,6 @@ public class DataSourceOperatorImpl implements DataSourceOperator{
             LOGGER.error("Unable to proceed due to invalid connection to URL: "+ queryURL);
         }
         return valuesList;
-    }
-
-    /**
-     * TODO: monitoring agent will be replaced by default datasource later
-     * returns DataSourceInfo objects for default datasource which is currently monitoring agent
-     * @return DataSourceInfo objects
-     */
-    public static DataSourceInfo getMonitoringAgent(String dataSource) throws MonitoringAgentNotFoundException, MalformedURLException {
-        String monitoringAgentEndpoint;
-        DataSourceInfo monitoringAgent = null;
-
-        if (dataSource.toLowerCase().equals(KruizeDeploymentInfo.monitoring_agent)) {
-            monitoringAgentEndpoint = KruizeDeploymentInfo.monitoring_agent_endpoint;
-            // Monitoring agent endpoint not set in the configmap
-            if (monitoringAgentEndpoint == null || monitoringAgentEndpoint.isEmpty()) {
-                monitoringAgentEndpoint = getServiceEndpoint(KruizeDeploymentInfo.monitoring_service);
-            }
-            if (dataSource.equals(AnalyzerConstants.PROMETHEUS_DATA_SOURCE)) {
-                monitoringAgent = new DataSourceInfo(KruizeDeploymentInfo.monitoring_agent, AnalyzerConstants.PROMETHEUS_DATA_SOURCE, new URL(monitoringAgentEndpoint));
-            }
-        }
-
-        if (monitoringAgent == null) {
-            LOGGER.error("Datasource " + dataSource + " not supported");
-        }
-
-        return monitoringAgent;
     }
 
     /**

--- a/src/main/java/com/autotune/jobs/CreatePartition.java
+++ b/src/main/java/com/autotune/jobs/CreatePartition.java
@@ -1,8 +1,7 @@
 package com.autotune.jobs;
 
 import com.autotune.analyzer.exceptions.K8sTypeNotSupportedException;
-import com.autotune.analyzer.exceptions.MonitoringAgentNotFoundException;
-import com.autotune.analyzer.exceptions.MonitoringAgentNotSupportedException;
+import com.autotune.analyzer.exceptions.DefaultDataSourceNotFoundException;
 import com.autotune.database.dao.ExperimentDAOImpl;
 import com.autotune.database.helper.DBConstants;
 import com.autotune.database.init.KruizeHibernateUtil;
@@ -47,8 +46,7 @@ public class CreatePartition {
                     timerAddBulkResultsDB.stop(MetricsConfig.timerAddBulkResultsDB);
                 }
             }
-        } catch (Exception | K8sTypeNotSupportedException | MonitoringAgentNotSupportedException |
-                 MonitoringAgentNotFoundException e) {
+        } catch (Exception | K8sTypeNotSupportedException | DefaultDataSourceNotFoundException e) {
             e.printStackTrace();
             System.exit(1);
         }

--- a/src/main/java/com/autotune/jobs/RetentionPartition.java
+++ b/src/main/java/com/autotune/jobs/RetentionPartition.java
@@ -1,8 +1,7 @@
 package com.autotune.jobs;
 
 import com.autotune.analyzer.exceptions.K8sTypeNotSupportedException;
-import com.autotune.analyzer.exceptions.MonitoringAgentNotFoundException;
-import com.autotune.analyzer.exceptions.MonitoringAgentNotSupportedException;
+import com.autotune.analyzer.exceptions.DefaultDataSourceNotFoundException;
 import com.autotune.database.init.KruizeHibernateUtil;
 import com.autotune.operator.InitializeDeployment;
 import org.hibernate.Session;
@@ -18,8 +17,7 @@ public class RetentionPartition {
         LOGGER.info("Checking Liveliness probe DB connection...");
         try {
             InitializeDeployment.setup_deployment_info();
-        } catch (Exception | K8sTypeNotSupportedException | MonitoringAgentNotSupportedException |
-                 MonitoringAgentNotFoundException e) {
+        } catch (Exception | K8sTypeNotSupportedException | DefaultDataSourceNotFoundException e) {
             e.printStackTrace();
             System.exit(1);
         }

--- a/src/main/java/com/autotune/operator/KruizeDeploymentInfo.java
+++ b/src/main/java/com/autotune/operator/KruizeDeploymentInfo.java
@@ -22,6 +22,8 @@ import com.autotune.analyzer.kruizeLayer.layers.ContainerLayer;
 import com.autotune.analyzer.kruizeLayer.layers.GenericLayer;
 import com.autotune.analyzer.kruizeLayer.layers.HotspotLayer;
 import com.autotune.analyzer.kruizeLayer.layers.QuarkusLayer;
+import com.autotune.common.datasource.DataSourceCollection;
+import com.autotune.common.datasource.DataSourceInfo;
 import com.autotune.utils.KruizeSupportedTypes;
 import com.autotune.utils.KubeEventLogger;
 import org.slf4j.Logger;
@@ -53,9 +55,7 @@ public class KruizeDeploymentInfo {
     public static String settings_hibernate_show_sql;
     public static String settings_hibernate_time_zone;
     public static String autotune_mode;
-    public static String monitoring_agent;
-    public static String monitoring_service;
-    public static String monitoring_agent_endpoint;
+    public static DataSourceInfo defaultDataSource;
     public static String cluster_type;
     public static String k8s_type;       // ABC
     public static String auth_type;
@@ -89,17 +89,6 @@ public class KruizeDeploymentInfo {
     public static Class getLayer(String layerName) {
         return tunableLayerPair.get(layerName);
     }
-
-
-    public static void setMonitoring_agent_endpoint(String monitoring_agent_endpoint) {
-        if (monitoring_agent_endpoint.endsWith("/")) {
-            KruizeDeploymentInfo.monitoring_agent_endpoint =
-                    monitoring_agent_endpoint.substring(0, monitoring_agent_endpoint.length() - 1);
-        } else {
-            KruizeDeploymentInfo.monitoring_agent_endpoint = monitoring_agent_endpoint;
-        }
-    }
-
 
     public static void setCluster_type(String cluster_type) throws ClusterTypeNotSupportedException {
         if (cluster_type != null)
@@ -144,33 +133,18 @@ public class KruizeDeploymentInfo {
         }
     }
 
+    public static void setDefaultDataSource() {
+        KruizeDeploymentInfo.defaultDataSource = DataSourceCollection.getInstance().getDefaultDataSource();
 
-    public static void setMonitoring_agent(String monitoring_agent) throws MonitoringAgentNotSupportedException {
-        if (monitoring_agent != null)
-            monitoring_agent = monitoring_agent.toLowerCase();
-
-        if (KruizeSupportedTypes.MONITORING_AGENTS_SUPPORTED.contains(monitoring_agent)) {
-            KruizeDeploymentInfo.monitoring_agent = monitoring_agent;
-        } else {
-            LOGGER.error("Monitoring agent {}  is not supported", monitoring_agent);
-            throw new MonitoringAgentNotSupportedException();
-        }
-    }
-
-
-    public static void setMonitoringAgentService(String monitoringAgentService) {
-        if (monitoringAgentService != null)
-            KruizeDeploymentInfo.monitoring_service = monitoringAgentService.toLowerCase();
     }
 
     public static void logDeploymentInfo() {
         LOGGER.info("Cluster Type: {}", KruizeDeploymentInfo.cluster_type);
         LOGGER.info("Kubernetes Type: {}", KruizeDeploymentInfo.k8s_type);
         LOGGER.info("Auth Type: {}", KruizeDeploymentInfo.auth_type);
-        LOGGER.info("Monitoring Agent: {}", KruizeDeploymentInfo.monitoring_agent);
-        LOGGER.info("Monitoring Agent URL: {}", KruizeDeploymentInfo.monitoring_agent_endpoint);
-        LOGGER.info("Monitoring agent service: {}\n\n", KruizeDeploymentInfo.monitoring_service);
+        LOGGER.info("Default Datasource: {}", KruizeDeploymentInfo.defaultDataSource.getName());
+        LOGGER.info("Default Datasource URL: {}", KruizeDeploymentInfo.defaultDataSource.getUrl());
+        LOGGER.info("Default Datasource Provider: {}\n\n", KruizeDeploymentInfo.defaultDataSource.getProvider());
     }
-
 
 }

--- a/src/main/java/com/autotune/operator/KruizeOperator.java
+++ b/src/main/java/com/autotune/operator/KruizeOperator.java
@@ -32,6 +32,7 @@ import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.analyzer.utils.AnalyzerConstants.AutotuneConfigConstants;
 import com.autotune.analyzer.utils.AnalyzerErrorConstants;
 import com.autotune.common.data.ValidationOutputData;
+import com.autotune.common.datasource.DataSourceCollection;
 import com.autotune.common.datasource.DataSourceInfo;
 import com.autotune.common.datasource.DataSourceOperatorImpl;
 import com.autotune.common.exceptions.DataSourceNotExist;
@@ -495,7 +496,7 @@ public class KruizeOperator {
                 for (Object query : layerPresenceQueryJson) {
                     JSONObject queryJson = (JSONObject) query;
                     String datasource = queryJson.getString(AnalyzerConstants.AutotuneConfigConstants.DATASOURCE);
-                    if (datasource.equalsIgnoreCase(KruizeDeploymentInfo.monitoring_agent)) {
+                    if (datasource.equalsIgnoreCase(KruizeDeploymentInfo.defaultDataSource.getProvider())) {
                         layerPresenceQueryStr = queryJson.getString(AnalyzerConstants.AutotuneConfigConstants.QUERY);
                         layerPresenceKey = queryJson.getString(AnalyzerConstants.AutotuneConfigConstants.KEY);
                         // Replace the queryvariables in the query
@@ -668,8 +669,11 @@ public class KruizeOperator {
             }
             DataSourceInfo autotuneDataSource = null;
             try {
-                autotuneDataSource = DataSourceOperatorImpl.getMonitoringAgent(KruizeDeploymentInfo.monitoring_agent);
-            } catch (MonitoringAgentNotFoundException e) {
+                autotuneDataSource = DataSourceCollection.getInstance().getDefaultDataSource();
+                if (autotuneDataSource == null){
+                    throw new DefaultDataSourceNotFoundException(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.DEFAULT_DATASOURCE_NOT_FOUND);
+                }
+            } catch (DefaultDataSourceNotFoundException e) {
                 e.printStackTrace();
             }
             ArrayList<String> appsForAllQueries = new ArrayList<>();

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -331,6 +331,7 @@ public class KruizeConstants {
 
     public static class DataSourceConstants {
         public static final String DATASOURCE_NAME = "name";
+        public static final String DEFAULT_DATASOURCE_NAME = "default";
         public static final String DATASOURCE_PROVIDER = "provider";
         public static final String DATASOURCE_SERVICE_NAME = "serviceName";
         public static final String DATASOURCE_SERVICE_NAMESPACE = "namespace";
@@ -374,6 +375,9 @@ public class KruizeConstants {
             public static final String DATASOURCE_NOT_SUPPORTED = "Datasource is not supported: ";
             public static final String SERVICE_NOT_FOUND = "Can not find service with specified name.";
             public static final String ENDPOINT_NOT_FOUND = "Service endpoint not found.";
+            public static final String INVALID_DEFAULT_DATASOURCE_NAME = "Invalid default datasource name.";
+            public static final String DEFAULT_DATASOURCE_NOT_FOUND = "Default datasource is not set.";
+
         }
         private DataSourceConstants() {
         }
@@ -461,9 +465,7 @@ public class KruizeConstants {
         public static final String K8S_TYPE = "k8stype";
         public static final String AUTH_TYPE = "authtype";
         public static final String AUTH_TOKEN = "authtoken";
-        public static final String MONITORING_AGENT = "monitoringagent";
-        public static final String MONITORING_SERVICE = "monitoringservice";
-        public static final String MONITORING_AGENT_ENDPOINT = "monitoringendpoint";
+
         public static final String CLUSTER_TYPE = "clustertype";
         public static final String AUTOTUNE_MODE = "autotunemode";
         public static final String EM_ONLY_MODE = "emonly";

--- a/src/main/java/com/autotune/utils/KruizeSupportedTypes.java
+++ b/src/main/java/com/autotune/utils/KruizeSupportedTypes.java
@@ -29,7 +29,7 @@ public class KruizeSupportedTypes
 	public static final Set<String> DIRECTIONS_SUPPORTED =
 			new HashSet<>(Arrays.asList("minimize", "maximize"));
 
-	public static final Set<String> MONITORING_AGENTS_SUPPORTED =
+	public static final Set<String> DATASOURCES_SUPPORTED =
 			new HashSet<>(Arrays.asList("prometheus"));
 
 	public static final Set<String> MODES_SUPPORTED =

--- a/src/main/java/com/autotune/utils/TrialHelpers.java
+++ b/src/main/java/com/autotune/utils/TrialHelpers.java
@@ -28,6 +28,7 @@ import com.autotune.analyzer.performanceProfiles.PerformanceProfilesDeployment;
 import com.autotune.common.annotations.json.KruizeJSONExclusionStrategy;
 import com.autotune.common.data.metrics.Metric;
 import com.autotune.common.data.metrics.MetricResults;
+import com.autotune.common.datasource.DataSourceCollection;
 import com.autotune.common.datasource.DataSourceInfo;
 import com.autotune.common.trials.*;
 import com.autotune.experimentManager.exceptions.IncompatibleInputJSONException;
@@ -145,9 +146,9 @@ public class TrialHelpers {
                 trialNumber,
                 trialResultUrl.toString());
 
-        DataSourceInfo datasourceInfo = new DataSourceInfo(KruizeDeploymentInfo.monitoring_agent, KruizeConstants.SupportedDatasources.PROMETHEUS, new URL(KruizeDeploymentInfo.monitoring_agent_endpoint));
+        DataSourceInfo datasourceInfo = KruizeDeploymentInfo.defaultDataSource;
         HashMap<String, DataSourceInfo> datasourceInfoHashMap = new HashMap<>();
-        datasourceInfoHashMap.put(KruizeDeploymentInfo.monitoring_agent, datasourceInfo);  //Change key value as per YAML input
+        datasourceInfoHashMap.put(KruizeConstants.DataSourceConstants.DEFAULT_DATASOURCE_NAME, datasourceInfo);  //Change key value as per YAML input
         DeploymentTracking deploymentTracking = new DeploymentTracking();
         DeploymentSettings deploymentSettings = new DeploymentSettings(deploymentPolicy,
                 deploymentTracking);
@@ -201,7 +202,7 @@ public class TrialHelpers {
                 LOGGER.error("ERROR: tunable is null for tunableName: " + tunableName);
             }
             ApplicationServiceStack applicationServiceStack = kruizeExperiment.getApplicationDeployment().getApplicationServiceStackMap().get(tunable.getStackName());
-            String tunableQuery = tunable.getQueries().get(KruizeDeploymentInfo.monitoring_agent);
+            String tunableQuery = tunable.getQueries().get(KruizeDeploymentInfo.defaultDataSource.getProvider());
             Class<Layer> classRef = KruizeDeploymentInfo.getLayer(tunable.getLayerName());
             try {
                 Object inst = classRef.getDeclaredConstructor().newInstance();
@@ -220,7 +221,7 @@ public class TrialHelpers {
             if (tunableQuery != null && !tunableQuery.isEmpty()) {
                 Metric queryMetric = new Metric(tunable.getName(),
                         tunableQuery,
-                        KruizeDeploymentInfo.monitoring_agent,
+                        KruizeDeploymentInfo.defaultDataSource.getProvider(),
                         tunable.getValueType(), null);
                 if (containerMetricsHashMap != null
                         && !containerMetricsHashMap.isEmpty()


### PR DESCRIPTION
## Description

This PR will add the support for setting up the `default datasource` instead of monitoring agent. Default datasource will use the newly implemented `DataSourceInfo` class objects. 

### Type of change

- [x] Refactoring Code
- [x] New feature

## How has this been tested?

Using kruize-demo scripts. 
Image: `quay.io/rh-ee-shesaxen/autotune:kruize-local-default-datasource-v1`

**Test Configuration**
* Kubernetes clusters tested on: minikube

## Checklist :dart:

- [X] Followed coding guidelines
- [X] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Remote Monitoring Demo Logs: https://pastebin.com/8JtWxsi5