### PR TITLE
Fixing numpods cant be zero error

### DIFF
--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -103,7 +103,7 @@ public class RecommendationEngine {
                 .stream()
                 .map(e -> {
                     Optional<MetricResults> numPodsResults = Optional.ofNullable(e.getMetricResultsMap().get(AnalyzerConstants.MetricName.namespaceTotalPods));
-                    double numPods = numPodsResults.map(m -> m.getAggregationInfoResult().getMax()).orElse(0.0);
+                    double numPods = numPodsResults.map(m -> m.getAggregationInfoResult().getSum()).orElse(0.0);
                     return numPods;
                 })
                 .max(Double::compareTo).get();


### PR DESCRIPTION
## Description

This PR fixes the issue for number of pods cant be zero.
```
"notifications": {
              "221001": {
              "type": "error",
             "message": "Number of pods cannot be zero",
             "code": 221001
}
```


### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes


**Test Configuration**
* Kubernetes clusters tested on: kruize-lm

## Checklist :dart:

- [x] Followed coding guidelines
- [ ] Comments added
- [x] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information
NA