### PR TITLE
Add initContainer in Kruize pod to check PostGres pod readiness

### DIFF
--- a/Dockerfile.autotune
+++ b/Dockerfile.autotune
@@ -59,7 +59,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # Install packages needed for Java to function correctly
 RUN microdnf install -y tzdata openssl curl ca-certificates fontconfig \
-                        glibc-langpack-en gzip tar \
+                        glibc-langpack-en gzip tar postgresql-devel \
     && microdnf update -y \
     && microdnf clean all
 

--- a/Dockerfile.autotune
+++ b/Dockerfile.autotune
@@ -59,7 +59,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # Install packages needed for Java to function correctly
 RUN microdnf install -y tzdata openssl curl ca-certificates fontconfig \
-                        glibc-langpack-en gzip tar postgresql-devel \
+                        glibc-langpack-en gzip tar \
     && microdnf update -y \
     && microdnf clean all
 

--- a/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
@@ -14,7 +14,7 @@ data:
       "database": {
         "adminPassword": "admin",
         "adminUsername": "admin",
-        "hostname": "postgres-service",
+        "hostname": "kruize-db-service",
         "name": "kruizeDB",
         "password": "admin",
         "port": 5432,
@@ -84,8 +84,8 @@ spec:
             - sh
             - -c
             - |
-              until pg_isready -h postgres-service -p 5432 -U admin; do
-                echo "Waiting for Postgres to be ready..."
+              until pg_isready -h kruize-db-service -p 5432 -U admin; do
+                echo "Waiting for kruize-db-service to be ready..."
                 sleep 2
               done
       containers:

--- a/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
@@ -76,6 +76,18 @@ spec:
         app: kruize
         name: kruize
     spec:
+      initContainers:
+        - name: wait-for-postgres
+          image: quay.io/kruizehub/postgres:15.2 # Use the same Postgres version as the Postgres deployment
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - |
+              until pg_isready -h postgres-service -p 5432 -U admin; do
+                echo "Waiting for Postgres to be ready..."
+                sleep 2
+              done
       containers:
         - name: kruize
           image: kruize/autotune_operator:0.0.22_rm
@@ -97,14 +109,6 @@ spec:
           ports:
             - name: kruize-port
               containerPort: 8080
-          startupProbe:
-            # checks for the postgres connection before starting kruize pod
-            exec:
-              command: [ "sh", "-c", "pg_isready -h postgres-service -U admin" ]
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 6
       #          livenessProbe:
       #            exec:
       #              command:

--- a/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
@@ -77,7 +77,7 @@ spec:
         name: kruize
     spec:
       initContainers:
-        - name: wait-for-postgres
+        - name: wait-for-kruize-db
           image: quay.io/kruizehub/postgres:15.2 # Use the same Postgres version as the Postgres deployment
           imagePullPolicy: IfNotPresent
           command:

--- a/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
@@ -97,6 +97,14 @@ spec:
           ports:
             - name: kruize-port
               containerPort: 8080
+          startupProbe:
+            # checks for the postgres connection before starting kruize pod
+            exec:
+              command: [ "sh", "-c", "pg_isready -h postgres-service -U admin" ]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
       #          livenessProbe:
       #            exec:
       #              command:

--- a/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
@@ -14,7 +14,7 @@ data:
       "database": {
         "adminPassword": "admin",
         "adminUsername": "admin",
-        "hostname": "postgres-service",
+        "hostname": "kruize-db-service",
         "name": "kruizeDB",
         "password": "admin",
         "port": 5432,
@@ -84,8 +84,8 @@ spec:
             - sh
             - -c
             - |
-              until pg_isready -h postgres-service -p 5432 -U admin; do
-                echo "Waiting for Postgres to be ready..."
+              until pg_isready -h kruize-db-service -p 5432 -U admin; do
+                echo "Waiting for kruize-db-service to be ready..."
                 sleep 2
               done
       containers:

--- a/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
@@ -104,6 +104,14 @@ spec:
           ports:
             - name: kruize-port
               containerPort: 8080
+          startupProbe:
+            # checks for the postgres connection before starting kruize pod
+            exec:
+              command: [ "sh", "-c", "pg_isready -h postgres-service -U admin" ]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
       #          livenessProbe:
       #            exec:
       #              command:

--- a/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
@@ -77,7 +77,7 @@ spec:
         name: kruize
     spec:
       initContainers:
-        - name: wait-for-postgres
+        - name: wait-for-kruize-db
           image: quay.io/kruizehub/postgres:15.2 # Use the same Postgres version as the Postgres deployment
           imagePullPolicy: IfNotPresent
           command:

--- a/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
@@ -76,6 +76,18 @@ spec:
         app: kruize
         name: kruize
     spec:
+      initContainers:
+        - name: wait-for-postgres
+          image: quay.io/kruizehub/postgres:15.2 # Use the same Postgres version as the Postgres deployment
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - |
+              until pg_isready -h postgres-service -p 5432 -U admin; do
+                echo "Waiting for Postgres to be ready..."
+                sleep 2
+              done
       containers:
         - name: kruize
           image: kruize/autotune_operator:0.0.22_rm
@@ -104,14 +116,6 @@ spec:
           ports:
             - name: kruize-port
               containerPort: 8080
-          startupProbe:
-            # checks for the postgres connection before starting kruize pod
-            exec:
-              command: [ "sh", "-c", "pg_isready -h postgres-service -U admin" ]
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 6
       #          livenessProbe:
       #            exec:
       #              command:

--- a/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
@@ -184,7 +184,8 @@ spec:
           ports:
             - name: kruize-port
               containerPort: 8080
-          readinessProbe:
+          startupProbe:
+            # checks for the postgres connection before starting kruize pod
             exec:
               command: [ "sh", "-c", "pg_isready -h postgres-service -U admin" ]
             initialDelaySeconds: 10

--- a/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
@@ -184,6 +184,13 @@ spec:
           ports:
             - name: kruize-port
               containerPort: 8080
+          readinessProbe:
+            exec:
+              command: [ "sh", "-c", "pg_isready -h postgres-service -U admin" ]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
       #          livenessProbe:
       #            exec:
       #              command:

--- a/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
@@ -68,7 +68,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: postgres-service
+  name: kruize-db-service
   namespace: monitoring
   labels:
     app: postgres
@@ -92,7 +92,7 @@ data:
       "database": {
         "adminPassword": "admin",
         "adminUsername": "admin",
-        "hostname": "postgres-service",
+        "hostname": "kruize-db-service",
         "name": "kruizeDB",
         "password": "admin",
         "port": 5432,
@@ -171,8 +171,8 @@ spec:
             - sh
             - -c
             - |
-              until pg_isready -h postgres-service -p 5432 -U admin; do
-                echo "Waiting for Postgres to be ready..."
+              until pg_isready -h kruize-db-service -p 5432 -U admin; do
+                echo "Waiting for kruize-db-service to be ready..."
                 sleep 2
               done
       containers:

--- a/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
@@ -163,6 +163,18 @@ spec:
         app: kruize
         name: kruize
     spec:
+      initContainers:
+        - name: wait-for-postgres
+          image: quay.io/kruizehub/postgres:15.2 # Use the same Postgres version as the Postgres deployment
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - |
+              until pg_isready -h postgres-service -p 5432 -U admin; do
+                echo "Waiting for Postgres to be ready..."
+                sleep 2
+              done
       containers:
         - name: kruize
           image: kruize/autotune_operator:0.0.22_rm
@@ -184,14 +196,6 @@ spec:
           ports:
             - name: kruize-port
               containerPort: 8080
-          startupProbe:
-            # checks for the postgres connection before starting kruize pod
-            exec:
-              command: [ "sh", "-c", "pg_isready -h postgres-service -U admin" ]
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 6
       #          livenessProbe:
       #            exec:
       #              command:

--- a/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
@@ -27,7 +27,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: postgres-deployment
+  name: kruize-db-deployment
   namespace: monitoring
   labels:
     app: postgres

--- a/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: postgres-pv
+  name: kruize-db-pv
   namespace: monitoring
 spec:
   capacity:
@@ -15,7 +15,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: postgres-pvc
+  name: kruize-db-pvc
   namespace: monitoring
 spec:
   accessModes:
@@ -30,22 +30,22 @@ metadata:
   name: kruize-db-deployment
   namespace: monitoring
   labels:
-    app: postgres
+    app: kruize-db
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: postgres
+      app: kruize-db
   template:
     metadata:
       labels:
-        app: postgres
+        app: kruize-db
     spec:
       #securityContext:      #todo
       #  runAsNonRoot: true
       #  runAsUser: 1000
       containers:
-        - name: postgres
+        - name: kruize-db
           image: quay.io/kruizehub/postgres:15.2
           imagePullPolicy: IfNotPresent
           env:
@@ -58,12 +58,12 @@ spec:
           ports:
             - containerPort: 5432
           volumeMounts:
-            - name: postgres-storage
+            - name: kruize-db-storage
               mountPath: /var/lib/postgresql/data
       volumes:
-        - name: postgres-storage
+        - name: kruize-db-storage
           persistentVolumeClaim:
-            claimName: postgres-pvc
+            claimName: kruize-db-pvc
 ---
 apiVersion: v1
 kind: Service
@@ -71,15 +71,15 @@ metadata:
   name: kruize-db-service
   namespace: monitoring
   labels:
-    app: postgres
+    app: kruize-db
 spec:
   type: ClusterIP
   ports:
-    - name: postgres-port
+    - name: kruize-db-port
       port: 5432
       targetPort: 5432
   selector:
-    app: postgres
+    app: kruize-db
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -164,7 +164,7 @@ spec:
         name: kruize
     spec:
       initContainers:
-        - name: wait-for-postgres
+        - name: wait-for-kruize-db
           image: quay.io/kruizehub/postgres:15.2 # Use the same Postgres version as the Postgres deployment
           imagePullPolicy: IfNotPresent
           command:
@@ -177,7 +177,7 @@ spec:
               done
       containers:
         - name: kruize
-          image: kruize/autotune_operator:0.0.22_rm
+          image: quay.io/kruize/autotune_operator:0.0.22_rm
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume
@@ -341,7 +341,7 @@ metadata:
 spec:
   containers:
     - name: kruize-ui-nginx-container
-      image: quay.io/kruize/kruize-ui:0.0.3
+      image: quay.io/kruize/kruize-ui:0.0.4
       imagePullPolicy: Always
       env:
         - name: KRUIZE_UI_ENV

--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -129,7 +129,7 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: postgres-deployment
+  name: kruize-db-deployment
   namespace: openshift-tuning
   labels:
     app: postgres

--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -73,7 +73,7 @@ data:
       "database": {
         "adminPassword": "admin",
         "adminUsername": "admin",
-        "hostname": "postgres-service",
+        "hostname": "kruize-db-service",
         "name": "kruizeDB",
         "password": "admin",
         "port": 5432,
@@ -177,7 +177,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: postgres-service
+  name: kruize-db-service
   namespace: openshift-tuning
   labels:
     app: postgres
@@ -217,8 +217,8 @@ spec:
             - sh
             - -c
             - |
-              until pg_isready -h postgres-service -p 5432 -U admin; do
-                echo "Waiting for Postgres to be ready..."
+              until pg_isready -h kruize-db-service -p 5432 -U admin; do
+                echo "Waiting for kruize-db-service to be ready..."
                 sleep 2
               done
       containers:

--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -169,6 +169,17 @@ spec:
           volumeMounts:
             - name: postgres-storage
               mountPath: /var/lib/pgsql/data
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - exec pg_isready -U admin -d kruizeDB
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
       volumes:
         - name: postgres-storage
           persistentVolumeClaim:
@@ -237,6 +248,13 @@ spec:
           ports:
             - name: kruize-port
               containerPort: 8080
+          readinessProbe:
+            exec:
+              command: [ "sh", "-c", "pg_isready -h postgres-service -U admin" ]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
       #          livenessProbe:
       #            exec:
       #              command:

--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -209,6 +209,18 @@ spec:
         name: kruize
     spec:
       serviceAccountName: kruize-sa
+      initContainers:
+        - name: wait-for-postgres
+          image: quay.io/kruizehub/postgres:15.2 # Use the same Postgres version as the Postgres deployment
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - |
+              until pg_isready -h postgres-service -p 5432 -U admin; do
+                echo "Waiting for Postgres to be ready..."
+                sleep 2
+              done
       containers:
         - name: kruize
           image: kruize/autotune_operator:0.0.22_rm
@@ -237,14 +249,6 @@ spec:
           ports:
             - name: kruize-port
               containerPort: 8080
-          startupProbe:
-            # checks for the postgres connection before starting kruize pod
-            exec:
-              command: [ "sh", "-c", "pg_isready -h postgres-service -U admin" ]
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 6
       #          livenessProbe:
       #            exec:
       #              command:

--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -169,17 +169,6 @@ spec:
           volumeMounts:
             - name: postgres-storage
               mountPath: /var/lib/pgsql/data
-          readinessProbe:
-            exec:
-              command:
-                - sh
-                - -c
-                - exec pg_isready -U admin -d kruizeDB
-            initialDelaySeconds: 10
-            periodSeconds: 5
-            timeoutSeconds: 5
-            successThreshold: 1
-            failureThreshold: 3
       volumes:
         - name: postgres-storage
           persistentVolumeClaim:
@@ -248,7 +237,8 @@ spec:
           ports:
             - name: kruize-port
               containerPort: 8080
-          readinessProbe:
+          startupProbe:
+            # checks for the postgres connection before starting kruize pod
             exec:
               command: [ "sh", "-c", "pg_isready -h postgres-service -U admin" ]
             initialDelaySeconds: 10

--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -33,11 +33,11 @@ volumeBindingMode: Immediate
 kind: PersistentVolume
 apiVersion: v1
 metadata:
-  name: postgres-pv-volume  # Sets PV's name
+  name: kruize-db-pv-volume  # Sets PV's name
   namespace: openshift-tuning
   labels:
     type: local  # Sets PV's type to local
-    app: postgres
+    app: kruize-db
 spec:
   storageClassName: manual
   capacity:
@@ -50,10 +50,10 @@ spec:
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: postgres-pv-claim  # Sets name of PVC
+  name: kruize-db-pv-claim  # Sets name of PVC
   namespace: openshift-tuning
   labels:
-    app: postgres
+    app: kruize-db
 spec:
   storageClassName: manual
   accessModes:
@@ -132,20 +132,20 @@ metadata:
   name: kruize-db-deployment
   namespace: openshift-tuning
   labels:
-    app: postgres
+    app: kruize-db
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: postgres
+      app: kruize-db
   template:
     metadata:
       labels:
-        app: postgres
+        app: kruize-db
     spec:
       serviceAccountName: kruize-sa
       containers:
-        - name: postgres
+        - name: kruize-db
           image: quay.io/kruizehub/postgres:15.2
           imagePullPolicy: IfNotPresent
           env:
@@ -167,12 +167,12 @@ spec:
           ports:
             - containerPort: 5432
           volumeMounts:
-            - name: postgres-storage
+            - name: kruize-db-storage
               mountPath: /var/lib/pgsql/data
       volumes:
-        - name: postgres-storage
+        - name: kruize-db-storage
           persistentVolumeClaim:
-            claimName: postgres-pv-claim
+            claimName: kruize-db-pv-claim
 ---
 apiVersion: v1
 kind: Service
@@ -180,15 +180,15 @@ metadata:
   name: kruize-db-service
   namespace: openshift-tuning
   labels:
-    app: postgres
+    app: kruize-db
 spec:
   type: ClusterIP
   ports:
-    - name: postgres-port
+    - name: kruize-db-port
       port: 5432
       targetPort: 5432
   selector:
-    app: postgres
+    app: kruize-db
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -210,7 +210,7 @@ spec:
     spec:
       serviceAccountName: kruize-sa
       initContainers:
-        - name: wait-for-postgres
+        - name: wait-for-kruize-db
           image: quay.io/kruizehub/postgres:15.2 # Use the same Postgres version as the Postgres deployment
           imagePullPolicy: IfNotPresent
           command:

--- a/scripts/common_utils.sh
+++ b/scripts/common_utils.sh
@@ -21,7 +21,8 @@ function check_running() {
 
 	check_pod=$1
 	check_pod_ns=$2
-	ignore_pod=$3
+	ignore_ui_pod=$3
+	ignore_db_pod=$4
 	kubectl_cmd="kubectl -n ${check_pod_ns}"
 
 	echo "Info: Waiting for ${check_pod} to come up....."
@@ -29,14 +30,13 @@ function check_running() {
 	counter=0
 	while true; do
 		sleep 2
-		#		Check if ignore pod is sent
-		if [[ ! -z "${ignore_pod}" ]]; then
-			${kubectl_cmd} get pods | grep ${check_pod} | grep -v ${ignore_pod}
-			pod_stat=$(${kubectl_cmd} get pods | grep ${check_pod} | grep -v ${ignore_pod} | awk '{ print $3 }')
-		else
-			${kubectl_cmd} get pods | grep ${check_pod}
-			pod_stat=$(${kubectl_cmd} get pods | grep ${check_pod} | awk '{ print $3 }')
-		fi
+		pod_list=$(${kubectl_cmd} get pods | grep ${check_pod} | grep -v "${ignore_ui_pod}" | grep -v "${ignore_db_pod}")
+		pod_stat=$(echo "${pod_list}" | awk '{ print $3 }')
+		if [[ -z "${pod_list}" ]]; then
+      echo "Error: No pods found matching ${check_pod}"
+      err=-1
+      break
+    fi
 
 		case "${pod_stat}" in
 		"Running")
@@ -57,7 +57,7 @@ function check_running() {
 			sleep 2
 			if [ $counter == 200 ]; then
 				${kubectl_cmd} describe pod ${check_pod}
-				echo "ERROR: Prometheus Pods failed to come up!"
+				echo "ERROR: ${check_pod} Pods failed to come up!"
 				exit -1
 			fi
 			((counter++))
@@ -109,7 +109,7 @@ kruize_crc_start() {
 	fi
 
 	${kubectl_cmd} apply -f ${CRC_MANIFEST_FILE}
-	check_running kruize ${autotune_ns} kruize-ui
+	check_running kruize ${autotune_ns} kruize-ui kruize-db
 	if [ "${err}" != "0" ]; then
 		# Indicate deploy failed on error
 		exit 1

--- a/scripts/common_utils.sh
+++ b/scripts/common_utils.sh
@@ -33,10 +33,10 @@ function check_running() {
 		pod_list=$(${kubectl_cmd} get pods | grep ${check_pod} | grep -v "${ignore_ui_pod}" | grep -v "${ignore_db_pod}")
 		pod_stat=$(echo "${pod_list}" | awk '{ print $3 }')
 		if [[ -z "${pod_list}" ]]; then
-      echo "Error: No pods found matching ${check_pod}"
-      err=-1
-      break
-    fi
+		  echo "Error: No pods found matching ${check_pod}"
+		  err=-1
+		  break
+		fi
 
 		case "${pod_stat}" in
 		"Running")

--- a/scripts/ffdc.sh
+++ b/scripts/ffdc.sh
@@ -41,7 +41,7 @@ function ffdc() {
 	pod_log="${log_dir}/kruize_pod_log.txt"
 	describe_log="${log_dir}/kruize_describe_pod_log.txt"
 
-	kruize_pod=$(kubectl get pod -n $namespace | grep $service | grep -v "kruize-ui" | cut -d " " -f1)
+	kruize_pod=$(kubectl get pod -n $namespace | grep $service | grep -v "kruize-ui" | grep -v "kruize-db" | cut -d " " -f1)
 
 	kubectl describe pod ${kruize_pod} -n ${namespace} > ${describe_log} 2>&1
 	check_err "Error getting kubectl describe kruize pod log! Check ${describe_log} for details!"


### PR DESCRIPTION
# Add `initContainer` in Kruize pod to check postGres pod readiness

## Description

This PR will do the following changes - 
- update Kruize deployment section in both minikube and openshift manifest yamls to have an `initContainer` which checks for the postgres pod service based and starts the main kruize container only when a successful connection is established.  

### Type of change

- [ ] Refactoring Code
- [x] New feature

## How has this been tested?

- Openshift ( ResourceHub cluster)/Minikube: Skipped the postgres installation first to deliberately fail the init container and restored it again to see the working of initContainer before starting the kruize pod 


**Test Configuration**
* Kubernetes clusters tested on: Minikube and Openshift

## Checklist :dart:

- [X] Followed coding guidelines
- [X] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information
- 