### PR TITLE
Change to cloudwatch logging structure to resemble similar to ROS

### DIFF
--- a/design/KruizeConfiguration.md
+++ b/design/KruizeConfiguration.md
@@ -93,27 +93,27 @@ The following environment variables are set using the `kubectl apply` command wi
 
 ## CloudWatch Configuration
 
-- **cloudwatch_accessKeyId**
+- **logging_cloudwatch_accessKeyId**
   - Description: AWS account's access key ID. If not provided, CloudWatch logging is disabled.
   - Value: ""
 
-- **cloudwatch_secretAccessKey**
+- **logging_cloudwatch_secretAccessKey**
   - Description: AWS account's secret access key. If not provided, CloudWatch logging is disabled.
   - Value: ""
 
-- **cloudwatch_region**
+- **logging_cloudwatch_region**
   - Description: AWS region where CloudWatch logs are stored. If not provided, CloudWatch logging is disabled.
   - Value: ""
 
-- **cloudwatch_logGroup**
+- **logging_cloudwatch_logGroup**
   - Description: Name of the CloudWatch log group. Defaults to "kruize-logs".
   - Value: "kruize-logs"
 
-- **cloudwatch_logStream**
+- **logging_cloudwatch_logStream**
   - Description: Name of the CloudWatch log stream within the log group. Defaults to "kruize-stream".
   - Value: "kruize-stream"
 
-- **cloudwatch_logLevel**
+- **logging_cloudwatch_logLevel**
   - Description:  The minimum level of log events to send to CloudWatch. Defaults to "INFO".
   - Value: "INFO"
 

--- a/design/KruizeConfigurationProcedure.md
+++ b/design/KruizeConfigurationProcedure.md
@@ -49,13 +49,15 @@ data:
         "hbm2ddlauto": "update",
         "showsql": "true"
       },
-      "cloudwatch": {
-        "accessKeyId": "",
-        "secretAccessKey": "",
-        "region": "",
-        "logGroup": "kruize-logs",
-        "logStream": "kruize-stream",
-        "logLevel": "INFO"
+      "logging": {
+        "cloudwatch": {
+          "accessKeyId": "",
+          "secretAccessKey": "",
+          "region": "",
+          "logGroup": "kruize-logs",
+          "logStream": "kruize-stream",
+          "logLevel": "INFO"
+        }
       }
     }
 ```

--- a/src/main/java/com/autotune/utils/CloudWatchAppender.java
+++ b/src/main/java/com/autotune/utils/CloudWatchAppender.java
@@ -109,7 +109,7 @@ public class CloudWatchAppender extends AbstractAppender {
                 LoggerConfig loggerConfig = config.getLoggerConfig("com.autotune");
                 loggerConfig.addAppender(appender, level, filter);
                 context.updateLoggers(config);
-                LOGGER.info("Enabled CloudWatch logs");
+                LOGGER.debug("Enabled CloudWatch logs");
 
             } catch (Exception e) {
                 LOGGER.error(e.getMessage());

--- a/src/main/java/com/autotune/utils/CloudWatchAppender.java
+++ b/src/main/java/com/autotune/utils/CloudWatchAppender.java
@@ -1,4 +1,5 @@
 package com.autotune.utils;
+
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Filter;
@@ -16,13 +17,15 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsAsyncClient;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 import software.amazon.awssdk.services.cloudwatchlogs.model.*;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import static com.autotune.operator.KruizeDeploymentInfo.*;
 
 public class CloudWatchAppender extends AbstractAppender {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CloudWatchAppender.class);
     private final String logGroupName;
     private final String logStreamName;
     private final CloudWatchLogsAsyncClient cloudWatchLogsClient;
@@ -106,6 +109,7 @@ public class CloudWatchAppender extends AbstractAppender {
                 LoggerConfig loggerConfig = config.getLoggerConfig("com.autotune");
                 loggerConfig.addAppender(appender, level, filter);
                 context.updateLoggers(config);
+                LOGGER.info("Enabled CloudWatch logs");
 
             } catch (Exception e) {
                 LOGGER.error(e.getMessage());

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -599,12 +599,12 @@ public class KruizeConstants {
         public static final String SETTINGS_HIBERNATE_SHOW_SQL = "hibernate_showsql";
         public static final String SETTINGS_HIBERNATE_TIME_ZONE = "hibernate_timezone";
         public static final String PLOTS = "plots";
-        public static final String CLOUDWATCH_LOGS_ACCESS_KEY_ID = "cloudwatch_accessKeyId";
-        public static final String CLOUDWATCH_LOGS_SECRET_ACCESS_KEY = "cloudwatch_secretAccessKey";
-        public static final String CLOUDWATCH_LOGS_LOG_GROUP = "cloudwatch_logGroup";
-        public static final String CLOUDWATCH_LOGS_REGION = "cloudwatch_region";
-        public static final String CLOUDWATCH_LOGS_LOG_STREAM = "cloudwatch_logStream";
-        public static final String CLOUDWATCH_LOGS_LOG_LEVEL = "cloudwatch_logLevel";
+        public static final String CLOUDWATCH_LOGS_ACCESS_KEY_ID = "logging_cloudwatch_accessKeyId";
+        public static final String CLOUDWATCH_LOGS_SECRET_ACCESS_KEY = "logging_cloudwatch_secretAccessKey";
+        public static final String CLOUDWATCH_LOGS_LOG_GROUP = "logging_cloudwatch_logGroup";
+        public static final String CLOUDWATCH_LOGS_REGION = "logging_cloudwatch_region";
+        public static final String CLOUDWATCH_LOGS_LOG_STREAM = "logging_cloudwatch_logStream";
+        public static final String CLOUDWATCH_LOGS_LOG_LEVEL = "logging_cloudwatch_logLevel";
         public static final String LOCAL = "local";
         public static final String LOG_HTTP_REQ_RESP = "logAllHttpReqAndResp";
     }


### PR DESCRIPTION
The current code supports cloudwatch logging structure as below:

```
 "logging": {
        "cloudwatch": {
          "accessKeyId": "",
          "logGroup": "kruize-logs",
          "logStream": "kruize-stream",
          "region": "",
          "secretAccessKey": "",
          "logLevel": "INFO"
        }
      }
```