### PR TITLE
Set box plots flag as true by default

### DIFF
--- a/src/main/java/com/autotune/operator/KruizeDeploymentInfo.java
+++ b/src/main/java/com/autotune/operator/KruizeDeploymentInfo.java
@@ -60,7 +60,7 @@ public class KruizeDeploymentInfo {
     public static String cluster_type;
     public static String k8s_type;       // ABC
     public static String auth_type;
-    public static Boolean plots = false;
+    public static Boolean plots = true;
     public static String auth_token;
     public static String database_admin_username;
     public static String database_admin_password;


### PR DESCRIPTION
# Set box plots flag as `true` by default

## Description

This PR will do the following changes - 
- update the box plot flag in code from `false` to `true` so that it remains enabled by default

### Type of change

- [x] Refactoring Code
- [ ] New feature

## How has this been tested?

- Using kruize-demo scripts. 
Image: `quay.io/kruize/autotune_operator:flag-update`
- Manually verified that the box plots are visible without passing the flag as env variable. 

**Test Configuration**
* Kubernetes clusters tested on: Minikube

## Checklist :dart:

- [X] Followed coding guidelines
- [X] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information
- 