### PR TITLE
Updated internal dependencies versions to fix security vulnerability issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,24 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <version>2.17.0</version>
+	</dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.17.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>2.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio</artifactId>
+            <version>1.17.6</version>
         </dependency>
 
         <dependency>
@@ -146,12 +164,12 @@
             <version>${postgresql-version}</version>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-core</artifactId>
             <version>${hibernatecore-version}</version>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-c3p0</artifactId>
             <version>${hibernatecp30-version}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -39,11 +39,19 @@
             <version>2.17.0</version>
 	</dependency>
 
+	<!-- jackson-databind is an internal dependency in pubnub-gson, upgrade this jar didn't seem to help. Check in future and remove this
+	     For now, including these dependencies explicitly to address the security vulnerabilities
+	 -->
+
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.17.0</version>
         </dependency>
+
+	<!-- snakeyaml and okio are internal dependencies in kubernetes-client, upgrading kubernetes client to latest needs code changes
+	     This needs to be looked into in future and resolved. For now, including these dependencies explicitly to address the security vulnerabilities
+	-->
 
         <dependency>
             <groupId>org.yaml</groupId>


### PR DESCRIPTION
Included the following internal dependencies explicitly in the pom.xml to fix the security vulnerability issues
- jackson-databind (Internally used in pubnub-gson, updating this version didn't help)
- snake yaml and okio (These are internal dependencies in the kubernetes-client, updating this did not help)
- Also fixed the below:
```
[WARNING] The artifact org.hibernate:hibernate-core:jar:6.1.7.Final has been relocated to org.hibernate.orm:hibernate-core:jar:6.1.7.Final
[WARNING] The artifact org.hibernate:hibernate-c3p0:jar:6.1.7.Final has been relocated to org.hibernate.orm:hibernate-c3p0:jar:6.1.7.Final
```