### PR TITLE
Add DataSourceMetadataInfo and nested object classes

### DIFF
--- a/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSource.java
+++ b/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSource.java
@@ -1,0 +1,49 @@
+package com.autotune.common.data.dataSourceMetadata;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+
+/**
+ * DataSource object represents a data source, and it's associated clusters
+ * used to store hashmap of DataSourceCluster objects representing cluster metadata
+ */
+public class DataSource {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DataSource.class);
+    // TODO - add KruizeConstants for attributes
+    private String dataSourceName;
+
+    /**
+     * Key: Cluster name
+     * Value: Associated DataSourceCluster object
+     */
+    private HashMap<String, DataSourceCluster> clusterHashMap;
+
+    public DataSource(String dataSourceName, HashMap<String,DataSourceCluster> clusterHashMap) {
+        this.dataSourceName = dataSourceName;
+        this.clusterHashMap = clusterHashMap;
+    }
+
+    public String getDataSourceName() {
+        return dataSourceName;
+    }
+
+    public HashMap<String, DataSourceCluster> getDataSourceClusterHashMap() {
+        return clusterHashMap;
+    }
+
+    public void setDataSourceClusterHashMap(HashMap<String, DataSourceCluster> clusterHashMap) {
+        // TODO: Validate input before setting the clusterHashMap
+        this.clusterHashMap = clusterHashMap;
+    }
+
+
+    @Override
+    public String toString() {
+        return "DataSource{" +
+                "dataSourceName='" + dataSourceName + '\'' +
+                ", clusterHashMap=" + clusterHashMap +
+                '}';
+    }
+}

--- a/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceCluster.java
+++ b/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceCluster.java
@@ -1,0 +1,48 @@
+package com.autotune.common.data.dataSourceMetadata;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+
+/**
+ * DataSourceCluster object represents the cluster of a data source, and it's associated namespaces
+ * used to store hashmap of DataSourceNamespace objects representing namespace metadata
+ */
+public class DataSourceCluster {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DataSourceCluster.class);
+    // TODO - add KruizeConstants for attributes
+    private String clusterName;
+
+    /**
+     * Key: Namespace
+     * Value: Associated DataSourceNamespace object
+     */
+    private HashMap<String, DataSourceNamespace> namespaceHashMap;
+
+    public DataSourceCluster(String clusterName, HashMap<String, DataSourceNamespace> namespaceHashMap) {
+        this.clusterName = clusterName;
+        this.namespaceHashMap = namespaceHashMap;
+    }
+
+    public String getDataSourceClusterName() {
+        return clusterName;
+    }
+
+    public HashMap<String, DataSourceNamespace> getDataSourceNamespaceHashMap() {
+        return namespaceHashMap;
+    }
+
+    public void setDataSourceNamespaceHashMap(HashMap<String, DataSourceNamespace> namespaceHashMap) {
+        // TODO: Validate input before setting the namespaceHashMap
+        this.namespaceHashMap = namespaceHashMap;
+    }
+
+    @Override
+    public String toString() {
+        return "DataSourceCluster{" +
+                "clusterName='" + clusterName + '\'' +
+                ", namespaceHashMap=" + namespaceHashMap +
+                '}';
+    }
+}

--- a/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceContainer.java
+++ b/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceContainer.java
@@ -1,0 +1,27 @@
+package com.autotune.common.data.dataSourceMetadata;
+
+
+/**
+ * DataSourceContainer object represents the container metadata for a workload
+ */
+public class DataSourceContainer {
+    // TODO - add KruizeConstants for attributes
+    private String containerName;
+    private String containerImageName;
+
+    public DataSourceContainer(String containerName, String containerImageName) {
+        this.containerName = containerName;
+        this.containerImageName = containerImageName;
+    }
+
+    public String getDataSourceContainerName() { return containerName;}
+    public String getDataSourceContainerImageName() { return containerImageName;}
+
+    @Override
+    public String toString() {
+        return "DataSourceContainer{" +
+                "containerName='" + containerName + '\'' +
+                ", containerImageName='" + containerImageName + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceMetadataInfo.java
+++ b/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceMetadataInfo.java
@@ -1,0 +1,43 @@
+package com.autotune.common.data.dataSourceMetadata;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+
+/**
+ * DataSourceMetadataInfo represents metadata information about data source(s) and its associated clusters, namespaces, workloads, and containers.
+ * It encapsulates a hierarchical structure starting from DataSource to DataSourceContainer, with each nested object containing specific metadata.
+ */
+
+public class DataSourceMetadataInfo {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DataSourceMetadataInfo.class);
+    // TODO - add KruizeConstants for attributes
+    /**
+     * Key: Data Source name
+     * Value: Associated DataSource object
+     */
+    private HashMap<String, DataSource> dataSourceHashMap;
+
+    public DataSourceMetadataInfo(HashMap<String, DataSource> dataSourceHashMap) {
+        this.dataSourceHashMap = dataSourceHashMap;
+    }
+
+    public HashMap<String, DataSource> getDataSourceHashMap() {
+        return dataSourceHashMap;
+    }
+
+    public void setDataSourceHashMap(HashMap<String, DataSource> dataSourceHashMap) {
+        if (null == dataSourceHashMap) {
+            LOGGER.debug("No data sources found");
+        }
+        this.dataSourceHashMap = dataSourceHashMap;
+    }
+
+    @Override
+    public String toString() {
+        return "DataSourceMetadataInfo{" +
+                "dataSourceHashMap=" + dataSourceHashMap +
+                '}';
+    }
+}

--- a/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceNamespace.java
+++ b/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceNamespace.java
@@ -1,0 +1,48 @@
+package com.autotune.common.data.dataSourceMetadata;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+
+/**
+ * DataSourceNamespace object represents the namespace of a cluster, and it's associated workloads
+ * used to store hashmap of DataSourceWorkload objects representing workload metadata
+ */
+public class DataSourceNamespace {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DataSourceNamespace.class);
+    // TODO - add KruizeConstants for attributes
+    private String namespace;
+
+    /**
+     * Key: Workload name
+     * Value: Associated DataSourceWorkload object
+     */
+    private HashMap<String, DataSourceWorkload> workloadHashMap;
+
+    public DataSourceNamespace(String namespace, HashMap<String, DataSourceWorkload> workloadHashMap) {
+        this.namespace = namespace;
+        this.workloadHashMap = workloadHashMap;
+    }
+
+    public String getDataSourceNamespaceName() {
+        return namespace;
+    }
+
+    public HashMap<String, DataSourceWorkload> getDataSourceWorkloadHashMap() {
+        return workloadHashMap;
+    }
+
+    public void setDataSourceWorkloadHashMap(HashMap<String, DataSourceWorkload> workloadHashMap) {
+        // TODO: Validate input before setting the workloadHashMap
+        this.workloadHashMap = workloadHashMap;
+    }
+
+    @Override
+    public String toString() {
+        return "DataSourceNamespace{" +
+                "namespace='" + namespace + '\'' +
+                ", workloadHashMap=" + workloadHashMap +
+                '}';
+    }
+}

--- a/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceWorkload.java
+++ b/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceWorkload.java
@@ -1,0 +1,51 @@
+package com.autotune.common.data.dataSourceMetadata;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+
+/**
+ * DataSourceWorkload object represents the workload of a namespace, and it's associated containers
+ * used to store hashmap of DataSourceContainer objects representing container metadata
+ */
+public class DataSourceWorkload {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DataSourceWorkload.class);
+    // TODO - add KruizeConstants for attributes
+    private String workloadName;
+    private String workloadType;
+
+    /**
+     * Key: Container name
+     * Value: Associated DataSourceContainer object
+     */
+    private HashMap<String, DataSourceContainer> containerHashMap;
+
+    public DataSourceWorkload(String workloadName, String workloadType, HashMap<String, DataSourceContainer> containerHashMap) {
+        this.workloadName = workloadName;
+        this.workloadType = workloadType;
+        this.containerHashMap = containerHashMap;
+    }
+
+    public String getDataSourceWorkloadName() {return workloadName;}
+
+    public String getDataSourceWorkloadType() {return workloadType;}
+
+    public HashMap<String, DataSourceContainer> getDataSourceContainerHashMap() {
+        return containerHashMap;
+    }
+
+    public void setDataSourceContainerHashMap(HashMap<String, DataSourceContainer> containerHashMap) {
+        // TODO: Validate input before setting the containerHashMap
+        this.containerHashMap = containerHashMap;
+    }
+
+    @Override
+    public String toString() {
+        return "DataSourceWorkload{" +
+                "workloadName='" + workloadName + '\'' +
+                ", workloadType='" + workloadType + '\'' +
+                ", containerHashMap=" + containerHashMap +
+                '}';
+    }
+}


### PR DESCRIPTION
## Description

This PR implements `DataSourceMetadataInfo` class and associated nested object classes representing JSON for importing cluster level metadata.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

**Test Configuration**
* Kubernetes clusters tested on: minikube

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

NA