### PR TITLE
DB Integration for Datasource APIs

### DIFF
--- a/src/main/java/com/autotune/analyzer/serviceObjects/DSMetadataAPIObject.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/DSMetadataAPIObject.java
@@ -5,7 +5,7 @@ import com.google.gson.annotations.SerializedName;
 
 public class DSMetadataAPIObject {
     private String version;
-    @SerializedName(KruizeConstants.JSONKeys.DATASOURCE_NAME)
+    @SerializedName(KruizeConstants.JSONKeys.DATASOURCE)
     private String dataSourceName;
 
     public String getVersion() {
@@ -21,7 +21,7 @@ public class DSMetadataAPIObject {
     }
     public boolean validateInputFields() {
         if (version == null || version.isEmpty() || dataSourceName == null || dataSourceName.isEmpty()) {
-            throw new IllegalArgumentException("Invalid input fields: version and name cannot be null or empty");
+            throw new IllegalArgumentException("Invalid input fields: version and datasource cannot be null or empty");
         }
         return true;
     }

--- a/src/main/java/com/autotune/analyzer/serviceObjects/DSMetadataAPIObject.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/DSMetadataAPIObject.java
@@ -5,7 +5,7 @@ import com.google.gson.annotations.SerializedName;
 
 public class DSMetadataAPIObject {
     private String version;
-    @SerializedName(KruizeConstants.JSONKeys.DATASOURCE)
+    @SerializedName(KruizeConstants.JSONKeys.DATASOURCE_NAME)
     private String dataSourceName;
 
     public String getVersion() {
@@ -21,7 +21,7 @@ public class DSMetadataAPIObject {
     }
     public boolean validateInputFields() {
         if (version == null || version.isEmpty() || dataSourceName == null || dataSourceName.isEmpty()) {
-            throw new IllegalArgumentException("Invalid input fields: version and datasource cannot be null or empty");
+            throw new IllegalArgumentException("Invalid input fields: version and datasource_name cannot be null or empty");
         }
         return true;
     }

--- a/src/main/java/com/autotune/analyzer/services/DSMetadataService.java
+++ b/src/main/java/com/autotune/analyzer/services/DSMetadataService.java
@@ -144,6 +144,7 @@ public class DSMetadataService extends HttpServlet {
         String dataSourceName = request.getParameter(AnalyzerConstants.ServiceConstants.DATASOURCE);
         String clusterName = request.getParameter(AnalyzerConstants.ServiceConstants.CLUSTER_NAME);
         String namespace = request.getParameter(AnalyzerConstants.ServiceConstants.NAMESPACE);
+        String verbose = request.getParameter(AnalyzerConstants.ServiceConstants.VERBOSE);
         //Key = dataSource name
         HashMap<String, DataSourceDetailsInfo> dataSourceDetailsMap = new HashMap<>();
         boolean error = false;
@@ -151,7 +152,7 @@ public class DSMetadataService extends HttpServlet {
         try {
             if (null != dataSourceName) {
                 try {
-                    DataSourceDetailsInfo dataSourceMetadata = new ExperimentDBService().loadMetadataFromDBByName(dataSourceName);
+                    DataSourceDetailsInfo dataSourceMetadata = new ExperimentDBService().loadMetadataFromDBByNamespace(dataSourceName, clusterName, namespace);
                     if (null != dataSourceMetadata) {
                         dataSourceDetailsMap.put(dataSourceName, dataSourceMetadata);
                     }

--- a/src/main/java/com/autotune/analyzer/services/ListDataSources.java
+++ b/src/main/java/com/autotune/analyzer/services/ListDataSources.java
@@ -6,6 +6,8 @@ import com.autotune.analyzer.utils.AnalyzerErrorConstants;
 import com.autotune.analyzer.utils.GsonUTCDateAdapter;
 import com.autotune.common.datasource.DataSourceCollection;
 import com.autotune.common.datasource.DataSourceInfo;;
+import com.autotune.common.datasource.DataSourceManager;
+import com.autotune.database.service.ExperimentDBService;
 import com.autotune.utils.MetricsConfig;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -58,8 +60,10 @@ public class ListDataSources extends HttpServlet {
 
             if (null != dataSourceName) {
                 try {
-                    // kruize_datasources -> loadDataSourceByName(dataSourceName)
-                    loadDataSourceByName(dataSourceMap, dataSourceName);
+                    DataSourceInfo dataSource = new ExperimentDBService().loadDataSourceFromDBByName(dataSourceName);
+                    if (null != dataSource) {
+                        dataSourceMap.put(dataSourceName, dataSource);
+                    }
                 } catch (Exception e) {
                     LOGGER.error("Loading saved Datasource {} failed: {} ", dataSourceName, e.getMessage());
                 }
@@ -76,8 +80,7 @@ public class ListDataSources extends HttpServlet {
                 dataSourceInfoList.add(dataSourceMap.get(dataSourceName));
             } else {
                 try {
-                    // kruize_datasources -> loadAllDataSources()
-                    loadAllDataSources(dataSourceMap);
+                    dataSourceInfoList = new ExperimentDBService().loadAllDataSources();
                 } catch (Exception e) {
                     LOGGER.error("Loading saved Datasources failed: {} ", e.getMessage());
                 }
@@ -115,25 +118,6 @@ public class ListDataSources extends HttpServlet {
             }
         }
 
-    }
-
-    public void loadDataSourceByName(HashMap<String, DataSourceInfo> dataSourceMap, String dataSourceName){
-        try {
-            if (null != dataSourceName || !dataSourceName.isEmpty()) {
-                if (!DataSourceCollection.getInstance().getDataSourcesCollection().isEmpty() && DataSourceCollection.getInstance().getDataSourcesCollection().containsKey(dataSourceName)) {
-                    dataSourceMap.put(dataSourceName, DataSourceCollection.getInstance().getDataSourcesCollection().get(dataSourceName));
-                }
-            }
-        } catch(Exception e) {
-            LOGGER.error(e.getMessage());
-        }
-    }
-    public void loadAllDataSources(HashMap<String, DataSourceInfo> dataSourceMap){
-        try {
-            dataSourceMap.putAll(DataSourceCollection.getInstance().getDataSourcesCollection());
-        } catch(Exception e) {
-            LOGGER.error(e.getMessage());
-        }
     }
 
     public void sendErrorResponse(HttpServletResponse response, Exception e, int httpStatusCode, String errorMsg) throws

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -315,6 +315,7 @@ public class AnalyzerConstants {
         public static final String DATASOURCE = "datasource";
         public static final String DATASOURCE_PROVIDER = "provider";
         public static final String CLUSTER_NAME = "cluster_name";
+        public static final String VERBOSE = "verbose";
         private ServiceConstants() {
         }
     }

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
@@ -177,11 +177,11 @@ public class AnalyzerErrorConstants {
         public static final class ImportDataSourceMetadataAPI {
             private ImportDataSourceMetadataAPI(){
             }
-            public static final String DATASOURCE_NAME_MANDATORY = KruizeConstants.JSONKeys.DATASOURCE_NAME + " is mandatory";
+            public static final String DATASOURCE_NAME_MANDATORY = KruizeConstants.JSONKeys.DATASOURCE + " is mandatory";
             public static final String INVALID_DATASOURCE_NAME_METADATA_EXCPTN = "Invalid DataSource Name";
             public static final String INVALID_DATASOURCE_NAME_METADATA_MSG = "Metadata for a given datasource name - \" %s \" either does not exist or is not valid";
             public static final String MISSING_DATASOURCE_METADATA_EXCPTN = "Invalid DataSource metadata";
-            public static final String MISSING_DATASOURCE_METADATA_MSG = "Metadata for a given datasource name - \" %s \", cluster name - \" %s \", namespace - \"%s \" " +
+            public static final String MISSING_DATASOURCE_METADATA_MSG = "Metadata for a given datasource - \" %s \", cluster name - \" %s \", namespace - \"%s \" " +
                     "either does not exist or is not valid";
             public static final String DATASOURCE_METADATA_IMPORT_ERROR_MSG = "Metadata cannot be imported for datasource - \" %s \" , either does not exist or is not valid";
         }

--- a/src/main/java/com/autotune/common/data/dataSourceDetails/DataSourceCluster.java
+++ b/src/main/java/com/autotune/common/data/dataSourceDetails/DataSourceCluster.java
@@ -45,7 +45,7 @@ public class DataSourceCluster {
 
     public void setDataSourceNamespaceHashMap(HashMap<String, DataSourceNamespace> namespaceHashMap) {
         if (null == namespaceHashMap) {
-            LOGGER.error(KruizeConstants.DataSourceConstants.DataSourceDetailsErrorMsgs.SET_NAMESPACE_MAP_ERROR + clusterName);
+            LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceDetailsErrorMsgs.SET_NAMESPACE_MAP_ERROR + clusterName);
         }
         this.namespaceHashMap = namespaceHashMap;
     }

--- a/src/main/java/com/autotune/common/data/dataSourceDetails/DataSourceClusterGroup.java
+++ b/src/main/java/com/autotune/common/data/dataSourceDetails/DataSourceClusterGroup.java
@@ -37,7 +37,7 @@ public class DataSourceClusterGroup {
 
     public void setDataSourceClusterHashMap(HashMap<String, DataSourceCluster> clusters) {
         if (null == clusters) {
-            LOGGER.error(KruizeConstants.DataSourceConstants.DataSourceDetailsErrorMsgs.SET_CLUSTER_MAP_ERROR + clusterGroupName);
+            LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceDetailsErrorMsgs.SET_CLUSTER_MAP_ERROR + clusterGroupName);
         }
         this.clusterHashMap = clusters;
     }

--- a/src/main/java/com/autotune/common/data/dataSourceDetails/DataSourceDetailsInfo.java
+++ b/src/main/java/com/autotune/common/data/dataSourceDetails/DataSourceDetailsInfo.java
@@ -26,7 +26,7 @@ public class DataSourceDetailsInfo {
 
     public void setDataSourceClusterGroupHashMap(HashMap<String, DataSourceClusterGroup> clusterGroupHashMap) {
         if (null == clusterGroupHashMap) {
-            LOGGER.error("No cluster groups found");
+            LOGGER.debug("No cluster groups found");
         }
         this.clusterGroupHashMap = clusterGroupHashMap;
     }

--- a/src/main/java/com/autotune/common/data/dataSourceDetails/DataSourceNamespace.java
+++ b/src/main/java/com/autotune/common/data/dataSourceDetails/DataSourceNamespace.java
@@ -36,7 +36,7 @@ public class DataSourceNamespace {
 
     public void setDataSourceWorkloadHashMap(HashMap<String, DataSourceWorkload> workloadHashMap) {
         if (null == workloadHashMap) {
-            LOGGER.error(KruizeConstants.DataSourceConstants.DataSourceDetailsErrorMsgs.SET_WORKLOAD_MAP_ERROR + namespace);
+            LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceDetailsErrorMsgs.SET_WORKLOAD_MAP_ERROR + namespace);
         }
        this.workloadHashMap = workloadHashMap;
     }

--- a/src/main/java/com/autotune/common/data/dataSourceDetails/DataSourceWorkload.java
+++ b/src/main/java/com/autotune/common/data/dataSourceDetails/DataSourceWorkload.java
@@ -40,7 +40,7 @@ public class DataSourceWorkload {
 
     public void setDataSourceContainerHashMap(HashMap<String, DataSourceContainer> containers) {
         if (containers == null) {
-            LOGGER.info(KruizeConstants.DataSourceConstants.DataSourceDetailsErrorMsgs.SET_CONTAINER_MAP_ERROR + workloadName);
+            LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceDetailsErrorMsgs.SET_CONTAINER_MAP_ERROR + workloadName);
         }
         this.containerHashMap = containers;
     }

--- a/src/main/java/com/autotune/common/datasource/DataSourceManager.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceManager.java
@@ -86,6 +86,20 @@ public class DataSourceManager {
                 throw new DataSourceNotExist(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.MISSING_DATASOURCE_INFO);
             }
             dataSourceDetailsOperator.createDataSourceDetails(dataSource);
+            saveDataFromSourceToDB(dataSource);
+        } catch (Exception e) {
+            LOGGER.error(e.getMessage());
+        }
+    }
+    public void saveDataFromSourceToDB(DataSourceInfo dataSource) {
+        try {
+            DataSourceDetailsInfo dataSourceDetails = dataSourceDetailsOperator.getDataSourceDetailsInfo(dataSource);
+            if (null == dataSourceDetails) {
+                return;
+            }
+            // save the metadata to DB
+            addMetadataToDB(dataSourceDetails);
+
         } catch (Exception e) {
             LOGGER.error(e.getMessage());
         }
@@ -163,7 +177,7 @@ public class DataSourceManager {
     private boolean checkIfClusterGroupExists(String clusterGroupName) {
         boolean isPresent = false;
         try {
-            DataSourceDetailsInfo dataSourceDetailsInfo = new ExperimentDBService().loadDataSourceClusterGroupFromDBByName(clusterGroupName);
+            DataSourceDetailsInfo dataSourceDetailsInfo = new ExperimentDBService().loadMetadataFromDBByName(clusterGroupName);
             if (dataSourceDetailsInfo != null) {
                 LOGGER.warn("Cluster group: {} already exists!", clusterGroupName);
                 isPresent = true;

--- a/src/main/java/com/autotune/database/dao/ExperimentDAO.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAO.java
@@ -76,7 +76,7 @@ public interface ExperimentDAO {
     // Load all the datasources
     List<KruizeDataSource> loadAllDataSources() throws Exception;
 
-    List<KruizeMetadata> loadDataSourceClusterGroupByName(String clusterGroupName) throws Exception;
+    List<KruizeMetadata> loadMetadataByName(String clusterGroupName) throws Exception;
 
     ValidationOutputData addMetadataToDB(KruizeMetadata kruizeMetadata);
 

--- a/src/main/java/com/autotune/database/dao/ExperimentDAO.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAO.java
@@ -77,6 +77,8 @@ public interface ExperimentDAO {
     List<KruizeDataSource> loadAllDataSources() throws Exception;
 
     List<KruizeMetadata> loadMetadataByName(String clusterGroupName) throws Exception;
+    List<KruizeMetadata> loadMetadataByClusterName(String clusterGroupName, String clusterName) throws Exception;
+    List<KruizeMetadata> loadMetadataByNamespace(String clusterGroupName, String clusterName, String namespace) throws Exception;
 
     ValidationOutputData addMetadataToDB(KruizeMetadata kruizeMetadata);
 

--- a/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
@@ -644,11 +644,11 @@ public class ExperimentDAOImpl implements ExperimentDAO {
      * @return
      */
     @Override
-    public List<KruizeMetadata> loadDataSourceClusterGroupByName(String clusterGroupName) throws Exception {
+    public List<KruizeMetadata> loadMetadataByName(String clusterGroupName) throws Exception {
         List<KruizeMetadata> kruizeMetadataList;
         try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
             kruizeMetadataList = session.createQuery(SELECT_FROM_METADATA_BY_CLUSTER_GROUP_NAME, KruizeMetadata.class)
-                    .setParameter("cluster_group_name", clusterGroupName).list();
+                    .setParameter("clusterGroupName", clusterGroupName).list();
         } catch (Exception e) {
             LOGGER.error("Unable to load metadata with clusterGroupName: {} : {}", clusterGroupName, e.getMessage());
             throw new Exception("Error while loading existing metadata object from database : " + e.getMessage());

--- a/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
@@ -655,6 +655,37 @@ public class ExperimentDAOImpl implements ExperimentDAO {
         }
         return kruizeMetadataList;
     }
+    @Override
+    public List<KruizeMetadata> loadMetadataByClusterName(String clusterGroupName, String clusterName) throws Exception {
+        List<KruizeMetadata> kruizeMetadataList;
+        try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
+            Query<KruizeMetadata> kruizeMetadataQuery = session.createQuery(SELECT_FROM_METADATA_BY_CLUSTER_GROUP_NAME_AND_CLUSTER_NAME, KruizeMetadata.class)
+                    .setParameter("cluster_group_name", clusterGroupName)
+                    .setParameter("cluster_name", clusterName);
+
+            kruizeMetadataList = kruizeMetadataQuery.list();
+        } catch (Exception e) {
+            LOGGER.error("Unable to load metadata with clusterGroupName: {} and clusterName : {} : {}", clusterGroupName, clusterName, e.getMessage());
+            throw new Exception("Error while loading existing metadata object from database : " + e.getMessage());
+        }
+        return kruizeMetadataList;
+    }
+
+    public List<KruizeMetadata> loadMetadataByNamespace(String clusterGroupName, String clusterName, String namespace) throws Exception {
+        List<KruizeMetadata> kruizeMetadataList;
+        try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
+            Query<KruizeMetadata> kruizeMetadataQuery = session.createQuery(SELECT_FROM_METADATA_BY_CLUSTER_GROUP_NAME_CLUSTER_NAME_AND_NAMESPACE, KruizeMetadata.class)
+                    .setParameter("cluster_group_name", clusterGroupName)
+                    .setParameter("cluster_name", clusterName)
+                    .setParameter("namespace",namespace);
+
+            kruizeMetadataList = kruizeMetadataQuery.list();
+        } catch (Exception e) {
+            LOGGER.error("Unable to load metadata with clusterGroupName: {}, clusterName : {} and namespace : {} : {}", clusterGroupName, clusterName, namespace, e.getMessage());
+            throw new Exception("Error while loading existing metadata object from database : " + e.getMessage());
+        }
+        return kruizeMetadataList;
+    }
 
     /**
      * @return

--- a/src/main/java/com/autotune/database/helper/DBConstants.java
+++ b/src/main/java/com/autotune/database/helper/DBConstants.java
@@ -11,6 +11,20 @@ public class DBConstants {
         public static final String SELECT_FROM_DATASOURCE_BY_NAME = "from KruizeDataSource kd WHERE kd.name = :name";
         public static final String SELECT_FROM_METADATA = "from KruizeMetadata";
         public static final String SELECT_FROM_METADATA_BY_CLUSTER_GROUP_NAME = "from KruizeMetadata km WHERE km.cluster_group_name = :clusterGroupName";
+        public static final String SELECT_FROM_METADATA_BY_CLUSTER_GROUP_NAME_AND_CLUSTER_NAME =
+                String.format("from KruizeMetadata km " +
+                        "WHERE km.cluster_group_name = :%s and " +
+                        "km.cluster_name = :%s",
+                        KruizeConstants.DataSourceConstants.DataSourceDetailsInfoJSONKeys.CLUSTER_GROUP_NAME,
+                        KruizeConstants.DataSourceConstants.DataSourceDetailsInfoJSONKeys.CLUSTER_NAME);
+        public static final String SELECT_FROM_METADATA_BY_CLUSTER_GROUP_NAME_CLUSTER_NAME_AND_NAMESPACE =
+                String.format("from KruizeMetadata km " +
+                        "WHERE km.cluster_group_name = :%s and " +
+                        "km.cluster_name = :%s and " +
+                        "km.namespace = :%s",
+                        KruizeConstants.DataSourceConstants.DataSourceDetailsInfoJSONKeys.CLUSTER_GROUP_NAME,
+                        KruizeConstants.DataSourceConstants.DataSourceDetailsInfoJSONKeys.CLUSTER_NAME,
+                        KruizeConstants.DataSourceConstants.DataSourceDetailsInfoJSONKeys.NAMESPACE);
         public static final String SELECT_FROM_RESULTS = "from KruizeResultsEntry";
         public static final String SELECT_FROM_RESULTS_BY_EXP_NAME = "from KruizeResultsEntry k WHERE k.experiment_name = :experimentName";
         public static final String SELECT_FROM_RESULTS_BY_EXP_NAME_AND_DATE_RANGE_AND_LIMIT =

--- a/src/main/java/com/autotune/database/helper/DBHelpers.java
+++ b/src/main/java/com/autotune/database/helper/DBHelpers.java
@@ -739,6 +739,81 @@ public class DBHelpers {
                 dataSourceDetailsInfoList.add(dataSourceDetailsInfo);
                 return dataSourceDetailsInfoList;
             }
+            public static List<DataSourceDetailsInfo> convertKruizeMetadataToClusterLevelDataSourceDetails(List<KruizeMetadata> kruizeMetadataList) throws Exception {
+                List<DataSourceDetailsInfo> dataSourceDetailsInfoList = new ArrayList<>();
+                int failureThreshHold = kruizeMetadataList.size();
+                int failureCount = 0;
+
+                // Create a single instance of DataSourceDetailsInfo
+                DataSourceDetailsInfo dataSourceDetailsInfo = new DataSourceDetailsInfo(new HashMap<>());
+
+                for (KruizeMetadata kruizeMetadata : kruizeMetadataList) {
+                    try {
+                        // Use provided functions to get DataSource objects
+                        DataSourceClusterGroup dataSourceClusterGroup = getDataSourceClusterGroup(kruizeMetadata, dataSourceDetailsInfo);
+                        DataSourceCluster dataSourceCluster = getDataSourceCluster(kruizeMetadata, dataSourceClusterGroup);
+                        dataSourceCluster.setDataSourceNamespaceHashMap(null);
+
+                        // Update DataSourceDetailsInfo with the DataSourceClusterGroup and DataSourceCluster
+                        dataSourceDetailsInfo.getDataSourceClusterGroupHashMap()
+                                .put(kruizeMetadata.getClusterGroupName(), dataSourceClusterGroup);
+
+                        dataSourceClusterGroup.getDataSourceClusterHashMap()
+                                .put(kruizeMetadata.getClusterName(), dataSourceCluster);
+
+                    } catch (Exception e) {
+                        LOGGER.error("Error occurred while converting to dataSourceDetailsInfo from DB object : {}", e.getMessage());
+                        LOGGER.error(e.getMessage());
+                        failureCount++;
+                    }
+                }
+
+                if (failureThreshHold > 0 && failureCount == failureThreshHold)
+                    throw new Exception("None of the Metadata loaded from DB.");
+
+                dataSourceDetailsInfoList.add(dataSourceDetailsInfo);
+                return dataSourceDetailsInfoList;
+            }
+
+            public static List<DataSourceDetailsInfo> convertKruizeMetadataToNamespaceLevelDataSourceDetails(List<KruizeMetadata> kruizeMetadataList) throws Exception {
+                List<DataSourceDetailsInfo> dataSourceDetailsInfoList = new ArrayList<>();
+                int failureThreshHold = kruizeMetadataList.size();
+                int failureCount = 0;
+
+                // Create a single instance of DataSourceDetailsInfo
+                DataSourceDetailsInfo dataSourceDetailsInfo = new DataSourceDetailsInfo(new HashMap<>());
+
+                for (KruizeMetadata kruizeMetadata : kruizeMetadataList) {
+                    try {
+                        // Use provided functions to get DataSource objects
+                        DataSourceClusterGroup dataSourceClusterGroup = getDataSourceClusterGroup(kruizeMetadata, dataSourceDetailsInfo);
+                        DataSourceCluster dataSourceCluster = getDataSourceCluster(kruizeMetadata, dataSourceClusterGroup);
+                        DataSourceNamespace dataSourceNamespace = getDataSourceNamespace(kruizeMetadata, dataSourceCluster);
+                        dataSourceNamespace.setDataSourceWorkloadHashMap(null);
+
+                        // Update DataSourceDetailsInfo with the DataSourceClusterGroup and DataSourceCluster
+                        dataSourceDetailsInfo.getDataSourceClusterGroupHashMap()
+                                .put(kruizeMetadata.getClusterGroupName(), dataSourceClusterGroup);
+
+                        dataSourceClusterGroup.getDataSourceClusterHashMap()
+                                .put(kruizeMetadata.getClusterName(), dataSourceCluster);
+
+                        dataSourceCluster.getDataSourceNamespaceHashMap()
+                                .put(kruizeMetadata.getNamespace(), dataSourceNamespace);
+
+                    } catch (Exception e) {
+                        LOGGER.error("Error occurred while converting to dataSourceDetailsInfo from DB object : {}", e.getMessage());
+                        LOGGER.error(e.getMessage());
+                        failureCount++;
+                    }
+                }
+
+                if (failureThreshHold > 0 && failureCount == failureThreshHold)
+                    throw new Exception("None of the Metadata loaded from DB.");
+
+                dataSourceDetailsInfoList.add(dataSourceDetailsInfo);
+                return dataSourceDetailsInfoList;
+            }
 
             public static List<KruizeMetadata> convertDataSourceDetailsToMetadataObj(DataSourceDetailsInfo dataSourceDetailsInfo) {
                 List<KruizeMetadata> kruizeMetadataList = new ArrayList<>();

--- a/src/main/java/com/autotune/database/service/ExperimentDBService.java
+++ b/src/main/java/com/autotune/database/service/ExperimentDBService.java
@@ -412,7 +412,6 @@ public class ExperimentDBService {
 
     public DataSourceDetailsInfo loadMetadataFromDBByName(String clusterGroupName) throws Exception {
         List<KruizeMetadata> kruizeMetadataList = experimentDAO.loadMetadataByName(clusterGroupName);
-        //LOGGER.info("load metadata list: {} ", kruizeMetadataList);
         List<DataSourceDetailsInfo> dataSourceDetailsInfoList = new ArrayList<>();
         if (null != kruizeMetadataList && !kruizeMetadataList.isEmpty()) {
             dataSourceDetailsInfoList = DBHelpers.Converters.KruizeObjectConverters

--- a/src/main/java/com/autotune/database/service/ExperimentDBService.java
+++ b/src/main/java/com/autotune/database/service/ExperimentDBService.java
@@ -415,6 +415,30 @@ public class ExperimentDBService {
         List<DataSourceDetailsInfo> dataSourceDetailsInfoList = new ArrayList<>();
         if (null != kruizeMetadataList && !kruizeMetadataList.isEmpty()) {
             dataSourceDetailsInfoList = DBHelpers.Converters.KruizeObjectConverters
+                    .convertKruizeMetadataToClusterLevelDataSourceDetails(kruizeMetadataList);
+        }
+        if (dataSourceDetailsInfoList.isEmpty())
+            return null;
+        else
+            return dataSourceDetailsInfoList.get(0);
+    }
+    public DataSourceDetailsInfo loadMetadataFromDBByClusterName(String clusterGroupName, String clusterName) throws Exception {
+        List<KruizeMetadata> kruizeMetadataList = experimentDAO.loadMetadataByClusterName(clusterGroupName, clusterName);
+        List<DataSourceDetailsInfo> dataSourceDetailsInfoList = new ArrayList<>();
+        if (null != kruizeMetadataList && !kruizeMetadataList.isEmpty()) {
+            dataSourceDetailsInfoList = DBHelpers.Converters.KruizeObjectConverters
+                    .convertKruizeMetadataToNamespaceLevelDataSourceDetails(kruizeMetadataList);
+        }
+        if (dataSourceDetailsInfoList.isEmpty())
+            return null;
+        else
+            return dataSourceDetailsInfoList.get(0);
+    }
+    public DataSourceDetailsInfo loadMetadataFromDBByNamespace(String clusterGroupName, String clusterName, String namespace) throws Exception {
+        List<KruizeMetadata> kruizeMetadataList = experimentDAO.loadMetadataByNamespace(clusterGroupName, clusterName, namespace);
+        List<DataSourceDetailsInfo> dataSourceDetailsInfoList = new ArrayList<>();
+        if (null != kruizeMetadataList && !kruizeMetadataList.isEmpty()) {
+            dataSourceDetailsInfoList = DBHelpers.Converters.KruizeObjectConverters
                     .convertKruizeMetadataToDataSourceDetailsObject(kruizeMetadataList);
         }
         if (dataSourceDetailsInfoList.isEmpty())

--- a/src/main/java/com/autotune/database/service/ExperimentDBService.java
+++ b/src/main/java/com/autotune/database/service/ExperimentDBService.java
@@ -412,10 +412,11 @@ public class ExperimentDBService {
 
     public DataSourceDetailsInfo loadMetadataFromDBByName(String clusterGroupName) throws Exception {
         List<KruizeMetadata> kruizeMetadataList = experimentDAO.loadMetadataByName(clusterGroupName);
+        //LOGGER.info("load metadata list: {} ", kruizeMetadataList);
         List<DataSourceDetailsInfo> dataSourceDetailsInfoList = new ArrayList<>();
         if (null != kruizeMetadataList && !kruizeMetadataList.isEmpty()) {
             dataSourceDetailsInfoList = DBHelpers.Converters.KruizeObjectConverters
-                    .convertKruizeMetadataToClusterGroupObject(kruizeMetadataList);
+                    .convertKruizeMetadataToDataSourceDetailsObject(kruizeMetadataList);
         }
         if (dataSourceDetailsInfoList.isEmpty())
             return null;
@@ -427,7 +428,7 @@ public class ExperimentDBService {
         List<DataSourceDetailsInfo> dataSourceDetailsInfoList = new ArrayList<>();
         if (null != kruizeMetadataList && !kruizeMetadataList.isEmpty()) {
             dataSourceDetailsInfoList = DBHelpers.Converters.KruizeObjectConverters
-                    .convertKruizeMetadataToClusterGroupObject(kruizeMetadataList);
+                    .convertKruizeMetadataToDataSourceDetailsObject(kruizeMetadataList);
         }
         if (dataSourceDetailsInfoList.isEmpty())
             return null;

--- a/src/main/java/com/autotune/database/service/ExperimentDBService.java
+++ b/src/main/java/com/autotune/database/service/ExperimentDBService.java
@@ -285,8 +285,10 @@ public class ExperimentDBService {
     public ValidationOutputData addMetadataToDB(DataSourceDetailsInfo dataSourceDetailsInfo) {
         ValidationOutputData validationOutputData = new ValidationOutputData(false, null, null);
         try {
-            KruizeMetadata kruizeMetadata = DBHelpers.Converters.KruizeObjectConverters.convertDataSourceDetailsToMetadataObj(dataSourceDetailsInfo);
-            validationOutputData = this.experimentDAO.addMetadataToDB(kruizeMetadata);
+            List<KruizeMetadata> kruizeMetadataList = DBHelpers.Converters.KruizeObjectConverters.convertDataSourceDetailsToMetadataObj(dataSourceDetailsInfo);
+            for(KruizeMetadata kruizeMetadata : kruizeMetadataList) {
+                validationOutputData = this.experimentDAO.addMetadataToDB(kruizeMetadata);
+            }
         } catch (Exception e) {
             LOGGER.error("Not able to save metadata due to {}", e.getMessage());
         }
@@ -408,8 +410,8 @@ public class ExperimentDBService {
         return experimentResultDataList;
     }
 
-    public DataSourceDetailsInfo loadDataSourceClusterGroupFromDBByName(String clusterGroupName) throws Exception {
-        List<KruizeMetadata> kruizeMetadataList = experimentDAO.loadDataSourceClusterGroupByName(clusterGroupName);
+    public DataSourceDetailsInfo loadMetadataFromDBByName(String clusterGroupName) throws Exception {
+        List<KruizeMetadata> kruizeMetadataList = experimentDAO.loadMetadataByName(clusterGroupName);
         List<DataSourceDetailsInfo> dataSourceDetailsInfoList = new ArrayList<>();
         if (null != kruizeMetadataList && !kruizeMetadataList.isEmpty()) {
             dataSourceDetailsInfoList = DBHelpers.Converters.KruizeObjectConverters

--- a/src/main/java/com/autotune/database/table/KruizeMetadata.java
+++ b/src/main/java/com/autotune/database/table/KruizeMetadata.java
@@ -27,13 +27,13 @@ public class KruizeMetadata {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String version;
-    private String clusterGroupName;
-    private String clusterName;
+    private String cluster_group_name;
+    private String cluster_name;
     private String namespace;
-    private String workloadType;
-    private String workloadName;
-    private String containerName;
-    private String containerImageName;
+    private String workload_name;
+    private String workload_type;
+    private String container_name;
+    private String container_image_name;
 //    TODO: Relation mapping needs to be done later
 //    @OneToMany(mappedBy = "metadata", cascade = CascadeType.ALL)
 //    private List<KruizeExperimentEntry> experimentEntries;
@@ -41,15 +41,15 @@ public class KruizeMetadata {
     public KruizeMetadata() {
     }
 
-    public KruizeMetadata(String version, String clusterGroupName, String clusterName, String namespace, String workloadType, String workloadName, String containerName, String containerImageName) {
+    public KruizeMetadata(String version, String cluster_group_name, String cluster_name, String namespace, String workload_type, String workload_name, String container_name, String container_image_name) {
         this.version = version;
-        this.clusterGroupName = clusterGroupName;
-        this.clusterName = clusterName;
+        this.cluster_group_name = cluster_group_name;
+        this.cluster_name = cluster_name;
         this.namespace = namespace;
-        this.workloadType = workloadType;
-        this.workloadName = workloadName;
-        this.containerName = containerName;
-        this.containerImageName = containerImageName;
+        this.workload_type = workload_type;
+        this.workload_name = workload_name;
+        this.container_name = container_name;
+        this.container_image_name = container_image_name;
     }
 
     public Long getId() {
@@ -65,19 +65,19 @@ public class KruizeMetadata {
     }
 
     public String getClusterGroupName() {
-        return clusterGroupName;
+        return cluster_group_name;
     }
 
-    public void setClusterGroupName(String clusterGroupName) {
-        this.clusterGroupName = clusterGroupName;
+    public void setClusterGroupName(String cluster_group_name) {
+        this.cluster_group_name = cluster_group_name;
     }
 
     public String getClusterName() {
-        return clusterName;
+        return cluster_name;
     }
 
-    public void setClusterName(String clusterName) {
-        this.clusterName = clusterName;
+    public void setClusterName(String cluster_name) {
+        this.cluster_name = cluster_name;
     }
 
     public String getNamespace() {
@@ -89,35 +89,35 @@ public class KruizeMetadata {
     }
 
     public String getWorkloadType() {
-        return workloadType;
+        return workload_type;
     }
 
-    public void setWorkloadType(String workloadType) {
-        this.workloadType = workloadType;
+    public void setWorkloadType(String workload_type) {
+        this.workload_type = workload_type;
     }
 
     public String getWorkloadName() {
-        return workloadName;
+        return workload_name;
     }
 
-    public void setWorkloadName(String workloadName) {
-        this.workloadName = workloadName;
+    public void setWorkloadName(String workload_name) {
+        this.workload_name = workload_name;
     }
 
     public String getContainerName() {
-        return containerName;
+        return container_name;
     }
 
-    public void setContainerName(String containerName) {
-        this.containerName = containerName;
+    public void setContainerName(String container_name) {
+        this.container_name = container_name;
     }
 
     public String getContainerImageName() {
-        return containerImageName;
+        return container_image_name;
     }
 
-    public void setContainerImageName(String containerImageName) {
-        this.containerImageName = containerImageName;
+    public void setContainerImageName(String container_image_name) {
+        this.container_image_name = container_image_name;
     }
 
     @Override
@@ -125,13 +125,13 @@ public class KruizeMetadata {
         return "KruizeMetadata{" +
                 "id=" + id +
                 ", version='" + version + '\'' +
-                ", clusterGroupName='" + clusterGroupName + '\'' +
-                ", clusterName='" + clusterName + '\'' +
+                ", clusterGroupName='" + cluster_group_name + '\'' +
+                ", clusterName='" + cluster_name + '\'' +
                 ", namespace='" + namespace + '\'' +
-                ", workloadType='" + workloadType + '\'' +
-                ", workloadName='" + workloadName + '\'' +
-                ", containerName='" + containerName + '\'' +
-                ", containerImageName='" + containerImageName + '\'' +
+                ", workloadType='" + workload_type + '\'' +
+                ", workloadName='" + workload_name + '\'' +
+                ", containerName='" + container_name + '\'' +
+                ", containerImageName='" + container_image_name + '\'' +
                 '}';
     }
 }

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -131,6 +131,7 @@ public class KruizeConstants {
         public static final String NAME = "name";
         public static final String QUERY = "query";
         public static final String DATASOURCE = "datasource";
+        public static final String DATASOURCE_NAME = "datasource_name";
         public static final String CPU = "cpu";
         public static final String MEMORY = "memory";
         public static final String REQUESTS = "requests";

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -178,7 +178,6 @@ public class KruizeConstants {
         public static final String RANGE = "range";
 
         // DataSource JSON keys
-        public static final String DATASOURCE_NAME = "name";
         public static final String DATASOURCES = "datasources";
 
         // UI support JSON keys

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -459,6 +459,7 @@ public class KruizeConstants {
             public static final String CLUSTERS = "clusters";
             public static final String CLUSTER_NAME = "cluster_name";
             public static final String NAMESPACES = "namespaces";
+            public static final String NAMESPACE = "namespace";
             public static final String WORKLOADS = "workloads";
             public static final String WORKLOAD_NAME = "workload_name";
             public static final String WORKLOAD_TYPE = "workload_type";

--- a/src/main/java/com/autotune/utils/ServerContext.java
+++ b/src/main/java/com/autotune/utils/ServerContext.java
@@ -63,7 +63,7 @@ public class ServerContext {
     public static final String EXPERIMENT_MANAGER_LIST_TRIAL_STATUS_END_POINT = EXPERIMENT_MANAGER_SERVER_URL + EXPERIMENT_MANAGER_LIST_TRIAL_STATUS;
 
     //Datasource EndPoints
-    public static final String LIST_DATASOURCES = ROOT_CONTEXT + "datasource";
+    public static final String LIST_DATASOURCES = ROOT_CONTEXT + "datasources";
     public static final String DATASOURCE_METADATA = ROOT_CONTEXT + "dsmetadata";
 
     // UI support EndPoints


### PR DESCRIPTION
This PR contains following changes -
- Integration of DB methods for `/datasources` [view datasource]
- Integration of DB methods for `/dsmetadata` [import datasource]
- Refactor convert functions to store and retrieve multiple records from KruizeMetadata
- Refactor add metadata functionality to store namespaces with no associated workloads in DB