### PR TITLE
Cloudwatch doc and awssdk version updates

### DIFF
--- a/design/KruizeConfiguration.md
+++ b/design/KruizeConfiguration.md
@@ -93,27 +93,27 @@ The following environment variables are set using the `kubectl apply` command wi
 
 ## CloudWatch Configuration
 
-- **accessKeyId**
+- **cloudwatch_accessKeyId**
   - Description: AWS account's access key ID. If not provided, CloudWatch logging is disabled.
   - Value: ""
 
-- **secretAccessKey**
+- **cloudwatch_secretAccessKey**
   - Description: AWS account's secret access key. If not provided, CloudWatch logging is disabled.
   - Value: ""
 
-- **region**
+- **cloudwatch_region**
   - Description: AWS region where CloudWatch logs are stored. If not provided, CloudWatch logging is disabled.
   - Value: ""
 
-- **logGroup**
+- **cloudwatch_logGroup**
   - Description: Name of the CloudWatch log group. Defaults to "kruize-logs".
   - Value: "kruize-logs"
 
-- **logStream**
+- **cloudwatch_logStream**
   - Description: Name of the CloudWatch log stream within the log group. Defaults to "kruize-stream".
   - Value: "kruize-stream"
 
-- **logLevel**
+- **cloudwatch_logLevel**
   - Description:  The minimum level of log events to send to CloudWatch. Defaults to "INFO".
   - Value: "INFO"
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <hibernatecp30-version>6.1.7.Final</hibernatecp30-version>
         <hibernate-Validator>8.0.1.Final</hibernate-Validator>
         <micrometer-version>1.9.9</micrometer-version>
-        <awssdk-version>2.17.102</awssdk-version>
+        <awssdk-version>2.25.35</awssdk-version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
This PR does:
- Update the aws sdk version to the latest available.
- Update the cloudwatch configuration in the design document to include the format similar to hibernate.