### PR TITLE
Adding Required Classes and Objects For Namespace Recommendations

### DIFF
--- a/src/main/java/com/autotune/analyzer/recommendations/NamespaceRecommendations.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/NamespaceRecommendations.java
@@ -18,6 +18,7 @@ package com.autotune.analyzer.recommendations;
 
 import com.autotune.analyzer.recommendations.objects.MappedRecommendationForTimestamp;
 import com.autotune.utils.KruizeConstants;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.SerializedName;
 
 import java.sql.Timestamp;
@@ -47,6 +48,7 @@ public class NamespaceRecommendations {
      * Returns the namespace recommendation data
      * @return hashmap containing the namespace recommendation data and monitoring end time as a key
      */
+    @JsonProperty(KruizeConstants.JSONKeys.DATA)
     public HashMap<Timestamp, MappedRecommendationForTimestamp> getData() {
         return data;
     }
@@ -84,6 +86,7 @@ public class NamespaceRecommendations {
      * Returns the recommendation notifications
      * @return hashmap containing the recommendation notifications
      */
+    @JsonProperty(KruizeConstants.JSONKeys.NOTIFICATIONS)
     public HashMap<Integer, RecommendationNotification> getNotificationMap() {
         return notificationMap;
     }

--- a/src/main/java/com/autotune/analyzer/recommendations/NamespaceRecommendations.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/NamespaceRecommendations.java
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package com.autotune.analyzer.recommendations;
+
+import com.autotune.analyzer.recommendations.objects.MappedRecommendationForTimestamp;
+import com.autotune.utils.KruizeConstants;
+import com.google.gson.annotations.SerializedName;
+
+import java.sql.Timestamp;
+import java.util.HashMap;
+
+/**
+ * This NamespaceRecommendations object is used to store recommendations generated for a namespace
+ */
+public class NamespaceRecommendations {
+    private String version;
+    @SerializedName(KruizeConstants.JSONKeys.NOTIFICATIONS)
+    private HashMap<Integer, RecommendationNotification> notificationMap;
+    @SerializedName(KruizeConstants.JSONKeys.DATA)
+    private HashMap<Timestamp, MappedRecommendationForTimestamp> data;
+
+    public NamespaceRecommendations() {
+        this.notificationMap = new HashMap<Integer, RecommendationNotification>();
+        this.data = new HashMap<Timestamp, MappedRecommendationForTimestamp>();
+        this.version = KruizeConstants.KRUIZE_RECOMMENDATION_API_VERSION.LATEST.getVersionNumber();
+        RecommendationNotification recommendationNotification = new RecommendationNotification(
+                RecommendationConstants.RecommendationNotification.INFO_NOT_ENOUGH_DATA
+        );
+        this.notificationMap.put(recommendationNotification.getCode(), recommendationNotification);
+    }
+
+    /**
+     * Returns the namespace recommendation data
+     * @return hashmap containing the namespace recommendation data and monitoring end time as a key
+     */
+    public HashMap<Timestamp, MappedRecommendationForTimestamp> getData() {
+        return data;
+    }
+
+    /**
+     * Stores the namespace recommendation data
+     * @param data hashmap containing the namespace recommendation data and monitoring end time as a key
+     */
+    public void setData(HashMap<Timestamp, MappedRecommendationForTimestamp> data) {
+        if (!data.isEmpty()) {
+            if (this.notificationMap.containsKey(RecommendationConstants.NotificationCodes.INFO_NOT_ENOUGH_DATA)) {
+                this.notificationMap.remove(RecommendationConstants.NotificationCodes.INFO_NOT_ENOUGH_DATA);
+            }
+        }
+        this.data = data;
+    }
+
+    /**
+     * Returns the version for recommendations
+     * @return string containing the version for the recommendations
+     */
+    public String getVersion() {
+        return version;
+    }
+
+    /**
+     * Sets the version for recommendations
+     * @param version string containing the version for the recommendations
+     */
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    /**
+     * Returns the recommendation notifications
+     * @return hashmap containing the recommendation notifications
+     */
+    public HashMap<Integer, RecommendationNotification> getNotificationMap() {
+        return notificationMap;
+    }
+
+    /**
+     * Sets the recommendation notifications
+     * @param notificationMap hashmap containing the recommendation notifications
+     */
+    public void setNotificationMap(HashMap<Integer, RecommendationNotification> notificationMap) {
+        this.notificationMap = notificationMap;
+    }
+
+    @Override
+    public String toString() {
+        return "NamespaceRecommendations{" +
+                "version='" + version + '\'' +
+                ", notificationMap=" + notificationMap +
+                ", data=" + data +
+                '}';
+    }
+}

--- a/src/main/java/com/autotune/analyzer/serviceObjects/KubernetesAPIObject.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/KubernetesAPIObject.java
@@ -30,7 +30,7 @@ public class KubernetesAPIObject {
     private String namespace;
     @SerializedName(KruizeConstants.JSONKeys.CONTAINERS)
     private List<ContainerAPIObject> containerAPIObjects;
-    @SerializedName(KruizeConstants.JSONKeys.NAMESPACE_INFO)
+    @SerializedName(KruizeConstants.JSONKeys.NAMESPACES)
     private NamespaceAPIObject namespaceAPIObject;
 
     public KubernetesAPIObject(String name, String type, String namespace) {
@@ -66,7 +66,7 @@ public class KubernetesAPIObject {
         this.containerAPIObjects = containerAPIObjects;
     }
 
-    @JsonProperty(KruizeConstants.JSONKeys.NAMESPACE_INFO)
+    @JsonProperty(KruizeConstants.JSONKeys.NAMESPACES)
     public NamespaceAPIObject getNamespaceAPIObjects() {
         return namespaceAPIObject;
     }

--- a/src/main/java/com/autotune/analyzer/serviceObjects/KubernetesAPIObject.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/KubernetesAPIObject.java
@@ -81,8 +81,8 @@ public class KubernetesAPIObject {
                 "type='" + type + '\'' +
                 ", name='" + name + '\'' +
                 ", namespace='" + namespace + '\'' +
-                ", namespace_info=" + namespaceAPIObject.toString() +
-                ", containers=" + containerAPIObjects.toString() +
+                ", namespace_info=" + namespaceAPIObject +
+                ", containers=" + containerAPIObjects +
                 '}';
     }
 }

--- a/src/main/java/com/autotune/analyzer/serviceObjects/KubernetesAPIObject.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/KubernetesAPIObject.java
@@ -30,6 +30,8 @@ public class KubernetesAPIObject {
     private String namespace;
     @SerializedName(KruizeConstants.JSONKeys.CONTAINERS)
     private List<ContainerAPIObject> containerAPIObjects;
+    @SerializedName(KruizeConstants.JSONKeys.NAMESPACE_INFO)
+    private NamespaceAPIObject namespaceAPIObject;
 
     public KubernetesAPIObject(String name, String type, String namespace) {
         this.name = name;
@@ -64,12 +66,22 @@ public class KubernetesAPIObject {
         this.containerAPIObjects = containerAPIObjects;
     }
 
+    @JsonProperty(KruizeConstants.JSONKeys.NAMESPACE_INFO)
+    public NamespaceAPIObject getNamespaceAPIObjects() {
+        return namespaceAPIObject;
+    }
+
+    public void setNamespaceAPIObject(NamespaceAPIObject namespaceAPIObject) {
+        this.namespaceAPIObject = namespaceAPIObject;
+    }
+
     @Override
     public String toString() {
         return "KubernetesObject{" +
                 "type='" + type + '\'' +
                 ", name='" + name + '\'' +
                 ", namespace='" + namespace + '\'' +
+                ", namespace_info=" + namespaceAPIObject.toString() +
                 ", containers=" + containerAPIObjects.toString() +
                 '}';
     }

--- a/src/main/java/com/autotune/analyzer/serviceObjects/NamespaceAPIObject.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/NamespaceAPIObject.java
@@ -1,0 +1,61 @@
+package com.autotune.analyzer.serviceObjects;
+
+import com.autotune.analyzer.recommendations.NamespaceRecommendations;
+import com.autotune.common.data.metrics.Metric;
+import com.autotune.utils.KruizeConstants;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+/**
+ * This NamespaceAPIObject class simulates the NamespaceData class for the create experiment and list experiment API
+ */
+public class NamespaceAPIObject {
+    @SerializedName(KruizeConstants.JSONKeys.NAMESPACE_NAME)
+    private String namespaceName;
+    @SerializedName(KruizeConstants.JSONKeys.RECOMMENDATIONS)
+    private NamespaceRecommendations namespaceRecommendations;
+    private List<Metric> metrics;
+
+    public NamespaceAPIObject(String namespaceName, NamespaceRecommendations namespaceRecommendations, List<Metric> metrics) {
+        this.namespaceName = namespaceName;
+        this.namespaceRecommendations = namespaceRecommendations;
+        this.metrics = metrics;
+    }
+
+    public NamespaceAPIObject() {
+    }
+
+    /**
+     * Returns the name of the namespace
+     * @return String containing the name of the namespace
+     */
+    public String getnamespace_name() {
+        return namespaceName;
+    }
+
+    /**
+     * Returns the recommendations object for the namespace
+     * @return namespace recommendations object containing the recommendations for a namespace
+     */
+    public NamespaceRecommendations getnamespaceRecommendations() {
+        return namespaceRecommendations;
+    }
+
+    /**
+     * Returns the namespace related metrics
+     * @return hashmap containing the namespace related metrics and metric name as a key
+     */
+    public List<Metric> getMetrics() {
+        return metrics;
+    }
+
+    @Override
+    public String toString() {
+        return "NamespaceAPIObject{" +
+                "namespaceName='" + namespaceName + '\'' +
+                ", namespaceRecommendations=" + namespaceRecommendations +
+                ", metrics=" + metrics +
+                '}';
+    }
+}

--- a/src/main/java/com/autotune/analyzer/serviceObjects/NamespaceAPIObject.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/NamespaceAPIObject.java
@@ -12,7 +12,7 @@ import java.util.List;
  * This NamespaceAPIObject class simulates the NamespaceData class for the create experiment and list experiment API
  */
 public class NamespaceAPIObject {
-    @SerializedName(KruizeConstants.JSONKeys.NAMESPACE)
+    @SerializedName(KruizeConstants.JSONKeys.NAMESPACE_NAME)
     private String namespaceName;
     @SerializedName(KruizeConstants.JSONKeys.RECOMMENDATIONS)
     private NamespaceRecommendations namespaceRecommendations;
@@ -31,7 +31,7 @@ public class NamespaceAPIObject {
      * Returns the name of the namespace
      * @return String containing the name of the namespace
      */
-    @JsonProperty(KruizeConstants.JSONKeys.NAMESPACE)
+    @JsonProperty(KruizeConstants.JSONKeys.NAMESPACE_NAME)
     public String getnamespace_name() {
         return namespaceName;
     }

--- a/src/main/java/com/autotune/analyzer/serviceObjects/NamespaceAPIObject.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/NamespaceAPIObject.java
@@ -3,6 +3,7 @@ package com.autotune.analyzer.serviceObjects;
 import com.autotune.analyzer.recommendations.NamespaceRecommendations;
 import com.autotune.common.data.metrics.Metric;
 import com.autotune.utils.KruizeConstants;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.List;
@@ -11,7 +12,7 @@ import java.util.List;
  * This NamespaceAPIObject class simulates the NamespaceData class for the create experiment and list experiment API
  */
 public class NamespaceAPIObject {
-    @SerializedName(KruizeConstants.JSONKeys.NAMESPACE_NAME)
+    @SerializedName(KruizeConstants.JSONKeys.NAMESPACE)
     private String namespaceName;
     @SerializedName(KruizeConstants.JSONKeys.RECOMMENDATIONS)
     private NamespaceRecommendations namespaceRecommendations;
@@ -30,6 +31,7 @@ public class NamespaceAPIObject {
      * Returns the name of the namespace
      * @return String containing the name of the namespace
      */
+    @JsonProperty(KruizeConstants.JSONKeys.NAMESPACE)
     public String getnamespace_name() {
         return namespaceName;
     }
@@ -38,6 +40,7 @@ public class NamespaceAPIObject {
      * Returns the recommendations object for the namespace
      * @return namespace recommendations object containing the recommendations for a namespace
      */
+    @JsonProperty(KruizeConstants.JSONKeys.RECOMMENDATIONS)
     public NamespaceRecommendations getnamespaceRecommendations() {
         return namespaceRecommendations;
     }
@@ -52,7 +55,7 @@ public class NamespaceAPIObject {
 
     @Override
     public String toString() {
-        return "NamespaceAPIObject{" +
+        return "NamespaceObject{" +
                 "namespaceName='" + namespaceName + '\'' +
                 ", namespaceRecommendations=" + namespaceRecommendations +
                 ", metrics=" + metrics +

--- a/src/main/java/com/autotune/common/data/result/NamespaceData.java
+++ b/src/main/java/com/autotune/common/data/result/NamespaceData.java
@@ -19,6 +19,7 @@ import com.autotune.analyzer.recommendations.NamespaceRecommendations;
 import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.common.data.metrics.Metric;
 import com.autotune.utils.KruizeConstants;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.SerializedName;
 
 import java.sql.Timestamp;
@@ -30,7 +31,7 @@ import java.util.HashMap;
  * data collected from the data source, and recommendations generated for a namespace.
  */
 public class NamespaceData {
-    @SerializedName(KruizeConstants.JSONKeys.NAMESPACE_NAME)
+    @SerializedName(KruizeConstants.JSONKeys.NAMESPACE)
     private String namespaceName;
     // key for the hashmap is intervalEndTime
     private HashMap<Timestamp, IntervalResults> results;
@@ -54,6 +55,7 @@ public class NamespaceData {
      * Returns the name of the namespace
      * @return String containing the name of the namespace
      */
+    @JsonProperty(KruizeConstants.JSONKeys.NAMESPACE)
     public String getNamespace_name() {
         return namespaceName;
     }
@@ -86,6 +88,7 @@ public class NamespaceData {
      * Returns the recommendations object for the namespace
      * @return namespace recommendations object containing the recommendations for a namespace
      */
+    @JsonProperty(KruizeConstants.JSONKeys.RECOMMENDATIONS)
     public NamespaceRecommendations getNamespaceRecommendations() {
         return namespaceRecommendations;
     }

--- a/src/main/java/com/autotune/common/data/result/NamespaceData.java
+++ b/src/main/java/com/autotune/common/data/result/NamespaceData.java
@@ -1,0 +1,126 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.autotune.common.data.result;
+
+import com.autotune.analyzer.recommendations.NamespaceRecommendations;
+import com.autotune.analyzer.utils.AnalyzerConstants;
+import com.autotune.common.data.metrics.Metric;
+import com.autotune.utils.KruizeConstants;
+import com.google.gson.annotations.SerializedName;
+
+import java.sql.Timestamp;
+import java.util.HashMap;
+
+
+/**
+ * This NamespaceData object is used to store information about namespace-related metrics,
+ * data collected from the data source, and recommendations generated for a namespace.
+ */
+public class NamespaceData {
+    @SerializedName(KruizeConstants.JSONKeys.NAMESPACE_NAME)
+    private String namespaceName;
+    // key for the hashmap is intervalEndTime
+    private HashMap<Timestamp, IntervalResults> results;
+    @SerializedName(KruizeConstants.JSONKeys.RECOMMENDATIONS)
+    private NamespaceRecommendations namespaceRecommendations;
+    private HashMap<AnalyzerConstants.MetricName, Metric> metrics;
+
+    public NamespaceData(String namespaceName, NamespaceRecommendations namespaceRecommendations, HashMap<AnalyzerConstants.MetricName, Metric> metrics) {
+        this.namespaceName = namespaceName;
+        if (null == namespaceRecommendations) {
+            namespaceRecommendations = new NamespaceRecommendations();
+        }
+        this.namespaceRecommendations = namespaceRecommendations;
+        this.metrics = metrics;
+    }
+
+    public NamespaceData() {
+    }
+
+    /**
+     * Returns the name of the namespace
+     * @return String containing the name of the namespace
+     */
+    public String getNamespace_name() {
+        return namespaceName;
+    }
+
+    /**
+     * Sets the name of the namespace
+     * @param namespace_name String containing the name of the namespace
+     */
+    public void setNamespace_name(String namespace_name) {
+        this.namespaceName = namespace_name;
+    }
+
+    /**
+     * Returns the hashmap containing the data collected from datasource
+     * @return hashmap containing the data collected from data source and intervalEndTime as a key
+     */
+    public HashMap<Timestamp, IntervalResults> getResults() {
+        return results;
+    }
+
+    /**
+     * Stores the data collected from datasource
+     * @param results hashmap containing the data collected from data source and intervalEndTime as a key
+     */
+    public void setResults(HashMap<Timestamp, IntervalResults> results) {
+        this.results = results;
+    }
+
+    /**
+     * Returns the recommendations object for the namespace
+     * @return namespace recommendations object containing the recommendatios for a namespace
+     */
+    public NamespaceRecommendations getNamespaceRecommendations() {
+        return namespaceRecommendations;
+    }
+
+    /**
+     * Stores the recommendations generated for a namespace
+     * @param namespaceRecommendations generated recommendations for a namespace
+     */
+    public void setNamespaceRecommendations(NamespaceRecommendations namespaceRecommendations) {
+        this.namespaceRecommendations = namespaceRecommendations;
+    }
+
+    /**
+     * Returns the namespace related metrics
+     * @return hashmap containing the namespace related metrics and metric name as a key
+     */
+    public HashMap<AnalyzerConstants.MetricName, Metric> getMetrics() {
+        return metrics;
+    }
+
+    /**
+     * Stores the metrics related to namespace
+     * @param metrics hashmap conatining metrics related to namespace and metric name as a key
+     */
+    public void setMetrics(HashMap<AnalyzerConstants.MetricName, Metric> metrics) {
+        this.metrics = metrics;
+    }
+
+    @Override
+    public String toString() {
+        return "NamespaceData{" +
+                "namespaceName='" + namespaceName + '\'' +
+                ", results=" + results +
+                ", namespaceRecommendations=" + namespaceRecommendations +
+                ", metrics=" + metrics +
+                '}';
+    }
+}

--- a/src/main/java/com/autotune/common/data/result/NamespaceData.java
+++ b/src/main/java/com/autotune/common/data/result/NamespaceData.java
@@ -84,7 +84,7 @@ public class NamespaceData {
 
     /**
      * Returns the recommendations object for the namespace
-     * @return namespace recommendations object containing the recommendatios for a namespace
+     * @return namespace recommendations object containing the recommendations for a namespace
      */
     public NamespaceRecommendations getNamespaceRecommendations() {
         return namespaceRecommendations;

--- a/src/main/java/com/autotune/common/k8sObjects/K8sObject.java
+++ b/src/main/java/com/autotune/common/k8sObjects/K8sObject.java
@@ -15,7 +15,7 @@ public class K8sObject {
     private String namespace;
     @SerializedName(KruizeConstants.JSONKeys.CONTAINERS)
     private HashMap<String, ContainerData> containerDataMap;
-    @SerializedName(KruizeConstants.JSONKeys.NAMESPACE_INFO)
+    @SerializedName(KruizeConstants.JSONKeys.NAMESPACES)
     private NamespaceData namespaceData;
 
     public K8sObject(String name, String type, String namespace) {
@@ -59,7 +59,7 @@ public class K8sObject {
         this.containerDataMap = containerDataMap;
     }
 
-    @JsonProperty(KruizeConstants.JSONKeys.NAMESPACE_INFO)
+    @JsonProperty(KruizeConstants.JSONKeys.NAMESPACES)
     public NamespaceData getNamespaceData() {
         return namespaceData;
     }

--- a/src/main/java/com/autotune/common/k8sObjects/K8sObject.java
+++ b/src/main/java/com/autotune/common/k8sObjects/K8sObject.java
@@ -2,6 +2,7 @@ package com.autotune.common.k8sObjects;
 
 import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.common.data.result.ContainerData;
+import com.autotune.common.data.result.NamespaceData;
 import com.autotune.utils.KruizeConstants;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.SerializedName;
@@ -14,6 +15,9 @@ public class K8sObject {
     private String namespace;
     @SerializedName(KruizeConstants.JSONKeys.CONTAINERS)
     private HashMap<String, ContainerData> containerDataMap;
+    @SerializedName(KruizeConstants.JSONKeys.NAMESPACE_INFO)
+    private NamespaceData namespaceData;
+
     public K8sObject(String name, String type, String namespace) {
         this.name = name;
         this.type = type;
@@ -55,6 +59,15 @@ public class K8sObject {
         this.containerDataMap = containerDataMap;
     }
 
+    @JsonProperty(KruizeConstants.JSONKeys.NAMESPACE_INFO)
+    public NamespaceData getNamespaceData() {
+        return namespaceData;
+    }
+
+    public void setNamespaceData(NamespaceData namespaceData) {
+        this.namespaceData = namespaceData;
+    }
+
     @Override
     public String toString() {
         return "K8sObject{" +
@@ -62,6 +75,7 @@ public class K8sObject {
                 ", name='" + name + '\'' +
                 ", namespace='" + namespace + '\'' +
                 ", containerDataMap=" + containerDataMap +
+                ", namespaceData=" + namespaceData +
                 '}';
     }
 }

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -161,7 +161,7 @@ public class KruizeConstants {
         // Deployments Section
         public static final String DEPLOYMENTS = "deployments";
         public static final String NAMESPACE = "namespace";
-        public static final String NAMESPACE_INFO = "namespace_info";
+        public static final String NAMESPACE_NAME = "namespace_name";
         public static final String POD_METRICS = "pod_metrics";
         public static final String CONTAINER_METRICS = "container_metrics";
         public static final String METRICS = "metrics";

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -161,7 +161,7 @@ public class KruizeConstants {
         // Deployments Section
         public static final String DEPLOYMENTS = "deployments";
         public static final String NAMESPACE = "namespace";
-        public static final String NAMESPACE_NAME = "namespace_name";
+        public static final String NAMESPACE_INFO = "namespace_info";
         public static final String POD_METRICS = "pod_metrics";
         public static final String CONTAINER_METRICS = "container_metrics";
         public static final String METRICS = "metrics";

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -161,6 +161,7 @@ public class KruizeConstants {
         // Deployments Section
         public static final String DEPLOYMENTS = "deployments";
         public static final String NAMESPACE = "namespace";
+        public static final String NAMESPACE_NAME = "namespace_name";
         public static final String POD_METRICS = "pod_metrics";
         public static final String CONTAINER_METRICS = "container_metrics";
         public static final String METRICS = "metrics";


### PR DESCRIPTION
## Description

This PR introduces new classes and objects to support namespace recommendations within the Kruize. These additions are essential for providing recommendations at the namespace level. This PR will - 

- Adds `NamespaceData`, `NamespaceRecommendations`, `NamespaceAPIObject` classes to hold namespace related data 
- Integrate these classes with `K8sObject`, `KubernetesAPIObject`

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

**Test Configuration**
* Kubernetes clusters tested on: OpenShift (Resource Hub) 

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Image: `quay.io/rh-ee-shesaxen/autotune:kruize-namespace-addclasses`