### PR TITLE
Fix error response message for list metadata tests

### DIFF
--- a/tests/scripts/helpers/utils.py
+++ b/tests/scripts/helpers/utils.py
@@ -55,6 +55,7 @@ LIST_METADATA_DATASOURCE_NAME_ERROR_MSG = "Metadata for a given datasource name 
 LIST_METADATA_ERROR_MSG = ("Metadata for a given datasource - %s, cluster name - %s, namespace - %s "
                            "either does not exist or is not valid")
 LIST_METADATA_DATASOURCE_NAME_CLUSTER_NAME_ERROR_MSG = "Metadata for a given datasource name - %s, cluster_name - %s either does not exist or is not valid"
+LIST_METADATA_MISSING_DATASOURCE = "datasource is mandatory"
 IMPORT_METADATA_DATASOURCE_CONNECTION_FAILURE_MSG = "Metadata cannot be imported, datasource connection refused or timed out"
 
 # Kruize Recommendations Notification codes

--- a/tests/scripts/local_monitoring_tests/rest_apis/test_list_metadata.py
+++ b/tests/scripts/local_monitoring_tests/rest_apis/test_list_metadata.py
@@ -89,8 +89,7 @@ def test_list_metadata_without_parameters(cluster_type):
 
     list_metadata_json = response.json()
     assert response.status_code == ERROR_STATUS_CODE
-    datasource = "null"
-    assert list_metadata_json['message'] == LIST_METADATA_DATASOURCE_NAME_ERROR_MSG % datasource
+    assert list_metadata_json['message'] == LIST_METADATA_MISSING_DATASOURCE
 
 
     response = delete_metadata(input_json_file)
@@ -132,7 +131,10 @@ def test_list_metadata_invalid_datasource(test_name, expected_status_code, datas
 
     list_metadata_json = response.json()
     assert response.status_code == ERROR_STATUS_CODE
-    assert list_metadata_json['message'] == LIST_METADATA_DATASOURCE_NAME_ERROR_MSG % datasource
+    if test_name == "blank_datasource":
+        assert list_metadata_json['message'] == LIST_METADATA_MISSING_DATASOURCE
+    else:
+        assert list_metadata_json['message'] == LIST_METADATA_DATASOURCE_NAME_ERROR_MSG % datasource
 
 
     response = delete_metadata(input_json_file)


### PR DESCRIPTION
This PR fixes error response message for below list metadata test cases:

- `test_list_metadata.test_list_metadata_invalid_datasource[blank_datasource-400-]`
- `test_list_metadata.test_list_metadata_without_parameters`

Updated local_monitoring tests result on `minikube` -
[local_monitoring_tests_minikube.zip](https://github.com/user-attachments/files/16009157/local_monitoring_tests_minikube.zip)

