### PR TITLE
Add Delete Metric Profile API

### DIFF
--- a/src/main/java/com/autotune/analyzer/Analyzer.java
+++ b/src/main/java/com/autotune/analyzer/Analyzer.java
@@ -55,6 +55,7 @@ public class Analyzer {
         context.addServlet(PerformanceProfileService.class, ServerContext.LIST_PERF_PROFILES);
         context.addServlet(MetricProfileService.class, ServerContext.CREATE_METRIC_PROFILE);
         context.addServlet(MetricProfileService.class, ServerContext.LIST_METRIC_PROFILES);
+        context.addServlet(MetricProfileService.class, ServerContext.DELETE_METRIC_PROFILE);
         context.addServlet(ListDatasources.class, ServerContext.LIST_DATASOURCES);
         context.addServlet(DSMetadataService.class, ServerContext.DATASOURCE_METADATA);
 

--- a/src/main/java/com/autotune/analyzer/services/MetricProfileService.java
+++ b/src/main/java/com/autotune/analyzer/services/MetricProfileService.java
@@ -29,6 +29,7 @@ import com.autotune.analyzer.utils.GsonUTCDateAdapter;
 import com.autotune.common.data.ValidationOutputData;
 import com.autotune.common.data.metrics.Metric;
 import com.autotune.common.data.result.ContainerData;
+import com.autotune.database.dao.ExperimentDAOImpl;
 import com.autotune.database.service.ExperimentDBService;
 import com.autotune.utils.KruizeConstants;
 import com.autotune.utils.KruizeSupportedTypes;
@@ -229,17 +230,70 @@ public class MetricProfileService extends HttpServlet {
     }
 
     /**
-     * TODO: Need to implement
      * Delete Metric profile
+     * Handles the DELETE request for deleting metric profile - DELETE /deleteMetricProfile
      *
-     * @param req
-     * @param resp
+     * Supported Query Parameters -
+     * name	- metric profile name to be deleted(required)
+     *
+     * @param request
+     * @param response
      * @throws ServletException
      * @throws IOException
      */
     @Override
-    protected void doDelete(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        super.doDelete(req, resp);
+    protected void doDelete(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        response.setContentType(JSON_CONTENT_TYPE);
+        response.setCharacterEncoding(CHARACTER_ENCODING);
+        response.setStatus(HttpServletResponse.SC_OK);
+
+        ConcurrentHashMap<String, PerformanceProfile> metricProfilesMap = new ConcurrentHashMap<>();
+        String metricProfileName = request.getParameter(AnalyzerConstants.PerformanceProfileConstants.METRIC_PROFILE_NAME);
+
+        if (null == metricProfileName || metricProfileName.isEmpty()) {
+            sendErrorResponse(
+                    response,
+                    new Exception(AnalyzerErrorConstants.APIErrors.DeleteMetricProfileAPI.MISSING_METRIC_PROFILE_NAME_EXCPTN),
+                    HttpServletResponse.SC_BAD_REQUEST,
+                    String.format(AnalyzerErrorConstants.APIErrors.DeleteMetricProfileAPI.MISSING_METRIC_PROFILE_NAME_MSG)
+            );
+            return;
+        }
+
+        try {
+            // load specified metric profile
+            loadMetricProfilesFromCollection(metricProfilesMap, metricProfileName);
+
+            // Check if metric profile exists
+            if (!metricProfilesMap.isEmpty() && metricProfilesMap.containsKey(metricProfileName)) {
+                try {
+                    // Deletes database and in-memory metric profile object stored
+                    deleteMetricProfile(metricProfileName);
+                    metricProfilesMap.remove(metricProfileName);
+                } catch (Exception e) {
+                    sendErrorResponse(
+                            response,
+                            e,
+                            HttpServletResponse.SC_BAD_REQUEST,
+                            e.getMessage());
+                    return;
+                }
+            } else {
+                sendErrorResponse(
+                        response,
+                        new Exception(AnalyzerErrorConstants.APIErrors.DeleteMetricProfileAPI.INVALID_METRIC_PROFILE_NAME_EXCPTN),
+                        HttpServletResponse.SC_BAD_REQUEST,
+                        String.format(AnalyzerErrorConstants.APIErrors.DeleteMetricProfileAPI.INVALID_METRIC_PROFILE_NAME_MSG, metricProfileName)
+                );
+                return;
+            }
+
+            sendSuccessResponse(response, String.format(KruizeConstants.MetricProfileAPIMessages.DELETE_METRIC_PROFILE_SUCCESS_MSG, metricProfileName));
+
+        } catch (Exception e) {
+            LOGGER.error(e.getMessage());
+            sendErrorResponse(response, e, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+        }
     }
 
     /**
@@ -301,6 +355,24 @@ public class MetricProfileService extends HttpServlet {
             metricProfilesMap.putAll(metricProfileCollection.getMetricProfileCollection());
         } catch (Exception e) {
             LOGGER.error("Failed to load all the metric profiles data: {} ", e.getMessage());
+        }
+    }
+
+    private void deleteMetricProfile(String metricProfileName) {
+        ValidationOutputData deletedMetricProfileFromDB = null;
+        try {
+            // delete the metric profile from DB
+            deletedMetricProfileFromDB = new ExperimentDAOImpl().deleteKruizeMetricProfileEntryByName(metricProfileName);
+            if (deletedMetricProfileFromDB.isSuccess()) {
+                // remove in-memory metric profile
+                MetricProfileCollection.getInstance().getMetricProfileCollection().remove(metricProfileName);
+                LOGGER.debug(KruizeConstants.MetricProfileAPIMessages.DELETE_METRIC_PROFILE_FROM_DB_SUCCESS_MSG);
+            } else {
+                LOGGER.error(AnalyzerErrorConstants.APIErrors.DeleteMetricProfileAPI.DELETE_METRIC_PROFILE_FROM_DB_FAILURE_MSG, deletedMetricProfileFromDB.getMessage());
+            }
+
+        }  catch (Exception e) {
+            LOGGER.error(AnalyzerErrorConstants.APIErrors.DeleteMetricProfileAPI.DELETE_METRIC_PROFILE_FAILURE_MSG, e.getMessage());
         }
     }
 

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
@@ -234,6 +234,17 @@ public class AnalyzerErrorConstants {
             public static final String NO_METRIC_PROFILES_EXCPTN = "No metric profile";
             public static final String NO_METRIC_PROFILES = "No metric profiles found!";
         }
+
+        public static final class DeleteMetricProfileAPI {
+            public DeleteMetricProfileAPI() {
+            }
+            public static final String INVALID_METRIC_PROFILE_NAME_EXCPTN = "Invalid Metric Profile Name";
+            public static final String INVALID_METRIC_PROFILE_NAME_MSG = "Given metric profile name - %s either does not exist or is not valid";
+            public static final String MISSING_METRIC_PROFILE_NAME_EXCPTN = "Missing Metric Profile Name";
+            public static final String MISSING_METRIC_PROFILE_NAME_MSG = "Missing metric profile 'name' parameter";
+            public static final String DELETE_METRIC_PROFILE_FROM_DB_FAILURE_MSG = "Failed to delete metric profile from DB: %s";
+            public static final String DELETE_METRIC_PROFILE_FAILURE_MSG = "Failed to delete the specified metric profile data: %s";
+        }
     }
 
     public static final class ConversionErrors {

--- a/src/main/java/com/autotune/database/dao/ExperimentDAO.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAO.java
@@ -73,6 +73,8 @@ public interface ExperimentDAO {
     // Load a single Metric Profile based on name
     List<KruizeMetricProfileEntry> loadMetricProfileByName(String metricProfileName) throws Exception;
 
+    // Delete metric profile for the specified metric profile name
+    public ValidationOutputData deleteKruizeMetricProfileEntryByName(String metricProfileName);
 
     // Load all recommendations of a particular experiment and interval end Time
     KruizeRecommendationEntry loadRecommendationsByExperimentNameAndDate(String experimentName, String cluster_name, Timestamp interval_end_time) throws Exception;

--- a/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
@@ -570,6 +570,44 @@ public class ExperimentDAOImpl implements ExperimentDAO {
         return validationOutputData;
     }
 
+    /**
+     * Delete metric profile with specified profile name
+     * This deletes the metadata from the KruizeMetricProfileEntry table
+     * @param metricProfileName
+     * @return
+     */
+    @Override
+    public ValidationOutputData deleteKruizeMetricProfileEntryByName(String metricProfileName) {
+        ValidationOutputData validationOutputData = new ValidationOutputData(false, null, null);
+        Transaction tx = null;
+        try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
+            try {
+                tx = session.beginTransaction();
+                Query query = session.createQuery(DELETE_FROM_METRIC_PROFILE_BY_PROFILE_NAME, null);
+                query.setParameter("metricProfileName", metricProfileName);
+                int deletedCount = query.executeUpdate();
+
+                if (deletedCount == 0) {
+                    validationOutputData.setSuccess(false);
+                    validationOutputData.setMessage("KruizeMetricProfileEntry not found with metric profile name: " + metricProfileName);
+                } else {
+                    validationOutputData.setSuccess(true);
+                }
+                tx.commit();
+            } catch (HibernateException e) {
+                LOGGER.error("Not able to delete metric profile for metric profile {} due to {}", metricProfileName, e.getMessage());
+                if (tx != null) tx.rollback();
+                e.printStackTrace();
+                validationOutputData.setSuccess(false);
+                validationOutputData.setMessage(e.getMessage());
+                //todo save error to API_ERROR_LOG
+            }
+        } catch (Exception e) {
+            LOGGER.error("Not able to delete metric profile for metric profile {} due to {}", metricProfileName, e.getMessage());
+        }
+        return validationOutputData;
+    }
+
     @Override
     public List<KruizeExperimentEntry> loadAllExperiments() throws Exception {
         //todo load only experimentStatus=inprogress , playback may not require completed experiments

--- a/src/main/java/com/autotune/database/helper/DBConstants.java
+++ b/src/main/java/com/autotune/database/helper/DBConstants.java
@@ -63,6 +63,7 @@ public class DBConstants {
         public static final String DELETE_FROM_RESULTS_BY_EXP_NAME = "DELETE FROM KruizeResultsEntry k WHERE k.experiment_name = :experimentName";
         public static final String DELETE_FROM_RECOMMENDATIONS_BY_EXP_NAME = "DELETE FROM KruizeRecommendationEntry k WHERE k.experiment_name = :experimentName";
         public static final String DELETE_FROM_METADATA_BY_DATASOURCE_NAME = "DELETE FROM KruizeDSMetadataEntry km WHERE km.datasource_name = :dataSourceName";
+        public static final String DELETE_FROM_METRIC_PROFILE_BY_PROFILE_NAME = "DELETE FROM KruizeMetricProfileEntry km WHERE km.name = :metricProfileName";
         public static final String DB_PARTITION_DATERANGE = "CREATE TABLE IF NOT EXISTS %s_%s%s%s PARTITION OF %s FOR VALUES FROM ('%s-%s-%s 00:00:00.000') TO ('%s-%s-%s 23:59:59');";
         public static final String SELECT_ALL_KRUIZE_TABLES = "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' " +
                 "and (table_name like 'kruize_results_%' or table_name like 'kruize_recommendations_%') ";

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -72,6 +72,8 @@ public class KruizeConstants {
         public static final String VIEW_METRIC_PROFILES_MSG = " View Metric Profiles at /listMetricProfiles";
         public static final String LOAD_METRIC_PROFILE_FAILURE = "Failed to load saved metric profile data: {}";
         public static final String ADD_METRIC_PROFILE_TO_DB_WITH_VERSION = "Added Metric Profile : {} into the DB with version: {}";
+        public static final String DELETE_METRIC_PROFILE_SUCCESS_MSG = "Metric profile: %s deleted successfully.";
+        public static final String DELETE_METRIC_PROFILE_FROM_DB_SUCCESS_MSG = "Metric profile deleted successfully from the DB.";
     }
 
     public static class MetricProfileConstants {

--- a/src/main/java/com/autotune/utils/ServerContext.java
+++ b/src/main/java/com/autotune/utils/ServerContext.java
@@ -45,6 +45,7 @@ public class ServerContext {
     public static final String LIST_PERF_PROFILES = ROOT_CONTEXT + "listPerformanceProfiles";
     public static final String CREATE_METRIC_PROFILE = ROOT_CONTEXT + "createMetricProfile";
     public static final String LIST_METRIC_PROFILES = ROOT_CONTEXT + "listMetricProfiles";
+    public static final String DELETE_METRIC_PROFILE = ROOT_CONTEXT + "deleteMetricProfile";
 
     public static final String KRUIZE_SERVER_URL = "http://localhost:" + KRUIZE_SERVER_PORT;
     public static final String SEARCH_SPACE_END_POINT = KRUIZE_SERVER_URL + SEARCH_SPACE;


### PR DESCRIPTION
## Description

This PR implements DELETE `/deleteMetricProfile` API supporting metric profile `name` query parameter

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [x] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: minikube 

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Image - quay.io/shbirada/delete_metric_profile:v1
