### PR TITLE
Enhance datasource info retrieval from DB with service name validation 

### DIFF
--- a/src/main/java/com/autotune/database/helper/DBHelpers.java
+++ b/src/main/java/com/autotune/database/helper/DBHelpers.java
@@ -690,7 +690,7 @@ public class DBHelpers {
                 for (KruizeDataSource kruizeDataSource : kruizeDataSourceList) {
                     try {
                         DataSourceInfo dataSourceInfo = null;
-                        if(null != kruizeDataSource.getUrl())
+                        if(kruizeDataSource.getServiceName().isEmpty() && null != kruizeDataSource.getUrl())
                              dataSourceInfo = new DataSourceInfo(kruizeDataSource.getName(), kruizeDataSource
                                     .getProvider(), new URL(kruizeDataSource.getUrl()));
                         else{

--- a/src/main/java/com/autotune/database/helper/DBHelpers.java
+++ b/src/main/java/com/autotune/database/helper/DBHelpers.java
@@ -690,10 +690,10 @@ public class DBHelpers {
                 for (KruizeDataSource kruizeDataSource : kruizeDataSourceList) {
                     try {
                         DataSourceInfo dataSourceInfo = null;
-                        if(kruizeDataSource.getServiceName().isEmpty() && null != kruizeDataSource.getUrl())
-                             dataSourceInfo = new DataSourceInfo(kruizeDataSource.getName(), kruizeDataSource
+                        if (kruizeDataSource.getServiceName().isEmpty() && null != kruizeDataSource.getUrl()) {
+                            dataSourceInfo = new DataSourceInfo(kruizeDataSource.getName(), kruizeDataSource
                                     .getProvider(), new URL(kruizeDataSource.getUrl()));
-                        else{
+                        } else{
                              dataSourceInfo = new DataSourceInfo(kruizeDataSource.getName(), kruizeDataSource
                                     .getProvider(), kruizeDataSource.getServiceName(), kruizeDataSource.getNamespace());
                         }


### PR DESCRIPTION
This PR resolves an issue where service name and namespace fields are missing in the `/datasources` API response  when the datasource URL is not null while retrieving datasource info from the database.

for a given datasource object -

```
"datasource": [
    {
      "name": "prometheus-1",
      "provider": "prometheus",
      "serviceName": "prometheus-k8s",
      "namespace": "monitoring",
      "url": ""
    }
]
```
list datasources - `/datasources` API response -

Current response (Incomplete API Response):
```
{
  "version": "v1.0",
  "datasources": [
    {
      "name": "prometheus-1",
      "provider": "prometheus",
      "serviceName": "",
      "namespace": "",
      "url": "http://prometheus-k8s.monitoring.svc.cluster.local:9090"
    }
  ]
}
```
Enhanced response after the fix: 
```
{
  "version": "v1.0",
  "datasources": [
    {
      "name": "prometheus-1",
      "provider": "prometheus",
      "serviceName": "prometheus-k8s",
      "namespace": "monitoring",
      "url": "http://prometheus-k8s.monitoring.svc.cluster.local:9090"
    }
  ]
}
```

