### PR TITLE
Restructured DataSourceInfo Class

### DIFF
--- a/src/main/java/com/autotune/common/datasource/DataSourceInfo.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceInfo.java
@@ -37,20 +37,16 @@ public class DataSourceInfo {
 
     private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(DataSourceInfo.class);
 
-    public DataSourceInfo(String name, String provider, URL url) {
+    public DataSourceInfo(String name, String provider, String serviceName, String namespace, URL url) {
         this.name = name;
         this.provider = provider;
-        this.url = url;
-        this.serviceName = "";
-        this.namespace = "";
-    }
-
-    public DataSourceInfo(String name, String provider, String serviceName, String namespace) {
-        this.name = name;
-        this.provider = provider;
+        if (null == url) {
+            this.url = getDNSBasedUrlForService(serviceName, namespace, provider);
+        } else {
+            this.url = url;
+        }
         this.serviceName = serviceName;
         this.namespace = namespace;
-        this.url = getDNSBasedUrlForService(serviceName, namespace, provider);
     }
 
     /**

--- a/src/main/java/com/autotune/common/datasource/DataSourceInfo.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceInfo.java
@@ -16,36 +16,100 @@
 package com.autotune.common.datasource;
 
 import java.net.URL;
-
+import org.slf4j.LoggerFactory;
 /**
- * This Data object is used to store information about metric collectors like Prometheus, LogicMonitor, Dynatrace, Amazon Timestream etc
+ * This DataSourceInfo object is used to store information about metric collectors like Prometheus, LogicMonitor, Dynatrace, Amazon Timestream etc
  * Example
- * "datasource_info": {
- * "name": "prometheus",
- * "url": "http://10.101.144.137:9090"
+ * "datasource": {
+ *     "name": "prometheus-1",
+ *     "provider": "prometheus",
+ *     "serviceName": "prometheus-k8s",
+ *     "namespace": "monitoring",
+ *     "url": ""
  * }
  */
 public class DataSourceInfo {
+    private final String name;
     private final String provider;
+    private final String serviceName;
+    private final String namespace;
     private final URL url;
 
-    public DataSourceInfo(String provider, URL url) {
+    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(DataSourceInfo.class);
+
+    public DataSourceInfo(String name, String provider, URL url) {
+        this.name = name;
         this.provider = provider;
         this.url = url;
+        this.serviceName = "";
+        this.namespace = "";
     }
 
+    public DataSourceInfo(String name, String provider, String serviceName, String namespace) {
+        this.name = name;
+        this.provider = provider;
+        this.serviceName = serviceName;
+        this.namespace = namespace;
+        this.url = getDNSBasedUrlForService(serviceName, namespace, provider);
+    }
+
+    /**
+     * Returns the name of the data source
+     * @return String containing the name of the data source
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the provider type of the data source
+     * @return String containing the provider of the data source
+     */
     public String getProvider() {
         return provider;
     }
 
+    /**
+     * Returns the serviceName of the data source
+     * @return String containing the name of service for the data source
+     */
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    /**
+     * Returns the namespace in which data source service is deployed
+     * @return String containing the namespace of service for the data source
+     */
+    public String getNamespace() {
+        return namespace;
+    }
+
+    /**
+     * Returns the URL of the data source
+     * @return URL containing the URL of the data source
+     */
     public URL getUrl() {
         return url;
+    }
+
+    /**
+     * Returns the DNS Based URL for accessing the service
+     * @return URL containing the URL of the data source
+     */
+    private URL getDNSBasedUrlForService(String serviceName, String namespace, String provider) {
+        URL dnsUrl = null;
+        // TODO: Implement this method
+        return dnsUrl;
     }
 
     @Override
     public String toString() {
         return "DataSourceInfo{" +
-                "provider='" + provider + '\'' +
+                "name='" + name + '\'' +
+                ", provider='" + provider + '\'' +
+                ", serviceName='" + serviceName + '\'' +
+                ", namespace='" + namespace + '\'' +
                 ", url=" + url +
                 '}';
     }

--- a/src/main/java/com/autotune/utils/TrialHelpers.java
+++ b/src/main/java/com/autotune/utils/TrialHelpers.java
@@ -145,7 +145,7 @@ public class TrialHelpers {
                 trialNumber,
                 trialResultUrl.toString());
 
-        DataSourceInfo datasourceInfo = new DataSourceInfo(KruizeDeploymentInfo.monitoring_agent, KruizeConstants.SupportedDatasources.PROMETHEUS, new URL(KruizeDeploymentInfo.monitoring_agent_endpoint));
+        DataSourceInfo datasourceInfo = new DataSourceInfo(KruizeDeploymentInfo.monitoring_agent, KruizeConstants.SupportedDatasources.PROMETHEUS, null, null, new URL(KruizeDeploymentInfo.monitoring_agent_endpoint));
         HashMap<String, DataSourceInfo> datasourceInfoHashMap = new HashMap<>();
         datasourceInfoHashMap.put(KruizeDeploymentInfo.monitoring_agent, datasourceInfo);  //Change key value as per YAML input
         DeploymentTracking deploymentTracking = new DeploymentTracking();

--- a/src/main/java/com/autotune/utils/TrialHelpers.java
+++ b/src/main/java/com/autotune/utils/TrialHelpers.java
@@ -145,8 +145,7 @@ public class TrialHelpers {
                 trialNumber,
                 trialResultUrl.toString());
 
-        DataSourceInfo datasourceInfo = new DataSourceInfo(KruizeDeploymentInfo.monitoring_agent,
-                new URL(KruizeDeploymentInfo.monitoring_agent_endpoint));
+        DataSourceInfo datasourceInfo = new DataSourceInfo(KruizeDeploymentInfo.monitoring_agent, KruizeConstants.SupportedDatasources.PROMETHEUS, new URL(KruizeDeploymentInfo.monitoring_agent_endpoint));
         HashMap<String, DataSourceInfo> datasourceInfoHashMap = new HashMap<>();
         datasourceInfoHashMap.put(KruizeDeploymentInfo.monitoring_agent, datasourceInfo);  //Change key value as per YAML input
         DeploymentTracking deploymentTracking = new DeploymentTracking();


### PR DESCRIPTION


## Description

This PR will modify the existing `dataSourceInfo` class as following - 
- added `name`, `serviceName`, `url` properties.
- modified constructor to accept these new parameters. 
- updated TrialHelpers.java to use the new constructor. 
- created `getDNSBasedUrlForService` method (implementation pending).

### Type of change

- [ ] Refactoring Code
- [x] New feature

## How has this been tested?

Using kruize-demo scripts. 
Image: `quay.io/rh-ee-shesaxen/autotune:kruize-mvp-add-datasource`

**Test Configuration**
* Kubernetes clusters tested on: minikube

## Checklist :dart:

- [X] Followed coding guidelines
- [X] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information
CRUD operations for DataSources will be in next PR.