### PR TITLE
Fix memory format for local monitoring

### DIFF
--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -44,6 +44,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.lang.reflect.Method;
 import java.net.URLEncoder;
 import java.sql.Timestamp;
+import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -1492,10 +1493,10 @@ public class RecommendationEngine {
                                 if (secondMethodName.equals(KruizeConstants.JSONKeys.SUM))
                                     secondMethodName = KruizeConstants.JSONKeys.AVG;
                                 promQL = String.format(metricEntry.getValue(), methodName, secondMethodName, namespace, containerName, measurementDurationMinutesInDouble.intValue());
-                                format = KruizeConstants.JSONKeys.GIBIBYTE;
+                                format = KruizeConstants.JSONKeys.KIBIBYTE;
                             } else if (metricEntry.getKey() == AnalyzerConstants.MetricName.memoryLimit || metricEntry.getKey() == AnalyzerConstants.MetricName.memoryRequest) {
                                 promQL = String.format(metricEntry.getValue(), methodName, namespace, containerName);
-                                format = KruizeConstants.JSONKeys.GIBIBYTE;
+                                format = KruizeConstants.JSONKeys.KIBIBYTE;
                             }
                             // If promQL is determined, fetch metrics from the datasource
                             if (promQL != null) {
@@ -1527,6 +1528,15 @@ public class RecommendationEngine {
                                             JsonArray valueArray = element.getAsJsonArray();
                                             long epochTime = valueArray.get(0).getAsLong();
                                             double value = valueArray.get(1).getAsDouble();
+
+                                            if (metricEntry.getKey() == AnalyzerConstants.MetricName.memoryUsage || metricEntry.getKey() == AnalyzerConstants.MetricName.memoryRSS
+                                                    || metricEntry.getKey() == AnalyzerConstants.MetricName.memoryLimit || metricEntry.getKey() == AnalyzerConstants.MetricName.memoryRequest) {
+                                                value = value * KruizeConstants.ConvUnits.Memory.BYTES_TO_KIBIBYTES;
+                                            }
+
+                                            DecimalFormat df = new DecimalFormat("0.000");
+                                            value = Double.parseDouble(df.format(value));
+
                                             String timestamp = sdf.format(new Date(epochTime * KruizeConstants.TimeConv.NO_OF_MSECS_IN_SEC));
                                             Date date = sdf.parse(timestamp);
                                             Timestamp eTime = new Timestamp(date.getTime());

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -44,7 +44,6 @@ import javax.servlet.http.HttpServletResponse;
 import java.lang.reflect.Method;
 import java.net.URLEncoder;
 import java.sql.Timestamp;
-import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -1493,10 +1492,10 @@ public class RecommendationEngine {
                                 if (secondMethodName.equals(KruizeConstants.JSONKeys.SUM))
                                     secondMethodName = KruizeConstants.JSONKeys.AVG;
                                 promQL = String.format(metricEntry.getValue(), methodName, secondMethodName, namespace, containerName, measurementDurationMinutesInDouble.intValue());
-                                format = KruizeConstants.JSONKeys.KIBIBYTE;
+                                format = KruizeConstants.JSONKeys.BYTES;
                             } else if (metricEntry.getKey() == AnalyzerConstants.MetricName.memoryLimit || metricEntry.getKey() == AnalyzerConstants.MetricName.memoryRequest) {
                                 promQL = String.format(metricEntry.getValue(), methodName, namespace, containerName);
-                                format = KruizeConstants.JSONKeys.KIBIBYTE;
+                                format = KruizeConstants.JSONKeys.BYTES;
                             }
                             // If promQL is determined, fetch metrics from the datasource
                             if (promQL != null) {
@@ -1528,15 +1527,6 @@ public class RecommendationEngine {
                                             JsonArray valueArray = element.getAsJsonArray();
                                             long epochTime = valueArray.get(0).getAsLong();
                                             double value = valueArray.get(1).getAsDouble();
-
-                                            if (metricEntry.getKey() == AnalyzerConstants.MetricName.memoryUsage || metricEntry.getKey() == AnalyzerConstants.MetricName.memoryRSS
-                                                    || metricEntry.getKey() == AnalyzerConstants.MetricName.memoryLimit || metricEntry.getKey() == AnalyzerConstants.MetricName.memoryRequest) {
-                                                value = value * KruizeConstants.ConvUnits.Memory.BYTES_TO_KIBIBYTES;
-                                            }
-
-                                            DecimalFormat df = new DecimalFormat("0.000");
-                                            value = Double.parseDouble(df.format(value));
-
                                             String timestamp = sdf.format(new Date(epochTime * KruizeConstants.TimeConv.NO_OF_MSECS_IN_SEC));
                                             Date date = sdf.parse(timestamp);
                                             Timestamp eTime = new Timestamp(date.getTime());

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -178,7 +178,7 @@ public class KruizeConstants {
         public static final String MEDIAN = "median";
         public static final String RANGE = "range";
         public static final String CORES = "cores";
-        public static final String KIBIBYTE = "KiB";
+        public static final String BYTES = "bytes";
 
         // Datasource JSON keys
         public static final String DATASOURCES = "datasources";

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -178,7 +178,7 @@ public class KruizeConstants {
         public static final String MEDIAN = "median";
         public static final String RANGE = "range";
         public static final String CORES = "cores";
-        public static final String GIBIBYTE = "GiB";
+        public static final String KIBIBYTE = "KiB";
 
         // Datasource JSON keys
         public static final String DATASOURCES = "datasources";


### PR DESCRIPTION
This PR has the following change:

- Replace `GiB` with `bytes` as the default format for memory representation in local monitoring usecase

Docker image - `quay.io/shbirada/fix_memory_format:kl`