### PR TITLE
Fix UpdateResults Test Failures

### DIFF
--- a/src/main/java/com/autotune/analyzer/serviceObjects/verification/validators/KubernetesElementsValidator.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/verification/validators/KubernetesElementsValidator.java
@@ -141,14 +141,11 @@ public class KubernetesElementsValidator implements ConstraintValidator<Kubernet
 
     /**
      * Validation method for a single ContainerData object
-     * @param containerData
+     * @param containerData contains the container data in which the container name is present which needs to be validated
      * @return list of errors if any, while validating the containerData Object
      */
     private static List<String> validateContainerData(ContainerData containerData) {
         List<String> errors = new ArrayList<>();
-        if (containerData.getContainer_image_name() == null || containerData.getContainer_image_name().trim().isEmpty()) {
-            errors.add(AnalyzerErrorConstants.AutotuneObjectErrors.NULL_OR_BLANK_CONTAINER_IMAGE_NAME);
-        }
         if (containerData.getContainer_name() == null || containerData.getContainer_name().trim().isEmpty()) {
             errors.add(AnalyzerErrorConstants.AutotuneObjectErrors.NULL_OR_BLANK_CONTAINER_NAME);
         }

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
@@ -95,6 +95,8 @@ public class AnalyzerErrorConstants {
         public static final String JSON_PARSING_ERROR = "Failed to parse the JSON. Please check the input payload ";
         public static final String AGGREGATION_INFO_INVALID_VALUE = "Invalid value type for aggregation_info objects. Expected a numeric value (Double).";
         public static final String VERSION_MISMATCH = "Version number mismatch found. Expected: %s , Found: %s";
+        public static final String NULL_OR_BLANK_CONTAINER_IMAGE_NAME = "container_image_name cannot be null or blank";
+        public static final String NULL_OR_BLANK_CONTAINER_NAME = "container_name cannot be null or blank";
 
 
         private AutotuneObjectErrors() {

--- a/tests/scripts/remote_monitoring_tests/helpers/utils.py
+++ b/tests/scripts/remote_monitoring_tests/helpers/utils.py
@@ -197,7 +197,7 @@ def generate_test_data(csvfile, test_data, api_name):
             for t in test_type:
                 data = []
                 # skip checking the invalid container name and container image name
-                if (key == "container_name" or key == "container_image_name") and t == "invalid":
+                if key == "container_image_name" or (key == "container_name" and t == "invalid"):
                     continue
                 #  skip checking the aggregation info values
                 if key in aggr_info_keys_to_skip and t == "null":

--- a/tests/scripts/remote_monitoring_tests/helpers/utils.py
+++ b/tests/scripts/remote_monitoring_tests/helpers/utils.py
@@ -200,7 +200,7 @@ def generate_test_data(csvfile, test_data, api_name):
                 if (key == "container_name" or key == "container_image_name") and t == "invalid":
                     continue
                 #  skip checking the aggregation info values
-                if key in aggr_info_keys_to_skip:
+                if key in aggr_info_keys_to_skip and t == "null":
                     continue
 
                 test_name = t + "_" + key

--- a/tests/scripts/remote_monitoring_tests/helpers/utils.py
+++ b/tests/scripts/remote_monitoring_tests/helpers/utils.py
@@ -138,43 +138,20 @@ update_results_test_data = {
     "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
     "container_name": "tfb-server",
     "cpuRequest_name": "cpuRequest",
-    "cpuRequest_sum": 4.4,
-    "cpuRequest_avg": 1.1,
     "cpuRequest_format": "cores",
     "cpuLimit_name": "cpuLimit",
-    "cpuLimit_sum": 5.4,
-    "cpuLimit_avg": 22.1,
     "cpuLimit_format": "cores",
     "cpuUsage_name": "cpuUsage",
-    "cpuUsage_sum": 3.4,
-    "cpuUsage_max": 2.4,
-    "cpuUsage_avg": 1.5,
-    "cpuUsage_min": 0.5,
     "cpuUsage_format": "cores",
     "cpuThrottle_name": "cpuThrottle",
-    "cpuThrottle_sum": 1.09,
-    "cpuThrottle_max": 0.09,
-    "cpuThrottle_avg": 0.045,
     "cpuThrottle_format": "cores",
     "memoryRequest_name": "memoryRequest",
-    "memoryRequest_sum": 250.85,
-    "memoryRequest_avg": 51.1,
     "memoryRequest_format": "MiB",
     "memoryLimit_name": "memoryLimit",
-    "memoryLimit_sum": 500,
-    "memoryLimit_avg": 100,
     "memoryLimit_format": "MiB",
     "memoryUsage_name": "memoryUsage",
-    "memoryUsage_sum": 298.5,
-    "memoryUsage_max": 198.4,
-    "memoryUsage_avg": 41.5,
-    "memoryUsage_min": 21.5,
     "memoryUsage_format": "MiB",
     "memoryRSS_name": "memoryRSS",
-    "memoryRSS_sum": 225.64,
-    "memoryRSS_max": 125.54,
-    "memoryRSS_avg": 46.5,
-    "memoryRSS_min": 26.5,
     "memoryRSS_format": "MiB"
 }
 
@@ -190,6 +167,9 @@ def generate_test_data(csvfile, test_data, api_name):
         for key in test_data:
             for t in test_type:
                 data = []
+                # skip checking the invalid container name and container image name
+                if (key == "container_name" or key == "container_image_name") and t == "invalid":
+                    continue
 
                 test_name = t + "_" + key
                 status_code = 400

--- a/tests/scripts/remote_monitoring_tests/helpers/utils.py
+++ b/tests/scripts/remote_monitoring_tests/helpers/utils.py
@@ -138,24 +138,53 @@ update_results_test_data = {
     "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
     "container_name": "tfb-server",
     "cpuRequest_name": "cpuRequest",
+    "cpuRequest_sum": 4.4,
+    "cpuRequest_avg": 1.1,
     "cpuRequest_format": "cores",
     "cpuLimit_name": "cpuLimit",
+    "cpuLimit_sum": 5.4,
+    "cpuLimit_avg": 22.1,
     "cpuLimit_format": "cores",
     "cpuUsage_name": "cpuUsage",
+    "cpuUsage_sum": 3.4,
+    "cpuUsage_max": 2.4,
+    "cpuUsage_avg": 1.5,
+    "cpuUsage_min": 0.5,
     "cpuUsage_format": "cores",
     "cpuThrottle_name": "cpuThrottle",
+    "cpuThrottle_sum": 1.09,
+    "cpuThrottle_max": 0.09,
+    "cpuThrottle_avg": 0.045,
     "cpuThrottle_format": "cores",
     "memoryRequest_name": "memoryRequest",
+    "memoryRequest_sum": 250.85,
+    "memoryRequest_avg": 51.1,
     "memoryRequest_format": "MiB",
     "memoryLimit_name": "memoryLimit",
+    "memoryLimit_sum": 500,
+    "memoryLimit_avg": 100,
     "memoryLimit_format": "MiB",
     "memoryUsage_name": "memoryUsage",
+    "memoryUsage_sum": 298.5,
+    "memoryUsage_max": 198.4,
+    "memoryUsage_avg": 41.5,
+    "memoryUsage_min": 21.5,
     "memoryUsage_format": "MiB",
     "memoryRSS_name": "memoryRSS",
+    "memoryRSS_sum": 225.64,
+    "memoryRSS_max": 125.54,
+    "memoryRSS_avg": 46.5,
+    "memoryRSS_min": 26.5,
     "memoryRSS_format": "MiB"
 }
 
 test_type = {"blank": "", "null": "null", "invalid": "xyz"}
+
+aggr_info_keys_to_skip = ["cpuRequest_sum", "cpuRequest_avg", "cpuLimit_sum", "cpuLimit_avg", "cpuUsage_sum", "cpuUsage_max",
+                          "cpuUsage_avg", "cpuUsage_min", "cpuThrottle_sum", "cpuThrottle_max", "cpuThrottle_avg",
+                          "memoryRequest_sum", "memoryRequest_avg", "memoryLimit_sum", "memoryRequest_avg",
+                          "memoryLimit_sum", "memoryLimit_avg", "memoryUsage_sum", "memoryUsage_max", "memoryUsage_avg",
+                          "memoryUsage_min", "memoryRSS_sum", "memoryRSS_max", "memoryRSS_avg", "memoryRSS_min"]
 
 
 def generate_test_data(csvfile, test_data, api_name):
@@ -169,6 +198,9 @@ def generate_test_data(csvfile, test_data, api_name):
                 data = []
                 # skip checking the invalid container name and container image name
                 if (key == "container_name" or key == "container_image_name") and t == "invalid":
+                    continue
+                #  skip checking the aggregation info values
+                if key in aggr_info_keys_to_skip:
                     continue
 
                 test_name = t + "_" + key

--- a/tests/scripts/remote_monitoring_tests/json_files/update_results_template.json
+++ b/tests/scripts/remote_monitoring_tests/json_files/update_results_template.json
@@ -18,8 +18,6 @@
                 "name": "{{cpuRequest_name}}",
                 "results": {
                   "aggregation_info": {
-                    "sum": {{cpuRequest_sum}},
-                    "avg": {{cpuRequest_avg}},
                     "format": "{{cpuRequest_format}}"
                   }
                 }
@@ -28,8 +26,6 @@
                 "name": "{{cpuLimit_name}}",
                 "results": {
                   "aggregation_info": {
-                    "sum": {{cpuLimit_sum}},
-                    "avg": {{cpuLimit_avg}},
                     "format": "{{cpuLimit_format}}"
                   }
                 }
@@ -38,10 +34,6 @@
                 "name": "{{cpuUsage_name}}",
                 "results": {
                   "aggregation_info": {
-                    "min": {{cpuUsage_min}},
-                    "max": {{cpuUsage_max}},
-                    "sum": {{cpuUsage_sum}},
-                    "avg": {{cpuUsage_avg}},
                     "format": "{{cpuUsage_format}}"
                   }
                 }
@@ -50,9 +42,6 @@
                 "name": "{{cpuThrottle_name}}",
                 "results": {
                   "aggregation_info": {
-                    "sum": {{cpuThrottle_sum}},
-                    "max": {{cpuThrottle_max}},
-                    "avg": {{cpuThrottle_avg}},
                     "format": "{{cpuThrottle_format}}"
                   }
                 }
@@ -61,8 +50,6 @@
                 "name": "{{memoryRequest_name}}",
                 "results": {
                   "aggregation_info": {
-                    "sum": {{memoryRequest_sum}},
-                    "avg": {{memoryRequest_avg}},
                     "format": "{{memoryRequest_format}}"
                   }
                 }
@@ -71,8 +58,6 @@
                 "name": "{{memoryLimit_name}}",
                 "results": {
                   "aggregation_info": {
-                    "sum": {{memoryLimit_sum}},
-                    "avg": {{memoryLimit_avg}},
                     "format": "{{memoryLimit_format}}"
                   }
                 }
@@ -81,10 +66,6 @@
                 "name": "{{memoryUsage_name}}",
                 "results": {
                   "aggregation_info": {
-                    "min": {{memoryUsage_min}},
-                    "max": {{memoryUsage_max}},
-                    "sum": {{memoryUsage_sum}},
-                    "avg": {{memoryUsage_avg}},
                     "format": "{{memoryUsage_format}}"
                   }
                 }
@@ -93,10 +74,6 @@
                 "name": "{{memoryRSS_name}}",
                 "results": {
                   "aggregation_info": {
-                    "min": {{memoryRSS_min}},
-                    "max": {{memoryRSS_max}},
-                    "sum": {{memoryRSS_sum}},
-                    "avg": {{memoryRSS_avg}},
                     "format": "{{memoryRSS_format}}"
                   }
                 }

--- a/tests/scripts/remote_monitoring_tests/json_files/update_results_template.json
+++ b/tests/scripts/remote_monitoring_tests/json_files/update_results_template.json
@@ -18,6 +18,8 @@
                 "name": "{{cpuRequest_name}}",
                 "results": {
                   "aggregation_info": {
+                    "sum": {{cpuRequest_sum}},
+                    "avg": {{cpuRequest_avg}},
                     "format": "{{cpuRequest_format}}"
                   }
                 }
@@ -26,6 +28,8 @@
                 "name": "{{cpuLimit_name}}",
                 "results": {
                   "aggregation_info": {
+                    "sum": {{cpuLimit_sum}},
+                    "avg": {{cpuLimit_avg}},
                     "format": "{{cpuLimit_format}}"
                   }
                 }
@@ -34,6 +38,10 @@
                 "name": "{{cpuUsage_name}}",
                 "results": {
                   "aggregation_info": {
+                    "min": {{cpuUsage_min}},
+                    "max": {{cpuUsage_max}},
+                    "sum": {{cpuUsage_sum}},
+                    "avg": {{cpuUsage_avg}},
                     "format": "{{cpuUsage_format}}"
                   }
                 }
@@ -42,6 +50,9 @@
                 "name": "{{cpuThrottle_name}}",
                 "results": {
                   "aggregation_info": {
+                    "sum": {{cpuThrottle_sum}},
+                    "max": {{cpuThrottle_max}},
+                    "avg": {{cpuThrottle_avg}},
                     "format": "{{cpuThrottle_format}}"
                   }
                 }
@@ -50,6 +61,8 @@
                 "name": "{{memoryRequest_name}}",
                 "results": {
                   "aggregation_info": {
+                    "sum": {{memoryRequest_sum}},
+                    "avg": {{memoryRequest_avg}},
                     "format": "{{memoryRequest_format}}"
                   }
                 }
@@ -58,6 +71,8 @@
                 "name": "{{memoryLimit_name}}",
                 "results": {
                   "aggregation_info": {
+                    "sum": {{memoryLimit_sum}},
+                    "avg": {{memoryLimit_avg}},
                     "format": "{{memoryLimit_format}}"
                   }
                 }
@@ -66,6 +81,10 @@
                 "name": "{{memoryUsage_name}}",
                 "results": {
                   "aggregation_info": {
+                    "min": {{memoryUsage_min}},
+                    "max": {{memoryUsage_max}},
+                    "sum": {{memoryUsage_sum}},
+                    "avg": {{memoryUsage_avg}},
                     "format": "{{memoryUsage_format}}"
                   }
                 }
@@ -74,6 +93,10 @@
                 "name": "{{memoryRSS_name}}",
                 "results": {
                   "aggregation_info": {
+                    "min": {{memoryRSS_min}},
+                    "max": {{memoryRSS_max}},
+                    "sum": {{memoryRSS_sum}},
+                    "avg": {{memoryRSS_avg}},
                     "format": "{{memoryRSS_format}}"
                   }
                 }

--- a/tests/scripts/remote_monitoring_tests/rest_apis/test_update_results.py
+++ b/tests/scripts/remote_monitoring_tests/rest_apis/test_update_results.py
@@ -27,20 +27,14 @@ missing_metrics = [
 
 @pytest.mark.negative
 @pytest.mark.parametrize(
-    "test_name, expected_status_code, version, experiment_name, interval_start_time, interval_end_time, kubernetes_obj_type, name, namespace, container_image_name, container_name, cpuRequest_name, cpuRequest_sum, cpuRequest_avg, cpuRequest_format, cpuLimit_name, cpuLimit_sum, cpuLimit_avg, cpuLimit_format, cpuUsage_name, cpuUsage_sum, cpuUsage_max, cpuUsage_avg, cpuUsage_min, cpuUsage_format, cpuThrottle_name, cpuThrottle_sum, cpuThrottle_max, cpuThrottle_avg, cpuThrottle_format, memoryRequest_name, memoryRequest_sum, memoryRequest_avg, memoryRequest_format, memoryLimit_name, memoryLimit_sum, memoryLimit_avg, memoryLimit_format, memoryUsage_name, memoryUsage_sum, memoryUsage_max, memoryUsage_avg, memoryUsage_min, memoryUsage_format, memoryRSS_name, memoryRSS_sum, memoryRSS_max, memoryRSS_avg, memoryRSS_min, memoryRSS_format",
+    "test_name, expected_status_code, version, experiment_name, interval_start_time, interval_end_time, kubernetes_obj_type, name, namespace, container_image_name, container_name, cpuRequest_name, cpuRequest_format, cpuLimit_name, cpuLimit_format, cpuUsage_name, cpuUsage_format, cpuThrottle_name, cpuThrottle_format, memoryRequest_name, memoryRequest_format, memoryLimit_name, memoryLimit_format, memoryUsage_name, memoryUsage_format, memoryRSS_name, memoryRSS_format",
     generate_test_data(csvfile, update_results_test_data, "update_results"))
 def test_update_results_invalid_tests(test_name, expected_status_code, version, experiment_name, interval_start_time,
                                       interval_end_time, kubernetes_obj_type, name, namespace, container_image_name,
-                                      container_name, cpuRequest_name, cpuRequest_sum, cpuRequest_avg,
-                                      cpuRequest_format, cpuLimit_name, cpuLimit_sum, cpuLimit_avg, cpuLimit_format,
-                                      cpuUsage_name, cpuUsage_sum, cpuUsage_max, cpuUsage_avg, cpuUsage_min,
-                                      cpuUsage_format, cpuThrottle_name, cpuThrottle_sum, cpuThrottle_max,
-                                      cpuThrottle_avg, cpuThrottle_format, memoryRequest_name, memoryRequest_sum,
-                                      memoryRequest_avg, memoryRequest_format, memoryLimit_name, memoryLimit_sum,
-                                      memoryLimit_avg, memoryLimit_format, memoryUsage_name, memoryUsage_sum,
-                                      memoryUsage_max, memoryUsage_avg, memoryUsage_min, memoryUsage_format,
-                                      memoryRSS_name, memoryRSS_sum, memoryRSS_max, memoryRSS_avg, memoryRSS_min,
-                                      memoryRSS_format, cluster_type):
+                                      container_name, cpuRequest_name, cpuRequest_format, cpuLimit_name, cpuLimit_format,
+                                      cpuUsage_name, cpuUsage_format, cpuThrottle_name, cpuThrottle_format,
+                                      memoryRequest_name, memoryRequest_format, memoryLimit_name, memoryLimit_format,
+                                      memoryUsage_name, memoryUsage_format, memoryRSS_name, memoryRSS_format, cluster_type):
     print("\n*******************************************************")
     print("Test - ", test_name)
     print("*******************************************************\n")
@@ -88,43 +82,20 @@ def test_update_results_invalid_tests(test_name, expected_status_code, version, 
         container_image_name=container_image_name,
         container_name=container_name,
         cpuRequest_name=cpuRequest_name,
-        cpuRequest_sum=cpuRequest_sum,
-        cpuRequest_avg=cpuRequest_avg,
         cpuRequest_format=cpuRequest_format,
         cpuLimit_name=cpuLimit_name,
-        cpuLimit_sum=cpuLimit_sum,
-        cpuLimit_avg=cpuLimit_avg,
         cpuLimit_format=cpuLimit_format,
         cpuUsage_name=cpuUsage_name,
-        cpuUsage_sum=cpuUsage_sum,
-        cpuUsage_max=cpuUsage_max,
-        cpuUsage_avg=cpuUsage_avg,
-        cpuUsage_min=cpuUsage_min,
         cpuUsage_format=cpuUsage_format,
         cpuThrottle_name=cpuThrottle_name,
-        cpuThrottle_sum=cpuThrottle_sum,
-        cpuThrottle_max=cpuThrottle_max,
-        cpuThrottle_avg=cpuThrottle_avg,
         cpuThrottle_format=cpuThrottle_format,
         memoryRequest_name=memoryRequest_name,
-        memoryRequest_sum=memoryRequest_sum,
-        memoryRequest_avg=memoryRequest_avg,
         memoryRequest_format=memoryRequest_format,
         memoryLimit_name=memoryLimit_name,
-        memoryLimit_sum=memoryLimit_sum,
-        memoryLimit_avg=memoryLimit_avg,
         memoryLimit_format=memoryLimit_format,
         memoryUsage_name=memoryUsage_name,
-        memoryUsage_sum=memoryUsage_sum,
-        memoryUsage_max=memoryUsage_max,
-        memoryUsage_avg=memoryUsage_avg,
-        memoryUsage_min=memoryUsage_min,
         memoryUsage_format=memoryUsage_format,
         memoryRSS_name=memoryRSS_name,
-        memoryRSS_sum=memoryRSS_sum,
-        memoryRSS_max=memoryRSS_max,
-        memoryRSS_avg=memoryRSS_avg,
-        memoryRSS_min=memoryRSS_min,
         memoryRSS_format=memoryRSS_format
     )
     with open(filename, mode="w", encoding="utf-8") as message:
@@ -609,10 +580,12 @@ def test_update_valid_results_without_create_exp(cluster_type):
     data = response.json()
     print("message = ", data['message'])
 
-    EXP_NAME_NOT_FOUND_MSG = "Experiment name : " + experiment_name + " not found"
+    EXP_NAME_NOT_FOUND_MSG = UPDATE_RECOMMENDATIONS_EXPERIMENT_NOT_FOUND + experiment_name
+    FAILED_RECORDS_MSG = "Out of a total of 1 records, 1 failed to save"
     assert response.status_code == ERROR_STATUS_CODE
     assert data['status'] == ERROR_STATUS
-    assert data['message'] == EXP_NAME_NOT_FOUND_MSG
+    assert data['message'] == FAILED_RECORDS_MSG
+    assert data['data'][0]['errors'][0]['message'] == EXP_NAME_NOT_FOUND_MSG
 
 
 @pytest.mark.sanity

--- a/tests/scripts/remote_monitoring_tests/rest_apis/test_update_results.py
+++ b/tests/scripts/remote_monitoring_tests/rest_apis/test_update_results.py
@@ -27,14 +27,20 @@ missing_metrics = [
 
 @pytest.mark.negative
 @pytest.mark.parametrize(
-    "test_name, expected_status_code, version, experiment_name, interval_start_time, interval_end_time, kubernetes_obj_type, name, namespace, container_image_name, container_name, cpuRequest_name, cpuRequest_format, cpuLimit_name, cpuLimit_format, cpuUsage_name, cpuUsage_format, cpuThrottle_name, cpuThrottle_format, memoryRequest_name, memoryRequest_format, memoryLimit_name, memoryLimit_format, memoryUsage_name, memoryUsage_format, memoryRSS_name, memoryRSS_format",
+    "test_name, expected_status_code, version, experiment_name, interval_start_time, interval_end_time, kubernetes_obj_type, name, namespace, container_image_name, container_name, cpuRequest_name, cpuRequest_sum, cpuRequest_avg, cpuRequest_format, cpuLimit_name, cpuLimit_sum, cpuLimit_avg, cpuLimit_format, cpuUsage_name, cpuUsage_sum, cpuUsage_max, cpuUsage_avg, cpuUsage_min, cpuUsage_format, cpuThrottle_name, cpuThrottle_sum, cpuThrottle_max, cpuThrottle_avg, cpuThrottle_format, memoryRequest_name, memoryRequest_sum, memoryRequest_avg, memoryRequest_format, memoryLimit_name, memoryLimit_sum, memoryLimit_avg, memoryLimit_format, memoryUsage_name, memoryUsage_sum, memoryUsage_max, memoryUsage_avg, memoryUsage_min, memoryUsage_format, memoryRSS_name, memoryRSS_sum, memoryRSS_max, memoryRSS_avg, memoryRSS_min, memoryRSS_format",
     generate_test_data(csvfile, update_results_test_data, "update_results"))
 def test_update_results_invalid_tests(test_name, expected_status_code, version, experiment_name, interval_start_time,
                                       interval_end_time, kubernetes_obj_type, name, namespace, container_image_name,
-                                      container_name, cpuRequest_name, cpuRequest_format, cpuLimit_name, cpuLimit_format,
-                                      cpuUsage_name, cpuUsage_format, cpuThrottle_name, cpuThrottle_format,
-                                      memoryRequest_name, memoryRequest_format, memoryLimit_name, memoryLimit_format,
-                                      memoryUsage_name, memoryUsage_format, memoryRSS_name, memoryRSS_format, cluster_type):
+                                      container_name, cpuRequest_name, cpuRequest_sum, cpuRequest_avg,
+                                      cpuRequest_format, cpuLimit_name, cpuLimit_sum, cpuLimit_avg, cpuLimit_format,
+                                      cpuUsage_name, cpuUsage_sum, cpuUsage_max, cpuUsage_avg, cpuUsage_min,
+                                      cpuUsage_format, cpuThrottle_name, cpuThrottle_sum, cpuThrottle_max,
+                                      cpuThrottle_avg, cpuThrottle_format, memoryRequest_name, memoryRequest_sum,
+                                      memoryRequest_avg, memoryRequest_format, memoryLimit_name, memoryLimit_sum,
+                                      memoryLimit_avg, memoryLimit_format, memoryUsage_name, memoryUsage_sum,
+                                      memoryUsage_max, memoryUsage_avg, memoryUsage_min, memoryUsage_format,
+                                      memoryRSS_name, memoryRSS_sum, memoryRSS_max, memoryRSS_avg, memoryRSS_min,
+                                      memoryRSS_format, cluster_type):
     print("\n*******************************************************")
     print("Test - ", test_name)
     print("*******************************************************\n")
@@ -82,20 +88,43 @@ def test_update_results_invalid_tests(test_name, expected_status_code, version, 
         container_image_name=container_image_name,
         container_name=container_name,
         cpuRequest_name=cpuRequest_name,
+        cpuRequest_sum=cpuRequest_sum,
+        cpuRequest_avg=cpuRequest_avg,
         cpuRequest_format=cpuRequest_format,
         cpuLimit_name=cpuLimit_name,
+        cpuLimit_sum=cpuLimit_sum,
+        cpuLimit_avg=cpuLimit_avg,
         cpuLimit_format=cpuLimit_format,
         cpuUsage_name=cpuUsage_name,
+        cpuUsage_sum=cpuUsage_sum,
+        cpuUsage_max=cpuUsage_max,
+        cpuUsage_avg=cpuUsage_avg,
+        cpuUsage_min=cpuUsage_min,
         cpuUsage_format=cpuUsage_format,
         cpuThrottle_name=cpuThrottle_name,
+        cpuThrottle_sum=cpuThrottle_sum,
+        cpuThrottle_max=cpuThrottle_max,
+        cpuThrottle_avg=cpuThrottle_avg,
         cpuThrottle_format=cpuThrottle_format,
         memoryRequest_name=memoryRequest_name,
+        memoryRequest_sum=memoryRequest_sum,
+        memoryRequest_avg=memoryRequest_avg,
         memoryRequest_format=memoryRequest_format,
         memoryLimit_name=memoryLimit_name,
+        memoryLimit_sum=memoryLimit_sum,
+        memoryLimit_avg=memoryLimit_avg,
         memoryLimit_format=memoryLimit_format,
         memoryUsage_name=memoryUsage_name,
+        memoryUsage_sum=memoryUsage_sum,
+        memoryUsage_max=memoryUsage_max,
+        memoryUsage_avg=memoryUsage_avg,
+        memoryUsage_min=memoryUsage_min,
         memoryUsage_format=memoryUsage_format,
         memoryRSS_name=memoryRSS_name,
+        memoryRSS_sum=memoryRSS_sum,
+        memoryRSS_max=memoryRSS_max,
+        memoryRSS_avg=memoryRSS_avg,
+        memoryRSS_min=memoryRSS_min,
         memoryRSS_format=memoryRSS_format
     )
     with open(filename, mode="w", encoding="utf-8") as message:
@@ -109,6 +138,7 @@ def test_update_results_invalid_tests(test_name, expected_status_code, version, 
 
     response = delete_experiment(input_json_file)
     print("delete exp = ", response.status_code)
+
 
 @pytest.mark.negative
 @pytest.mark.parametrize("test_name, result_json_file, expected_message, error_message", missing_metrics)
@@ -158,6 +188,7 @@ def test_update_results_with_missing_metrics_section(test_name, result_json_file
     
     response = delete_experiment(input_json_file)
     print("delete exp = ", response.status_code)
+
 
 @pytest.mark.sanity
 def test_update_valid_results_after_create_exp(cluster_type):


### PR DESCRIPTION
This PR fixes the pending negative test failures of the updateResults API. 

- Added validation for the null and blank container images
- Skipped tests for the aggregation_info variables
- Skipped tests for invalid container name and container_image name