### PR TITLE
Add Create and List MetricProfile APIs

### DIFF
--- a/migrations/kruize_local_ddl.sql
+++ b/migrations/kruize_local_ddl.sql
@@ -1,3 +1,4 @@
 create table IF NOT EXISTS kruize_datasources (version varchar(255), name varchar(255), provider varchar(255), serviceName varchar(255), namespace varchar(255), url varchar(255), primary key (name));
 create table IF NOT EXISTS kruize_dsmetadata (id serial, version varchar(255), datasource_name varchar(255), cluster_name varchar(255), namespace varchar(255), workload_type varchar(255), workload_name varchar(255), container_name varchar(255), container_image_name varchar(255), primary key (id));
 alter table kruize_experiments add column metadata_id bigint references kruize_dsmetadata(id), alter column datasource type varchar(255);
+create table IF NOT EXISTS kruize_metric_profiles (api_version varchar(255), kind varchar(255), metadata jsonb, name varchar(255) not null, k8s_type varchar(255), profile_version float(53) not null, slo jsonb, primary key (name));

--- a/src/main/java/com/autotune/analyzer/Analyzer.java
+++ b/src/main/java/com/autotune/analyzer/Analyzer.java
@@ -53,6 +53,8 @@ public class Analyzer {
         context.addServlet(ListRecommendations.class, ServerContext.RECOMMEND_RESULTS);
         context.addServlet(PerformanceProfileService.class, ServerContext.CREATE_PERF_PROFILE);
         context.addServlet(PerformanceProfileService.class, ServerContext.LIST_PERF_PROFILES);
+        context.addServlet(MetricProfileService.class, ServerContext.CREATE_METRIC_PROFILE);
+        context.addServlet(MetricProfileService.class, ServerContext.LIST_METRIC_PROFILES);
         context.addServlet(ListDatasources.class, ServerContext.LIST_DATASOURCES);
         context.addServlet(DSMetadataService.class, ServerContext.DATASOURCE_METADATA);
 

--- a/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
+++ b/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
@@ -122,6 +122,7 @@ public class ExperimentValidation {
                             errorMsg = AnalyzerErrorConstants.AutotuneObjectErrors.MISSING_SLO_DATA;
                             validationOutputData.setErrorCode(HttpServletResponse.SC_BAD_REQUEST);
                         } else {
+                            // TODO - set metric profile when local=true
                             String perfProfileName = KruizeOperator.setDefaultPerformanceProfile(kruizeObject.getSloInfo(), mode, target_cluster);
                             kruizeObject.setPerformanceProfile(perfProfileName);
                             proceed = true;

--- a/src/main/java/com/autotune/analyzer/performanceProfiles/PerformanceProfile.java
+++ b/src/main/java/com/autotune/analyzer/performanceProfiles/PerformanceProfile.java
@@ -17,6 +17,7 @@ package com.autotune.analyzer.performanceProfiles;
 
 import com.autotune.analyzer.kruizeObject.SloInfo;
 import com.autotune.analyzer.recommendations.term.Terms;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.Map;
@@ -25,9 +26,17 @@ import java.util.Map;
  * Container class for the PerformanceProfile kubernetes kind, which is used to define
  * a profile
  *
+ * This class provides a direct representation of MetricProfile CRD in JSON format,
+ * corresponding to the structure of PerformanceProfile YAML file. It includes mandatory fields
+ * for API version, kind, metadata and additional custom fields - profile_version, k8s_type and sloInfo
  */
 
 public class PerformanceProfile {
+    private String apiVersion;
+
+    private String kind;
+
+    private JsonNode metadata;
 
     private String name;
 
@@ -40,6 +49,30 @@ public class PerformanceProfile {
     private SloInfo sloInfo;
 
     private Map<String, Terms> terms;
+
+    public String getApiVersion() {
+        return apiVersion;
+    }
+
+    public void setApiVersion(String apiVersion) {
+        this.apiVersion = apiVersion;
+    }
+
+    public String getKind() {
+        return kind;
+    }
+
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    public JsonNode getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(JsonNode metadata) {
+        this.metadata = metadata;
+    }
 
     public void setName(String name) {
         this.name = name;
@@ -63,6 +96,17 @@ public class PerformanceProfile {
 
     public PerformanceProfile(String name, double profile_version, String k8s_type, SloInfo sloInfo) {
         this.name = name;
+        this.profile_version = profile_version;
+        this.k8s_type = k8s_type;
+        this.sloInfo = sloInfo;
+    }
+
+    // Constructor for MetricProfile
+    public PerformanceProfile(String apiVersion, String kind, JsonNode metadata,
+                              double profile_version, String k8s_type, SloInfo sloInfo) {
+        this.apiVersion = apiVersion;
+        this.kind = kind;
+        this.metadata = metadata;
         this.profile_version = profile_version;
         this.k8s_type = k8s_type;
         this.sloInfo = sloInfo;
@@ -95,7 +139,10 @@ public class PerformanceProfile {
     @Override
     public String toString() {
         return "PerformanceProfile{" +
-                "name='" + name + '\'' +
+                "apiVersion='" + apiVersion + '\'' +
+                ", kind='" + kind + '\'' +
+                ", metadata=" + metadata +
+                " name='" + name + '\'' +
                 ", profile_version=" + profile_version +
                 ", k8s_type='" + k8s_type + '\'' +
                 ", sloInfo=" + sloInfo +

--- a/src/main/java/com/autotune/analyzer/performanceProfiles/PerformanceProfileValidation.java
+++ b/src/main/java/com/autotune/analyzer/performanceProfiles/PerformanceProfileValidation.java
@@ -26,6 +26,7 @@ import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.analyzer.utils.AnalyzerErrorConstants;
 import com.autotune.utils.KruizeConstants;
 import com.autotune.utils.KruizeSupportedTypes;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,9 +47,17 @@ public class PerformanceProfileValidation {
     private String errorMessage;
     private final Map<String, PerformanceProfile> performanceProfilesMap;
 
-    //Mandatory fields
+    //Mandatory fields for PerformanceProfile
     private final List<String> mandatoryFields = new ArrayList<>(Arrays.asList(
             AnalyzerConstants.PerformanceProfileConstants.PERF_PROFILE_NAME,
+            AnalyzerConstants.SLO
+    ));
+
+    //Mandatory fields for MetricProfile
+    private final List<String> mandatoryMetricFields = new ArrayList<>(Arrays.asList(
+            AnalyzerConstants.API_VERSION,
+            AnalyzerConstants.KIND,
+            AnalyzerConstants.AutotuneObjectConstants.METADATA,
             AnalyzerConstants.SLO
     ));
 
@@ -81,6 +90,17 @@ public class PerformanceProfileValidation {
     }
 
     /**
+     * Validates function variables
+     *
+     * @param metricProfile Metric Profile Object to be validated
+     * @return Returns the ValidationOutputData containing the response based on the validation
+     */
+    public ValidationOutputData validateMetricProfile(PerformanceProfile metricProfile) {
+
+        return validateMetricProfileData(metricProfile);
+    }
+
+    /**
      * Validates the data present in the performance profile object before adding it to the map
      * @param performanceProfile
      * @return
@@ -102,118 +122,17 @@ public class PerformanceProfileValidation {
                 errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.DUPLICATE_PERF_PROFILE).append(performanceProfile.getName());
                 return new ValidationOutputData(false, errorString.toString(), HttpServletResponse.SC_CONFLICT);
             }
-            // Check if k8s type is supported
-            String k8sType = performanceProfile.getK8S_TYPE();
-            if (!KruizeSupportedTypes.K8S_TYPES_SUPPORTED.contains(k8sType)) {
-                errorString.append(AnalyzerConstants.PerformanceProfileConstants.K8S_TYPE).append(k8sType)
-                        .append(AnalyzerErrorConstants.AutotuneObjectErrors.UNSUPPORTED);
-            }
 
-            SloInfo sloInfo = performanceProfile.getSloInfo();
-            // Check if direction is supported
-            if (!KruizeSupportedTypes.DIRECTIONS_SUPPORTED.contains(sloInfo.getDirection()))
-                errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.DIRECTION_NOT_SUPPORTED);
-            // if slo_class is present, do further validations
-            if (sloInfo.getSloClass() != null) {
-                // Check if slo_class is supported
-                if (!KruizeSupportedTypes.SLO_CLASSES_SUPPORTED.contains(sloInfo.getSloClass()))
-                    errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.SLO_CLASS_NOT_SUPPORTED);
-
-                //check if slo_class is 'response_time' and direction is 'minimize'
-                if (sloInfo.getSloClass().equalsIgnoreCase(EMConstants.StandardDefaults.RESPONSE_TIME) && !sloInfo.getDirection()
-                        .equalsIgnoreCase(AnalyzerConstants.AutotuneObjectConstants.MINIMIZE)) {
-                    errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.INVALID_DIRECTION_FOR_SLO_CLASS);
-                }
-
-                //check if slo_class is 'throughput' and direction is 'maximize'
-                if (sloInfo.getSloClass().equalsIgnoreCase(EMConstants.StandardDefaults.THROUGHPUT) && !sloInfo.getDirection()
-                        .equalsIgnoreCase(AnalyzerConstants.AutotuneObjectConstants.MAXIMIZE)) {
-                    errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.INVALID_DIRECTION_FOR_SLO_CLASS);
-                }
-            }
-            // Check if function_variables is empty
-            if (sloInfo.getFunctionVariables().isEmpty())
-                errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.FUNCTION_VARIABLES_EMPTY);
-
-            // Check if objective_function and it's type exists
-            if (sloInfo.getObjectiveFunction() == null)
-                errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.OBJECTIVE_FUNCTION_MISSING);
-
-            // Get the objective_function type
-            String objFunctionType = sloInfo.getObjectiveFunction().getFunction_type();
-            String expression = null;
-            for (Metric functionVariable : sloInfo.getFunctionVariables()) {
-                // Check if datasource is supported
-                if (!KruizeSupportedTypes.MONITORING_AGENTS_SUPPORTED.contains(functionVariable.getDatasource().toLowerCase())) {
-                    errorString.append(AnalyzerConstants.AutotuneObjectConstants.FUNCTION_VARIABLE)
-                            .append(functionVariable.getName())
-                            .append(AnalyzerErrorConstants.AutotuneObjectErrors.DATASOURCE_NOT_SUPPORTED);
-                }
-
-                // Check if value_type is supported
-                if (!KruizeSupportedTypes.VALUE_TYPES_SUPPORTED.contains(functionVariable.getValueType().toLowerCase())) {
-                    errorString.append(AnalyzerConstants.AutotuneObjectConstants.FUNCTION_VARIABLE)
-                            .append(functionVariable.getName())
-                            .append(AnalyzerErrorConstants.AutotuneObjectErrors.VALUE_TYPE_NOT_SUPPORTED);
-                }
-
-                // Check if kubernetes_object type is supported, set default to 'container' if it's absent.
-                String kubernetes_object = functionVariable.getKubernetesObject();
-                if (null == kubernetes_object)
-                    functionVariable.setKubernetesObject(KruizeConstants.JSONKeys.CONTAINER);
-                else {
-                    if (!KruizeSupportedTypes.KUBERNETES_OBJECTS_SUPPORTED.contains(kubernetes_object.toLowerCase()))
-                        errorString.append(AnalyzerConstants.KUBERNETES_OBJECTS).append(kubernetes_object)
-                                .append(AnalyzerErrorConstants.AutotuneObjectErrors.UNSUPPORTED);
-                }
-
-                // Validate Objective Function
-                try {
-                    if (objFunctionType.equals(AnalyzerConstants.AutotuneObjectConstants.EXPRESSION)) {
-
-                        expression = sloInfo.getObjectiveFunction().getExpression();
-                        if (null == expression || expression.equals(AnalyzerConstants.NULL)) {
-                            throw new NullPointerException(AnalyzerErrorConstants.AutotuneObjectErrors.MISSING_EXPRESSION);
-                        }
-
-                    } else if (objFunctionType.equals(AnalyzerConstants.PerformanceProfileConstants.SOURCE)) {
-                        if (null != sloInfo.getObjectiveFunction().getExpression()) {
-                            errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.MISPLACED_EXPRESSION);
-                            throw new InvalidValueException(errorString.toString());
-                        }
-                    } else {
-                        errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.INVALID_TYPE);
-                        throw new InvalidValueException(errorString.toString());
-                    }
-                } catch (NullPointerException | InvalidValueException npe) {
-                    errorString.append(npe.getMessage());
-                    validationOutputData.setSuccess(false);
-                    validationOutputData.setMessage(errorString.toString());
-                }
-
-                // Check if function_variable is part of objective_function
-                if (objFunctionType.equals(AnalyzerConstants.AutotuneObjectConstants.EXPRESSION)) {
-                    if (!expression.contains(functionVariable.getName())) {
-                        errorString.append(AnalyzerConstants.AutotuneObjectConstants.FUNCTION_VARIABLE)
-                                .append(functionVariable.getName()).append(" ")
-                                .append(AnalyzerErrorConstants.AutotuneObjectErrors.FUNCTION_VARIABLE_ERROR);
-                    }
-                }
-            }
-
-            // Check if objective_function is correctly formatted
-            if (objFunctionType.equals(AnalyzerConstants.AutotuneObjectConstants.EXPRESSION)) {
-                if (expression.equals(AnalyzerConstants.NULL) || !new EvalExParser().validate(sloInfo.getObjectiveFunction().getExpression(), sloInfo.getFunctionVariables())) {
-                    errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.INVALID_OBJECTIVE_FUNCTION);
-                }
-            }
+            // Validates fields like k8s_type and slo object
+            validateCommonProfileFields(performanceProfile, errorString, validationOutputData);
 
             if (!errorString.toString().isEmpty()) {
                 validationOutputData.setSuccess(false);
                 validationOutputData.setMessage(errorString.toString());
                 validationOutputData.setErrorCode(HttpServletResponse.SC_BAD_REQUEST);
-            } else
+            } else {
                 validationOutputData.setSuccess(true);
+            }
         }
         return validationOutputData;
     }
@@ -302,6 +221,278 @@ public class PerformanceProfileValidation {
 
         return validationOutputData;
     }
+
+    /**
+     * Validates the data present in the metric profile object before adding it to the map
+     * @param metricProfile Metric Profile Object to be validated
+     * @return Returns the ValidationOutputData containing the response based on the validation
+     */
+    private ValidationOutputData validateMetricProfileData(PerformanceProfile metricProfile) {
+        ValidationOutputData validationOutputData = new ValidationOutputData(false, null, null);
+        StringBuilder errorString = new StringBuilder();
+        try {
+            // validate the mandatory values first
+            validationOutputData = validateMandatoryMetricProfileFieldsAndData(metricProfile);
+
+            // If the mandatory values are present,proceed for further validation else return the validation object directly
+            if (validationOutputData.isSuccess()) {
+                try {
+                    new ExperimentDBService().loadAllMetricProfiles(performanceProfilesMap);
+                } catch (Exception e) {
+                    LOGGER.error("Loading saved metric profiles failed: {} ", e.getMessage());
+                }
+
+                // Check if metadata exists
+                JsonNode metadata = metricProfile.getMetadata();
+                if (null == metadata) {
+                    errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.MISSING_METRIC_PROFILE_METADATA);
+                }
+                // check if the performance profile already exists
+                if (null != performanceProfilesMap.get(metricProfile.getMetadata().get("name").asText())) {
+                    errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.DUPLICATE_METRIC_PROFILE).append(metricProfile.getMetadata().get("name").asText());
+                    return new ValidationOutputData(false, errorString.toString(), HttpServletResponse.SC_CONFLICT);
+                }
+
+                // Validates fields like k8s_type and slo object
+                validateCommonProfileFields(metricProfile, errorString, validationOutputData);
+
+                if (!errorString.toString().isEmpty()) {
+                    validationOutputData.setSuccess(false);
+                    validationOutputData.setMessage(errorString.toString());
+                    validationOutputData.setErrorCode(HttpServletResponse.SC_BAD_REQUEST);
+                } else {
+                    validationOutputData.setSuccess(true);
+                }
+            }
+        } catch (Exception e){
+            validationOutputData.setSuccess(false);
+            validationOutputData.setMessage(errorString.toString());
+            validationOutputData.setErrorCode(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        }
+        return validationOutputData;
+    }
+
+    /**
+     * Check if all mandatory values are present.
+     *
+     * @param metricObj Mandatory fields of this Metric Profile Object will be validated
+     * @return ValidationOutputData object containing status of the validations
+     */
+    public ValidationOutputData validateMandatoryMetricProfileFieldsAndData(PerformanceProfile metricObj) {
+        List<String> missingMandatoryFields = new ArrayList<>();
+        ValidationOutputData validationOutputData = new ValidationOutputData(false, null, null);
+        String errorMsg;
+        errorMsg = "";
+        mandatoryMetricFields.forEach(
+                mField -> {
+                    String methodName = "get" + mField.substring(0, 1).toUpperCase() + mField.substring(1);
+                    try {
+                        LOGGER.debug("MethodName = {}",methodName);
+                        Method getNameMethod = metricObj.getClass().getMethod(methodName);
+                        if (null == getNameMethod.invoke(metricObj) || getNameMethod.invoke(metricObj).toString().isEmpty())
+                            missingMandatoryFields.add(mField);
+                    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+                        LOGGER.error("Method name {} doesn't exist!", mField);
+                    }
+                }
+        );
+        if (missingMandatoryFields.size() == 0) {
+            try {
+                String mandatoryMetadataPerf = AnalyzerConstants.PerformanceProfileConstants.PERF_PROFILE_NAME;
+                try {
+                    JsonNode metadata = metricObj.getMetadata();
+                    String metricProfileName = metadata.get(mandatoryMetadataPerf).asText();
+                    if (null == metricProfileName || metricProfileName.isEmpty() || metricProfileName.equals("null")) {
+                        missingMandatoryFields.add(mandatoryMetadataPerf);
+                    }
+                } catch (Exception e) {
+                    LOGGER.error("Method name doesn't exist for: {}!", mandatoryMetadataPerf);
+                }
+
+                if (missingMandatoryFields.size() == 0) {
+                    mandatorySLOPerf.forEach(
+                            mField -> {
+                                String methodName = "get" + mField.substring(0, 1).toUpperCase() + mField.substring(1);
+                                try {
+                                    LOGGER.debug("MethodName = {}", methodName);
+                                    Method getNameMethod = metricObj.getSloInfo().getClass().getMethod(methodName);
+                                    if (getNameMethod.invoke(metricObj.getSloInfo()) == null)
+                                        missingMandatoryFields.add(mField);
+                                } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+                                    LOGGER.error("Method name {} doesn't exist!", mField);
+                                }
+
+                            });
+                    if (missingMandatoryFields.size() == 0) {
+                        mandatoryFuncVariables.forEach(
+                                mField -> {
+                                    String methodName = "get" + mField.substring(0, 1).toUpperCase() + mField.substring(1);
+                                    try {
+                                        LOGGER.debug("MethodName = {}", methodName);
+                                        Method getNameMethod = metricObj.getSloInfo().getFunctionVariables().get(0)
+                                                .getClass().getMethod(methodName);
+                                        if (getNameMethod.invoke(metricObj.getSloInfo().getFunctionVariables().get(0)) == null)
+                                            missingMandatoryFields.add(mField);
+                                    } catch (NoSuchMethodException | IllegalAccessException |
+                                             InvocationTargetException e) {
+                                        LOGGER.error("Method name {} doesn't exist!", mField);
+                                    }
+
+                                });
+                        String mandatoryObjFuncData = AnalyzerConstants.AutotuneObjectConstants.OBJ_FUNCTION_TYPE;
+                        String methodName = "get" + mandatoryObjFuncData.substring(0, 1).toUpperCase() +
+                                mandatoryObjFuncData.substring(1);
+                        try {
+                            LOGGER.debug("MethodName = {}", methodName);
+                            Method getNameMethod = metricObj.getSloInfo().getObjectiveFunction()
+                                    .getClass().getMethod(methodName);
+                            if (getNameMethod.invoke(metricObj.getSloInfo().getObjectiveFunction()) == null)
+                                missingMandatoryFields.add(mandatoryObjFuncData);
+                        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+                            LOGGER.error("Method name {} doesn't exist!", mandatoryObjFuncData);
+                        }
+                        validationOutputData.setSuccess(true);
+                    }
+                }
+
+                if (!missingMandatoryFields.isEmpty()) {
+                    errorMsg = errorMsg.concat(String.format("Missing mandatory parameters: %s ", missingMandatoryFields));
+                    validationOutputData.setSuccess(false);
+                    validationOutputData.setMessage(errorMsg);
+                    validationOutputData.setErrorCode(HttpServletResponse.SC_BAD_REQUEST);
+                    LOGGER.error("Validation error message :{}", errorMsg);
+                }
+            } catch (Exception e) {
+                validationOutputData.setSuccess(false);
+                errorMsg = errorMsg.concat(e.getMessage());
+                validationOutputData.setMessage(errorMsg);
+                validationOutputData.setErrorCode(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            }
+        } else {
+            errorMsg = errorMsg.concat(String.format("Missing mandatory parameters: %s ", missingMandatoryFields));
+            validationOutputData.setSuccess(false);
+            validationOutputData.setMessage(errorMsg);
+            validationOutputData.setErrorCode(HttpServletResponse.SC_BAD_REQUEST);
+            LOGGER.error("Validation error message :{}", errorMsg);
+        }
+
+        return validationOutputData;
+    }
+
+    /**
+     *  Validates fields like k8s_type and slo object common to both Metric and Performance Profile
+     * @param metricProfile Metric/Performance Profile object to be validated
+     * @param errorString   StringBuilder to collect error messages during validation of multiple fields
+     * @param validationOutputData ValidationOutputData containing the response based on the validation
+     */
+    private void validateCommonProfileFields(PerformanceProfile metricProfile, StringBuilder errorString, ValidationOutputData validationOutputData){
+        // Check if k8s type is supported
+        String k8sType = metricProfile.getK8S_TYPE();
+        if (!KruizeSupportedTypes.K8S_TYPES_SUPPORTED.contains(k8sType)) {
+            errorString.append(AnalyzerConstants.PerformanceProfileConstants.K8S_TYPE).append(k8sType)
+                    .append(AnalyzerErrorConstants.AutotuneObjectErrors.UNSUPPORTED);
+        }
+
+        SloInfo sloInfo = metricProfile.getSloInfo();
+        // Check if direction is supported
+        if (!KruizeSupportedTypes.DIRECTIONS_SUPPORTED.contains(sloInfo.getDirection()))
+            errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.DIRECTION_NOT_SUPPORTED);
+        // if slo_class is present, do further validations
+        if (sloInfo.getSloClass() != null) {
+            // Check if slo_class is supported
+            if (!KruizeSupportedTypes.SLO_CLASSES_SUPPORTED.contains(sloInfo.getSloClass()))
+                errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.SLO_CLASS_NOT_SUPPORTED);
+
+            //check if slo_class is 'response_time' and direction is 'minimize'
+            if (sloInfo.getSloClass().equalsIgnoreCase(EMConstants.StandardDefaults.RESPONSE_TIME) && !sloInfo.getDirection()
+                    .equalsIgnoreCase(AnalyzerConstants.AutotuneObjectConstants.MINIMIZE)) {
+                errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.INVALID_DIRECTION_FOR_SLO_CLASS);
+            }
+
+            //check if slo_class is 'throughput' and direction is 'maximize'
+            if (sloInfo.getSloClass().equalsIgnoreCase(EMConstants.StandardDefaults.THROUGHPUT) && !sloInfo.getDirection()
+                    .equalsIgnoreCase(AnalyzerConstants.AutotuneObjectConstants.MAXIMIZE)) {
+                errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.INVALID_DIRECTION_FOR_SLO_CLASS);
+            }
+        }
+        // Check if function_variables is empty
+        if (sloInfo.getFunctionVariables().isEmpty())
+            errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.FUNCTION_VARIABLES_EMPTY);
+
+        // Check if objective_function and it's type exists
+        if (sloInfo.getObjectiveFunction() == null)
+            errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.OBJECTIVE_FUNCTION_MISSING);
+
+        // Get the objective_function type
+        String objFunctionType = sloInfo.getObjectiveFunction().getFunction_type();
+        String expression = null;
+        for (Metric functionVariable : sloInfo.getFunctionVariables()) {
+            // Check if datasource is supported
+            if (!KruizeSupportedTypes.MONITORING_AGENTS_SUPPORTED.contains(functionVariable.getDatasource().toLowerCase())) {
+                errorString.append(AnalyzerConstants.AutotuneObjectConstants.FUNCTION_VARIABLE)
+                        .append(functionVariable.getName())
+                        .append(AnalyzerErrorConstants.AutotuneObjectErrors.DATASOURCE_NOT_SUPPORTED);
+            }
+
+            // Check if value_type is supported
+            if (!KruizeSupportedTypes.VALUE_TYPES_SUPPORTED.contains(functionVariable.getValueType().toLowerCase())) {
+                errorString.append(AnalyzerConstants.AutotuneObjectConstants.FUNCTION_VARIABLE)
+                        .append(functionVariable.getName())
+                        .append(AnalyzerErrorConstants.AutotuneObjectErrors.VALUE_TYPE_NOT_SUPPORTED);
+            }
+
+            // Check if kubernetes_object type is supported, set default to 'container' if it's absent.
+            String kubernetes_object = functionVariable.getKubernetesObject();
+            if (null == kubernetes_object)
+                functionVariable.setKubernetesObject(KruizeConstants.JSONKeys.CONTAINER);
+            else {
+                if (!KruizeSupportedTypes.KUBERNETES_OBJECTS_SUPPORTED.contains(kubernetes_object.toLowerCase()))
+                    errorString.append(AnalyzerConstants.KUBERNETES_OBJECTS).append(kubernetes_object)
+                            .append(AnalyzerErrorConstants.AutotuneObjectErrors.UNSUPPORTED);
+            }
+
+            // Validate Objective Function
+            try {
+                if (objFunctionType.equals(AnalyzerConstants.AutotuneObjectConstants.EXPRESSION)) {
+
+                    expression = sloInfo.getObjectiveFunction().getExpression();
+                    if (null == expression || expression.equals(AnalyzerConstants.NULL)) {
+                        throw new NullPointerException(AnalyzerErrorConstants.AutotuneObjectErrors.MISSING_EXPRESSION);
+                    }
+
+                } else if (objFunctionType.equals(AnalyzerConstants.PerformanceProfileConstants.SOURCE)) {
+                    if (null != sloInfo.getObjectiveFunction().getExpression()) {
+                        errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.MISPLACED_EXPRESSION);
+                        throw new InvalidValueException(errorString.toString());
+                    }
+                } else {
+                    errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.INVALID_TYPE);
+                    throw new InvalidValueException(errorString.toString());
+                }
+            } catch (NullPointerException | InvalidValueException npe) {
+                errorString.append(npe.getMessage());
+                validationOutputData.setSuccess(false);
+                validationOutputData.setMessage(errorString.toString());
+            }
+
+            // Check if function_variable is part of objective_function
+            if (objFunctionType.equals(AnalyzerConstants.AutotuneObjectConstants.EXPRESSION)) {
+                if (!expression.contains(functionVariable.getName())) {
+                    errorString.append(AnalyzerConstants.AutotuneObjectConstants.FUNCTION_VARIABLE)
+                            .append(functionVariable.getName()).append(" ")
+                            .append(AnalyzerErrorConstants.AutotuneObjectErrors.FUNCTION_VARIABLE_ERROR);
+                }
+            }
+        }
+
+        // Check if objective_function is correctly formatted
+        if (objFunctionType.equals(AnalyzerConstants.AutotuneObjectConstants.EXPRESSION)) {
+            if (expression.equals(AnalyzerConstants.NULL) || !new EvalExParser().validate(sloInfo.getObjectiveFunction().getExpression(), sloInfo.getFunctionVariables())) {
+                errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.INVALID_OBJECTIVE_FUNCTION);
+            }
+        }
+    }
+
     public boolean isSuccess() {
         return success;
     }

--- a/src/main/java/com/autotune/analyzer/performanceProfiles/utils/PerformanceProfileUtil.java
+++ b/src/main/java/com/autotune/analyzer/performanceProfiles/utils/PerformanceProfileUtil.java
@@ -62,6 +62,28 @@ public class PerformanceProfileUtil {
     }
 
     /**
+     * validates the metric profile fields and the data and then adds it to the map
+     * @param metricProfilesMap
+     * @param metricProfile     Metric profile to be validated
+     * @return ValidationOutputData object
+     */
+    public static ValidationOutputData validateAndAddMetricProfile(Map<String, PerformanceProfile> metricProfilesMap, PerformanceProfile metricProfile) {
+        ValidationOutputData validationOutputData;
+        try {
+            validationOutputData = new PerformanceProfileValidation(metricProfilesMap).validateMetricProfile(metricProfile);
+            if (validationOutputData.isSuccess()) {
+                addMetricProfile(metricProfilesMap, metricProfile);
+            } else {
+                validationOutputData.setMessage("Validation failed: " + validationOutputData.getMessage());
+            }
+        } catch (Exception e) {
+            LOGGER.error("Validate and add metric profile failed: {}", e.getMessage());
+            validationOutputData = new ValidationOutputData(false, "Validation failed: " + e.getMessage(), HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        }
+        return validationOutputData;
+    }
+
+    /**
      * @param performanceProfile
      * @param updateResultsAPIObject
      * @return
@@ -160,6 +182,11 @@ public class PerformanceProfileUtil {
     public static void addPerformanceProfile(Map<String, PerformanceProfile> performanceProfileMap, PerformanceProfile performanceProfile) {
         performanceProfileMap.put(performanceProfile.getName(), performanceProfile);
         LOGGER.debug("Added PerformanceProfile: {} ",performanceProfile.getName());
+    }
+
+    public static void addMetricProfile(Map<String, PerformanceProfile> performanceProfileMap, PerformanceProfile performanceProfile) {
+        performanceProfileMap.put(performanceProfile.getMetadata().get("name").asText(), performanceProfile);
+        LOGGER.debug("Added MetricProfile: {} ",performanceProfile.getMetadata().get("name"));
     }
 
     /**

--- a/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
@@ -318,16 +318,16 @@ public class Converters {
                     String kubeObject = functionVarObj.has(AnalyzerConstants.KUBERNETES_OBJECT) ? functionVarObj.getString(AnalyzerConstants.KUBERNETES_OBJECT) : null;
                     Metric metric = new Metric(name, query, datasource, valueType, kubeObject);
                     JSONArray aggrFunctionArray = functionVarObj.has(AnalyzerConstants.AGGREGATION_FUNCTIONS) ? functionVarObj.getJSONArray(AnalyzerConstants.AGGREGATION_FUNCTIONS) : null;
+                    HashMap<String, AggregationFunctions> aggregationFunctionsMap = new HashMap<>();
                     for (Object innerObject : aggrFunctionArray) {
                         JSONObject aggrFuncJsonObject = (JSONObject) innerObject;
-                        HashMap<String, AggregationFunctions> aggregationFunctionsMap = new HashMap<>();
                         String function = aggrFuncJsonObject.getString(AnalyzerConstants.FUNCTION);
                         String aggrFuncQuery = aggrFuncJsonObject.getString(KruizeConstants.JSONKeys.QUERY);
                         String version = aggrFuncJsonObject.has(KruizeConstants.JSONKeys.VERSION) ? aggrFuncJsonObject.getString(KruizeConstants.JSONKeys.VERSION) : null;
                         AggregationFunctions aggregationFunctions = new AggregationFunctions(function, aggrFuncQuery, version);
                         aggregationFunctionsMap.put(function, aggregationFunctions);
-                        metric.setAggregationFunctionsMap(aggregationFunctionsMap);
                     }
+                    metric.setAggregationFunctionsMap(aggregationFunctionsMap);
                     functionVariablesList.add(metric);
                 }
                 String sloClass = sloJsonObject.has(AnalyzerConstants.AutotuneObjectConstants.SLO_CLASS) ? sloJsonObject.get(AnalyzerConstants.AutotuneObjectConstants.SLO_CLASS).toString() : null;

--- a/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
@@ -31,6 +31,8 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class Converters {
     private Converters() {
@@ -288,6 +290,53 @@ public class Converters {
                 performanceProfile = new PerformanceProfile(perfProfileName, profileVersion, k8sType, sloInfo);
             }
             return performanceProfile;
+        }
+
+        public static PerformanceProfile convertInputJSONToCreateMetricProfile(String inputData) throws InvalidValueException, Exception {
+            PerformanceProfile metricProfile = null;
+            if (inputData != null) {
+                JSONObject jsonObject = new JSONObject(inputData);
+                String apiVersion = jsonObject.getString(AnalyzerConstants.API_VERSION);
+                String kind = jsonObject.getString(AnalyzerConstants.KIND);
+
+                JSONObject metadataObject = jsonObject.getJSONObject(AnalyzerConstants.AutotuneObjectConstants.METADATA);
+                ObjectMapper objectMapper = new ObjectMapper();
+                ObjectNode metadata = objectMapper.readValue(metadataObject.toString(), ObjectNode.class);
+                metadata.put("name", metadataObject.getString("name"));
+
+                Double profileVersion = jsonObject.has(AnalyzerConstants.PROFILE_VERSION) ? jsonObject.getDouble(AnalyzerConstants.PROFILE_VERSION) : null;
+                String k8sType = jsonObject.has(AnalyzerConstants.PerformanceProfileConstants.K8S_TYPE) ? jsonObject.getString(AnalyzerConstants.PerformanceProfileConstants.K8S_TYPE) : null;
+                JSONObject sloJsonObject = jsonObject.getJSONObject(AnalyzerConstants.AutotuneObjectConstants.SLO);
+                JSONArray functionVariableArray = sloJsonObject.getJSONArray(AnalyzerConstants.AutotuneObjectConstants.FUNCTION_VARIABLES);
+                ArrayList<Metric> functionVariablesList = new ArrayList<>();
+                for (Object object : functionVariableArray) {
+                    JSONObject functionVarObj = (JSONObject) object;
+                    String name = functionVarObj.getString(AnalyzerConstants.AutotuneObjectConstants.NAME);
+                    String datasource = functionVarObj.getString(AnalyzerConstants.AutotuneObjectConstants.DATASOURCE);
+                    String query = functionVarObj.has(AnalyzerConstants.AutotuneObjectConstants.QUERY) ? functionVarObj.getString(AnalyzerConstants.AutotuneObjectConstants.QUERY) : null;
+                    String valueType = functionVarObj.getString(AnalyzerConstants.AutotuneObjectConstants.VALUE_TYPE);
+                    String kubeObject = functionVarObj.has(AnalyzerConstants.KUBERNETES_OBJECT) ? functionVarObj.getString(AnalyzerConstants.KUBERNETES_OBJECT) : null;
+                    Metric metric = new Metric(name, query, datasource, valueType, kubeObject);
+                    JSONArray aggrFunctionArray = functionVarObj.has(AnalyzerConstants.AGGREGATION_FUNCTIONS) ? functionVarObj.getJSONArray(AnalyzerConstants.AGGREGATION_FUNCTIONS) : null;
+                    for (Object innerObject : aggrFunctionArray) {
+                        JSONObject aggrFuncJsonObject = (JSONObject) innerObject;
+                        HashMap<String, AggregationFunctions> aggregationFunctionsMap = new HashMap<>();
+                        String function = aggrFuncJsonObject.getString(AnalyzerConstants.FUNCTION);
+                        String aggrFuncQuery = aggrFuncJsonObject.getString(KruizeConstants.JSONKeys.QUERY);
+                        String version = aggrFuncJsonObject.has(KruizeConstants.JSONKeys.VERSION) ? aggrFuncJsonObject.getString(KruizeConstants.JSONKeys.VERSION) : null;
+                        AggregationFunctions aggregationFunctions = new AggregationFunctions(function, aggrFuncQuery, version);
+                        aggregationFunctionsMap.put(function, aggregationFunctions);
+                        metric.setAggregationFunctionsMap(aggregationFunctionsMap);
+                    }
+                    functionVariablesList.add(metric);
+                }
+                String sloClass = sloJsonObject.has(AnalyzerConstants.AutotuneObjectConstants.SLO_CLASS) ? sloJsonObject.get(AnalyzerConstants.AutotuneObjectConstants.SLO_CLASS).toString() : null;
+                String direction = sloJsonObject.has(AnalyzerConstants.AutotuneObjectConstants.DIRECTION) ? sloJsonObject.get(AnalyzerConstants.AutotuneObjectConstants.DIRECTION).toString() : null;
+                ObjectiveFunction objectiveFunction = new Gson().fromJson(sloJsonObject.getJSONObject(AnalyzerConstants.AutotuneObjectConstants.OBJECTIVE_FUNCTION).toString(), ObjectiveFunction.class);
+                SloInfo sloInfo = new SloInfo(sloClass, objectiveFunction, direction, functionVariablesList);
+                metricProfile = new PerformanceProfile(apiVersion, kind, metadata, profileVersion, k8sType, sloInfo);
+            }
+            return metricProfile;
         }
 
         public static ConcurrentHashMap<String, KruizeObject> ConvertUpdateResultDataToAPIResponse(ConcurrentHashMap<String, KruizeObject> mainKruizeExperimentMap) {

--- a/src/main/java/com/autotune/analyzer/services/MetricProfileService.java
+++ b/src/main/java/com/autotune/analyzer/services/MetricProfileService.java
@@ -1,0 +1,243 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package com.autotune.analyzer.services;
+
+import com.autotune.analyzer.exceptions.InvalidValueException;
+import com.autotune.analyzer.exceptions.PerformanceProfileResponse;
+import com.autotune.analyzer.performanceProfiles.PerformanceProfile;
+import com.autotune.analyzer.performanceProfiles.utils.PerformanceProfileUtil;
+import com.autotune.analyzer.serviceObjects.Converters;
+import com.autotune.analyzer.utils.AnalyzerConstants;
+import com.autotune.analyzer.utils.AnalyzerErrorConstants;
+import com.autotune.analyzer.utils.GsonUTCDateAdapter;
+import com.autotune.common.data.ValidationOutputData;
+import com.autotune.common.data.metrics.Metric;
+import com.autotune.database.service.ExperimentDBService;
+import com.autotune.utils.KruizeConstants;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.gson.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.Serial;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import static com.autotune.analyzer.utils.AnalyzerConstants.ServiceConstants.CHARACTER_ENCODING;
+import static com.autotune.analyzer.utils.AnalyzerConstants.ServiceConstants.JSON_CONTENT_TYPE;
+
+/**
+ * REST API to create metric profile .
+ */
+@WebServlet(asyncSupported = true)
+public class MetricProfileService extends HttpServlet {
+    @Serial
+    private static final long serialVersionUID = 1L;
+    private static final Logger LOGGER = LoggerFactory.getLogger(MetricProfileService.class);
+    private ConcurrentHashMap<String, PerformanceProfile> metricProfilesMap;
+
+    @Override
+    public void init(ServletConfig config) throws ServletException {
+        super.init(config);
+        metricProfilesMap = (ConcurrentHashMap<String, PerformanceProfile>) getServletContext()
+                .getAttribute(AnalyzerConstants.PerformanceProfileConstants.METRIC_PROFILE_MAP);
+    }
+
+    /**
+     * Validate and create new Metric Profile.
+     *
+     * @param request
+     * @param response
+     * @throws IOException
+     */
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        try {
+            Map<String, PerformanceProfile> metricProfilesMap = new ConcurrentHashMap<>();
+            String inputData = request.getReader().lines().collect(Collectors.joining());
+            PerformanceProfile metricProfile = Converters.KruizeObjectConverters.convertInputJSONToCreateMetricProfile(inputData);
+            ValidationOutputData validationOutputData = PerformanceProfileUtil.validateAndAddMetricProfile(metricProfilesMap, metricProfile);
+            if (validationOutputData.isSuccess()) {
+                ValidationOutputData addedToDB = new ExperimentDBService().addMetricProfileToDB(metricProfile);
+                if (addedToDB.isSuccess()) {
+                    metricProfilesMap.put(String.valueOf(metricProfile.getMetadata().get("name")), metricProfile);
+                    getServletContext().setAttribute(AnalyzerConstants.PerformanceProfileConstants.METRIC_PROFILE_MAP, metricProfilesMap);
+                    LOGGER.debug(KruizeConstants.MetricProfileAPIMessages.ADD_METRIC_PROFILE_TO_DB_WITH_VERSION,
+                            metricProfile.getMetadata().get("name").asText(), metricProfile.getProfile_version());
+                    sendSuccessResponse(response, String.format(KruizeConstants.MetricProfileAPIMessages.CREATE_METRIC_PROFILE_SUCCESS_MSG, metricProfile.getMetadata().get("name").asText()));
+                } else {
+                    sendErrorResponse(response, null, HttpServletResponse.SC_BAD_REQUEST, addedToDB.getMessage());
+                }
+            } else
+                sendErrorResponse(response, null, validationOutputData.getErrorCode(), validationOutputData.getMessage());
+        } catch (Exception e) {
+            sendErrorResponse(response, e, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Validation failed: " + e.getMessage());
+        } catch (InvalidValueException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Get List of Metric Profiles
+     *
+     * @param req
+     * @param response
+     * @throws ServletException
+     * @throws IOException
+     */
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse response) throws ServletException, IOException {
+        response.setContentType(JSON_CONTENT_TYPE);
+        response.setCharacterEncoding(CHARACTER_ENCODING);
+        response.setStatus(HttpServletResponse.SC_OK);
+        String gsonStr = "[]";
+        // Fetch all metric profiles from the DB
+        try {
+            new ExperimentDBService().loadAllMetricProfiles(metricProfilesMap);
+        } catch (Exception e) {
+            LOGGER.error(KruizeConstants.MetricProfileAPIMessages.LOAD_METRIC_PROFILE_FAILURE, e.getMessage());
+        }
+        if (metricProfilesMap.size() > 0) {
+            Collection<PerformanceProfile> values = metricProfilesMap.values();
+            Gson gsonObj = new GsonBuilder()
+                    .disableHtmlEscaping()
+                    .setPrettyPrinting()
+                    .enableComplexMapKeySerialization()
+                    .registerTypeAdapter(Date.class, new GsonUTCDateAdapter())
+                    // a custom serializer for serializing metadata of JsonNode type.
+                    .registerTypeAdapter(JsonNode.class, new JsonSerializer<JsonNode>() {
+                        @Override
+                        public JsonElement serialize(JsonNode jsonNode, Type typeOfSrc, JsonSerializationContext context) {
+                            if (jsonNode instanceof ObjectNode) {
+                                ObjectNode objectNode = (ObjectNode) jsonNode;
+                                JsonObject metadataJson = new JsonObject();
+
+                                // Extract the "name" field directly if it exists
+                                if (objectNode.has("name")) {
+                                    metadataJson.addProperty("name", objectNode.get("name").asText());
+                                }
+
+                                return metadataJson;
+                            }
+                            return context.serialize(jsonNode);
+                        }
+                    })
+                    .setExclusionStrategies(new ExclusionStrategy() {
+                        @Override
+                        public boolean shouldSkipField(FieldAttributes f) {
+                            return f.getDeclaringClass() == Metric.class && (
+                                    f.getName().equals("trialSummaryResult")
+                                            || f.getName().equals("cycleDataMap")
+                            );
+                        }
+
+                        @Override
+                        public boolean shouldSkipClass(Class<?> aClass) {
+                            return false;
+                        }
+                    })
+                    .create();
+            gsonStr = gsonObj.toJson(values);
+        } else {
+            LOGGER.debug(AnalyzerErrorConstants.AutotuneObjectErrors.NO_PERF_PROFILE);
+        }
+        response.getWriter().println(gsonStr);
+        response.getWriter().close();
+    }
+
+    /**
+     * TODO: Need to implement
+     * Update Metric Profile
+     *
+     * @param req
+     * @param resp
+     * @throws ServletException
+     * @throws IOException
+     */
+    @Override
+    protected void doPut(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        super.doPut(req, resp);
+    }
+
+    /**
+     * TODO: Need to implement
+     * Delete Metric profile
+     *
+     * @param req
+     * @param resp
+     * @throws ServletException
+     * @throws IOException
+     */
+    @Override
+    protected void doDelete(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        super.doDelete(req, resp);
+    }
+
+    /**
+     * Send success response in case of no errors or exceptions.
+     *
+     * @param response
+     * @param message
+     * @throws IOException
+     */
+    private void sendSuccessResponse(HttpServletResponse response, String message) throws IOException {
+        response.setContentType(JSON_CONTENT_TYPE);
+        response.setCharacterEncoding(CHARACTER_ENCODING);
+        response.setStatus(HttpServletResponse.SC_CREATED);
+        PrintWriter out = response.getWriter();
+        out.append(
+                new Gson().toJson(
+                        new PerformanceProfileResponse(message +
+                                KruizeConstants.MetricProfileAPIMessages.VIEW_METRIC_PROFILES_MSG,
+                                HttpServletResponse.SC_CREATED, "", "SUCCESS")
+                )
+        );
+        out.flush();
+    }
+
+    /**
+     * Send response containing corresponding error message in case of failures and exceptions
+     *
+     * @param response
+     * @param e
+     * @param httpStatusCode
+     * @param errorMsg
+     * @throws IOException
+     */
+    public void sendErrorResponse(HttpServletResponse response, Exception e, int httpStatusCode, String errorMsg) throws
+            IOException {
+        if (null != e) {
+            LOGGER.error(e.toString());
+            if (null == errorMsg)
+                errorMsg = e.getMessage();
+        }
+        response.sendError(httpStatusCode, errorMsg);
+    }
+}

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -453,6 +453,7 @@ public class AnalyzerConstants {
         public static final String K8S_TYPE = "k8s_type";
         public static final String PERF_PROFILE = "performanceProfile";
         public static final String PERF_PROFILE_MAP = "performanceProfileMap";
+        public static final String METRIC_PROFILE_MAP = "metricProfileMap";
         public static final String PERF_PROFILE_NAME = "name";
         public static final String OBJECTIVE_FUNCTION = "objectiveFunction";
         public static final String FUNCTION_VARIABLES = "functionVariables";

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
@@ -79,6 +79,8 @@ public class AnalyzerErrorConstants {
         public static final String SLO_REDUNDANCY_ERROR = "SLO Data and Performance Profile cannot exist simultaneously!";
         public static final String DUPLICATE_PERF_PROFILE = "Performance Profile already exists: ";
         public static final String MISSING_PERF_PROFILE = "Not Found: performance_profile does not exist: ";
+        public static final String MISSING_METRIC_PROFILE_METADATA= "metadata missing\n";
+        public static final String DUPLICATE_METRIC_PROFILE = "Metric Profile already exists: ";
         public static final String MISSING_EXPERIMENT_NAME = "Not Found: experiment_name does not exist: ";
         public static final String NO_METRICS_AVAILABLE = "No metrics available from %s to %s";
         public static final String UNSUPPORTED_EXPERIMENT = String.format("At present, the system does not support bulk entries!");

--- a/src/main/java/com/autotune/database/dao/ExperimentDAO.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAO.java
@@ -25,6 +25,9 @@ public interface ExperimentDAO {
     // Add Performance Profile  to DB
     public ValidationOutputData addPerformanceProfileToDB(KruizePerformanceProfileEntry kruizePerformanceProfileEntry);
 
+    // Add Metric Profile  to DB
+    public ValidationOutputData addMetricProfileToDB(KruizeMetricProfileEntry kruizeMetricProfileEntry);
+
     // Add DataSource to DB
     ValidationOutputData addDataSourceToDB(KruizeDataSourceEntry kruizeDataSourceEntry);
 
@@ -45,6 +48,9 @@ public interface ExperimentDAO {
 
     // If Kruize restarts load all performance profiles
     List<KruizePerformanceProfileEntry> loadAllPerformanceProfiles() throws Exception;
+
+    // If Kruize restarts load all metric profiles
+    List<KruizeMetricProfileEntry> loadAllMetricProfiles() throws Exception;
 
     // Load a single experiment based on experimentName
     List<KruizeExperimentEntry> loadExperimentByName(String experimentName) throws Exception;

--- a/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
@@ -385,6 +385,38 @@ public class ExperimentDAOImpl implements ExperimentDAO {
     }
 
     /**
+     * Adds MetricProfile to database
+     * @param kruizeMetricProfileEntry Metric Profile Database object to be added
+     * @return validationOutputData contains the status of the DB insert operation
+     */
+    public ValidationOutputData addMetricProfileToDB(KruizeMetricProfileEntry kruizeMetricProfileEntry) {
+        ValidationOutputData validationOutputData = new ValidationOutputData(false, null, null);
+        String statusValue = "failure";
+        Timer.Sample timerAddMetricProfileDB = Timer.start(MetricsConfig.meterRegistry());
+        Transaction tx = null;
+        try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
+            try {
+                tx = session.beginTransaction();
+                session.persist(kruizeMetricProfileEntry);
+                tx.commit();
+                validationOutputData.setSuccess(true);
+                statusValue = "success";
+            } catch (HibernateException e) {
+                LOGGER.error("Not able to save metric profile due to {}", e.getMessage());
+                if (tx != null) tx.rollback();
+                e.printStackTrace();
+                validationOutputData.setSuccess(false);
+                validationOutputData.setMessage(e.getMessage());
+                //todo save error to API_ERROR_LOG
+            }
+        } catch (Exception e) {
+            LOGGER.error("Not able to save metric profile due to {}", e.getMessage());
+            validationOutputData.setMessage(e.getMessage());
+        }
+        return validationOutputData;
+    }
+
+    /**
      * @param kruizeDataSourceEntry
      * @return validationOutputData contains the status of the DB insert operation
      */
@@ -622,6 +654,25 @@ public class ExperimentDAOImpl implements ExperimentDAO {
         return entries;
     }
 
+    /**
+     * Fetches all the Metric Profile records from KruizeMetricProfileEntry database table
+     * @return List of all KruizeMetricProfileEntry database objects
+     * @throws Exception
+     */
+    @Override
+    public List<KruizeMetricProfileEntry> loadAllMetricProfiles() throws Exception {
+        String statusValue = "failure";
+        Timer.Sample timerLoadAllMetricProfiles = Timer.start(MetricsConfig.meterRegistry());
+        List<KruizeMetricProfileEntry> entries = null;
+        try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
+            entries = session.createQuery(DBConstants.SQLQUERY.SELECT_FROM_METRIC_PROFILE, KruizeMetricProfileEntry.class).list();
+        } catch (Exception e) {
+            LOGGER.error("Not able to load Metric Profile  due to {}", e.getMessage());
+            throw new Exception("Error while loading existing Metric Profile from database due to : " + e.getMessage());
+        }
+        return entries;
+    }
+
     @Override
     public List<KruizeExperimentEntry> loadExperimentByName(String experimentName) throws Exception {
         //todo load only experimentStatus=inprogress , playback may not require completed experiments
@@ -794,6 +845,26 @@ public class ExperimentDAOImpl implements ExperimentDAO {
                 MetricsConfig.timerLoadPerfProfileName = MetricsConfig.timerBLoadPerfProfileName.tag("status", statusValue).register(MetricsConfig.meterRegistry());
                 timerLoadPerfProfileName.stop(MetricsConfig.timerLoadPerfProfileName);
             }
+        }
+        return entries;
+    }
+
+    /**
+     * Fetched Metric Profile by name from KruizeMetricProfileEntry database table
+     * @param metricProfileName Metric profile name
+     * @return List of KruizeMetricProfileEntry objects
+     * @throws Exception
+     */
+    public List<KruizeMetricProfileEntry> loadMetricProfileByName(String metricProfileName) throws Exception {
+        String statusValue = "failure";
+        Timer.Sample timerLoadMetricProfileName = Timer.start(MetricsConfig.meterRegistry());
+        List<KruizeMetricProfileEntry> entries = null;
+        try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
+            entries = session.createQuery(DBConstants.SQLQUERY.SELECT_FROM_METRIC_PROFILE_BY_NAME, KruizeMetricProfileEntry.class)
+                    .setParameter("name", metricProfileName).list();
+        } catch (Exception e) {
+            LOGGER.error("Not able to load Metric Profile {} due to {}", metricProfileName, e.getMessage());
+            throw new Exception("Error while loading existing metric profile from database due to : " + e.getMessage());
         }
         return entries;
     }

--- a/src/main/java/com/autotune/database/helper/DBConstants.java
+++ b/src/main/java/com/autotune/database/helper/DBConstants.java
@@ -57,6 +57,8 @@ public class DBConstants {
         public static final String SELECT_FROM_RECOMMENDATIONS = "from KruizeRecommendationEntry";
         public static final String SELECT_FROM_PERFORMANCE_PROFILE = "from KruizePerformanceProfileEntry";
         public static final String SELECT_FROM_PERFORMANCE_PROFILE_BY_NAME = "from KruizePerformanceProfileEntry k WHERE k.name = :name";
+        public static final String SELECT_FROM_METRIC_PROFILE = "from KruizeMetricProfileEntry";
+        public static final String SELECT_FROM_METRIC_PROFILE_BY_NAME = "from KruizeMetricProfileEntry k WHERE k.name = :name";
         public static final String DELETE_FROM_EXPERIMENTS_BY_EXP_NAME = "DELETE FROM KruizeExperimentEntry k WHERE k.experiment_name = :experimentName";
         public static final String DELETE_FROM_RESULTS_BY_EXP_NAME = "DELETE FROM KruizeResultsEntry k WHERE k.experiment_name = :experimentName";
         public static final String DELETE_FROM_RECOMMENDATIONS_BY_EXP_NAME = "DELETE FROM KruizeRecommendationEntry k WHERE k.experiment_name = :experimentName";

--- a/src/main/java/com/autotune/database/init/KruizeHibernateUtil.java
+++ b/src/main/java/com/autotune/database/init/KruizeHibernateUtil.java
@@ -59,6 +59,7 @@ public class KruizeHibernateUtil {
             if (KruizeDeploymentInfo.local) {
                 configuration.addAnnotatedClass(KruizeDataSourceEntry.class);
                 configuration.addAnnotatedClass(KruizeDSMetadataEntry.class);
+                configuration.addAnnotatedClass(KruizeMetricProfileEntry.class);
             }
             LOGGER.info("DB is trying to connect to {}", connectionURL);
             sfTemp = configuration.buildSessionFactory();

--- a/src/main/java/com/autotune/database/service/ExperimentDBService.java
+++ b/src/main/java/com/autotune/database/service/ExperimentDBService.java
@@ -140,6 +140,17 @@ public class ExperimentDBService {
         }
     }
 
+    public void loadAllMetricProfiles(Map<String, PerformanceProfile> metricProfileMap) throws Exception {
+        List<KruizeMetricProfileEntry> entries = experimentDAO.loadAllMetricProfiles();
+        if (null != entries && !entries.isEmpty()) {
+            List<PerformanceProfile> performanceProfiles = DBHelpers.Converters.KruizeObjectConverters.convertMetricProfileEntryToMetricProfileObject(entries);
+            if (!performanceProfiles.isEmpty()) {
+                performanceProfiles.forEach(performanceProfile ->
+                        PerformanceProfileUtil.addMetricProfile(metricProfileMap, performanceProfile));
+            }
+        }
+    }
+
     public boolean loadResultsFromDBByName(Map<String, KruizeObject> mainKruizeExperimentMap, String experimentName, Timestamp calculated_start_time, Timestamp interval_end_time) throws Exception {
         ExperimentInterface experimentInterface = new ExperimentInterfaceImpl();
         KruizeObject kruizeObject = mainKruizeExperimentMap.get(experimentName);
@@ -267,6 +278,22 @@ public class ExperimentDBService {
             validationOutputData = this.experimentDAO.addPerformanceProfileToDB(kruizePerformanceProfileEntry);
         } catch (Exception e) {
             LOGGER.error("Not able to save Performance Profile due to {}", e.getMessage());
+        }
+        return validationOutputData;
+    }
+
+    /**
+     * Adds Metric Profile to kruizeMetricProfileEntry
+     * @param metricProfile Metric profile object to be added
+     * @return ValidationOutputData object
+     */
+    public ValidationOutputData addMetricProfileToDB(PerformanceProfile metricProfile) {
+        ValidationOutputData validationOutputData = new ValidationOutputData(false, null, null);
+        try {
+            KruizeMetricProfileEntry kruizeMetricProfileEntry = DBHelpers.Converters.KruizeObjectConverters.convertMetricProfileObjToMetricProfileDBObj(metricProfile);
+            validationOutputData = this.experimentDAO.addMetricProfileToDB(kruizeMetricProfileEntry);
+        } catch (Exception e) {
+            LOGGER.error("Not able to save Metric Profile due to {}", e.getMessage());
         }
         return validationOutputData;
     }

--- a/src/main/java/com/autotune/database/table/KruizeMetricProfileEntry.java
+++ b/src/main/java/com/autotune/database/table/KruizeMetricProfileEntry.java
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.autotune.database.table;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.persistence.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+/**
+ * This is a Java class named KruizeMetricProfileEntry annotated with JPA annotations.
+ * It represents a table named kruize_metric_profiles in a relational database.
+ * <p>
+ * The class has the following fields:
+ * <p>
+ * id: A unique identifier for each metric profile detail.
+ * apiVersion: A string representing version of the Kubernetes API to create this object
+ * kind: A string representing type of kubernetes object
+ * metadata: A JSON object containing the metadata of the CRD, including name field
+ * name: A string representing the name of the metric profile.
+ * profile_version: A string representing the version of the metric profile.
+ * k8s_type: A string representing kubernetes type.
+ * SLO: A string representing the slo class, direction, Objective function and function variables.
+ */
+@Entity
+@Table(name = "kruize_metric_profiles")
+public class KruizeMetricProfileEntry {
+    private String api_version;
+    private String kind;
+    @JdbcTypeCode(SqlTypes.JSON)
+    private JsonNode metadata;
+    @Id
+    private String name;
+    private double profile_version;
+    private String k8s_type;
+    @JdbcTypeCode(SqlTypes.JSON)
+    private JsonNode slo;
+
+    public String getApi_version() {
+        return api_version;
+    }
+
+    public void setApi_version(String api_version) {
+        this.api_version = api_version;
+    }
+
+    public String getKind() {
+        return kind;
+    }
+
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    public JsonNode getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(JsonNode metadata) {
+        this.metadata = metadata;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public double getProfile_version() {
+        return profile_version;
+    }
+
+    public void setProfile_version(double profile_version) {
+        this.profile_version = profile_version;
+    }
+
+    public String getK8s_type() {
+        return k8s_type;
+    }
+
+    public void setK8s_type(String k8s_type) {
+        this.k8s_type = k8s_type;
+    }
+
+    public JsonNode getSlo() {
+        return slo;
+    }
+
+    public void setSlo(JsonNode slo) {
+        this.slo = slo;
+    }
+}

--- a/src/main/java/com/autotune/service/InitiateListener.java
+++ b/src/main/java/com/autotune/service/InitiateListener.java
@@ -25,6 +25,7 @@ import com.autotune.experimentManager.data.ExperimentDetailsMap;
 import com.autotune.experimentManager.utils.EMConstants;
 import com.autotune.experimentManager.utils.EMConstants.ParallelEngineConfigs;
 import com.autotune.experimentManager.workerimpl.IterationManager;
+import com.autotune.operator.KruizeDeploymentInfo;
 import com.autotune.operator.KruizeOperator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -156,6 +157,19 @@ public class InitiateListener implements ServletContextListener {
             LOGGER.error("Failed to load performance profile: {} ", e.getMessage());
         }
         sce.getServletContext().setAttribute(AnalyzerConstants.PerformanceProfileConstants.PERF_PROFILE_MAP, performanceProfilesMap);
+
+        if(KruizeDeploymentInfo.local == true) {
+            /*
+            Kruize Metric Profile configuration
+            */
+            ConcurrentHashMap<String, PerformanceProfile> metricProfilesMap = new ConcurrentHashMap<>();
+            try {
+                new ExperimentDBService().loadAllMetricProfiles(metricProfilesMap);
+            } catch (Exception e) {
+                LOGGER.error("Failed to load metric profile: {} ", e.getMessage());
+            }
+            sce.getServletContext().setAttribute(AnalyzerConstants.PerformanceProfileConstants.METRIC_PROFILE_MAP, metricProfilesMap);
+        }
     }
 
     @Override

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -66,6 +66,13 @@ public class KruizeConstants {
         public static final String UPDATE_RECOMMENDATIONS_FAILURE_MSG = "UpdateRecommendations API failed for experiment_name: %s and intervalEndTimeStr : %s due to %s";
     }
 
+    public static class MetricProfileAPIMessages {
+        public static final String CREATE_METRIC_PROFILE_SUCCESS_MSG = "Metric Profile : %s created successfully.";
+        public static final String VIEW_METRIC_PROFILES_MSG = " View Metric Profiles at /listMetricProfiles";
+        public static final String LOAD_METRIC_PROFILE_FAILURE = "Failed to load saved metric profile data: {}";
+        public static final String ADD_METRIC_PROFILE_TO_DB_WITH_VERSION = "Added Metric Profile : {} into the DB with version: {}";
+    }
+
     /**
      * Holds the constants of env vars and values to start Autotune in different Modes
      */

--- a/src/main/java/com/autotune/utils/KruizeSupportedTypes.java
+++ b/src/main/java/com/autotune/utils/KruizeSupportedTypes.java
@@ -75,7 +75,7 @@ public class KruizeSupportedTypes
 					"((request_count / (request_sum / request_count)) / request_max) * 100"));
 
 	public static final Set<String> KUBERNETES_OBJECTS_SUPPORTED =
-			new HashSet<>(Arrays.asList("deployment", "pod", "container"));
+			new HashSet<>(Arrays.asList("deployment", "pod", "container", "namespace"));
 
 	public static final Set<String> DSMETADATA_QUERY_PARAMS_SUPPORTED = new HashSet<>(Arrays.asList(
 			"datasource", "cluster_name", "namespace", "verbose"

--- a/src/main/java/com/autotune/utils/ServerContext.java
+++ b/src/main/java/com/autotune/utils/ServerContext.java
@@ -43,6 +43,8 @@ public class ServerContext {
     public static final String RECOMMEND_RESULTS = ROOT_CONTEXT + "listRecommendations";
     public static final String CREATE_PERF_PROFILE = ROOT_CONTEXT + "createPerformanceProfile";
     public static final String LIST_PERF_PROFILES = ROOT_CONTEXT + "listPerformanceProfiles";
+    public static final String CREATE_METRIC_PROFILE = ROOT_CONTEXT + "createMetricProfile";
+    public static final String LIST_METRIC_PROFILES = ROOT_CONTEXT + "listMetricProfiles";
 
     public static final String KRUIZE_SERVER_URL = "http://localhost:" + KRUIZE_SERVER_PORT;
     public static final String SEARCH_SPACE_END_POINT = KRUIZE_SERVER_URL + SEARCH_SPACE;


### PR DESCRIPTION
## Description

This PR has following changes:

- Add `KruizeMetricProfileEntry` database table and creates metric profile when `local=true`
- Add `MetricProfileService` with `/createMetricProfile` and `/listMetricProfiles` REST APIs
- Modifies existing `PerformanceProfile` object to include `apiVersion`, `kind`, `metadata` as optional fields

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [x] Requires DB changes

## How has this been tested?

Tested using local monitoring demo scripts `./local_monitoring_demo_script.sh`

**Test Configuration**
* Kubernetes clusters tested on: minikube, openshift

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Image - `quay.io/shbirada/mvp_demo:metric-profile-apis`
