### PR TITLE
increase timeout and avoid 504 gateway timeout issue

### DIFF
--- a/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
@@ -170,7 +170,13 @@ data:
       upstream kruize-api {
         server kruize:8080;
       }
-
+    
+      # Set these timeout settings to a very high value
+      proxy_connect_timeout       86400s;
+      proxy_send_timeout          86400s;
+      proxy_read_timeout          86400s;
+      send_timeout                86400s;
+    
       server {
         listen 8080;
         server_name localhost;

--- a/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
@@ -177,7 +177,13 @@ data:
       upstream kruize-api {
         server kruize:8080;
       }
-
+    
+      # Set these timeout settings to a very high value
+      proxy_connect_timeout       86400s;
+      proxy_send_timeout          86400s;
+      proxy_read_timeout          86400s;
+      send_timeout                86400s;
+    
       server {
         listen 8080;
         server_name localhost;

--- a/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
@@ -298,7 +298,13 @@ data:
       upstream kruize-api {
         server kruize:8080;
       }
-
+    
+      # Set these timeout settings to a very high value
+      proxy_connect_timeout       86400s;
+      proxy_send_timeout          86400s;
+      proxy_read_timeout          86400s;
+      send_timeout                86400s;
+    
       server {
         listen 8080;
         server_name localhost;

--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -394,7 +394,13 @@ data:
       upstream kruize-api {
         server kruize:8080;
       }
-
+    
+      # Set these timeout settings to a very high value
+      proxy_connect_timeout       86400s;
+      proxy_send_timeout          86400s;
+      proxy_read_timeout          86400s;
+      send_timeout                86400s;
+    
       server {
         listen 8080;
         server_name localhost;


### PR DESCRIPTION
## Description

This should avoid timeout issue while generating recommendations.

Fixes # (issue)

### Type of change

- [ x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
