### PR TITLE
DB integration for Datasource Metadata

### DIFF
--- a/migrations/kruize_local_ddl.sql
+++ b/migrations/kruize_local_ddl.sql
@@ -1,3 +1,3 @@
 create table IF NOT EXISTS kruize_datasources (version varchar(255), name varchar(255), provider varchar(255), serviceName varchar(255), namespace varchar(255), url varchar(255), primary key (name));
-create table IF NOT EXISTS kruize_dsmetadata (id serial, version varchar(255), cluster_group_name varchar(255), cluster_name varchar(255), namespace varchar(255), workload_type varchar(255), workload_name varchar(255), container_name varchar(255), container_image_name varchar(255), primary key (id));
+create table IF NOT EXISTS kruize_dsmetadata (id serial, version varchar(255), datasource_name varchar(255), cluster_name varchar(255), namespace varchar(255), workload_type varchar(255), workload_name varchar(255), container_name varchar(255), container_image_name varchar(255), primary key (id));
 alter table kruize_experiments add column metadata_id bigint references kruize_dsmetadata(id), alter column datasource type varchar(255);

--- a/src/main/java/com/autotune/database/dao/ExperimentDAO.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAO.java
@@ -80,7 +80,7 @@ public interface ExperimentDAO {
     List<KruizeDataSourceEntry> loadAllDataSources() throws Exception;
 
     // Load data source cluster group by name
-    List<KruizeDSMetadataEntry> loadDataSourceClusterGroupByName(String clusterGroupName) throws Exception;
+    List<KruizeDSMetadataEntry> loadMetadataByName(String clusterGroupName) throws Exception;
 
     // add metadata
     ValidationOutputData addMetadataToDB(KruizeDSMetadataEntry kruizeDSMetadataEntry);

--- a/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
@@ -810,17 +810,17 @@ public class ExperimentDAOImpl implements ExperimentDAO {
     }
 
     /**
-     * @param clusterGroupName
+     * @param dataSourceName
      * @return
      */
     @Override
-    public List<KruizeDSMetadataEntry> loadDataSourceClusterGroupByName(String clusterGroupName) throws Exception {
+    public List<KruizeDSMetadataEntry> loadMetadataByName(String dataSourceName) throws Exception {
         List<KruizeDSMetadataEntry> kruizeMetadataList;
         try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
-            kruizeMetadataList = session.createQuery(SELECT_FROM_METADATA_BY_CLUSTER_GROUP_NAME, KruizeDSMetadataEntry.class)
-                    .setParameter("cluster_group_name", clusterGroupName).list();
+            kruizeMetadataList = session.createQuery(SELECT_FROM_METADATA_BY_DATASOURCE_NAME, KruizeDSMetadataEntry.class)
+                    .setParameter("dataSourceName", dataSourceName).list();
         } catch (Exception e) {
-            LOGGER.error("Unable to load metadata with clusterGroupName: {} : {}", clusterGroupName, e.getMessage());
+            LOGGER.error("Unable to load metadata with dataSourceName: {} : {}", dataSourceName, e.getMessage());
             throw new Exception("Error while loading existing metadata object from database : " + e.getMessage());
         }
         return kruizeMetadataList;

--- a/src/main/java/com/autotune/database/helper/DBConstants.java
+++ b/src/main/java/com/autotune/database/helper/DBConstants.java
@@ -12,7 +12,7 @@ public class DBConstants {
         public static final String SELECT_FROM_DATASOURCE = "from KruizeDataSourceEntry";
         public static final String SELECT_FROM_DATASOURCE_BY_NAME = "from KruizeDataSourceEntry kd WHERE kd.name = :name";
         public static final String SELECT_FROM_METADATA = "from KruizeDSMetadataEntry";
-        public static final String SELECT_FROM_METADATA_BY_CLUSTER_GROUP_NAME = "from KruizeDSMetadataEntry km WHERE km.cluster_group_name = :clusterGroupName";
+        public static final String SELECT_FROM_METADATA_BY_DATASOURCE_NAME = "from KruizeDSMetadataEntry km WHERE km.datasource_name = :dataSourceName";
         public static final String SELECT_FROM_RESULTS_BY_EXP_NAME_AND_DATE_RANGE_AND_LIMIT =
                 String.format("from KruizeResultsEntry k " +
                                 "WHERE k.experiment_name = :%s and " +

--- a/src/main/java/com/autotune/database/table/KruizeDSMetadataEntry.java
+++ b/src/main/java/com/autotune/database/table/KruizeDSMetadataEntry.java
@@ -20,19 +20,19 @@ import jakarta.persistence.*;
 
 /**
  * This is a Java class named KruizeDSMetadataEntry annotated with JPA annotations.
- * It represents a table named kruize_metadata in a relational database.
+ * It represents a table named kruize_dsmetadata in a relational database.
  * <p>
  * The class has the following fields:
  * <p>
  * id: A unique identifier for each experiment detail.
  * version: A String representing the version of the experiment.
- * clusterGroupName: A String representing the datasource name.
- * clusterName: A String representing the cluster name.
+ * datasource_name: A String representing the datasource name.
+ * cluster_name: A String representing the cluster name.
  * namespace: A String representing the namespace name.
- * workloadType: A String representing the type of workload.
- * workloadName: A String representing the workload name.
- * containerName: A String representing the container name.
- * containerImageName: A String representing the container image name.
+ * workload_type: A String representing the type of workload.
+ * workload_name: A String representing the workload name.
+ * container_name: A String representing the container name.
+ * container_image_name: A String representing the container image name.
  */
 @Entity
 @Table(name = "kruize_dsmetadata")
@@ -41,13 +41,13 @@ public class KruizeDSMetadataEntry {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String version;
-    private String clusterGroupName;
-    private String clusterName;
+    private String datasource_name;
+    private String cluster_name;
     private String namespace;
-    private String workloadType;
-    private String workloadName;
-    private String containerName;
-    private String containerImageName;
+    private String workload_type;
+    private String workload_name;
+    private String container_name;
+    private String container_image_name;
 //    TODO: Relation mapping needs to be done later
 //    @OneToMany(mappedBy = "metadata", cascade = CascadeType.ALL)
 //    private List<KruizeExperimentEntry> experimentEntries;
@@ -55,15 +55,15 @@ public class KruizeDSMetadataEntry {
     public KruizeDSMetadataEntry() {
     }
 
-    public KruizeDSMetadataEntry(String version, String clusterGroupName, String clusterName, String namespace, String workloadType, String workloadName, String containerName, String containerImageName) {
+    public KruizeDSMetadataEntry(String version, String datasource_name, String cluster_name, String namespace, String workload_type, String workload_name, String container_name, String container_image_name) {
         this.version = version;
-        this.clusterGroupName = clusterGroupName;
-        this.clusterName = clusterName;
+        this.datasource_name = datasource_name;
+        this.cluster_name = cluster_name;
         this.namespace = namespace;
-        this.workloadType = workloadType;
-        this.workloadName = workloadName;
-        this.containerName = containerName;
-        this.containerImageName = containerImageName;
+        this.workload_type = workload_type;
+        this.workload_name = workload_name;
+        this.container_name = container_name;
+        this.container_image_name = container_image_name;
     }
 
     public Long getId() {
@@ -78,20 +78,20 @@ public class KruizeDSMetadataEntry {
         this.version = version;
     }
 
-    public String getClusterGroupName() {
-        return clusterGroupName;
+    public String getDataSourceName() {
+        return datasource_name;
     }
 
-    public void setClusterGroupName(String clusterGroupName) {
-        this.clusterGroupName = clusterGroupName;
+    public void setDataSourceName(String datasource_name) {
+        this.datasource_name = datasource_name;
     }
 
     public String getClusterName() {
-        return clusterName;
+        return cluster_name;
     }
 
-    public void setClusterName(String clusterName) {
-        this.clusterName = clusterName;
+    public void setClusterName(String cluster_name) {
+        this.cluster_name = cluster_name;
     }
 
     public String getNamespace() {
@@ -103,35 +103,35 @@ public class KruizeDSMetadataEntry {
     }
 
     public String getWorkloadType() {
-        return workloadType;
+        return workload_type;
     }
 
-    public void setWorkloadType(String workloadType) {
-        this.workloadType = workloadType;
+    public void setWorkloadType(String workload_type) {
+        this.workload_type = workload_type;
     }
 
     public String getWorkloadName() {
-        return workloadName;
+        return workload_name;
     }
 
-    public void setWorkloadName(String workloadName) {
-        this.workloadName = workloadName;
+    public void setWorkloadName(String workload_name) {
+        this.workload_name = workload_name;
     }
 
     public String getContainerName() {
-        return containerName;
+        return container_name;
     }
 
-    public void setContainerName(String containerName) {
-        this.containerName = containerName;
+    public void setContainerName(String container_name) {
+        this.container_name = container_name;
     }
 
     public String getContainerImageName() {
-        return containerImageName;
+        return container_image_name;
     }
 
-    public void setContainerImageName(String containerImageName) {
-        this.containerImageName = containerImageName;
+    public void setContainerImageName(String container_image_name) {
+        this.container_image_name = container_image_name;
     }
 
     @Override
@@ -139,13 +139,13 @@ public class KruizeDSMetadataEntry {
         return "KruizeDSMetadataEntry{" +
                 "id=" + id +
                 ", version='" + version + '\'' +
-                ", clusterGroupName='" + clusterGroupName + '\'' +
-                ", clusterName='" + clusterName + '\'' +
+                ", datasource_name='" + datasource_name + '\'' +
+                ", cluster_name='" + cluster_name + '\'' +
                 ", namespace='" + namespace + '\'' +
-                ", workloadType='" + workloadType + '\'' +
-                ", workloadName='" + workloadName + '\'' +
-                ", containerName='" + containerName + '\'' +
-                ", containerImageName='" + containerImageName + '\'' +
+                ", workload_type='" + workload_type + '\'' +
+                ", workload_name='" + workload_name + '\'' +
+                ", container_name='" + container_name + '\'' +
+                ", container_image_name='" + container_image_name + '\'' +
                 '}';
     }
 }


### PR DESCRIPTION
This PR has the following changes :

- Implementation of DB converter and helper functions for `KruizeDSMetadataEntry` table
- Integration of DB methods with metadata CRUD functionalities

Docker image - `quay.io/shbirada/metadata_db:mvp_demo`