### PR TITLE
Implement CRUD operations for Datasource Metadata

### DIFF
--- a/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSource.java
+++ b/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSource.java
@@ -1,5 +1,7 @@
 package com.autotune.common.data.dataSourceMetadata;
 
+import com.autotune.utils.KruizeConstants;
+import com.google.gson.annotations.SerializedName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,13 +13,14 @@ import java.util.HashMap;
  */
 public class DataSource {
     private static final Logger LOGGER = LoggerFactory.getLogger(DataSource.class);
-    // TODO - add KruizeConstants for attributes
+    @SerializedName(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.DATASOURCE_NAME)
     private String dataSourceName;
 
     /**
      * Key: Cluster name
      * Value: Associated DataSourceCluster object
      */
+    @SerializedName(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.CLUSTERS)
     private HashMap<String, DataSourceCluster> clusterHashMap;
 
     public DataSource(String dataSourceName, HashMap<String,DataSourceCluster> clusterHashMap) {
@@ -34,7 +37,9 @@ public class DataSource {
     }
 
     public void setDataSourceClusterHashMap(HashMap<String, DataSourceCluster> clusterHashMap) {
-        // TODO: Validate input before setting the clusterHashMap
+        if (null == clusterHashMap) {
+            LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.SET_CLUSTER_MAP_ERROR + "{}", dataSourceName);
+        }
         this.clusterHashMap = clusterHashMap;
     }
 
@@ -48,8 +53,8 @@ public class DataSource {
     @Override
     public String toString() {
         return "DataSource{" +
-                "dataSourceName='" + dataSourceName + '\'' +
-                ", clusterHashMap=" + clusterHashMap +
+                "datasource_name='" + dataSourceName + '\'' +
+                ", clusters=" + clusterHashMap +
                 '}';
     }
 }

--- a/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSource.java
+++ b/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSource.java
@@ -38,6 +38,12 @@ public class DataSource {
         this.clusterHashMap = clusterHashMap;
     }
 
+    public DataSourceCluster getDataSourceClusterObject(String clusterName) {
+        if (null != clusterHashMap && clusterHashMap.containsKey(clusterName)) {
+            return clusterHashMap.get(clusterName);
+        }
+        return null;
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceCluster.java
+++ b/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceCluster.java
@@ -38,6 +38,13 @@ public class DataSourceCluster {
         this.namespaceHashMap = namespaceHashMap;
     }
 
+    public DataSourceNamespace getDataSourceNamespaceObject(String namespace) {
+        if  (null != namespaceHashMap && namespaceHashMap.containsKey(namespace)) {
+            return namespaceHashMap.get(namespace);
+        }
+        return null;
+    }
+
     @Override
     public String toString() {
         return "DataSourceCluster{" +

--- a/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceCluster.java
+++ b/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceCluster.java
@@ -1,5 +1,7 @@
 package com.autotune.common.data.dataSourceMetadata;
 
+import com.autotune.utils.KruizeConstants;
+import com.google.gson.annotations.SerializedName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,13 +13,14 @@ import java.util.HashMap;
  */
 public class DataSourceCluster {
     private static final Logger LOGGER = LoggerFactory.getLogger(DataSourceCluster.class);
-    // TODO - add KruizeConstants for attributes
+    @SerializedName(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.CLUSTER_NAME)
     private String clusterName;
 
     /**
      * Key: Namespace
      * Value: Associated DataSourceNamespace object
      */
+    @SerializedName(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.NAMESPACES)
     private HashMap<String, DataSourceNamespace> namespaceHashMap;
 
     public DataSourceCluster(String clusterName, HashMap<String, DataSourceNamespace> namespaceHashMap) {
@@ -34,7 +37,9 @@ public class DataSourceCluster {
     }
 
     public void setDataSourceNamespaceHashMap(HashMap<String, DataSourceNamespace> namespaceHashMap) {
-        // TODO: Validate input before setting the namespaceHashMap
+        if (null == namespaceHashMap) {
+            LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.SET_NAMESPACE_MAP_ERROR + "{}", clusterName);
+        }
         this.namespaceHashMap = namespaceHashMap;
     }
 
@@ -48,8 +53,8 @@ public class DataSourceCluster {
     @Override
     public String toString() {
         return "DataSourceCluster{" +
-                "clusterName='" + clusterName + '\'' +
-                ", namespaceHashMap=" + namespaceHashMap +
+                "cluster_name='" + clusterName + '\'' +
+                ", namespaces=" + namespaceHashMap +
                 '}';
     }
 }

--- a/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceContainer.java
+++ b/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceContainer.java
@@ -1,12 +1,15 @@
 package com.autotune.common.data.dataSourceMetadata;
 
+import com.autotune.utils.KruizeConstants;
+import com.google.gson.annotations.SerializedName;
 
 /**
  * DataSourceContainer object represents the container metadata for a workload
  */
 public class DataSourceContainer {
-    // TODO - add KruizeConstants for attributes
+    @SerializedName(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.CONTAINER_NAME)
     private String containerName;
+    @SerializedName(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.CONTAINER_IMAGE_NAME)
     private String containerImageName;
 
     public DataSourceContainer(String containerName, String containerImageName) {
@@ -20,8 +23,8 @@ public class DataSourceContainer {
     @Override
     public String toString() {
         return "DataSourceContainer{" +
-                "containerName='" + containerName + '\'' +
-                ", containerImageName='" + containerImageName + '\'' +
+                "container_name='" + containerName + '\'' +
+                ", container_image_name='" + containerImageName + '\'' +
                 '}';
     }
 }

--- a/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceMetadataHelper.java
+++ b/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceMetadataHelper.java
@@ -1,6 +1,5 @@
-package com.autotune.common.utils;
+package com.autotune.common.data.dataSourceMetadata;
 
-import com.autotune.common.data.dataSourceMetadata.*;
 import com.autotune.utils.KruizeConstants;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;

--- a/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceMetadataInfo.java
+++ b/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceMetadataInfo.java
@@ -1,5 +1,7 @@
 package com.autotune.common.data.dataSourceMetadata;
 
+import com.autotune.utils.KruizeConstants;
+import com.google.gson.annotations.SerializedName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -12,11 +14,12 @@ import java.util.HashMap;
 
 public class DataSourceMetadataInfo {
     private static final Logger LOGGER = LoggerFactory.getLogger(DataSourceMetadataInfo.class);
-    // TODO - add KruizeConstants for attributes
+
     /**
      * Key: Data Source name
      * Value: Associated DataSource object
      */
+    @SerializedName(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.DATASOURCES)
     private HashMap<String, DataSource> dataSourceHashMap;
 
     public DataSourceMetadataInfo(HashMap<String, DataSource> dataSourceHashMap) {
@@ -43,7 +46,7 @@ public class DataSourceMetadataInfo {
     @Override
     public String toString() {
         return "DataSourceMetadataInfo{" +
-                "dataSourceHashMap=" + dataSourceHashMap +
+                "datasources=" + dataSourceHashMap +
                 '}';
     }
 }

--- a/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceMetadataInfo.java
+++ b/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceMetadataInfo.java
@@ -33,6 +33,12 @@ public class DataSourceMetadataInfo {
         }
         this.dataSourceHashMap = dataSourceHashMap;
     }
+    public DataSource getDataSourceObject(String dataSourceName) {
+        if (null != dataSourceHashMap && dataSourceHashMap.containsKey(dataSourceName)) {
+            return dataSourceHashMap.get(dataSourceName);
+        }
+        return null;
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceNamespace.java
+++ b/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceNamespace.java
@@ -38,6 +38,14 @@ public class DataSourceNamespace {
         this.workloadHashMap = workloadHashMap;
     }
 
+    public DataSourceWorkload getDataSourceWorkloadObject(String workloadName) {
+        if (null != workloadHashMap && workloadHashMap.containsKey(workloadName)) {
+            return workloadHashMap.get(workloadName);
+        }
+
+        return null;
+    }
+
     @Override
     public String toString() {
         return "DataSourceNamespace{" +

--- a/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceNamespace.java
+++ b/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceNamespace.java
@@ -1,5 +1,7 @@
 package com.autotune.common.data.dataSourceMetadata;
 
+import com.autotune.utils.KruizeConstants;
+import com.google.gson.annotations.SerializedName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,13 +13,14 @@ import java.util.HashMap;
  */
 public class DataSourceNamespace {
     private static final Logger LOGGER = LoggerFactory.getLogger(DataSourceNamespace.class);
-    // TODO - add KruizeConstants for attributes
+    @SerializedName(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.NAMESPACE)
     private String namespace;
 
     /**
      * Key: Workload name
      * Value: Associated DataSourceWorkload object
      */
+    @SerializedName(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.WORKLOADS)
     private HashMap<String, DataSourceWorkload> workloadHashMap;
 
     public DataSourceNamespace(String namespace, HashMap<String, DataSourceWorkload> workloadHashMap) {
@@ -34,7 +37,9 @@ public class DataSourceNamespace {
     }
 
     public void setDataSourceWorkloadHashMap(HashMap<String, DataSourceWorkload> workloadHashMap) {
-        // TODO: Validate input before setting the workloadHashMap
+        if (null == workloadHashMap) {
+            LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.SET_WORKLOAD_MAP_ERROR + "{}", namespace);
+        }
         this.workloadHashMap = workloadHashMap;
     }
 
@@ -50,7 +55,7 @@ public class DataSourceNamespace {
     public String toString() {
         return "DataSourceNamespace{" +
                 "namespace='" + namespace + '\'' +
-                ", workloadHashMap=" + workloadHashMap +
+                ", workloads=" + workloadHashMap +
                 '}';
     }
 }

--- a/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceWorkload.java
+++ b/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceWorkload.java
@@ -1,5 +1,7 @@
 package com.autotune.common.data.dataSourceMetadata;
 
+import com.autotune.utils.KruizeConstants;
+import com.google.gson.annotations.SerializedName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,14 +13,16 @@ import java.util.HashMap;
  */
 public class DataSourceWorkload {
     private static final Logger LOGGER = LoggerFactory.getLogger(DataSourceWorkload.class);
-    // TODO - add KruizeConstants for attributes
+    @SerializedName(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.WORKLOAD_NAME)
     private String workloadName;
+    @SerializedName(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.WORKLOAD_TYPE)
     private String workloadType;
 
     /**
      * Key: Container name
      * Value: Associated DataSourceContainer object
      */
+    @SerializedName(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.CONTAINERS)
     private HashMap<String, DataSourceContainer> containerHashMap;
 
     public DataSourceWorkload(String workloadName, String workloadType, HashMap<String, DataSourceContainer> containerHashMap) {
@@ -36,16 +40,18 @@ public class DataSourceWorkload {
     }
 
     public void setDataSourceContainerHashMap(HashMap<String, DataSourceContainer> containerHashMap) {
-        // TODO: Validate input before setting the containerHashMap
+        if (containerHashMap == null) {
+            LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.SET_CONTAINER_MAP_ERROR + "{}", workloadName);
+        }
         this.containerHashMap = containerHashMap;
     }
 
     @Override
     public String toString() {
         return "DataSourceWorkload{" +
-                "workloadName='" + workloadName + '\'' +
-                ", workloadType='" + workloadType + '\'' +
-                ", containerHashMap=" + containerHashMap +
+                "workload_name='" + workloadName + '\'' +
+                ", workload_type='" + workloadType + '\'' +
+                ", conatiners=" + containerHashMap +
                 '}';
     }
 }

--- a/src/main/java/com/autotune/common/datasource/DataSourceManager.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceManager.java
@@ -3,6 +3,8 @@ package com.autotune.common.datasource;
 import com.autotune.common.exceptions.datasource.DataSourceDoesNotExist;
 import com.autotune.common.data.dataSourceMetadata.DataSourceMetadataInfo;
 import com.autotune.utils.KruizeConstants;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,4 +58,39 @@ public class DataSourceManager {
         return null;
     }
 
+    /**
+     * Updates metadata of the specified data source and metadata object
+     * @param dataSource The information about the data source to be updated.
+     * @param dataSourceMetadataInfo The existing DataSourceMetadataInfo object containing the current
+     *                             metadata information of the data source.
+     */
+    public void updateMetadataFromDataSource(DataSourceInfo dataSource, DataSourceMetadataInfo dataSourceMetadataInfo) {
+        try {
+            if (null == dataSource) {
+                throw new KruizeDatasourceDoesNotExist(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.MISSING_DATASOURCE_INFO);
+            }
+            if (null == dataSourceMetadataInfo) {
+                throw new KruizeDatasourceDoesNotExist(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.DATASOURCE_METADATA_INFO_NOT_AVAILABLE);
+            }
+            dataSourceMetadataOperator.updateDataSourceMetadata(dataSource, dataSourceMetadataInfo);
+        } catch (Exception e) {
+            LOGGER.error(e.getMessage());
+        }
+    }
+
+    /**
+     * Deletes metadata of the specified data source
+     * @param dataSource The metadata associated with the specified data source to be deleted.
+     */
+    public void deleteMetadataFromDataSource(DataSourceInfo dataSource) {
+
+        try {
+            if (null == dataSource) {
+                throw new KruizeDatasourceDoesNotExist(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.MISSING_DATASOURCE_INFO);
+            }
+            dataSourceMetadataOperator.deleteDataSourceMetadata(dataSource);
+        } catch (Exception e) {
+            LOGGER.error(e.getMessage());
+        }
+    }
 }

--- a/src/main/java/com/autotune/common/datasource/DataSourceManager.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceManager.java
@@ -1,6 +1,7 @@
 package com.autotune.common.datasource;
 
 import com.autotune.common.exceptions.datasource.DataSourceDoesNotExist;
+import com.autotune.common.data.dataSourceMetadata.DataSourceMetadataInfo;
 import com.autotune.utils.KruizeConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,15 +44,16 @@ public class DataSourceManager {
      * @return DataSourceMetadataInfo containing details about the data source, or null if not found.
      * @throws DataSourceDoesNotExist Thrown when the provided data source information is null.
      */
-    public void getMetadataFromDataSource(DataSourceInfo dataSource) {
+    public DataSourceMetadataInfo getMetadataFromDataSource(DataSourceInfo dataSource) {
         try {
             if (null == dataSource) {
                 throw new DataSourceDoesNotExist(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.MISSING_DATASOURCE_INFO);
             }
-            dataSourceMetadataOperator.getDataSourceMetadataInfo(dataSource);
+            return dataSourceMetadataOperator.getDataSourceMetadataInfo(dataSource);
         } catch (Exception e) {
             LOGGER.error(e.getMessage());
         }
+        return null;
     }
 
 }

--- a/src/main/java/com/autotune/common/datasource/DataSourceManager.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceManager.java
@@ -67,10 +67,10 @@ public class DataSourceManager {
     public void updateMetadataFromDataSource(DataSourceInfo dataSource, DataSourceMetadataInfo dataSourceMetadataInfo) {
         try {
             if (null == dataSource) {
-                throw new KruizeDatasourceDoesNotExist(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.MISSING_DATASOURCE_INFO);
+                throw new DataSourceDoesNotExist(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.MISSING_DATASOURCE_INFO);
             }
             if (null == dataSourceMetadataInfo) {
-                throw new KruizeDatasourceDoesNotExist(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.DATASOURCE_METADATA_INFO_NOT_AVAILABLE);
+                throw new DataSourceDoesNotExist(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.DATASOURCE_METADATA_INFO_NOT_AVAILABLE);
             }
             dataSourceMetadataOperator.updateDataSourceMetadata(dataSource, dataSourceMetadataInfo);
         } catch (Exception e) {
@@ -86,7 +86,7 @@ public class DataSourceManager {
 
         try {
             if (null == dataSource) {
-                throw new KruizeDatasourceDoesNotExist(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.MISSING_DATASOURCE_INFO);
+                throw new DataSourceDoesNotExist(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.MISSING_DATASOURCE_INFO);
             }
             dataSourceMetadataOperator.deleteDataSourceMetadata(dataSource);
         } catch (Exception e) {

--- a/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
@@ -1,7 +1,14 @@
 package com.autotune.common.datasource;
 
+import com.autotune.common.data.dataSourceQueries.PromQLDataSourceQueries;
+import com.autotune.common.utils.DataSourceMetadataHelper;
+import com.autotune.common.data.dataSourceMetadata.*;
+import com.autotune.utils.KruizeConstants;
+import com.google.gson.JsonArray;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
 
 /**
  * DataSourceMetadataOperator is an abstraction with CRUD operations to manage DataSourceMetadataInfo Object
@@ -14,15 +21,110 @@ import org.slf4j.LoggerFactory;
 public class DataSourceMetadataOperator {
     private static final Logger LOGGER = LoggerFactory.getLogger(DataSourceMetadataOperator.class);
     private static final DataSourceMetadataOperator dataSourceMetadataOperatorInstance = new DataSourceMetadataOperator();
-    private DataSourceMetadataOperator() {
-    }
+    private DataSourceMetadataInfo dataSourceMetadataInfo;
+    private DataSourceMetadataOperator() { this.dataSourceMetadataInfo = null; }
     public static DataSourceMetadataOperator getInstance() { return dataSourceMetadataOperatorInstance; }
 
-    public void createDataSourceMetadata(DataSourceInfo dataSource) {
-        //TODO - Implementation
+    /**
+     * Creates and populates metadata for a data source based on the provided DataSourceInfo object.
+     *
+     * Currently supported DataSourceProvider - Prometheus
+     *
+     * @param dataSourceInfo The DataSourceInfo object containing information about the data source.
+     * TODO - support multiple data sources
+     */
+    public void createDataSourceMetadata(DataSourceInfo dataSourceInfo) {
+        DataSourceMetadataHelper dataSourceDetailsHelper = new DataSourceMetadataHelper();
+        /**
+         * Get DataSourceOperatorImpl instance on runtime based on dataSource provider
+         */
+        DataSourceOperatorImpl op = DataSourceOperatorImpl.getInstance().getOperator(dataSourceInfo.getProvider());
+
+        if (null == op) {
+            return;
+        }
+
+        /**
+         * For the "prometheus" data source, fetches and processes data related to namespaces, workloads, and containers,
+         * creating a comprehensive DataSourceMetadataInfo object that is then added to a list.
+         * TODO - Process cluster metadata using a custom query
+         */
+        try {
+            JsonArray namespacesDataResultArray =  op.getResultArrayForQuery(dataSourceInfo.getUrl().toString(), PromQLDataSourceQueries.NAMESPACE_QUERY);
+            if (false == op.validateResultArray(namespacesDataResultArray)){
+                dataSourceMetadataInfo = dataSourceDetailsHelper.createDataSourceMetadataInfoObject(dataSourceInfo.getName(), null);
+                return;
+            }
+
+            /**
+             * Key: Name of namespace
+             * Value: DataSourceNamespace object corresponding to a namespace
+             */
+            HashMap<String, DataSourceNamespace> datasourceNamespaces = dataSourceDetailsHelper.getActiveNamespaces(namespacesDataResultArray);
+            dataSourceMetadataInfo = dataSourceDetailsHelper.createDataSourceMetadataInfoObject(dataSourceInfo.getName(), datasourceNamespaces);
+
+            /**
+             * Outer map:
+             * Key: Name of namespace
+             * <p>
+             * Inner map:
+             * Key: Name of workload
+             * Value: DataSourceWorkload object matching the name
+             * TODO -  get workload metadata for a given namespace
+             */
+            HashMap<String, HashMap<String, DataSourceWorkload>> datasourceWorkloads = new HashMap<>();
+            JsonArray workloadDataResultArray = op.getResultArrayForQuery(dataSourceInfo.getUrl().toString(), PromQLDataSourceQueries.WORKLOAD_QUERY);
+            if (true == op.validateResultArray(workloadDataResultArray)) {
+                datasourceWorkloads = dataSourceDetailsHelper.getWorkloadInfo(workloadDataResultArray);
+            }
+            dataSourceDetailsHelper.updateWorkloadDataSourceMetadataInfoObject(dataSourceInfo.getName(), dataSourceMetadataInfo, datasourceWorkloads);
+
+            /**
+             * Outer map:
+             * Key: Name of workload
+             * <p>
+             * Inner map:
+             * Key: Name of container
+             * Value: DataSourceContainer object matching the name
+             * TODO - get container metadata for a given workload
+             */
+            HashMap<String, HashMap<String, DataSourceContainer>> datasourceContainers = new HashMap<>();
+            JsonArray containerDataResultArray = op.getResultArrayForQuery(dataSourceInfo.getUrl().toString(), PromQLDataSourceQueries.CONTAINER_QUERY);
+            if (true == op.validateResultArray(containerDataResultArray)) {
+                datasourceContainers = dataSourceDetailsHelper.getContainerInfo(containerDataResultArray);
+            }
+            dataSourceDetailsHelper.updateContainerDataSourceMetadataInfoObject(dataSourceInfo.getName(), dataSourceMetadataInfo, datasourceWorkloads, datasourceContainers);
+        } catch (Exception e) {
+            LOGGER.error(e.getMessage());
+        }
     }
-    public void getDataSourceMetadataInfo(DataSourceInfo dataSource) {
-        //TODO - Implementation
+
+    /**
+     * Retrieves DataSourceMetadataInfo object.
+     * @return DataSourceMetadataInfo containing metadata about the data source if found, otherwise null.
+     */
+    public DataSourceMetadataInfo getDataSourceMetadataInfo(DataSourceInfo dataSourceInfo) {
+        try {
+            if (null == dataSourceMetadataInfo) {
+                LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.DATASOURCE_METADATA_INFO_NOT_AVAILABLE);
+                return null;
+            }
+            String dataSourceName = dataSourceInfo.getName();
+            HashMap<String, DataSource> dataSourceHashMap = dataSourceMetadataInfo.getDataSourceHashMap();
+
+            if (null == dataSourceHashMap || !dataSourceHashMap.containsKey(dataSourceName)) {
+                LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.DATASOURCE_METADATA_DATASOURCE_NOT_AVAILABLE + dataSourceName);
+                return null;
+            }
+
+            DataSource targetDataSource = dataSourceHashMap.get(dataSourceName);
+            HashMap<String, DataSource> targetDataSourceHashMap = new HashMap<>();
+            targetDataSourceHashMap.put(dataSourceName, targetDataSource);
+            return new DataSourceMetadataInfo(targetDataSourceHashMap);
+        } catch (Exception e) {
+            LOGGER.error(e.getMessage());
+            return null;
+        }
     }
 
 }

--- a/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
@@ -1,14 +1,13 @@
 package com.autotune.common.datasource;
 
 import com.autotune.common.data.dataSourceQueries.PromQLDataSourceQueries;
-import com.autotune.common.utils.DataSourceMetadataHelper;
+import com.autotune.common.data.dataSourceMetadata.DataSourceMetadataHelper;
 import com.autotune.common.data.dataSourceMetadata.*;
 import com.autotune.utils.KruizeConstants;
 import com.google.gson.JsonArray;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.xml.crypto.Data;
 import java.util.HashMap;
 
 /**
@@ -42,6 +41,7 @@ public class DataSourceMetadataOperator {
         DataSourceOperatorImpl op = DataSourceOperatorImpl.getInstance().getOperator(dataSourceInfo.getProvider());
 
         if (null == op) {
+            LOGGER.error("Failed to retrieve data source operator for provider: {}", dataSourceInfo.getProvider());
             return;
         }
 
@@ -54,6 +54,7 @@ public class DataSourceMetadataOperator {
             JsonArray namespacesDataResultArray =  op.getResultArrayForQuery(dataSourceInfo.getUrl().toString(), PromQLDataSourceQueries.NAMESPACE_QUERY);
             if (false == op.validateResultArray(namespacesDataResultArray)){
                 dataSourceMetadataInfo = dataSourceDetailsHelper.createDataSourceMetadataInfoObject(dataSourceInfo.getName(), null);
+                LOGGER.error("Validation failed for namespace data query.");
                 return;
             }
 
@@ -107,14 +108,14 @@ public class DataSourceMetadataOperator {
     public DataSourceMetadataInfo getDataSourceMetadataInfo(DataSourceInfo dataSourceInfo) {
         try {
             if (null == dataSourceMetadataInfo) {
-                LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.DATASOURCE_METADATA_INFO_NOT_AVAILABLE);
+                LOGGER.error(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.DATASOURCE_METADATA_INFO_NOT_AVAILABLE);
                 return null;
             }
             String dataSourceName = dataSourceInfo.getName();
             HashMap<String, DataSource> dataSourceHashMap = dataSourceMetadataInfo.getDataSourceHashMap();
 
             if (null == dataSourceHashMap || !dataSourceHashMap.containsKey(dataSourceName)) {
-                LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.DATASOURCE_METADATA_DATASOURCE_NOT_AVAILABLE + dataSourceName);
+                LOGGER.error(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.DATASOURCE_METADATA_DATASOURCE_NOT_AVAILABLE + "{}", dataSourceName);
                 return null;
             }
 
@@ -138,7 +139,12 @@ public class DataSourceMetadataOperator {
      *                            metadata information of the data source.
      */
     public void updateDataSourceMetadata(DataSourceInfo dataSourceInfo, DataSourceMetadataInfo existingMetadataInfo) {
-        if (dataSourceInfo == null || existingMetadataInfo == null) {
+        if (null == dataSourceInfo) {
+            LOGGER.error(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.MISSING_DATASOURCE_INFO);
+            return;
+        }
+        if (null == existingMetadataInfo) {
+            LOGGER.error(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.DATASOURCE_METADATA_INFO_NOT_AVAILABLE);
             return;
         }
         String dataSourceName = dataSourceInfo.getName();
@@ -147,6 +153,7 @@ public class DataSourceMetadataOperator {
         DataSourceOperatorImpl op = DataSourceOperatorImpl.getInstance().getOperator(dataSourceInfo.getProvider());
 
         if (null == op) {
+            LOGGER.error("Failed to retrieve data source operator for provider: {}", dataSourceInfo.getProvider());
             return;
         }
 
@@ -155,6 +162,7 @@ public class DataSourceMetadataOperator {
             JsonArray namespacesDataResultArray = op.getResultArrayForQuery(dataSourceInfo.getUrl().toString(),
                     PromQLDataSourceQueries.NAMESPACE_QUERY);
             if (!op.validateResultArray(namespacesDataResultArray)) {
+                LOGGER.debug("Validation failed for namespace data query.");
                 return;
             }
             HashMap<String, DataSourceNamespace> newNamespaces = dataSourceDetailsHelper.getActiveNamespaces(namespacesDataResultArray);
@@ -209,6 +217,7 @@ public class DataSourceMetadataOperator {
         try{
             if (null == dataSourceMetadataInfo) {
                 LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.DATASOURCE_METADATA_INFO_NOT_AVAILABLE);
+                return;
             }
             String dataSourceName = dataSourceInfo.getName();
             HashMap<String, DataSource> dataSourceHashMap = dataSourceMetadataInfo.getDataSourceHashMap();

--- a/src/main/java/com/autotune/common/utils/DataSourceMetadataHelper.java
+++ b/src/main/java/com/autotune/common/utils/DataSourceMetadataHelper.java
@@ -288,6 +288,35 @@ public class DataSourceMetadataHelper {
     }
 
     /**
+     * Updates the namespace metadata in the provided DataSourceMetadataInfo object for a specific data source.
+     *
+     * @param dataSourceName        The name of the data source to update.
+     * @param dataSourceMetadataInfo The DataSourceMetadataInfo object to update.
+     * @param namespaceMap          A map containing namespace name as keys and namespace object as values.
+     */
+    public void updateNamespaceDataSourceMetadataInfoObject(String dataSourceName, DataSourceMetadataInfo dataSourceMetadataInfo,
+                                                            HashMap<String, DataSourceNamespace> namespaceMap) {
+        try {
+            DataSourceCluster dataSourceCluster = dataSourceMetadataInfo.getDataSourceObject(dataSourceName)
+                    .getDataSourceClusterObject("default");
+
+            dataSourceCluster.getDataSourceNamespaceHashMap().entrySet().removeIf(entry -> !namespaceMap.containsKey(entry.getKey()));
+
+            //Add new namespaces, if not present
+            for (HashMap.Entry<String, DataSourceNamespace> entry : namespaceMap.entrySet()) {
+                String namespaceName = entry.getKey();
+                DataSourceNamespace namespace = entry.getValue();
+                if (!dataSourceCluster.getDataSourceNamespaceHashMap().containsKey(namespaceName)) {
+                    dataSourceCluster.getDataSourceNamespaceHashMap().put(namespaceName, namespace);
+                }
+            }
+
+        } catch (Exception e) {
+            LOGGER.error(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.NAMESPACE_METADATA_UPDATE_ERROR + "{}", e.getMessage());
+        }
+    }
+
+    /**
      * Validates input parameters and retrieves the DataSourceCluster object.
      *
      * @param dataSourceName      The name of the data source.

--- a/src/main/java/com/autotune/common/utils/DataSourceMetadataHelper.java
+++ b/src/main/java/com/autotune/common/utils/DataSourceMetadataHelper.java
@@ -1,0 +1,420 @@
+package com.autotune.common.utils;
+
+import com.autotune.common.data.dataSourceMetadata.*;
+import com.autotune.utils.KruizeConstants;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+
+/**
+ * Utility class for handling DataSourceMetadataInfo and related metadata.
+ * This class provides methods to parse and organize information from JSON arrays
+ * into appropriate data structures, facilitating the creation and update of DataSourceMetadataInfo objects.
+ */
+public class DataSourceMetadataHelper {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DataSourceMetadataHelper.class);
+
+    public DataSourceMetadataHelper() {
+    }
+
+    /**
+     * Parses namespace information from a JsonArray and organizes
+     * into a HashMap of namespaces
+     *
+     * @param resultArray The JsonArray containing the namespace information.
+     * @return A HashMap<String, DataSourceNamespace> representing namespaces
+     *
+     * Example:
+     * input resultArray structure:
+     * {
+     *   "result": [
+     *     {
+     *       "metric": {
+     *         "namespace": "exampleNamespace"
+     *       }
+     *     },
+     *     // ... additional result objects ...
+     *   ]
+     * }
+     *
+     * The function would parse the JsonObject and return a HashMap like:
+     * {
+     *   "exampleNamespace": {
+     *     "namespaceName": "exampleNamespace"
+     *   },
+     *   // ... additional namespace entries ...
+     * }
+     */
+    public HashMap<String, DataSourceNamespace> getActiveNamespaces(JsonArray resultArray) {
+        HashMap<String, DataSourceNamespace> namespaceMap = new HashMap<>();
+
+        try {
+            // Iterate through the "result" array to extract namespaces
+            for (JsonElement result : resultArray) {
+
+                JsonObject resultObject = result.getAsJsonObject();
+
+                // Check if the result object contains the "metric" field with "namespace"
+                if (!resultObject.has(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.METRIC) ||
+                        !resultObject.get(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.METRIC).isJsonObject()) {
+                    continue;
+                }
+                JsonObject metricObject = resultObject.getAsJsonObject(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.METRIC);
+
+                // Extract the namespace value
+                if (!metricObject.has(KruizeConstants.DataSourceConstants.DataSourceQueryMetricKeys.NAMESPACE)) {
+                    continue;
+                }
+                String namespace = metricObject.get(KruizeConstants.DataSourceConstants.DataSourceQueryMetricKeys.NAMESPACE).getAsString();
+
+                DataSourceNamespace dataSourceNamespace = new DataSourceNamespace(namespace,null);
+                namespaceMap.put(namespace, dataSourceNamespace);
+            }
+        } catch (JsonParseException e) {
+            LOGGER.error(e.getMessage());
+        } catch (NullPointerException e) {
+            LOGGER.error(e.getMessage());
+        } catch (Exception e) {
+            LOGGER.error(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.NAMESPACE_JSON_PARSING_ERROR + e.getMessage());
+        }
+
+        if (null == namespaceMap || namespaceMap.isEmpty()) {
+            LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.NAMESPACE_MAP_NOT_POPULATED);
+        }
+
+        return namespaceMap;
+    }
+
+    /**
+     * Parses workload information from a JsonArray and organizes it into a nested map,
+     * outer HashMap with namespaces as keys and
+     * inner HashMap with workload name as keys and DataSourceWorkload objects as values.
+     *
+     * @param resultArray The JsonArray containing the workload information.
+     * @return A HashMap<String, HashMap<String, DataSourceWorkload>> representing namespaces
+     *         and their associated workload details.
+     *
+     * Example:
+     * input resultArray structure:
+     * {
+     *   "result": [
+     *     {
+     *       "metric": {
+     *         "namespace": "exampleNamespace",
+     *         "workload": "exampleWorkload",
+     *         "workloadType": "exampleWorkloadType"
+     *       }
+     *     },
+     *     // ... additional result objects ...
+     *   ]
+     * }
+     *
+     * The function would parse the JsonObject and return a nested HashMap like:
+     * {
+     *   "exampleNamespace": {
+     *     "exampleWorkload": {
+     *       "workload": "exampleWorkload",
+     *       "workloadType": "exampleWorkloadType"
+     *     }
+     *   },
+     *   // ... additional namespace entries ...
+     * }
+     */
+    public HashMap<String, HashMap<String, DataSourceWorkload>> getWorkloadInfo(JsonArray resultArray) {
+        HashMap<String, HashMap<String, DataSourceWorkload>> namespaceWorkloadMap = new HashMap<>();
+
+        try {
+            // Iterate through the "result" array to extract namespaces
+            for (JsonElement result : resultArray) {
+                JsonObject resultObject = result.getAsJsonObject();
+
+                // Check if the result object contains the "metric" field with "namespace"
+                if (!resultObject.has(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.METRIC) ||
+                        !resultObject.get(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.METRIC).isJsonObject()) {
+                    continue;
+                }
+                JsonObject metricObject = resultObject.getAsJsonObject(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.METRIC);
+
+                // Extract the namespace name
+                if (!metricObject.has(KruizeConstants.DataSourceConstants.DataSourceQueryMetricKeys.NAMESPACE)) {
+                    continue;
+                }
+                String namespace = metricObject.get(KruizeConstants.DataSourceConstants.DataSourceQueryMetricKeys.NAMESPACE).getAsString();
+
+                // Check if the outer map already contains the namespace
+                if (!namespaceWorkloadMap.containsKey(namespace)) {
+                    namespaceWorkloadMap.put(namespace, new HashMap<>());
+                }
+
+                String workloadName = metricObject.get(KruizeConstants.DataSourceConstants.DataSourceQueryMetricKeys.WORKLOAD).getAsString();
+                String workloadType = metricObject.get(KruizeConstants.DataSourceConstants.DataSourceQueryMetricKeys.WORKLOAD_TYPE).getAsString();
+                DataSourceWorkload dataSourceWorkload = new DataSourceWorkload(workloadName, workloadType,null);
+
+                // Put the DataSourceWorkload into the inner hashmap directly
+                namespaceWorkloadMap.get(namespace).put(workloadName, dataSourceWorkload);
+            }
+        } catch (JsonParseException e) {
+            LOGGER.error(e.getMessage());
+        } catch (NullPointerException e) {
+            LOGGER.error(e.getMessage());
+        } catch (Exception e) {
+            LOGGER.error(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.WORKLOAD_JSON_PARSING_ERROR + e.getMessage());
+        }
+
+        if (null == namespaceWorkloadMap || namespaceWorkloadMap.isEmpty()) {
+            LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.NAMESPACE_WORKLOAD_MAP_NOT_POPULATED);
+        }
+        return namespaceWorkloadMap;
+    }
+
+    /**
+     * Parses container information from a JsonArray and organizes it into a nested map,
+     * outer HashMap with workload names as keys and
+     * inner HashMap with container name as keys and DataSourceWorkload objects as values.
+     *
+     * @param resultArray The JsonArray containing the container information.
+     * @return A HashMap<String, HashMap<String, DataSourceContainer>> representing workloads
+     *         and their associated container details.
+     *
+     * Example:
+     * input resultArray structure:
+     * {
+     *   "result": [
+     *     {
+     *       "metric": {
+     *         "workload_name": "exampleWorkloadName",
+     *         "container": "exampleContainer",
+     *         "image_name": "exampleImageName"
+     *       }
+     *     },
+     *     // ... additional result objects ...
+     *   ]
+     * }
+     *
+     * The function would parse the JsonObject and return a nested HashMap like:
+     * {
+     *   "exampleWorkloadName": {
+     *     "exampleContainer": {
+     *       "containerName": "exampleContainer",
+     *       "containerImageName": "exampleImageName"
+     *     }
+     *   },
+     *   // ... additional workload entries ...
+     * }
+     */
+    public HashMap<String, HashMap<String, DataSourceContainer>> getContainerInfo(JsonArray resultArray) {
+        HashMap<String, HashMap<String, DataSourceContainer>> workloadContainerMap = new HashMap<>();
+
+        try {
+            // Iterate through the "result" array to extract namespaces
+            for (JsonElement result : resultArray) {
+                JsonObject resultObject = result.getAsJsonObject();
+
+                // Check if the result object contains the "metric" field with "workload"
+                if (!resultObject.has(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.METRIC) ||
+                        !resultObject.get(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.METRIC).isJsonObject()) {
+                    continue;
+                }
+                JsonObject metricObject = resultObject.getAsJsonObject(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.METRIC);
+
+                if (!metricObject.has(KruizeConstants.DataSourceConstants.DataSourceQueryMetricKeys.WORKLOAD)) {
+                    continue;
+                }
+                // Extract the workload name value
+                String workloadName = metricObject.get(KruizeConstants.DataSourceConstants.DataSourceQueryMetricKeys.WORKLOAD).getAsString();
+
+                if (!workloadContainerMap.containsKey(workloadName)) {
+                    workloadContainerMap.put(workloadName, new HashMap<>());
+                }
+
+                String containerName = metricObject.get(KruizeConstants.DataSourceConstants.DataSourceQueryMetricKeys.CONTAINER_NAME).getAsString();
+                String containerImageName = metricObject.get(KruizeConstants.DataSourceConstants.DataSourceQueryMetricKeys.CONTAINER_IMAGE_NAME).getAsString();
+                DataSourceContainer dataSourceContainer = new DataSourceContainer(containerName, containerImageName);
+                workloadContainerMap.get(workloadName).put(containerName, dataSourceContainer);
+            }
+        } catch (JsonParseException e) {
+            LOGGER.error(e.getMessage());
+        } catch (NullPointerException e) {
+            LOGGER.error(e.getMessage());
+        } catch (Exception e) {
+            LOGGER.error(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.CONTAINER_JSON_PARSING_ERROR + e.getMessage());
+        }
+
+        if (null == workloadContainerMap || workloadContainerMap.isEmpty()) {
+            LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.WORKLOAD_CONTAINER_MAP_NOT_POPULATED);
+        }
+        return workloadContainerMap;
+    }
+
+    /**
+     * Creates and returns a DataSourceMetadataInfo object based on the provided parameters.
+     * This function populates the DataSourceMetadataInfo object with information about active namespaces
+     *
+     * @param dataSourceName         Name of the data source.
+     * @param namespaceMap           Map of namespace objects
+     * @return                       A DataSourceMetadataInfo object with populated information.
+     */
+    public DataSourceMetadataInfo createDataSourceMetadataInfoObject(String dataSourceName, HashMap<String, DataSourceNamespace> namespaceMap) {
+
+        try {
+            DataSourceMetadataInfo dataSourceMetadataInfo = new DataSourceMetadataInfo(null);
+
+            DataSource dataSource = new DataSource(dataSourceName,null);
+
+            DataSourceCluster dataSourceCluster = new DataSourceCluster(KruizeConstants.DataSourceConstants.
+                    DataSourceMetadataInfoConstants.CLUSTER_NAME, namespaceMap);
+
+            // Set cluster in data source
+            HashMap<String, DataSourceCluster> clusters = new HashMap<>();
+            clusters.put(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoConstants.CLUSTER_NAME,
+                    dataSourceCluster);
+            dataSource.setDataSourceClusterHashMap(clusters);
+
+            // Set data source in DataSourceMetadataInfo
+            HashMap<String, DataSource> dataSources = new HashMap<>();
+            dataSources.put(dataSourceName, dataSource);
+            dataSourceMetadataInfo.setDataSourceHashMap(dataSources);
+
+            return dataSourceMetadataInfo;
+        } catch (Exception e) {
+            LOGGER.error(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.DATASOURCE_METADATA_INFO_CREATION_ERROR + e.getMessage());
+        }
+        return null;
+    }
+
+    /**
+     * Validates input parameters and retrieves the DataSourceCluster object.
+     *
+     * @param dataSourceName      The name of the data source.
+     * @param dataSourceMetadataInfo The DataSourceMetadataInfo object.
+     * @param namespaceWorkloadMap  The map containing workload information.
+     * @return The DataSourceCluster object if validation passes, or null if validation fails.
+     */
+    private DataSourceCluster validateInputParametersAndGetClusterObject(String dataSourceName, DataSourceMetadataInfo dataSourceMetadataInfo,
+                                                                         HashMap<String, HashMap<String, DataSourceWorkload>> namespaceWorkloadMap) {
+
+        if (null == dataSourceName || dataSourceName.isEmpty()) {
+            LOGGER.error(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.MISSING_DATASOURCE_METADATA_DATASOURCE_NAME);
+            return null;
+        }
+
+        if (null == dataSourceMetadataInfo) {
+            LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.MISSING_DATASOURCE_METADATA_INFO_OBJECT);
+            return null;
+        }
+
+        if (null == namespaceWorkloadMap || namespaceWorkloadMap.isEmpty()) {
+            LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.MISSING_DATASOURCE_METADATA_WORKLOAD_MAP);
+            return null;
+        }
+
+        DataSource dataSource = dataSourceMetadataInfo.getDataSourceObject(dataSourceName);
+
+        if (null == dataSource) {
+            LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.MISSING_DATASOURCE_METADATA_DATASOURCE_OBJECT + dataSourceName);
+            return null;
+        }
+
+        return dataSource.getDataSourceClusterObject(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoConstants.CLUSTER_NAME);
+    }
+
+    /**
+     * Updates the workload metadata in the provided DataSourceMetadataInfo object for a specific data source.
+     *
+     * @param dataSourceName        The name of the data source to update.
+     * @param dataSourceMetadataInfo The DataSourceMetadataInfo object to update.
+     * @param namespaceWorkloadMap  A map containing namespace as keys and workload data as values.
+     */
+    public void updateWorkloadDataSourceMetadataInfoObject(String dataSourceName, DataSourceMetadataInfo dataSourceMetadataInfo,
+                                                          HashMap<String, HashMap<String, DataSourceWorkload>> namespaceWorkloadMap) {
+        try {
+
+            // Retrieve DataSourceCluster
+            DataSourceCluster dataSourceCluster = validateInputParametersAndGetClusterObject(dataSourceName,
+                    dataSourceMetadataInfo, namespaceWorkloadMap);
+
+            if (null == dataSourceCluster) {
+                LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.INVALID_DATASOURCE_METADATA_CLUSTER);
+                return;
+            }
+
+            if (null == dataSourceCluster.getDataSourceNamespaceHashMap() || dataSourceCluster.getDataSourceNamespaceHashMap().isEmpty()) {
+                LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.INVALID_DATASOURCE_METADATA_NAMESPACE_DATA);
+                return;
+            }
+
+            // Update the DataSourceNamespaces using the provided map
+            for (String namespace : namespaceWorkloadMap.keySet()) {
+                DataSourceNamespace dataSourceNamespace = dataSourceCluster.getDataSourceNamespaceObject(namespace);
+
+                if (null == dataSourceNamespace) {
+                    continue;
+                }
+                // Bulk update workload data for the namespace
+                dataSourceNamespace.setDataSourceWorkloadHashMap(namespaceWorkloadMap.get(namespace));
+            }
+        } catch (Exception e) {
+            LOGGER.error(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.WORKLOAD_METADATA_UPDATE_ERROR+ e.getMessage());
+        }
+    }
+    /**
+     * Updates the container metadata in the provided DataSourceMetadataInfo object for a specific data source.
+     *
+     * @param dataSourceName         The name of the data source to update.
+     * @param dataSourceMetadataInfo The DataSourceMetadataInfo object to update.
+     * @param namespaceWorkloadMap   A map containing namespace as keys and workload data as values.
+     * @param workloadContainerMap  A map containing workload names as keys and container data as values.
+     */
+    public void updateContainerDataSourceMetadataInfoObject(String dataSourceName, DataSourceMetadataInfo dataSourceMetadataInfo,
+                                                           HashMap<String, HashMap<String, DataSourceWorkload>> namespaceWorkloadMap,
+                                                           HashMap<String, HashMap<String, DataSourceContainer>> workloadContainerMap) {
+        try {
+
+            if (null == workloadContainerMap || workloadContainerMap.isEmpty()) {
+                LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.MISSING_DATASOURCE_METADATA_CONTAINER_MAP);
+                return;
+            }
+            // Retrieve DataSourceCluster
+            DataSourceCluster dataSourceCluster = validateInputParametersAndGetClusterObject(dataSourceName,
+                    dataSourceMetadataInfo, namespaceWorkloadMap);
+
+            if (null == dataSourceCluster) {
+                LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.INVALID_DATASOURCE_METADATA_CLUSTER);
+                return;
+            }
+
+            if (null == dataSourceCluster.getDataSourceNamespaceHashMap() || dataSourceCluster.getDataSourceNamespaceHashMap().isEmpty()) {
+                LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.INVALID_DATASOURCE_METADATA_NAMESPACE_DATA);
+                return;
+            }
+
+            // Iterate over namespaces in namespaceWorkloadMap
+            for (String namespace : namespaceWorkloadMap.keySet()) {
+                DataSourceNamespace dataSourceNamespace = dataSourceCluster.getDataSourceNamespaceObject(namespace);
+
+                if (null == dataSourceNamespace) {
+                    LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.INVALID_DATASOURCE_METADATA_NAMESPACE);
+                    return;
+                }
+
+                // Iterate over workloads in namespaceWorkloadMap
+                for (String workloadName : namespaceWorkloadMap.get(namespace).keySet()) {
+                    DataSourceWorkload dataSourceWorkload = dataSourceNamespace.getDataSourceWorkloadObject(workloadName);
+
+                    // Bulk update container data for the workload
+                    if (null == dataSourceWorkload || !workloadContainerMap.containsKey(workloadName)) {
+                        continue;
+                    }
+                    dataSourceWorkload.setDataSourceContainerHashMap(workloadContainerMap.get(workloadName));
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.error(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.CONTAINER_METADATA_UPDATE_ERROR + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -412,6 +412,51 @@ public class KruizeConstants {
         }
         private DataSourceConstants() {
         }
+
+        public static class DataSourceQueryMetricKeys {
+            private DataSourceQueryMetricKeys() {
+            }
+
+            public static final String NAMESPACE = "namespace";
+            public static final String WORKLOAD = "workload";
+            public static final String WORKLOAD_TYPE = "workload_type";
+            public static final String CONTAINER_NAME = "container";
+            public static final String CONTAINER_IMAGE_NAME = "image";
+        }
+
+        public static class DataSourceMetadataInfoConstants {
+            private DataSourceMetadataInfoConstants() {
+            }
+
+            public static final String version = "v1.0";
+            public static final String CLUSTER_NAME = "default";
+        }
+
+        public static class DataSourceMetadataErrorMsgs {
+            private DataSourceMetadataErrorMsgs() {
+            }
+            public static final String MISSING_DATASOURCE_METADATA_DATASOURCE_NAME = "DataSourceMetadata Datasource name cannot be empty";
+            public static final String MISSING_DATASOURCE_METADATA_WORKLOAD_MAP = "DataSourceMetadata Workload data cannot be empty or null";
+            public static final String MISSING_DATASOURCE_METADATA_CONTAINER_MAP = "DataSourceMetadata Container data cannot be empty or null";
+            public static final String MISSING_DATASOURCE_METADATA_INFO_OBJECT = "DataSourceMetadataInfo Object cannot be null";
+            public static final String MISSING_DATASOURCE_METADATA_DATASOURCE_OBJECT = "DataSourceMetadata DataSource Object cannot be empty or null";
+            public static final String NAMESPACE_JSON_PARSING_ERROR = "Error parsing namespace JSON array: ";
+            public static final String WORKLOAD_JSON_PARSING_ERROR = "Error parsing workload JSON array: ";
+            public static final String CONTAINER_JSON_PARSING_ERROR = "Error parsing container JSON array: ";
+            public static final String DATASOURCE_METADATA_INFO_CREATION_ERROR = "Error creating DataSourceMetadataInfo: ";
+            public static final String WORKLOAD_METADATA_UPDATE_ERROR = "Error updating DataSourceMetadataInfo with workload metadata: ";
+            public static final String CONTAINER_METADATA_UPDATE_ERROR = "Error updating DataSourceMetadataInfo with container metadata: ";
+            public static final String NAMESPACE_MAP_NOT_POPULATED = "The namespaceMap is not populated, is either null or empty.";
+            public static final String NAMESPACE_WORKLOAD_MAP_NOT_POPULATED = "The namespaceWorkloadMap is not populated, is either null or empty.";
+            public static final String WORKLOAD_CONTAINER_MAP_NOT_POPULATED = "The workloadContainerMap is not populated, is either null or empty.";
+            public static final String INVALID_DATASOURCE_METADATA_CLUSTER = "dataSourceCluster object is null";
+            public static final String INVALID_DATASOURCE_METADATA_NAMESPACE = "dataSourceNamespace object is null";
+            public static final String INVALID_DATASOURCE_METADATA_NAMESPACE_DATA = "namespaceHashMap is either null or empty";
+            public static final String DATASOURCE_METADATA_INFO_NOT_AVAILABLE = "DataSourceMetadataInfo is null. Metadata is not populated.";
+            public static final String DATASOURCE_METADATA_DATASOURCE_NOT_AVAILABLE = "DataSource information is not available for the specified DataSource: ";
+            public static final String DATASOURCE_METADATA_CLUSTER_NOT_AVAILABLE = "DataSourceCluster information is not available for the specified Cluster {} and DataSource {}";
+            public static final String DATASOURCE_METADATA_NAMESPACE_NOT_AVAILABLE = "DataSourceNamespace information is not available for the specified Namespace {}, Cluster {} and DataSource {}";
+        }
     }
 
     public static class ErrorMsgs {

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -446,6 +446,7 @@ public class KruizeConstants {
             public static final String DATASOURCE_METADATA_INFO_CREATION_ERROR = "Error creating DataSourceMetadataInfo: ";
             public static final String WORKLOAD_METADATA_UPDATE_ERROR = "Error updating DataSourceMetadataInfo with workload metadata: ";
             public static final String CONTAINER_METADATA_UPDATE_ERROR = "Error updating DataSourceMetadataInfo with container metadata: ";
+            public static final String NAMESPACE_METADATA_UPDATE_ERROR = "Error updating DataSourceMetadataInfo with namespace metadata: ";
             public static final String NAMESPACE_MAP_NOT_POPULATED = "The namespaceMap is not populated, is either null or empty.";
             public static final String NAMESPACE_WORKLOAD_MAP_NOT_POPULATED = "The namespaceWorkloadMap is not populated, is either null or empty.";
             public static final String WORKLOAD_CONTAINER_MAP_NOT_POPULATED = "The workloadContainerMap is not populated, is either null or empty.";

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -457,6 +457,27 @@ public class KruizeConstants {
             public static final String DATASOURCE_METADATA_DATASOURCE_NOT_AVAILABLE = "DataSource information is not available for the specified DataSource: ";
             public static final String DATASOURCE_METADATA_CLUSTER_NOT_AVAILABLE = "DataSourceCluster information is not available for the specified Cluster {} and DataSource {}";
             public static final String DATASOURCE_METADATA_NAMESPACE_NOT_AVAILABLE = "DataSourceNamespace information is not available for the specified Namespace {}, Cluster {} and DataSource {}";
+            public static final String SET_CLUSTER_MAP_ERROR = "clusterHashMap is null, no clusters provided for cluster group: ";
+            public static final String SET_WORKLOAD_MAP_ERROR = "workloadHashMap is null, no workloads provided for namespace: ";
+            public static final String SET_CONTAINER_MAP_ERROR = "containerHashMap is null, no containers provided for workload: ";
+            public static final String SET_NAMESPACE_MAP_ERROR = "namespaceHashMap is null, no namespaces provided for cluster: ";
+        }
+
+        public static class DataSourceMetadataInfoJSONKeys {
+            private DataSourceMetadataInfoJSONKeys() {
+            }
+            public static final String DATASOURCES = "datasources";
+            public static final String DATASOURCE_NAME = "datasource_name";
+            public static final String CLUSTERS = "clusters";
+            public static final String CLUSTER_NAME = "cluster_name";
+            public static final String NAMESPACES = "namespaces";
+            public static final String NAMESPACE = "namespace";
+            public static final String WORKLOADS = "workloads";
+            public static final String WORKLOAD_NAME = "workload_name";
+            public static final String WORKLOAD_TYPE = "workload_type";
+            public static final String CONTAINERS = "containers";
+            public static final String CONTAINER_NAME = "container_name";
+            public static final String CONTAINER_IMAGE_NAME = "container_image_name";
         }
     }
 


### PR DESCRIPTION
## Description

This PR has the following changes:

- Implementation of create and get methods for data source metadata
- Adds `DataSourceMetadataHelper` - a helper class to fetch and process PromQL query metric data
- Adds metadata constants

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [x] Requires DB changes

## How has this been tested?

**Test Configuration**
* Kubernetes clusters tested on: minikube

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

This PR has a dependency on [PR 1144](https://github.com/kruize/autotune/pull/1144) to be merged first, as it uses the abstractions
Database changes for datasource metadata will be in next PR