### PR TITLE
Log updateRecommendations failure message

### DIFF
--- a/src/main/java/com/autotune/analyzer/services/UpdateRecommendations.java
+++ b/src/main/java/com/autotune/analyzer/services/UpdateRecommendations.java
@@ -187,6 +187,7 @@ public class UpdateRecommendations extends HttpServlet {
             LOGGER.error(e.toString());
             if (null == errorMsg) errorMsg = e.getMessage();
         }
+        LOGGER.error("Update Recommendation failed due to {}", errorMsg);
         response.sendError(httpStatusCode, errorMsg);
     }
 }

--- a/src/main/java/com/autotune/analyzer/services/UpdateRecommendations.java
+++ b/src/main/java/com/autotune/analyzer/services/UpdateRecommendations.java
@@ -112,8 +112,6 @@ public class UpdateRecommendations extends HttpServlet {
                     sendErrorResponse(response, null, kruizeObject.getValidation_data().getErrorCode(), kruizeObject.getValidation_data().getMessage(), experiment_name, intervalEndTimeStr);
                 }
             } else {
-                LOGGER.error(String.format(KruizeConstants.APIMessages.UPDATE_RECOMMENDATIONS_VALIDATION_FAILURE, validationMessage,
-                        experiment_name, intervalEndTimeStr));
                 sendErrorResponse(response, null, HttpServletResponse.SC_BAD_REQUEST, validationMessage, experiment_name, intervalEndTimeStr);
             }
 

--- a/src/main/java/com/autotune/analyzer/services/UpdateRecommendations.java
+++ b/src/main/java/com/autotune/analyzer/services/UpdateRecommendations.java
@@ -109,21 +109,18 @@ public class UpdateRecommendations extends HttpServlet {
                     statusValue = KruizeConstants.APIMessages.SUCCESS;
                 } else {
                     LOGGER.error(String.format(AnalyzerErrorConstants.APIErrors.UpdateRecommendationsAPI.UPDATE_RECOMMENDATIONS_FAILED_COUNT, calCount));
-                    LOGGER.error(String.format(KruizeConstants.APIMessages.UPDATE_RECOMMENDATIONS_FAILURE, experiment_name, intervalEndTimeStr));
-                    sendErrorResponse(response, null, kruizeObject.getValidation_data().getErrorCode(), kruizeObject.getValidation_data().getMessage());
+                    sendErrorResponse(response, null, kruizeObject.getValidation_data().getErrorCode(), kruizeObject.getValidation_data().getMessage(), experiment_name, intervalEndTimeStr);
                 }
             } else {
                 LOGGER.error(String.format(KruizeConstants.APIMessages.UPDATE_RECOMMENDATIONS_VALIDATION_FAILURE, validationMessage,
                         experiment_name, intervalEndTimeStr));
-                sendErrorResponse(response, null, HttpServletResponse.SC_BAD_REQUEST, validationMessage);
+                sendErrorResponse(response, null, HttpServletResponse.SC_BAD_REQUEST, validationMessage, experiment_name, intervalEndTimeStr);
             }
 
         } catch (Exception e) {
             LOGGER.error(String.format(AnalyzerErrorConstants.APIErrors.UpdateRecommendationsAPI.UPDATE_RECOMMENDATIONS_FAILED_COUNT, calCount));
-            LOGGER.error(String.format(AnalyzerErrorConstants.APIErrors.UpdateRecommendationsAPI.RECOMMENDATION_EXCEPTION,
-                    experiment_name, intervalEndTimeStr, e.getMessage()));
             e.printStackTrace();
-            sendErrorResponse(response, e, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+            sendErrorResponse(response, e, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage(), experiment_name, intervalEndTimeStr);
         } finally {
             LOGGER.debug(String.format(AnalyzerErrorConstants.APIErrors.UpdateRecommendationsAPI.UPDATE_RECOMMENDATIONS_COMPLETED_COUNT, calCount));
             if (null != timerBUpdateRecommendations) {
@@ -180,14 +177,14 @@ public class UpdateRecommendations extends HttpServlet {
         response.getWriter().close();
     }
 
-    public void sendErrorResponse(HttpServletResponse response, Exception e, int httpStatusCode, String errorMsg) throws
-            IOException {
+    public void sendErrorResponse(HttpServletResponse response, Exception e, int httpStatusCode, String errorMsg,
+                                  String experiment_name, String intervalEndTimeStr) throws IOException {
         if (null != e) {
             e.printStackTrace();
             LOGGER.error(e.toString());
             if (null == errorMsg) errorMsg = e.getMessage();
         }
-        LOGGER.error("Update Recommendation failed due to {}", errorMsg);
+        LOGGER.error(String.format(KruizeConstants.APIMessages.UPDATE_RECOMMENDATIONS_FAILURE_MSG, experiment_name, intervalEndTimeStr, errorMsg));
         response.sendError(httpStatusCode, errorMsg);
     }
 }

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -44,6 +44,7 @@ public class KruizeConstants {
         public static final String UPDATE_RECOMMENDATIONS_FAILURE = "UpdateRecommendations API failure response, experiment_name: %s and intervalEndTimeStr : %s";
         public static final String UPDATE_RECOMMENDATIONS_VALIDATION_FAILURE = "Validation failed: %s for experiment_name: %s and interval_end_time: %s";
         public static final String UPDATE_RECOMMENDATIONS_RESPONSE = "Update Recommendation API response: %s";
+        public static final String UPDATE_RECOMMENDATIONS_FAILURE_MSG = "UpdateRecommendations API failed for experiment_name: %s and intervalEndTimeStr : %s due to %s";
     }
 
 

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -42,7 +42,6 @@ public class KruizeConstants {
         public static final String UPDATE_RECOMMENDATIONS_INPUT_PARAMS = "experiment_name : %s and interval_start_time : %s and interval_end_time : %s ";
         public static final String UPDATE_RECOMMENDATIONS_SUCCESS = "Update Recommendation API success response, experiment_name: %s and interval_end_time : %s";
         public static final String UPDATE_RECOMMENDATIONS_FAILURE = "UpdateRecommendations API failure response, experiment_name: %s and intervalEndTimeStr : %s";
-        public static final String UPDATE_RECOMMENDATIONS_VALIDATION_FAILURE = "Validation failed: %s for experiment_name: %s and interval_end_time: %s";
         public static final String UPDATE_RECOMMENDATIONS_RESPONSE = "Update Recommendation API response: %s";
         public static final String UPDATE_RECOMMENDATIONS_FAILURE_MSG = "UpdateRecommendations API failed for experiment_name: %s and intervalEndTimeStr : %s due to %s";
     }


### PR DESCRIPTION
This PR has following changes:

-  Adds an error log to capture the `updateRecommendations` failure error response message capturing `experiment_name` and `interval_end_time`
- Removes redundant log statements 