### PR TITLE
temp thanos fix

### DIFF
--- a/src/main/java/com/autotune/common/datasource/prometheus/PrometheusDataOperatorImpl.java
+++ b/src/main/java/com/autotune/common/datasource/prometheus/PrometheusDataOperatorImpl.java
@@ -171,8 +171,8 @@ public class PrometheusDataOperatorImpl extends DataSourceOperatorImpl {
                 return null;
             if (!jsonObject.getJSONObject(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.DATA).has(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.RESULT))
                 return null;
-            if (jsonObject.getJSONObject(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.DATA).getJSONArray(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.RESULT).isEmpty())
-                return null;
+            //if (jsonObject.getJSONObject(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.DATA).getJSONArray(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.RESULT).isEmpty())
+            //    return null;
 
             return jsonObject;
 


### PR DESCRIPTION
## Description

Temp fix for Thanos Setup .. 


Not sure if it is fix or setup  issue
curl http://thanos-query-frontend-thanos-bench.apps.kruize-scalelab.h0b5.p1.openshiftapps.com/api/v1/query?query=up
{"status":"success","data":{"resultType":"vector","result":[]}}
In the above response, Thanos setup returns an empty results list with a 200 status code, whereas in our Prometheus setup, the response is a 200 status code with some results
 {"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"up","instance":"prometheus-k8s.openshift-monitoring.svc:9091
Kruize code check if "up" is available if yes it says data source connection is successful (edited) 

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
