### PR TITLE
Clean up recommendation classes

### DIFF
--- a/src/main/java/com/autotune/analyzer/services/UpdateRecommendations.java
+++ b/src/main/java/com/autotune/analyzer/services/UpdateRecommendations.java
@@ -20,6 +20,7 @@ import com.autotune.analyzer.recommendations.engine.RecommendationEngine;
 import com.autotune.analyzer.serviceObjects.ContainerAPIObject;
 import com.autotune.analyzer.serviceObjects.Converters;
 import com.autotune.analyzer.serviceObjects.ListRecommendationsAPIObject;
+import com.autotune.analyzer.utils.AnalyzerErrorConstants;
 import com.autotune.analyzer.utils.GsonUTCDateAdapter;
 import com.autotune.common.data.result.ContainerData;
 import com.autotune.operator.KruizeDeploymentInfo;
@@ -75,8 +76,8 @@ public class UpdateRecommendations extends HttpServlet {
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         int calCount = ++requestCount;
-        LOGGER.debug("UpdateRecommendations API request count: {}", calCount);
-        String statusValue = "failure";
+        LOGGER.debug(String.format(AnalyzerErrorConstants.APIErrors.UpdateRecommendationsAPI.UPDATE_RECOMMENDATIONS_COUNT, calCount));
+        String statusValue = KruizeConstants.APIMessages.FAILURE;
         Timer.Sample timerBUpdateRecommendations = Timer.start(MetricsConfig.meterRegistry());
         // Set the character encoding of the request to UTF-8
         request.setCharacterEncoding(CHARACTER_ENCODING);
@@ -88,7 +89,7 @@ public class UpdateRecommendations extends HttpServlet {
         Timestamp interval_end_time;
         Timestamp interval_start_time = null;
         if (KruizeDeploymentInfo.log_http_req_resp)
-            LOGGER.info("experiment_name : {} and interval_start_time : {} and interval_end_time : {} ", experiment_name, intervalStartTimeStr, intervalEndTimeStr);
+            LOGGER.info(String.format(KruizeConstants.APIMessages.UPDATE_RECOMMENDATIONS_INPUT_PARAMS, experiment_name, intervalStartTimeStr, intervalEndTimeStr));
         try {
             // create recommendation engine object
             RecommendationEngine recommendationEngine = new RecommendationEngine(experiment_name, intervalEndTimeStr, intervalStartTimeStr);
@@ -97,37 +98,36 @@ public class UpdateRecommendations extends HttpServlet {
             if (validationMessage.isEmpty()) {
                 KruizeObject kruizeObject = recommendationEngine.prepareRecommendations(calCount);
                 if (kruizeObject.getValidation_data().isSuccess()) {
-                    LOGGER.debug("UpdateRecommendations API request count: {} success", calCount);
+                    LOGGER.debug(String.format(AnalyzerErrorConstants.APIErrors.UpdateRecommendationsAPI.UPDATE_RECOMMENDATIONS_SUCCESS_COUNT, calCount));
                     interval_end_time = Utils.DateUtils.getTimeStampFrom(KruizeConstants.DateFormats.STANDARD_JSON_DATE_FORMAT,
                             intervalEndTimeStr);
                     SimpleDateFormat sdf = new SimpleDateFormat(KruizeConstants.DateFormats.STANDARD_JSON_DATE_FORMAT, Locale.ROOT);
                     sdf.setTimeZone(TimeZone.getTimeZone(KruizeConstants.TimeUnitsExt.TimeZones.UTC));
-                    LOGGER.info("Update Recommendation API success response, experiment_name: {} and interval_end_time : {}",
-                            experiment_name, sdf.format(interval_end_time));
+                    LOGGER.info(String.format(KruizeConstants.APIMessages.UPDATE_RECOMMENDATIONS_SUCCESS, experiment_name,
+                            sdf.format(interval_end_time)));
                     sendSuccessResponse(response, kruizeObject, interval_end_time);
-                    statusValue = "success";
+                    statusValue = KruizeConstants.APIMessages.SUCCESS;
                 } else {
-                    LOGGER.error("UpdateRecommendations API request count: {} failed", calCount);
-                    LOGGER.error("UpdateRecommendations API failure response, experiment_name: {} and intervalEndTimeStr : {}",
-                            experiment_name, intervalEndTimeStr);
+                    LOGGER.error(String.format(AnalyzerErrorConstants.APIErrors.UpdateRecommendationsAPI.UPDATE_RECOMMENDATIONS_FAILED_COUNT, calCount));
+                    LOGGER.error(String.format(KruizeConstants.APIMessages.UPDATE_RECOMMENDATIONS_FAILURE, experiment_name, intervalEndTimeStr));
                     sendErrorResponse(response, null, kruizeObject.getValidation_data().getErrorCode(), kruizeObject.getValidation_data().getMessage());
                 }
             } else {
-                LOGGER.error("Validation failed: {} for experiment_name: {} and interval_end_time: {}", validationMessage,
-                        experiment_name, intervalEndTimeStr);
+                LOGGER.error(String.format(KruizeConstants.APIMessages.UPDATE_RECOMMENDATIONS_VALIDATION_FAILURE, validationMessage,
+                        experiment_name, intervalEndTimeStr));
                 sendErrorResponse(response, null, HttpServletResponse.SC_BAD_REQUEST, validationMessage);
             }
 
         } catch (Exception e) {
-            LOGGER.error("UpdateRecommendations API request count: {} failed", calCount);
-            LOGGER.error("UpdateRecommendations API, experiment_name: {},  intervalEndTimeStr: {}", experiment_name, intervalEndTimeStr);
-            LOGGER.error("Exception: {}", e.getMessage());
+            LOGGER.error(String.format(AnalyzerErrorConstants.APIErrors.UpdateRecommendationsAPI.UPDATE_RECOMMENDATIONS_FAILED_COUNT, calCount));
+            LOGGER.error(String.format(AnalyzerErrorConstants.APIErrors.UpdateRecommendationsAPI.RECOMMENDATION_EXCEPTION,
+                    experiment_name, intervalEndTimeStr, e.getMessage()));
             e.printStackTrace();
             sendErrorResponse(response, e, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
         } finally {
-            LOGGER.debug("UpdateRecommendations API request count: {} completed", calCount);
+            LOGGER.debug(String.format(AnalyzerErrorConstants.APIErrors.UpdateRecommendationsAPI.UPDATE_RECOMMENDATIONS_COMPLETED_COUNT, calCount));
             if (null != timerBUpdateRecommendations) {
-                MetricsConfig.timerUpdateRecomendations = MetricsConfig.timerBUpdateRecommendations.tag("status", statusValue).register(MetricsConfig.meterRegistry());
+                MetricsConfig.timerUpdateRecomendations = MetricsConfig.timerBUpdateRecommendations.tag(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.STATUS, statusValue).register(MetricsConfig.meterRegistry());
                 timerBUpdateRecommendations.stop(MetricsConfig.timerUpdateRecomendations);
             }
         }
@@ -148,13 +148,14 @@ public class UpdateRecommendations extends HttpServlet {
                             interval_end_time);
             recommendationList.add(listRecommendationsAPIObject);
         } catch (Exception e) {
-            LOGGER.error("Not able to generate recommendation for expName : {} due to {}", ko.getExperimentName(), e.getMessage());
+            LOGGER.error(String.format(AnalyzerErrorConstants.APIErrors.UpdateRecommendationsAPI.GENERATE_RECOMMENDATION_FAILURE,
+                    ko.getExperimentName(), e.getMessage()));
         }
         ExclusionStrategy strategy = new ExclusionStrategy() {
             @Override
             public boolean shouldSkipField(FieldAttributes field) {
-                return field.getDeclaringClass() == ContainerData.class && (field.getName().equals("results"))
-                        || (field.getDeclaringClass() == ContainerAPIObject.class && (field.getName().equals("metrics")));
+                return field.getDeclaringClass() == ContainerData.class && (field.getName().equals(KruizeConstants.JSONKeys.RESULTS))
+                        || (field.getDeclaringClass() == ContainerAPIObject.class && (field.getName().equals(KruizeConstants.JSONKeys.METRICS)));
             }
 
             @Override
@@ -174,7 +175,7 @@ public class UpdateRecommendations extends HttpServlet {
             gsonStr = gsonObj.toJson(recommendationList);
         }
         if (KruizeDeploymentInfo.log_http_req_resp)
-            LOGGER.info("Update Recommendation API response: {}", new Gson().toJson(JsonParser.parseString(gsonStr)));
+            LOGGER.info(String.format(KruizeConstants.APIMessages.UPDATE_RECOMMENDATIONS_RESPONSE, new Gson().toJson(JsonParser.parseString(gsonStr))));
         response.getWriter().println(gsonStr);
         response.getWriter().close();
     }

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
@@ -164,6 +164,29 @@ public class AnalyzerErrorConstants {
             public static final String DATA_NOT_FOUND = "Data not found!";
             public static final String TIME_COMPARE = "The Start time should precede the End time!";
             public static final String TIME_GAP_LIMIT = String.format("The gap between the interval_start_time and interval_end_time must be within a maximum of %s days!", KruizeDeploymentInfo.generate_recommendations_date_range_limit_in_days);
+            public static final String UPDATE_RECOMMENDATIONS_COUNT = "UpdateRecommendations API request count: %s ";
+
+            public static final String UPDATE_RECOMMENDATIONS_FAILED_COUNT = UPDATE_RECOMMENDATIONS_COUNT + "failed";
+            public static final String UPDATE_RECOMMENDATIONS_SUCCESS_COUNT = UPDATE_RECOMMENDATIONS_COUNT + "success";
+            public static final String UPDATE_RECOMMENDATIONS_COMPLETED_COUNT = UPDATE_RECOMMENDATIONS_COUNT + "completed";
+            public static final String RECOMMENDATION_ERROR = "Failed to create recommendation for experiment: %s and interval_start_time: %s and interval_end_time: %s";
+            public static final String RECOMMENDATION_EXCEPTION = "Exception occurred while generating recommendations for experiment: %s and interval_end_time: %s : %s ";
+            public static final String METRIC_EXCEPTION = "Exception occurred while fetching metrics from the datasource: ";
+            public static final String FETCHING_RESULTS_FAILED = "Failed to fetch the results from the DB: %s";
+            public static final String INTERNAL_MAP_EMPTY = "Internal map sent to populate method cannot be null or empty";
+            public static final String NULL_NOTIFICATIONS = "Notifications cannot be null";
+            public static final String NULL_RECOMMENDATIONS = "Recommendation cannot be null";
+            public static final String INVALID_RECOMMENDATION_TERM = "Invalid Recommendation Term : %s";
+            public static final String NULL_RECOMMENDATION_TERM = "Recommendation term cannot be null";
+            public static final String INVALID_MEMORY_THRESHOLD = "Given Memory Threshold is invalid, setting Default Memory Threshold : %s";
+            public static final String INVALID_CPU_THRESHOLD = "Given CPU Threshold is invalid, setting Default CPU Threshold :  %s";
+            public static final String NULL_RECOMMENDATION_SETTINGS = "Recommendation Settings are null, setting Default CPU Threshold : %s and Memory Threshold : %s";
+            public static final String INVALID_THRESHOLD = "Given Threshold is invalid, setting Default CPU Threshold : %s and Memory Threshold : %s";
+            public static final String THRESHOLD_NOT_SET = "Threshold is not set, setting Default CPU Threshold : %s and Memory Threshold : %s";
+            public static final String BOX_PLOTS_FAILURE = "Box plots Failed due to : %s";
+            public static final String LOAD_EXPERIMENT_FAILURE = "Failed to load experiment from DB: %s";
+            public static final String GENERATE_RECOMMENDATION_FAILURE = "Not able to generate recommendation for expName : %s due to %s";
+
 
             private UpdateRecommendationsAPI() {
             }

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -29,6 +29,23 @@ public class KruizeConstants {
     private KruizeConstants() {
     }
 
+    public static class APIMessages {
+        public static final String MAX_DAY = "maxDay : %s";
+        public static final String SUCCESS = "success";
+        public static final String FAILURE = "failure";
+        public static final String GET = "get";
+        public static final String SET = "set";
+        public static final String CONTAINER_USAGE_INFO = "Determine the date of the last activity for the container based on its usage. ";
+        public static final String RECOMMENDATION_TERM = "recommendationTerm : %s";
+        public static final String MONITORING_START_TIME = "monitoringStartTime : %s";
+        public static final String EXPERIMENT_DATASOURCE = "Experiment: %s,  Datasource: %s";
+        public static final String UPDATE_RECOMMENDATIONS_INPUT_PARAMS = "experiment_name : %s and interval_start_time : %s and interval_end_time : %s ";
+        public static final String UPDATE_RECOMMENDATIONS_SUCCESS = "Update Recommendation API success response, experiment_name: %s and interval_end_time : %s";
+        public static final String UPDATE_RECOMMENDATIONS_FAILURE = "UpdateRecommendations API failure response, experiment_name: %s and intervalEndTimeStr : %s";
+        public static final String UPDATE_RECOMMENDATIONS_VALIDATION_FAILURE = "Validation failed: %s for experiment_name: %s and interval_end_time: %s";
+        public static final String UPDATE_RECOMMENDATIONS_RESPONSE = "Update Recommendation API response: %s";
+    }
+
 
     public static enum KRUIZE_RECOMMENDATION_API_VERSION {
         V1_0("1.0"),


### PR DESCRIPTION
# Clean up recommendation classes to update Strings with constants

## Description

This PR will do the following changes - 
- update recommendation classes to replace the hardcoded strings with their corresponding constant variables

### Type of change

- [x] Refactoring Code
- [ ] New feature

## How has this been tested?

- Using kruize-demo scripts. 
Image: `quay.io/khansaad/autotune_operator:cleanup`
- Manually verified the logs getting printed as usual. 

**Test Configuration**
* Kubernetes clusters tested on: minikube

## Checklist :dart:

- [X] Followed coding guidelines
- [X] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information
- 