### PR TITLE
Update List Experiments API to accept input JSON as params

### DIFF
--- a/design/MonitoringModeAPI.md
+++ b/design/MonitoringModeAPI.md
@@ -1656,11 +1656,9 @@ name parameter**
 
 Returns all the recommendations and all the results of the specified experiment.
 <br><br>
-
-
-###List Experiments also allows the user to send a request body to fetch the records based on `cluster_name` and 
-`kubernetes_object`. 
-**Note: This request body can be sent along with other query params which are mentioned above. 
+**List Experiments also allows the user to send a request body to fetch the records based on `cluster_name` and `kubernetes_object`.**
+<br><br>
+*Note: This request body can be sent along with other query params which are mentioned above.* 
 
 `curl -H 'Accept: application/json' -X POST --data 'copy paste below JSON' http://<URL>:<PORT>/listExperiments`
 

--- a/design/MonitoringModeAPI.md
+++ b/design/MonitoringModeAPI.md
@@ -1655,6 +1655,42 @@ name parameter**
 `curl -H 'Accept: application/json' http://<URL>:<PORT>/listExperiments?recommendations=true&results=true&latest=false`
 
 Returns all the recommendations and all the results of the specified experiment.
+<br><br>
+
+
+###List Experiments also allows the user to send a request body to fetch the records based on `cluster_name` and 
+`kubernetes_object`. 
+**Note: This request body can be sent along with other query params which are mentioned above. 
+
+`curl -H 'Accept: application/json' -X POST --data 'copy paste below JSON' http://<URL>:<PORT>/listExperiments`
+
+<details>
+
+<summary><b>Example Request</b></summary>
+
+### Example Request
+
+```json
+{
+  "cluster_name": "cluster-one-division-bell",
+  "kubernetes_objects": [
+    {
+      "type": "deployment",
+      "name": "tfb-qrh-deployment",
+      "namespace": "default",
+      "containers": [
+        {
+          "container_image_name": "kruize/tfb-db:1.15",
+          "container_name": "tfb-server-1"
+        }
+      ]
+    }
+  ]
+}
+```
+
+</details>
+Returns all the experiments matching the input JSON data.
 
 <a name="list-recommendations-api"></a>
 

--- a/src/main/java/com/autotune/analyzer/services/ListExperiments.java
+++ b/src/main/java/com/autotune/analyzer/services/ListExperiments.java
@@ -131,13 +131,13 @@ public class ListExperiments extends HttpServlet {
                     // Check if JSON input is provided in the request body and validate it
                     if (!requestBody.isEmpty()) {
                         isJSONValid = validateInputJSON(requestBody);
-                        // parse the requestBody JSON into corresponding classes
-                        parseInputJSON(requestBody, clusterName, kubernetesAPIObjectList);
                     }
                     if (isJSONValid) {
                         try {
                             // Fetch experiments data based on request body input, if it's present
                             if (!requestBody.isEmpty()) {
+                                // parse the requestBody JSON into corresponding classes
+                                parseInputJSON(requestBody, clusterName, kubernetesAPIObjectList);
                                 try {
                                     new ExperimentDBService().loadExperimentFromDBByInputJSON(mKruizeExperimentMap, clusterName, kubernetesAPIObjectList);
                                 } catch (Exception e) {
@@ -146,17 +146,18 @@ public class ListExperiments extends HttpServlet {
                             } else {
                                 // Fetch experiments data from the DB and check if the requested experiment exists
                                 loadExperimentsFromDatabase(mKruizeExperimentMap, experimentName);
-                                // Check if experiment exists
-                                if (experimentName != null && !mKruizeExperimentMap.containsKey(experimentName)) {
-                                    error = true;
-                                    sendErrorResponse(
-                                            response,
-                                            new Exception(AnalyzerErrorConstants.APIErrors.ListRecommendationsAPI.INVALID_EXPERIMENT_NAME_EXCPTN),
-                                            HttpServletResponse.SC_BAD_REQUEST,
-                                            String.format(AnalyzerErrorConstants.APIErrors.ListRecommendationsAPI.INVALID_EXPERIMENT_NAME_MSG, experimentName)
-                                    );
-                                }
-                                if (!error) {
+                            }
+                            // Check if experiment exists
+                            if (experimentName != null && !mKruizeExperimentMap.containsKey(experimentName)) {
+                                error = true;
+                                sendErrorResponse(
+                                        response,
+                                        new Exception(AnalyzerErrorConstants.APIErrors.ListRecommendationsAPI.INVALID_EXPERIMENT_NAME_EXCPTN),
+                                        HttpServletResponse.SC_BAD_REQUEST,
+                                        String.format(AnalyzerErrorConstants.APIErrors.ListRecommendationsAPI.INVALID_EXPERIMENT_NAME_MSG, experimentName)
+                                );
+                            }
+                            if (!error) {
                                     // create Gson Object
                                     Gson gsonObj = createGsonObject();
 
@@ -169,7 +170,6 @@ public class ListExperiments extends HttpServlet {
                                     response.getWriter().close();
                                     statusValue = "success";
                                 }
-                            }
                         } catch (Exception e) {
                             LOGGER.error("Exception: " + e.getMessage());
                             e.printStackTrace();
@@ -212,29 +212,29 @@ public class ListExperiments extends HttpServlet {
         JsonObject jsonObject = new Gson().fromJson(requestBody, JsonObject.class);
 
         // Extract cluster name
-        clusterName.append(jsonObject.get("cluster_name").getAsString());
+        clusterName.append(jsonObject.get(KruizeConstants.JSONKeys.CLUSTER_NAME).getAsString());
 
         // Extract Kubernetes objects
-        JsonArray kubernetesObjectsArray = jsonObject.getAsJsonArray("kubernetes_objects");
+        JsonArray kubernetesObjectsArray = jsonObject.getAsJsonArray(KruizeConstants.JSONKeys.KUBERNETES_OBJECTS);
         for (JsonElement element : kubernetesObjectsArray) {
             JsonObject kubernetesObjectJson = element.getAsJsonObject();
-            String type = kubernetesObjectJson.get("type").getAsString();
-            String name = kubernetesObjectJson.get("name").getAsString();
-            String namespace = kubernetesObjectJson.get("namespace").getAsString();
+            String type = kubernetesObjectJson.get(KruizeConstants.JSONKeys.TYPE).getAsString();
+            String name = kubernetesObjectJson.get(KruizeConstants.JSONKeys.NAME).getAsString();
+            String namespace = kubernetesObjectJson.get(KruizeConstants.JSONKeys.NAMESPACE).getAsString();
             List<ContainerAPIObject> containerAPIObjects = extractContainersFromJson(kubernetesObjectJson);
-            KubernetesAPIObject kubernetesAPIObject = new KubernetesAPIObject(type, name, namespace);
+            KubernetesAPIObject kubernetesAPIObject = new KubernetesAPIObject(name, type, namespace);
             kubernetesAPIObject.setContainerAPIObjects(containerAPIObjects);
             kubernetesAPIObjectList.add(kubernetesAPIObject);
         }
     }
 
     public List<ContainerAPIObject> extractContainersFromJson(JsonObject jsonObject) {
-        JsonArray containersArray = jsonObject.getAsJsonArray("containers");
+        JsonArray containersArray = jsonObject.getAsJsonArray(KruizeConstants.JSONKeys.CONTAINERS);
         List<ContainerAPIObject> containerAPIObjects = new ArrayList<>();
         for (JsonElement element : containersArray) {
             JsonObject containerJson = element.getAsJsonObject();
-            String containerName = containerJson.get("container_name").getAsString();
-            String containerImageName = containerJson.get("container_image_name").getAsString();
+            String containerName = containerJson.get(KruizeConstants.JSONKeys.CONTAINER_NAME).getAsString();
+            String containerImageName = containerJson.get(KruizeConstants.JSONKeys.CONTAINER_IMAGE_NAME).getAsString();
             ContainerAPIObject containerAPIObject = new ContainerAPIObject(containerName, containerImageName, null, null);
             containerAPIObjects.add(containerAPIObject);
         }

--- a/src/main/java/com/autotune/database/dao/ExperimentDAO.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAO.java
@@ -1,6 +1,7 @@
 package com.autotune.database.dao;
 
 import com.autotune.analyzer.kruizeObject.KruizeObject;
+import com.autotune.analyzer.serviceObjects.KubernetesAPIObject;
 import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.common.data.ValidationOutputData;
 import com.autotune.database.table.KruizeExperimentEntry;
@@ -70,4 +71,5 @@ public interface ExperimentDAO {
 
     public void addPartitions(String tableName, String month, String year, int dayOfTheMonth, String partitionType) throws Exception;
 
+    List<KruizeExperimentEntry> loadExperimentFromDBByInputJSON(StringBuilder clusterName, KubernetesAPIObject kubernetesAPIObject) throws Exception;
 }

--- a/src/main/java/com/autotune/database/helper/DBConstants.java
+++ b/src/main/java/com/autotune/database/helper/DBConstants.java
@@ -46,7 +46,15 @@ public class DBConstants {
         public static final String DB_PARTITION_DATERANGE = "CREATE TABLE IF NOT EXISTS %s_%s%s%s PARTITION OF %s FOR VALUES FROM ('%s-%s-%s 00:00:00.000') TO ('%s-%s-%s 23:59:59');";
         public static final String SELECT_ALL_KRUIZE_TABLES = "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' " +
                 "and (table_name like 'kruize_results_%' or table_name like 'kruize_recommendations_%') ";
-        public static final String SELECT_FROM_EXPERIMENTS_BY_INPUT_JSON = "SELECT * FROM kruize_experiments WHERE cluster_name = :clusterName ";
+        public static final String SELECT_FROM_EXPERIMENTS_BY_INPUT_JSON = "SELECT * FROM kruize_experiments WHERE cluster_name = :cluster_name " +
+                "AND EXISTS (SELECT 1 FROM jsonb_array_elements(extended_data->'kubernetes_objects') AS kubernetes_object" +
+                " WHERE kubernetes_object->>'name' = :name " +
+                " AND kubernetes_object->>'namespace' = :namespace " +
+                " AND kubernetes_object->>'type' = :type " +
+                " AND EXISTS (SELECT 1 FROM jsonb_array_elements(kubernetes_object->'containers') AS container" +
+                " WHERE container->>'container_name' = :container_name" +
+                " AND container->>'container_image_name' = :container_image_name" +
+                " ))";
 
     }
 

--- a/src/main/java/com/autotune/database/helper/DBConstants.java
+++ b/src/main/java/com/autotune/database/helper/DBConstants.java
@@ -46,6 +46,8 @@ public class DBConstants {
         public static final String DB_PARTITION_DATERANGE = "CREATE TABLE IF NOT EXISTS %s_%s%s%s PARTITION OF %s FOR VALUES FROM ('%s-%s-%s 00:00:00.000') TO ('%s-%s-%s 23:59:59');";
         public static final String SELECT_ALL_KRUIZE_TABLES = "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' " +
                 "and (table_name like 'kruize_results_%' or table_name like 'kruize_recommendations_%') ";
+        public static final String SELECT_FROM_EXPERIMENTS_BY_INPUT_JSON = "SELECT * FROM kruize_experiments WHERE cluster_name = :clusterName ";
+
     }
 
     public static final class TABLE_NAMES {

--- a/src/main/java/com/autotune/database/service/ExperimentDBService.java
+++ b/src/main/java/com/autotune/database/service/ExperimentDBService.java
@@ -21,10 +21,7 @@ import com.autotune.analyzer.experiment.ExperimentInterfaceImpl;
 import com.autotune.analyzer.kruizeObject.KruizeObject;
 import com.autotune.analyzer.performanceProfiles.PerformanceProfile;
 import com.autotune.analyzer.performanceProfiles.utils.PerformanceProfileUtil;
-import com.autotune.analyzer.serviceObjects.Converters;
-import com.autotune.analyzer.serviceObjects.CreateExperimentAPIObject;
-import com.autotune.analyzer.serviceObjects.ListRecommendationsAPIObject;
-import com.autotune.analyzer.serviceObjects.UpdateResultsAPIObject;
+import com.autotune.analyzer.serviceObjects.*;
 import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.common.data.ValidationOutputData;
 import com.autotune.common.data.result.ExperimentResultData;
@@ -300,6 +297,25 @@ public class ExperimentDBService {
         }
     }
 
+    public void loadExperimentFromDBByInputJSON(Map<String, KruizeObject> mKruizeExperimentMap, StringBuilder clusterName, List<KubernetesAPIObject> kubernetesAPIObjectList) throws Exception {
+        ExperimentInterface experimentInterface = new ExperimentInterfaceImpl();
+        // assuming there will be only one Kubernetes object
+        KubernetesAPIObject kubernetesAPIObject = kubernetesAPIObjectList.get(0);
+        List<KruizeExperimentEntry> entries = experimentDAO.loadExperimentFromDBByInputJSON(clusterName, kubernetesAPIObject);
+        if (null != entries && !entries.isEmpty()) {
+            List<CreateExperimentAPIObject> createExperimentAPIObjects = DBHelpers.Converters.KruizeObjectConverters.convertExperimentEntryToCreateExperimentAPIObject(entries);
+            if (!createExperimentAPIObjects.isEmpty()) {
+                List<KruizeObject> kruizeExpList = new ArrayList<>();
+                for (CreateExperimentAPIObject createExperimentAPIObject : createExperimentAPIObjects) {
+                    KruizeObject kruizeObject = Converters.KruizeObjectConverters.convertCreateExperimentAPIObjToKruizeObject(createExperimentAPIObject);
+                    if (null != kruizeObject) {
+                        kruizeExpList.add(kruizeObject);
+                    }
+                }
+                experimentInterface.addExperimentToLocalStorage(mKruizeExperimentMap, kruizeExpList);
+            }
+        }
+    }
 
     public void loadExperimentAndResultsFromDBByName(Map<String, KruizeObject> mainKruizeExperimentMap, String experimentName) throws Exception {
 


### PR DESCRIPTION
This PR adds new request body input feature in the listExperiments API. Input can be sent in the form of JSON as shown below to fetch the experiment records from the DB.

```
{
    "cluster_name": "cluster-one-division-bell",
    "kubernetes_objects": [
        {
            "type": "deployment",
            "name": "tfb-qrh-deployment",
            "namespace": "default",
            "containers": [
                {
                    "container_image_name": "kruize/tfb-db:1.15",
                    "container_name": "front-data-platform"
                }
            ]
        }
    ]
}
```
JIRA: https://issues.redhat.com/browse/KRUIZE-98