### PR TITLE
Update cluster_group_name in DataSource Metadata JSON

### DIFF
--- a/src/main/java/com/autotune/common/data/dataSourceDetails/DataSourceDetailsHelper.java
+++ b/src/main/java/com/autotune/common/data/dataSourceDetails/DataSourceDetailsHelper.java
@@ -257,8 +257,7 @@ public class DataSourceDetailsHelper {
     public DataSourceDetailsInfo createDataSourceDetailsInfoObject(String clusterGroupName, HashMap<String, DataSourceNamespace> namespaceMap) {
 
         try {
-            DataSourceDetailsInfo dataSourceDetailsInfo = new DataSourceDetailsInfo(KruizeConstants.
-                    DataSourceConstants.DataSourceDetailsInfoConstants.version, null);
+            DataSourceDetailsInfo dataSourceDetailsInfo = new DataSourceDetailsInfo(null);
 
             DataSourceClusterGroup dataSourceClusterGroup = new DataSourceClusterGroup(clusterGroupName,null);
 

--- a/src/main/java/com/autotune/common/data/dataSourceDetails/DataSourceDetailsInfo.java
+++ b/src/main/java/com/autotune/common/data/dataSourceDetails/DataSourceDetailsInfo.java
@@ -8,7 +8,6 @@ import java.util.HashMap;
 
 public class DataSourceDetailsInfo {
     private static final Logger LOGGER = LoggerFactory.getLogger(DataSourceDetailsInfo.class);
-    private String version;
 
     /**
      * Key: Cluster group name
@@ -17,17 +16,8 @@ public class DataSourceDetailsInfo {
     @SerializedName(KruizeConstants.DataSourceConstants.DataSourceDetailsInfoJSONKeys.CLUSTER_GROUPS)
     private HashMap<String, DataSourceClusterGroup> clusterGroupHashMap;
 
-    public DataSourceDetailsInfo(String version, HashMap<String, DataSourceClusterGroup> clusterGroupHashMap) {
-        this.version = version;
+    public DataSourceDetailsInfo(HashMap<String, DataSourceClusterGroup> clusterGroupHashMap) {
         this.clusterGroupHashMap = clusterGroupHashMap;
-    }
-
-    public String getVersion() {
-        return version;
-    }
-
-    public void setVersion(String version) {
-        this.version = version;
     }
 
     public HashMap<String, DataSourceClusterGroup> getDataSourceClusterGroupHashMap() {
@@ -51,8 +41,7 @@ public class DataSourceDetailsInfo {
     @Override
     public String toString() {
         return "DataSourceDetailsInfo{" +
-                "version ='" + version + '\'' +
-                ", cluster_group ='" + clusterGroupHashMap.toString() + '\'' +
+                "cluster_group ='" + clusterGroupHashMap.toString() + '\'' +
                 '}';
     }
 }

--- a/src/main/java/com/autotune/common/datasource/DataSourceDetailsOperator.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceDetailsOperator.java
@@ -54,7 +54,7 @@ public class DataSourceDetailsOperator {
         try {
             JsonArray namespacesDataResultArray =  op.getResultArrayForQuery(dataSourceInfo.getUrl().toString(), PromQLDataSourceQueries.NAMESPACE_QUERY);
             if (false == op.validateResultArray(namespacesDataResultArray)){
-                dataSourceDetailsInfo = dataSourceDetailsHelper.createDataSourceDetailsInfoObject(dataSourceInfo.getProvider(), null);
+                dataSourceDetailsInfo = dataSourceDetailsHelper.createDataSourceDetailsInfoObject(dataSourceInfo.getName(), null);
                 return;
             }
 
@@ -63,7 +63,7 @@ public class DataSourceDetailsOperator {
              * Value: DataSourceNamespace object corresponding to a namespace
              */
             HashMap<String, DataSourceNamespace> datasourceNamespaces = dataSourceDetailsHelper.getActiveNamespaces(namespacesDataResultArray);
-            dataSourceDetailsInfo = dataSourceDetailsHelper.createDataSourceDetailsInfoObject(dataSourceInfo.getProvider(), datasourceNamespaces);
+            dataSourceDetailsInfo = dataSourceDetailsHelper.createDataSourceDetailsInfoObject(dataSourceInfo.getName(), datasourceNamespaces);
 
             /**
              * Outer map:
@@ -79,7 +79,7 @@ public class DataSourceDetailsOperator {
             if (true == op.validateResultArray(workloadDataResultArray)) {
                 datasourceWorkloads = dataSourceDetailsHelper.getWorkloadInfo(workloadDataResultArray);
             }
-            dataSourceDetailsHelper.updateWorkloadDataSourceDetailsInfoObject(dataSourceInfo.getProvider(), dataSourceDetailsInfo, datasourceWorkloads);
+            dataSourceDetailsHelper.updateWorkloadDataSourceDetailsInfoObject(dataSourceInfo.getName(), dataSourceDetailsInfo, datasourceWorkloads);
 
             /**
              * Outer map:
@@ -95,7 +95,7 @@ public class DataSourceDetailsOperator {
             if (true == op.validateResultArray(containerDataResultArray)) {
                 datasourceContainers = dataSourceDetailsHelper.getContainerInfo(containerDataResultArray);
             }
-            dataSourceDetailsHelper.updateContainerDataSourceDetailsInfoObject(dataSourceInfo.getProvider(), dataSourceDetailsInfo, datasourceWorkloads, datasourceContainers);
+            dataSourceDetailsHelper.updateContainerDataSourceDetailsInfoObject(dataSourceInfo.getName(), dataSourceDetailsInfo, datasourceWorkloads, datasourceContainers);
         } catch (Exception e) {
             LOGGER.error(e.getMessage());
         }
@@ -106,7 +106,7 @@ public class DataSourceDetailsOperator {
      * @return DataSourceDetailsInfo containing details about the data source if found, otherwise null.
      */
     public DataSourceDetailsInfo getDataSourceDetailsInfo(DataSourceInfo dataSource) {
-        String clusterGroupName = dataSource.getProvider();
+        String clusterGroupName = dataSource.getName();
 
         if (null == dataSourceDetailsInfo) {
             LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceDetailsErrorMsgs.DATASOURCE_DETAILS_INFO_NOT_AVAILABLE);
@@ -122,7 +122,7 @@ public class DataSourceDetailsOperator {
         DataSourceClusterGroup targetClusterGroup = clusterGroupHashMap.get(clusterGroupName);
         HashMap<String, DataSourceClusterGroup> targetClusterGroupHashMap = new HashMap<>();
         targetClusterGroupHashMap.put(clusterGroupName, targetClusterGroup);
-        return new DataSourceDetailsInfo(dataSourceDetailsInfo.getVersion(), targetClusterGroupHashMap);
+        return new DataSourceDetailsInfo(targetClusterGroupHashMap);
     }
 
     /*

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -412,7 +412,6 @@ public class KruizeConstants {
             private DataSourceDetailsInfoConstants() {
             }
 
-            public static final String version = "v1.0";
             public static final String CLUSTER_NAME = "default";
         }
 

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -412,6 +412,7 @@ public class KruizeConstants {
             private DataSourceDetailsInfoConstants() {
             }
 
+            public static final String version = "v1.0";
             public static final String CLUSTER_NAME = "default";
         }
 


### PR DESCRIPTION
This PR -

- Updates `cluster_group_name` variable assignment from datasource 'provider' to 'name'
- Removes 'version' field from `DataSourceDetailsInfo` object (to be included as part of ImportDataSourceMetadata API)