### PR TITLE
Adding Support for Auth Token For Openshift Enviroment

### DIFF
--- a/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
@@ -127,7 +127,8 @@ data:
           "provider": "prometheus",
           "serviceName": "prometheus-k8s",
           "namespace": "monitoring",
-          "url": ""
+          "url": "",
+          "authToken": ""
         }
       ]
     }

--- a/src/main/java/com/autotune/common/datasource/DataSourceDetailsOperator.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceDetailsOperator.java
@@ -52,7 +52,7 @@ public class DataSourceDetailsOperator {
          * TODO - Process cluster metadata using a custom query
          */
         try {
-            JsonArray namespacesDataResultArray =  op.getResultArrayForQuery(dataSourceInfo.getUrl().toString(), PromQLDataSourceQueries.NAMESPACE_QUERY);
+            JsonArray namespacesDataResultArray =  op.getResultArrayForQuery(dataSourceInfo.getUrl().toString(), PromQLDataSourceQueries.NAMESPACE_QUERY, dataSourceInfo.authToken);
             if (false == op.validateResultArray(namespacesDataResultArray)){
                 dataSourceDetailsInfo = dataSourceDetailsHelper.createDataSourceDetailsInfoObject(dataSourceInfo.getName(), null);
                 return;
@@ -75,7 +75,7 @@ public class DataSourceDetailsOperator {
              * TODO -  get workload metadata for a given namespace
              */
             HashMap<String, HashMap<String, DataSourceWorkload>> datasourceWorkloads = new HashMap<>();
-            JsonArray workloadDataResultArray = op.getResultArrayForQuery(dataSourceInfo.getUrl().toString(), PromQLDataSourceQueries.WORKLOAD_QUERY);
+            JsonArray workloadDataResultArray = op.getResultArrayForQuery(dataSourceInfo.getUrl().toString(), PromQLDataSourceQueries.WORKLOAD_QUERY, dataSourceInfo.authToken);
             if (true == op.validateResultArray(workloadDataResultArray)) {
                 datasourceWorkloads = dataSourceDetailsHelper.getWorkloadInfo(workloadDataResultArray);
             }
@@ -91,7 +91,7 @@ public class DataSourceDetailsOperator {
              * TODO - get container metadata for a given workload
              */
             HashMap<String, HashMap<String, DataSourceContainer>> datasourceContainers = new HashMap<>();
-            JsonArray containerDataResultArray = op.getResultArrayForQuery(dataSourceInfo.getUrl().toString(), PromQLDataSourceQueries.CONTAINER_QUERY);
+            JsonArray containerDataResultArray = op.getResultArrayForQuery(dataSourceInfo.getUrl().toString(), PromQLDataSourceQueries.CONTAINER_QUERY, dataSourceInfo.authToken);
             if (true == op.validateResultArray(containerDataResultArray)) {
                 datasourceContainers = dataSourceDetailsHelper.getContainerInfo(containerDataResultArray);
             }

--- a/src/main/java/com/autotune/common/datasource/DataSourceInfo.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceInfo.java
@@ -121,8 +121,8 @@ public class DataSourceInfo {
     }
 
     /**
-     * Returns the authToken for the data source
-     * @return BearerAccessToken containing the authToken for the data source
+     * Returns the authToken for accessing the data source
+     * @return BearerAccessToken containing the authToken for accessing the data source
      */
     public BearerAccessToken getAuthToken() {
         return authToken;

--- a/src/main/java/com/autotune/common/datasource/DataSourceInfo.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceInfo.java
@@ -20,6 +20,7 @@ import java.net.URL;
 import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.operator.KruizeDeploymentInfo;
 import com.autotune.utils.KruizeConstants;
+import com.autotune.utils.authModels.BearerAccessToken;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -39,6 +40,7 @@ public class DataSourceInfo {
     private final String serviceName;
     private final String namespace;
     private final URL url;
+    BearerAccessToken authToken;
 
     private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(DataSourceOperatorImpl.class);
 
@@ -48,6 +50,25 @@ public class DataSourceInfo {
         this.url = url;
         this.serviceName = "";
         this.namespace = "";
+        this.authToken = null;
+    }
+
+    public DataSourceInfo(String name, String provider, URL url, BearerAccessToken authToken) {
+        this.name = name;
+        this.provider = provider;
+        this.url = url;
+        this.serviceName = "";
+        this.namespace = "";
+        this.authToken = authToken;
+    }
+
+    public DataSourceInfo(String name, String provider, String serviceName, String namespace, BearerAccessToken authToken) {
+        this.name = name;
+        this.provider = provider;
+        this.serviceName = serviceName;
+        this.namespace = namespace;
+        this.url = getDNSBasedUrlForService(serviceName, namespace, provider);
+        this.authToken = authToken;
     }
 
     public DataSourceInfo(String name, String provider, String serviceName, String namespace) {
@@ -56,6 +77,7 @@ public class DataSourceInfo {
         this.serviceName = serviceName;
         this.namespace = namespace;
         this.url = getDNSBasedUrlForService(serviceName, namespace, provider);
+        this.authToken = null;
     }
 
     /**
@@ -96,6 +118,14 @@ public class DataSourceInfo {
      */
     public URL getUrl() {
         return url;
+    }
+
+    /**
+     * Returns the authToken for the data source
+     * @return BearerAccessToken containing the authToken for the data source
+     */
+    public BearerAccessToken getAuthToken() {
+        return authToken;
     }
 
     /**

--- a/src/main/java/com/autotune/common/datasource/DataSourceOperator.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceOperator.java
@@ -16,6 +16,7 @@
 package com.autotune.common.datasource;
 
 import com.autotune.common.utils.CommonUtils;
+import com.autotune.utils.authModels.BearerAccessToken;
 import com.google.gson.JsonArray;
 import org.json.JSONObject;
 
@@ -50,7 +51,7 @@ public interface DataSourceOperator {
      * @param dataSourceUrl String containing the url for the datasource
      * @return DatasourceReachabilityStatus
      */
-    CommonUtils.DatasourceReachabilityStatus isServiceable(String dataSourceUrl);
+    CommonUtils.DatasourceReachabilityStatus isServiceable(String dataSourceUrl, BearerAccessToken authToken);
 
     /**
      * executes specified query on datasource and returns the result value
@@ -58,7 +59,7 @@ public interface DataSourceOperator {
      * @param query String containing the query to be executed
      * @return Object containing the result value for the specified query
      */
-    Object getValueForQuery(String url, String query);
+    Object getValueForQuery(String url, String query, BearerAccessToken authToken);
 
     /**
      * executes specified query on datasource and returns the JSON Object
@@ -66,7 +67,7 @@ public interface DataSourceOperator {
      * @param query String containing the query to be executed
      * @return JSONObject for the specified query
      */
-    JSONObject getJsonObjectForQuery(String url, String query);
+    JSONObject getJsonObjectForQuery(String url, String query, BearerAccessToken authToken);
 
     /**
      * executes specified query on datasource and returns the result array
@@ -74,7 +75,7 @@ public interface DataSourceOperator {
      * @param query String containing the query to be executed
      * @return JsonArray containing the result array for the specified query
      */
-    public JsonArray getResultArrayForQuery(String url, String query);
+    public JsonArray getResultArrayForQuery(String url, String query, BearerAccessToken authToken);
 
     /**
      * Validates a JSON array to ensure it is not null, not a JSON null, and has at least one element.

--- a/src/main/java/com/autotune/common/datasource/DataSourceOperatorImpl.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceOperatorImpl.java
@@ -75,7 +75,7 @@ public class DataSourceOperatorImpl implements DataSourceOperator {
      * @return DatasourceReachabilityStatus
      */
     @Override
-    public CommonUtils.DatasourceReachabilityStatus isServiceable(String dataSourceUrl) {
+    public CommonUtils.DatasourceReachabilityStatus isServiceable(String dataSourceUrl, BearerAccessToken authToken) {
         return null;
     }
 
@@ -86,7 +86,7 @@ public class DataSourceOperatorImpl implements DataSourceOperator {
      * @return Object containing the result value for the specified query
      */
     @Override
-    public Object getValueForQuery(String url, String query) {
+    public Object getValueForQuery(String url, String query, BearerAccessToken authToken) {
         return null;
     }
 
@@ -105,7 +105,7 @@ public class DataSourceOperatorImpl implements DataSourceOperator {
      * @return JSONObject for the specified query
      */
     @Override
-    public JSONObject getJsonObjectForQuery(String url, String query) {
+    public JSONObject getJsonObjectForQuery(String url, String query, BearerAccessToken authToken) {
         return null;
     }
 
@@ -116,7 +116,7 @@ public class DataSourceOperatorImpl implements DataSourceOperator {
      * @return JsonArray containing the result array for the specified query
      */
     @Override
-    public JsonArray getResultArrayForQuery(String url, String query) {
+    public JsonArray getResultArrayForQuery(String url, String query, BearerAccessToken authToken) {
         return null;
     }
 

--- a/src/main/java/com/autotune/common/datasource/prometheus/PrometheusDataOperatorImpl.java
+++ b/src/main/java/com/autotune/common/datasource/prometheus/PrometheusDataOperatorImpl.java
@@ -20,6 +20,7 @@ import com.autotune.common.datasource.DataSourceOperatorImpl;
 import com.autotune.common.utils.CommonUtils;
 import com.autotune.utils.KruizeConstants;
 import com.autotune.utils.GenericRestApiClient;
+import com.autotune.utils.authModels.BearerAccessToken;
 import com.google.gson.*;
 import org.apache.http.conn.HttpHostConnectException;
 import org.json.JSONArray;
@@ -71,14 +72,14 @@ public class PrometheusDataOperatorImpl extends DataSourceOperatorImpl {
      * @return DatasourceReachabilityStatus
      */
     @Override
-    public CommonUtils.DatasourceReachabilityStatus isServiceable(String dataSourceURL) {
+    public CommonUtils.DatasourceReachabilityStatus isServiceable(String dataSourceURL, BearerAccessToken authToken) {
         String dataSourceStatus;
         Object queryResult;
 
         String query = KruizeConstants.DataSourceConstants.PROMETHEUS_REACHABILITY_QUERY;
         CommonUtils.DatasourceReachabilityStatus reachabilityStatus;
 
-        queryResult = this.getValueForQuery(dataSourceURL, query);
+        queryResult = this.getValueForQuery(dataSourceURL, query, authToken);
 
         if (queryResult != null){
             dataSourceStatus = queryResult.toString();
@@ -101,9 +102,9 @@ public class PrometheusDataOperatorImpl extends DataSourceOperatorImpl {
      * @return Object containing the result value for the specified query
      */
     @Override
-    public Object getValueForQuery(String url, String query) {
+    public Object getValueForQuery(String url, String query, BearerAccessToken authToken) {
         try {
-            JSONObject jsonObject = getJsonObjectForQuery(url, query);
+            JSONObject jsonObject = getJsonObjectForQuery(url, query, authToken);
 
             if (null == jsonObject) {
                 return null;
@@ -132,13 +133,25 @@ public class PrometheusDataOperatorImpl extends DataSourceOperatorImpl {
      * @return JSONObject for the specified query
      */
     @Override
-    public JSONObject getJsonObjectForQuery(String url, String query) {
-        GenericRestApiClient apiClient = new GenericRestApiClient(
-                CommonUtils.getBaseDataSourceUrl(
-                        url,
-                        KruizeConstants.SupportedDatasources.PROMETHEUS
-                )
-        );
+    public JSONObject getJsonObjectForQuery(String url, String query, BearerAccessToken authToken) {
+        GenericRestApiClient apiClient = null;
+
+        if (null != authToken) {
+            apiClient = new GenericRestApiClient(
+                    CommonUtils.getBaseDataSourceUrl(
+                            url,
+                            KruizeConstants.SupportedDatasources.PROMETHEUS
+                    ), authToken
+            );
+        } else {
+            apiClient = new GenericRestApiClient(
+                    CommonUtils.getBaseDataSourceUrl(
+                            url,
+                            KruizeConstants.SupportedDatasources.PROMETHEUS
+                    )
+            );
+        }
+
 
         if (null == apiClient) {
             return null;
@@ -202,9 +215,9 @@ public class PrometheusDataOperatorImpl extends DataSourceOperatorImpl {
      */
 
     @Override
-    public JsonArray getResultArrayForQuery(String url, String query) {
+    public JsonArray getResultArrayForQuery(String url, String query, BearerAccessToken authToken) {
         try {
-            JSONObject jsonObject = getJsonObjectForQuery(url, query);
+            JSONObject jsonObject = getJsonObjectForQuery(url, query, authToken);
 
             if (null == jsonObject) {
                 return null;

--- a/src/main/java/com/autotune/experimentManager/handler/MetricCollectionHandler.java
+++ b/src/main/java/com/autotune/experimentManager/handler/MetricCollectionHandler.java
@@ -37,6 +37,7 @@ import com.autotune.experimentManager.utils.EMConstants;
 import com.autotune.experimentManager.utils.EMUtil;
 import com.autotune.operator.KruizeDeploymentInfo;
 import com.autotune.utils.KruizeConstants;
+import com.autotune.utils.authModels.BearerAccessToken;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -123,7 +124,7 @@ public class MetricCollectionHandler implements EMHandlerInterface {
                             }
                             String queryResult = (String) op.getValueForQuery(experimentTrial.getDatasourceInfoHashMap()
                                     .get(podMetric.getDatasource())
-                                    .getUrl().toString(), updatedPodQuery);
+                                    .getUrl().toString(), updatedPodQuery, null);
                             if (null != queryResult && !queryResult.isEmpty() && !queryResult.isBlank()) {
                                 try {
                                     queryResult = queryResult.trim();
@@ -162,7 +163,7 @@ public class MetricCollectionHandler implements EMHandlerInterface {
                                     LOGGER.debug("Updated Query - " + updatedContainerQuery);
                                     String queryResult = (String) op.getValueForQuery(experimentTrial.getDatasourceInfoHashMap()
                                             .get(containerMetric.getDatasource())
-                                            .getUrl().toString(), updatedContainerQuery);
+                                            .getUrl().toString(), updatedContainerQuery, null);
                                     if (null != queryResult && !queryResult.isEmpty() && !queryResult.isBlank()) {
                                         try {
                                             queryResult = queryResult.trim();

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -335,6 +335,7 @@ public class KruizeConstants {
         public static final String DATASOURCE_SERVICE_NAME = "serviceName";
         public static final String DATASOURCE_SERVICE_NAMESPACE = "namespace";
         public static final String DATASOURCE_URL = "url";
+        public static final String DATASOURCE_AUTH_TOKEN = "authToken";
         public static final String KRUIZE_DATASOURCE = "datasource";
         public static final String SERVICE_DNS = ".svc.cluster.local";
         public static final String PROMETHEUS_DEFAULT_SERVICE_PORT = "9090";


### PR DESCRIPTION
## Description

This PR adds the support for Bearer Access Token for accessing the Prometheus in Openshift environment. 

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

- Tested on scltest cluster using deploy.sh script. 
- Still needs to be tested using autotune use case 

**Test Configuration**
* Kubernetes clusters tested on: kruize-scltest

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [ ] Dependent changes merged
- [x] Documentation updated
- [ ] Tests added or updated

## Additional information

Image: `quay.io/rh-ee-shesaxen/autotune:add-auth-os`