### PR TITLE
Integrate MetricProfile with local Experiments and GenerateRecommendations

### DIFF
--- a/design/KruizeLocalAPI.md
+++ b/design/KruizeLocalAPI.md
@@ -30,6 +30,16 @@ Documentation still in progress stay tuned.
   - Example Request and Response
   - Invalid Scenarios
 
+- [Create Metric Profile API](#create-metric-profile-api)
+  - Introduction
+  - Example Request and Response
+  - Invalid Scenarios
+
+- [List Metric Profiles API](#list-metric-profiles-api)
+  - Introduction
+  - Example Request and Response
+  - Invalid Scenarios
+
 - [Create Experiment API](#create-experiment-api)
     - Introduction
     - Example Request and Response
@@ -1017,6 +1027,1026 @@ This is quick guide instructions to delete metadata using input JSON as follows.
   "documentationLink": "",
   "status": "SUCCESS"
 }
+```
+
+</details>
+
+<br>
+
+<a name="create-metric-profile-api"></a>
+
+### Create Metric Profile API
+
+This is quick guide instructions to create metric profiles using input JSON as follows. For a more detailed guide,
+see [Create MetricProfile](/design/MetricProfileAPI.md)
+
+**Request**
+`POST /createMetricProfile`
+
+`curl -H 'Accept: application/json' -X POST --data 'copy paste below JSON' http://<URL>:<PORT>/createMetricProfile`
+
+<details>
+
+<summary><b>Example Request for profile name - `resource-optimization-local-monitoring`</b></summary>
+
+### Example Request
+
+```json
+{
+  "apiVersion": "recommender.com/v1",
+  "kind": "KruizePerformanceProfile",
+  "metadata": {
+    "name": "resource-optimization-local-monitoring"
+  },
+  "profile_version": 1,
+  "k8s_type": "openshift",
+  "slo": {
+    "slo_class": "resource_usage",
+    "direction": "minimize",
+    "objective_function": {
+      "function_type": "source"
+    },
+    "function_variables": [
+      {
+        "name": "cpuRequest",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD ', pod!='', resource='cpu', unit='core' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          },
+          {
+            "function": "sum",
+            "query": "sum by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='cpu', unit='core' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          },
+          {
+            "function": "min",
+            "query": "min by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='cpu', unit='core' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          },
+          {
+            "function": "max",
+            "query": "max by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='cpu', unit='core' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          }
+        ]
+      },
+      {
+        "name": "cpuLimit",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='cpu', unit='core',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          },
+          {
+            "function": "sum",
+            "query": "sum by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='cpu', unit='core',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          },
+          {
+            "function": "max",
+            "query": "max by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='cpu', unit='core',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          },
+          {
+            "function": "min",
+            "query": "min by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='cpu', unit='core',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          }
+        ]
+      },
+      {
+        "name": "cpuUsage",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))"
+
+          },
+          {
+            "function": "min",
+            "query": "min by(container, namespace)(min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))"
+
+          },
+          {
+            "function": "max",
+            "query": "max by(container, namespace)(max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))"
+
+          },
+          {
+            "function": "sum",
+            "query": "sum by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          }
+        ]
+      },
+      {
+        "name": "cpuThrottle",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          },
+          {
+            "function": "max",
+            "query": "max by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          },
+          {
+            "function": "min",
+            "query": "min by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          },
+          {
+            "function": "sum",
+            "query": "sum by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          }
+        ]
+      },
+      {
+        "name": "memoryRequest",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='memory', unit='byte' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          },
+          {
+            "function": "sum",
+            "query": "sum by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='memory', unit='byte' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          },
+          {
+            "function": "max",
+            "query": "max by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='memory', unit='byte' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          },
+          {
+            "function": "min",
+            "query": "min by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='memory', unit='byte' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          }
+        ]
+      },
+      {
+        "name": "memoryLimit",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='memory', unit='byte',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          },
+          {
+            "function": "sum",
+            "query": "sum by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='memory', unit='byte',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          },
+          {
+            "function": "max",
+            "query": "max by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='memory', unit='byte',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          },
+          {
+            "function": "min",
+            "query": "min by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='memory', unit='byte',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          }
+        ]
+      },
+      {
+        "name": "memoryUsage",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg by(container, namespace) (avg_over_time(container_memory_working_set_bytes{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          },
+          {
+            "function": "min",
+            "query": "min by(container, namespace) (min_over_time(container_memory_working_set_bytes{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          },
+          {
+            "function": "max",
+            "query": "max by(container, namespace) (max_over_time(container_memory_working_set_bytes{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          },
+          {
+            "function": "sum",
+            "query": "sum by(container, namespace) (avg_over_time(container_memory_working_set_bytes{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          }
+        ]
+      },
+      {
+        "name": "memoryRSS",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg by(container, namespace) (avg_over_time(container_memory_rss{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          },
+          {
+            "function": "min",
+            "query": "min by(container, namespace) (min_over_time(container_memory_rss{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          },
+          {
+            "function": "max",
+            "query": "max by(container, namespace) (max_over_time(container_memory_rss{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          },
+          {
+            "function": "sum",
+            "query": "sum by(container, namespace) (avg_over_time(container_memory_rss{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          }
+        ]
+      },
+      {
+        "name": "maxDate",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "max",
+            "query": "max by(namespace,container) (last_over_time((timestamp(container_cpu_usage_seconds_total{namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"} > 0))[15d:]))"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+</details>
+
+
+**Response**
+
+<details>
+<summary><b>Example Response</b></summary>
+
+### Example Response
+
+```json
+{
+  "message": "Metric Profile : resource-optimization-local-monitoring created successfully. View all metric profiles at /listMetricProfiles",
+  "httpcode": 201,
+  "documentationLink": "",
+  "status": "SUCCESS"
+}
+```
+
+</details>
+
+<br>
+
+<a name="list-metric-profiles-api"></a>
+
+### List Metric Profiles API
+
+This is quick guide instructions to retrieve metric profiles created as follows.
+
+**Request Parameters**
+
+| Parameter | Type   | Required | Description                             |
+|-----------|--------|----------|-----------------------------------------|
+| name      | string | optional | The name of the metric profile          |
+| verbose   | string | optional | Flag to retrieve all the metric queries |
+
+**Request without passing parameters**
+
+`GET /listMetricProfiles`
+
+`curl -H 'Accept: application/json' http://<URL>:<PORT>/listMetricProfiles`
+
+Returns list of all the metric profile names created
+
+<details>
+<summary><b>Example Response</b></summary>
+
+### Example Response
+
+```json
+[
+  {
+    "name": "resource-optimization-local-monitoring"
+  },
+  {
+    "name": "resource-optimization-local-monitoring1"
+  }
+]
+```
+
+</details>
+
+<br>
+
+**Request with metric profile name**
+
+`GET /listMetricProfiles`
+
+`curl -H 'Accept: application/json' http://<URL>:<PORT>/listMetricProfiles?name=resource-optimization-local-monitoring`
+
+Returns metric profile of the name specified
+
+<details>
+<summary><b>Example Response</b></summary>
+
+### Example Response
+
+```json
+[
+  {
+    "apiVersion": "recommender.com/v1",
+    "kind": "KruizePerformanceProfile",
+    "metadata": {
+      "name": "resource-optimization-local-monitoring"
+    },
+    "profile_version": 1.0,
+    "k8s_type": "openshift",
+    "slo": {
+      "sloClass": "resource_usage",
+      "objective_function": {
+        "function_type": "source"
+      },
+      "direction": "minimize",
+      "function_variables": [
+        {
+          "name": "cpuRequest",
+          "datasource": "prometheus",
+          "value_type": "double",
+          "kubernetes_object": "container",
+          "aggregation_functions": {
+            "avg": {
+              "function": "avg",
+              "query": "avg by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD ', pod!='', resource='cpu', unit='core' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "min": {
+              "function": "min",
+              "query": "min by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='cpu', unit='core' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "max": {
+              "function": "max",
+              "query": "max by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='cpu', unit='core' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "sum": {
+              "function": "sum",
+              "query": "sum by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='cpu', unit='core' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            }
+          }
+        },
+        {
+          "name": "cpuLimit",
+          "datasource": "prometheus",
+          "value_type": "double",
+          "kubernetes_object": "container",
+          "aggregation_functions": {
+            "avg": {
+              "function": "avg",
+              "query": "avg by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='cpu', unit='core',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "min": {
+              "function": "min",
+              "query": "min by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='cpu', unit='core',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "max": {
+              "function": "max",
+              "query": "max by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='cpu', unit='core',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "sum": {
+              "function": "sum",
+              "query": "sum by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='cpu', unit='core',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            }
+          }
+        },
+        {
+          "name": "cpuUsage",
+          "datasource": "prometheus",
+          "value_type": "double",
+          "kubernetes_object": "container",
+          "aggregation_functions": {
+            "avg": {
+              "function": "avg",
+              "query": "avg by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "min": {
+              "function": "min",
+              "query": "min by(container, namespace)(min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "max": {
+              "function": "max",
+              "query": "max by(container, namespace)(max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "sum": {
+              "function": "sum",
+              "query": "sum by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            }
+          }
+        },
+        {
+          "name": "cpuThrottle",
+          "datasource": "prometheus",
+          "value_type": "double",
+          "kubernetes_object": "container",
+          "aggregation_functions": {
+            "avg": {
+              "function": "avg",
+              "query": "avg by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "min": {
+              "function": "min",
+              "query": "min by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "max": {
+              "function": "max",
+              "query": "max by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "sum": {
+              "function": "sum",
+              "query": "sum by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            }
+          }
+        },
+        {
+          "name": "memoryRequest",
+          "datasource": "prometheus",
+          "value_type": "double",
+          "kubernetes_object": "container",
+          "aggregation_functions": {
+            "avg": {
+              "function": "avg",
+              "query": "avg by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='memory', unit='byte' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "min": {
+              "function": "min",
+              "query": "min by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='memory', unit='byte' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "max": {
+              "function": "max",
+              "query": "max by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='memory', unit='byte' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "sum": {
+              "function": "sum",
+              "query": "sum by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='memory', unit='byte' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            }
+          }
+        },
+        {
+          "name": "memoryLimit",
+          "datasource": "prometheus",
+          "value_type": "double",
+          "kubernetes_object": "container",
+          "aggregation_functions": {
+            "avg": {
+              "function": "avg",
+              "query": "avg by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='memory', unit='byte',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "min": {
+              "function": "min",
+              "query": "min by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='memory', unit='byte',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "max": {
+              "function": "max",
+              "query": "max by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='memory', unit='byte',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "sum": {
+              "function": "sum",
+              "query": "sum by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='memory', unit='byte',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            }
+          }
+        },
+        {
+          "name": "memoryUsage",
+          "datasource": "prometheus",
+          "value_type": "double",
+          "kubernetes_object": "container",
+          "aggregation_functions": {
+            "avg": {
+              "function": "avg",
+              "query": "avg by(container, namespace) (avg_over_time(container_memory_working_set_bytes{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "min": {
+              "function": "min",
+              "query": "min by(container, namespace) (min_over_time(container_memory_working_set_bytes{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "max": {
+              "function": "max",
+              "query": "max by(container, namespace) (max_over_time(container_memory_working_set_bytes{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "sum": {
+              "function": "sum",
+              "query": "sum by(container, namespace) (avg_over_time(container_memory_working_set_bytes{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            }
+          }
+        },
+        {
+          "name": "memoryRSS",
+          "datasource": "prometheus",
+          "value_type": "double",
+          "kubernetes_object": "container",
+          "aggregation_functions": {
+            "avg": {
+              "function": "avg",
+              "query": "avg by(container, namespace) (avg_over_time(container_memory_rss{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "min": {
+              "function": "min",
+              "query": "min by(container, namespace) (min_over_time(container_memory_rss{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "max": {
+              "function": "max",
+              "query": "max by(container, namespace) (max_over_time(container_memory_rss{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "sum": {
+              "function": "sum",
+              "query": "sum by(container, namespace) (avg_over_time(container_memory_rss{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            }
+          }
+        },
+        {
+          "name": "maxDate",
+          "datasource": "prometheus",
+          "value_type": "double",
+          "kubernetes_object": "container",
+          "aggregation_functions": {
+            "max": {
+              "function": "max",
+              "query": "max by(namespace,container) (last_over_time((timestamp(container_cpu_usage_seconds_total{namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"} > 0))[15d:]))"
+            }
+          }
+        }
+      ]
+    }
+  }
+]
+```
+
+</details>
+
+<br>
+
+**Request**
+
+`GET /listMetricProfiles`
+
+`curl -H 'Accept: application/json' http://<URL>:<PORT>/listMetricProfiles?verbose=true`
+
+Returns list of all the metric profile created with all the metric queries
+
+<details>
+<summary><b>Example Response</b></summary>
+
+### Example Response
+
+```json
+[
+  {
+    "apiVersion": "recommender.com/v1",
+    "kind": "KruizePerformanceProfile",
+    "metadata": {
+      "name": "resource-optimization-local-monitoring"
+    },
+    "profile_version": 1.0,
+    "k8s_type": "openshift",
+    "slo": {
+      "sloClass": "resource_usage",
+      "objective_function": {
+        "function_type": "source"
+      },
+      "direction": "minimize",
+      "function_variables": [
+        {
+          "name": "cpuRequest",
+          "datasource": "prometheus",
+          "value_type": "double",
+          "kubernetes_object": "container",
+          "aggregation_functions": {
+            "avg": {
+              "function": "avg",
+              "query": "avg by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD ', pod!='', resource='cpu', unit='core' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "min": {
+              "function": "min",
+              "query": "min by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='cpu', unit='core' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "max": {
+              "function": "max",
+              "query": "max by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='cpu', unit='core' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "sum": {
+              "function": "sum",
+              "query": "sum by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='cpu', unit='core' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            }
+          }
+        },
+        {
+          "name": "cpuLimit",
+          "datasource": "prometheus",
+          "value_type": "double",
+          "kubernetes_object": "container",
+          "aggregation_functions": {
+            "avg": {
+              "function": "avg",
+              "query": "avg by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='cpu', unit='core',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "min": {
+              "function": "min",
+              "query": "min by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='cpu', unit='core',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "max": {
+              "function": "max",
+              "query": "max by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='cpu', unit='core',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "sum": {
+              "function": "sum",
+              "query": "sum by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='cpu', unit='core',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            }
+          }
+        },
+        {
+          "name": "cpuUsage",
+          "datasource": "prometheus",
+          "value_type": "double",
+          "kubernetes_object": "container",
+          "aggregation_functions": {
+            "avg": {
+              "function": "avg",
+              "query": "avg by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "min": {
+              "function": "min",
+              "query": "min by(container, namespace)(min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "max": {
+              "function": "max",
+              "query": "max by(container, namespace)(max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "sum": {
+              "function": "sum",
+              "query": "sum by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            }
+          }
+        },
+        {
+          "name": "cpuThrottle",
+          "datasource": "prometheus",
+          "value_type": "double",
+          "kubernetes_object": "container",
+          "aggregation_functions": {
+            "avg": {
+              "function": "avg",
+              "query": "avg by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "min": {
+              "function": "min",
+              "query": "min by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "max": {
+              "function": "max",
+              "query": "max by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "sum": {
+              "function": "sum",
+              "query": "sum by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            }
+          }
+        },
+        {
+          "name": "memoryRequest",
+          "datasource": "prometheus",
+          "value_type": "double",
+          "kubernetes_object": "container",
+          "aggregation_functions": {
+            "avg": {
+              "function": "avg",
+              "query": "avg by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='memory', unit='byte' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "min": {
+              "function": "min",
+              "query": "min by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='memory', unit='byte' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "max": {
+              "function": "max",
+              "query": "max by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='memory', unit='byte' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "sum": {
+              "function": "sum",
+              "query": "sum by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='memory', unit='byte' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            }
+          }
+        },
+        {
+          "name": "memoryLimit",
+          "datasource": "prometheus",
+          "value_type": "double",
+          "kubernetes_object": "container",
+          "aggregation_functions": {
+            "avg": {
+              "function": "avg",
+              "query": "avg by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='memory', unit='byte',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "min": {
+              "function": "min",
+              "query": "min by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='memory', unit='byte',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "max": {
+              "function": "max",
+              "query": "max by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='memory', unit='byte',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "sum": {
+              "function": "sum",
+              "query": "sum by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='memory', unit='byte',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            }
+          }
+        },
+        {
+          "name": "memoryUsage",
+          "datasource": "prometheus",
+          "value_type": "double",
+          "kubernetes_object": "container",
+          "aggregation_functions": {
+            "avg": {
+              "function": "avg",
+              "query": "avg by(container, namespace) (avg_over_time(container_memory_working_set_bytes{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "min": {
+              "function": "min",
+              "query": "min by(container, namespace) (min_over_time(container_memory_working_set_bytes{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "max": {
+              "function": "max",
+              "query": "max by(container, namespace) (max_over_time(container_memory_working_set_bytes{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "sum": {
+              "function": "sum",
+              "query": "sum by(container, namespace) (avg_over_time(container_memory_working_set_bytes{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            }
+          }
+        },
+        {
+          "name": "memoryRSS",
+          "datasource": "prometheus",
+          "value_type": "double",
+          "kubernetes_object": "container",
+          "aggregation_functions": {
+            "avg": {
+              "function": "avg",
+              "query": "avg by(container, namespace) (avg_over_time(container_memory_rss{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "min": {
+              "function": "min",
+              "query": "min by(container, namespace) (min_over_time(container_memory_rss{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "max": {
+              "function": "max",
+              "query": "max by(container, namespace) (max_over_time(container_memory_rss{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "sum": {
+              "function": "sum",
+              "query": "sum by(container, namespace) (avg_over_time(container_memory_rss{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            }
+          }
+        },
+        {
+          "name": "maxDate",
+          "datasource": "prometheus",
+          "value_type": "double",
+          "kubernetes_object": "container",
+          "aggregation_functions": {
+            "max": {
+              "function": "max",
+              "query": "max by(namespace,container) (last_over_time((timestamp(container_cpu_usage_seconds_total{namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"} > 0))[15d:]))"
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "apiVersion": "recommender.com/v1",
+    "kind": "KruizePerformanceProfile",
+    "metadata": {
+      "name": "resource-optimization-local-monitoring1"
+    },
+    "profile_version": 1.0,
+    "k8s_type": "openshift",
+    "slo": {
+      "sloClass": "resource_usage",
+      "objective_function": {
+        "function_type": "source"
+      },
+      "direction": "minimize",
+      "function_variables": [
+        {
+          "name": "cpuRequest",
+          "datasource": "prometheus",
+          "value_type": "double",
+          "kubernetes_object": "container",
+          "aggregation_functions": {
+            "avg": {
+              "function": "avg",
+              "query": "avg by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD ', pod!='', resource='cpu', unit='core' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "min": {
+              "function": "min",
+              "query": "min by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='cpu', unit='core' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "max": {
+              "function": "max",
+              "query": "max by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='cpu', unit='core' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "sum": {
+              "function": "sum",
+              "query": "sum by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='cpu', unit='core' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            }
+          }
+        },
+        {
+          "name": "cpuLimit",
+          "datasource": "prometheus",
+          "value_type": "double",
+          "kubernetes_object": "container",
+          "aggregation_functions": {
+            "avg": {
+              "function": "avg",
+              "query": "avg by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='cpu', unit='core',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "min": {
+              "function": "min",
+              "query": "min by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='cpu', unit='core',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "max": {
+              "function": "max",
+              "query": "max by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='cpu', unit='core',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "sum": {
+              "function": "sum",
+              "query": "sum by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='cpu', unit='core',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            }
+          }
+        },
+        {
+          "name": "cpuUsage",
+          "datasource": "prometheus",
+          "value_type": "double",
+          "kubernetes_object": "container",
+          "aggregation_functions": {
+            "avg": {
+              "function": "avg",
+              "query": "avg by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "min": {
+              "function": "min",
+              "query": "min by(container, namespace)(min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "max": {
+              "function": "max",
+              "query": "max by(container, namespace)(max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "sum": {
+              "function": "sum",
+              "query": "sum by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            }
+          }
+        },
+        {
+          "name": "cpuThrottle",
+          "datasource": "prometheus",
+          "value_type": "double",
+          "kubernetes_object": "container",
+          "aggregation_functions": {
+            "avg": {
+              "function": "avg",
+              "query": "avg by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "min": {
+              "function": "min",
+              "query": "min by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "max": {
+              "function": "max",
+              "query": "max by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "sum": {
+              "function": "sum",
+              "query": "sum by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            }
+          }
+        },
+        {
+          "name": "memoryRequest",
+          "datasource": "prometheus",
+          "value_type": "double",
+          "kubernetes_object": "container",
+          "aggregation_functions": {
+            "avg": {
+              "function": "avg",
+              "query": "avg by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='memory', unit='byte' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "min": {
+              "function": "min",
+              "query": "min by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='memory', unit='byte' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "max": {
+              "function": "max",
+              "query": "max by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='memory', unit='byte' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "sum": {
+              "function": "sum",
+              "query": "sum by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='memory', unit='byte' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            }
+          }
+        },
+        {
+          "name": "memoryLimit",
+          "datasource": "prometheus",
+          "value_type": "double",
+          "kubernetes_object": "container",
+          "aggregation_functions": {
+            "avg": {
+              "function": "avg",
+              "query": "avg by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='memory', unit='byte',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "min": {
+              "function": "min",
+              "query": "min by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='memory', unit='byte',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "max": {
+              "function": "max",
+              "query": "max by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='memory', unit='byte',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            },
+            "sum": {
+              "function": "sum",
+              "query": "sum by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='memory', unit='byte',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            }
+          }
+        },
+        {
+          "name": "memoryUsage",
+          "datasource": "prometheus",
+          "value_type": "double",
+          "kubernetes_object": "container",
+          "aggregation_functions": {
+            "avg": {
+              "function": "avg",
+              "query": "avg by(container, namespace) (avg_over_time(container_memory_working_set_bytes{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "min": {
+              "function": "min",
+              "query": "min by(container, namespace) (min_over_time(container_memory_working_set_bytes{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "max": {
+              "function": "max",
+              "query": "max by(container, namespace) (max_over_time(container_memory_working_set_bytes{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "sum": {
+              "function": "sum",
+              "query": "sum by(container, namespace) (avg_over_time(container_memory_working_set_bytes{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            }
+          }
+        },
+        {
+          "name": "memoryRSS",
+          "datasource": "prometheus",
+          "value_type": "double",
+          "kubernetes_object": "container",
+          "aggregation_functions": {
+            "avg": {
+              "function": "avg",
+              "query": "avg by(container, namespace) (avg_over_time(container_memory_rss{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "min": {
+              "function": "min",
+              "query": "min by(container, namespace) (min_over_time(container_memory_rss{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "max": {
+              "function": "max",
+              "query": "max by(container, namespace) (max_over_time(container_memory_rss{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            },
+            "sum": {
+              "function": "sum",
+              "query": "sum by(container, namespace) (avg_over_time(container_memory_rss{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            }
+          }
+        },
+        {
+          "name": "maxDate",
+          "datasource": "prometheus",
+          "value_type": "double",
+          "kubernetes_object": "container",
+          "aggregation_functions": {
+            "max": {
+              "function": "max",
+              "query": "max by(namespace,container) (last_over_time((timestamp(container_cpu_usage_seconds_total{namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"} > 0))[15d:]))"
+            }
+          }
+        }
+      ]
+    }
+  }
+]
 ```
 
 </details>

--- a/design/MetricProfileAPI.md
+++ b/design/MetricProfileAPI.md
@@ -1,0 +1,1019 @@
+# Metric Profile
+
+The metric profile contains a list of queries used to retrieve metrics such as CPU usage, throttling, memory
+usage, and more. Users can create metric profiles based on their cluster or datasource provider, such as Prometheus or
+Thanos. These profiles can be tagged to create experiment APIs, which will then fetch metrics according to the metric
+profile to generate recommendations.
+
+This article describes how to add and list Metric Profiles with REST APIs using curl command.
+Documentation still in progress stay tuned.
+
+# Attributes
+
+- **apiVersion** \
+  A string representing version of the Kubernetes API to create metric profile
+- **kind** \
+  A string representing type of kubernetes object
+- **metadata** \
+  A JSON object containing Data that helps to uniquely identify the metric profile, including a name string
+    - **name** \
+      A unique string name for identifying each metric profile.
+- **profile_version** \
+  a double value specifying the current version of the profile.
+- **slo** \
+  Service Level Objective containing the _direction_, _objective_function_ and _function_variables_
+    - **slo_class** \
+      a standard slo "bucket" defined by Kruize. Can be "_resource_usage_", "_throughput_" or "_response_time_"
+    - **direction** \
+      based on the slo_class, it can be '_maximize_' or '_minimize_'
+    - **objective_function** \
+      Define the performance objective here.
+        - **function_type** \
+          can be specified as '_source_' (a java file) or as an '_expression_'(algebraic). If it's an expression, it needs to defined below.
+        - **expression** \
+          an algebraic expression that details the calculation using function variables. Only valid if the "_function_type_" is "expression"
+    - **function_variables** \
+      Define the variables used in the _objective_function_
+        - **name** \
+          name of the variable
+        - **datasource** \
+          datasource of the query
+        - **value_type** \
+          can be double or integer
+        - **query** \
+          one of the query or _aggregation_functions_ is mandatory. Both can be present.
+        - **kubernetes_object** \
+          k8s object that this query is tied to: "_deployment_", "_pod_" or "_container_"
+        - **aggregation_functions** \
+          aggregate functions associated with this variable
+            - **function** \
+              can be '_avg_', '_sum_', '_min_', '_max_'
+            - **query** \
+              corresponding query
+            - **versions** \
+              Any specific versions that this query is tied to
+
+
+## CreateMetricProfile
+
+This is quick guide instructions to create metric profile using input JSON as follows.
+
+**Request**
+`POST /createMetricProfile`
+
+`curl -H 'Accept: application/json' -X POST --data 'copy paste below JSON' http://<URL>:<PORT>/createMetricProfile`
+
+```
+{
+    "apiVersion": "recommender.com/v1",
+    "kind": "KruizePerformanceProfile",
+    "metadata": {
+        "name": "resource-optimization-openshift"
+    },
+    "profile_version": 1,
+    "k8s_type": "openshift",
+    "slo": {
+        "slo_class": "resource_usage",
+        "direction": "minimize",
+        "objective_function": {
+            "function_type": "source"
+        },
+        "function_variables": [
+            {
+                "name": "cpuRequest",
+                "datasource": "prometheus",
+                "value_type": "double",
+                "kubernetes_object": "container",
+                "aggregation_functions": [
+                    {
+                        "function": "avg",
+                        "query": "avg by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD ', pod!='', resource='cpu', unit='core' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                    },
+                    {
+                        "function": "sum",
+                        "query": "sum by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='cpu', unit='core' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                    },
+                    {
+                        "function": "min",
+                        "query": "min by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='cpu', unit='core' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                    },
+                    {
+                        "function": "max",
+                        "query": "max by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='cpu', unit='core' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                    }
+                ]
+            },
+            {
+                "name": "cpuLimit",
+                "datasource": "prometheus",
+                "value_type": "double",
+                "kubernetes_object": "container",
+                "aggregation_functions": [
+                    {
+                        "function": "avg",
+                        "query": "avg by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='cpu', unit='core',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                    },
+                    {
+                        "function": "sum",
+                        "query": "sum by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='cpu', unit='core',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                    },
+                    {
+                        "function": "max",
+                        "query": "max by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='cpu', unit='core',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                    },
+                    {
+                        "function": "min",
+                        "query": "min by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='cpu', unit='core',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                    }
+                ]
+            },
+            {
+                "name": "cpuUsage",
+                "datasource": "prometheus",
+                "value_type": "double",
+                "kubernetes_object": "container",
+                "aggregation_functions": [
+                    {
+                        "function": "avg",
+                        "query": "avg by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))"
+
+                    },
+                    {
+                        "function": "min",
+                        "query": "min by(container, namespace)(min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))"
+
+                    },
+                    {
+                        "function": "max",
+                        "query": "max by(container, namespace)(max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))"
+
+                    },
+                    {
+                        "function": "sum",
+                        "query": "sum by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))"
+                    }
+                ]
+            },
+            {
+                "name": "cpuThrottle",
+                "datasource": "prometheus",
+                "value_type": "double",
+                "kubernetes_object": "container",
+                "aggregation_functions": [
+                    {
+                        "function": "avg",
+                        "query": "avg by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+                    },
+                    {
+                        "function": "max",
+                        "query": "max by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+                    },
+                    {
+                        "function": "min",
+                        "query": "min by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+                    },
+                    {
+                        "function": "sum",
+                        "query": "sum by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+                    }
+                ]
+            },
+            {
+                "name": "memoryRequest",
+                "datasource": "prometheus",
+                "value_type": "double",
+                "kubernetes_object": "container",
+                "aggregation_functions": [
+                    {
+                        "function": "avg",
+                        "query": "avg by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='memory', unit='byte' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                    },
+                    {
+                        "function": "sum",
+                        "query": "sum by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='memory', unit='byte' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                    },
+                    {
+                        "function": "max",
+                        "query": "max by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='memory', unit='byte' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                    },
+                    {
+                        "function": "min",
+                        "query": "min by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='memory', unit='byte' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                    }
+                ]
+            },
+            {
+                "name": "memoryLimit",
+                "datasource": "prometheus",
+                "value_type": "double",
+                "kubernetes_object": "container",
+                "aggregation_functions": [
+                    {
+                        "function": "avg",
+                        "query": "avg by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='memory', unit='byte',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                    },
+                    {
+                        "function": "sum",
+                        "query": "sum by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='memory', unit='byte',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                    },
+                    {
+                        "function": "max",
+                        "query": "max by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='memory', unit='byte',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                    },
+                    {
+                        "function": "min",
+                        "query": "min by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='memory', unit='byte',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                    }
+                ]
+            },
+            {
+                "name": "memoryUsage",
+                "datasource": "prometheus",
+                "value_type": "double",
+                "kubernetes_object": "container",
+                "aggregation_functions": [
+                    {
+                        "function": "avg",
+                        "query": "avg by(container, namespace) (avg_over_time(container_memory_working_set_bytes{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+                    },
+                    {
+                        "function": "min",
+                        "query": "min by(container, namespace) (min_over_time(container_memory_working_set_bytes{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))"
+                    },
+                    {
+                        "function": "max",
+                        "query": "max by(container, namespace) (max_over_time(container_memory_working_set_bytes{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+                    },
+                    {
+                        "function": "sum",
+                        "query": "sum by(container, namespace) (avg_over_time(container_memory_working_set_bytes{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+                    }
+                ]
+            },
+            {
+                "name": "memoryRSS",
+                "datasource": "prometheus",
+                "value_type": "double",
+                "kubernetes_object": "container",
+                "aggregation_functions": [
+                    {
+                        "function": "avg",
+                        "query": "avg by(container, namespace) (avg_over_time(container_memory_rss{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+                    },
+                    {
+                        "function": "min",
+                        "query": "min by(container, namespace) (min_over_time(container_memory_rss{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+                    },
+                    {
+                        "function": "max",
+                        "query": "max by(container, namespace) (max_over_time(container_memory_rss{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+                    },
+                    {
+                        "function": "sum",
+                        "query": "sum by(container, namespace) (avg_over_time(container_memory_rss{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+                    }
+                ]
+            },
+            {
+                "name": "maxDate",
+                "datasource": "prometheus",
+                "value_type": "double",
+                "kubernetes_object": "container",
+                "aggregation_functions": [
+                    {
+                        "function": "max",
+                        "query": "max by(namespace,container) (last_over_time((timestamp(container_cpu_usage_seconds_total{namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"} > 0))[15d:]))"
+                    }
+                ]
+            },
+            {
+                "name": "namespaceCpuRequest",
+                "datasource": "prometheus",
+                "value_type": "double",
+                "kubernetes_object": "namespace",
+                "aggregation_functions": [
+                    {
+                        "function": "sum",
+                        "query": "sum by (namespace) (kube_resourcequota{namespace=\"$NAMESPACE$\", resource=\"requests.cpu\", type=\"hard\"})",
+                        "version": ""
+                    }
+                ]
+            },
+            {
+                "name": "namespaceCpuLimit",
+                "datasource": "prometheus",
+                "value_type": "double",
+                "kubernetes_object": "namespace",
+                "aggregation_functions": [
+                    {
+                        "function": "sum",
+                        "query": "sum by (namespace) (kube_resourcequota{namespace=\"$NAMESPACE$\", resource=\"limits.cpu\", type=\"hard\"})",
+                        "version": ""
+                    }
+                ]
+            },
+            {
+                "name": "namespaceMemoryRequest",
+                "datasource": "prometheus",
+                "value_type": "double",
+                "kubernetes_object": "namespace",
+                "aggregation_functions": [
+                    {
+                        "function": "sum",
+                        "query": "sum by (namespace) (kube_resourcequota{namespace=\"$NAMESPACE$\", resource=\"requests.memory\", type=\"hard\"})",
+                        "version": ""
+                    }
+                ]
+            },
+            {
+                "name": "namespaceMemoryLimit",
+                "datasource": "prometheus",
+                "value_type": "double",
+                "kubernetes_object": "namespace",
+                "aggregation_functions": [
+                    {
+                        "function": "sum",
+                        "query": "sum by (namespace) (kube_resourcequota{namespace=\"$NAMESPACE$\", resource=\"limits.memory\", type=\"hard\"})",
+                        "version": ""
+                    }
+                ]
+            },
+            {
+                "name": "namespaceCpuUsage",
+                "datasource": "prometheus",
+                "value_type": "double",
+                "kubernetes_object": "namespace",
+                "aggregation_functions": [
+                    {
+                        "function": "avg",
+                        "query": "avg_over_time(sum by(namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''})[$MEASUREMENT_DURATION_IN_MIN$m:])",
+                        "version": ""
+                    },
+                    {
+                        "function": "max",
+                        "query": "max_over_time(sum by(namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''})[$MEASUREMENT_DURATION_IN_MIN$m:])",
+                        "version": ""
+                    },
+                    {
+                        "function": "min",
+                        "query": "min_over_time(sum by(namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''})[$MEASUREMENT_DURATION_IN_MIN$m:])",
+                        "version": ""
+                    }
+                ]
+            },
+            {
+                "name": "namespaceCpuThrottle",
+                "datasource": "prometheus",
+                "value_type": "double",
+                "kubernetes_object": "namespace",
+                "aggregation_functions": [
+                    {
+                        "function": "avg",
+                        "query": "avg_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''}[5m]))[$MEASUREMENT_DURATION_IN_MIN$m:])",
+                        "version": ""
+                    },
+                    {
+                        "function": "max",
+                        "query": "max_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''}[5m]))[$MEASUREMENT_DURATION_IN_MIN$m:])",
+                        "version": ""
+                    },
+                    {
+                        "function": "min",
+                        "query": "min_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''}[5m]))[$MEASUREMENT_DURATION_IN_MIN$m:])",
+                        "version": ""
+                    }
+                ]
+            },
+            {
+                "name": "namespaceMemoryUsage",
+                "datasource": "prometheus",
+                "value_type": "double",
+                "kubernetes_object": "namespace",
+                "aggregation_functions": [
+                    {
+                        "function": "avg",
+                        "query": "avg_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''})[$MEASUREMENT_DURATION_IN_MIN$m:])",
+                        "version": ""
+                    },
+                    {
+                        "function": "max",
+                        "query": "max_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''})[$MEASUREMENT_DURATION_IN_MIN$m:])",
+                        "version": ""
+                    },
+                    {
+                        "function": "min",
+                        "query": "min_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''})[$MEASUREMENT_DURATION_IN_MIN$m:])",
+                        "version": ""
+                    }
+                ]
+            },
+            {
+                "name": "namespaceMemoryRSS",
+                "datasource": "prometheus",
+                "value_type": "double",
+                "kubernetes_object": "namespace",
+                "aggregation_functions": [
+                    {
+                        "function": "avg",
+                        "query": "avg_over_time(sum by(namespace) (container_memory_rss{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''})[$MEASUREMENT_DURATION_IN_MIN$m:])",
+                        "version": ""
+                    },
+                    {
+                        "function": "max",
+                        "query": "max_over_time(sum by(namespace) (container_memory_rss{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''})[$MEASUREMENT_DURATION_IN_MIN$m:])",
+                        "version": ""
+                    },
+                    {
+                        "function": "min",
+                        "query": "min_over_time(sum by(namespace) (container_memory_rss{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''})[$MEASUREMENT_DURATION_IN_MIN$m:])",
+                        "version": ""
+                    }
+                ]
+            },
+            {
+                "name": "namespaceTotalPods",
+                "datasource": "prometheus",
+                "value_type": "double",
+                "kubernetes_object": "namespace",
+                "aggregation_functions": [
+                    {
+                        "function": "sum",
+                        "query": "sum(count(kube_pod_status_phase{namespace=\"$NAMESPACE$\"}))",
+                        "version": ""
+                    }
+                ]
+            },
+            {
+                "name": "namespaceRunningPods",
+                "datasource": "prometheus",
+                "value_type": "double",
+                "kubernetes_object": "namespace",
+                "aggregation_functions": [
+                    {
+                        "function": "sum",
+                        "query": "sum(count(kube_pod_status_phase{namespace=\"$NAMESPACE$\", phase=\"Running\"}))",
+                        "version": ""
+                    }
+                ]
+            },
+            {
+                "name": "gpuCoreUsage",
+                "datasource": "prometheus",
+                "value_type": "double",
+                "kubernetes_object": "container",
+                "aggregation_functions": [
+                    {
+                        "function": "avg",
+                        "query": "avg by (Hostname,device,modelName,UUID,exported_container,exported_namespace) (avg_over_time(DCGM_FI_DEV_GPU_UTIL{exported_namespace=\"$NAMESPACE$\",exported_container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))",
+                        "version": ""
+                    },
+                    {
+                        "function": "min",
+                        "query": "min by (Hostname,device,modelName,UUID,exported_container,exported_namespace) (min_over_time(DCGM_FI_DEV_GPU_UTIL{exported_namespace=\"$NAMESPACE$\",exported_container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))",
+                        "version": ""
+                    },
+                    {
+                        "function": "max",
+                        "query": "max by (Hostname,device,modelName,UUID,exported_container,exported_namespace) (max_over_time(DCGM_FI_DEV_GPU_UTIL{exported_namespace=\"$NAMESPACE$\",exported_container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))",
+                        "version": ""
+                    }
+                ]
+            },
+            {
+                "name": "gpuMemoryUsage",
+                "datasource": "prometheus",
+                "value_type": "double",
+                "kubernetes_object": "container",
+                "aggregation_functions": [
+                    {
+                        "function": "avg",
+                        "query": "avg by (Hostname,device,modelName,UUID,exported_container,exported_namespace) (avg_over_time(DCGM_FI_DEV_MEM_COPY_UTIL{exported_namespace=\"$NAMESPACE$\",exported_container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))",
+                        "version": ""
+                    },
+                    {
+                        "function": "min",
+                        "query": "min by (Hostname,device,modelName,UUID,exported_container,exported_namespace) (min_over_time(DCGM_FI_DEV_MEM_COPY_UTIL{exported_namespace=\"$NAMESPACE$\",exported_container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))",
+                        "version": ""
+                    },
+                    {
+                        "function": "max",
+                        "query": "max by (Hostname,device,modelName,UUID,exported_container,exported_namespace) (max_over_time(DCGM_FI_DEV_MEM_COPY_UTIL{exported_namespace=\"$NAMESPACE$\",exported_container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))",
+                        "version": ""
+                    }
+                ]
+            }
+        ]
+    }
+}
+```
+
+**Response**
+
+* Success
+```
+{
+    "message": "Metric Profile : <name> created successfully. View all metric profiles at /listMetricProfiles",
+    "httpcode": 201,
+    "documentationLink": "",
+    "status": "SUCCESS"
+}
+```
+
+* Failure
+    * Duplicate Metric Profile name.
+  ```
+  {
+      "message": "Metric Profile already exists",
+      "httpcode": 409,
+      "documentationLink": "",
+      "status": "ERROR"
+  }
+  ```
+    * Mandatory parameters are missing.
+  ```
+  {
+      "message": "Missing mandatory parameters",
+      "httpcode": 400,
+      "documentationLink": "",
+      "status": "ERROR"
+  }
+  ```
+    * Any unknown exception on server side
+  ```
+  {
+      "message": "Internal Server Error",
+      "httpcode": 500,
+      "documentationLink": "",
+      "status": "ERROR"
+  }
+  ```
+#### Note: One of query or aggregation_functions is mandatory. Both can be present together.
+
+## List Metric Profiles
+
+List metric profiles output JSON as follows.
+
+**Request**
+`GET /listMetricProfiles`
+
+`curl -H 'Accept: application/json' http://<URL>:<PORT>/listMetricProfiles`
+
+**Response**
+```
+[
+    {
+        "name": "resource-optimization-openshift"
+    }
+]
+```
+
+**Request**
+`GET /listMetricProfiles`
+
+`curl -H 'Accept: application/json' http://<URL>:<PORT>/listMetricProfiles?name=resource-optimization-openshift`
+
+
+**Response**
+
+```
+[
+    {
+        "apiVersion": "recommender.com/v1",
+        "kind": "KruizePerformanceProfile",
+        "metadata": {
+            "name": "resource-optimization-openshift"
+        },
+        "profile_version": 1.0,
+        "k8s_type": "openshift",
+        "slo": {
+            "sloClass": "resource_usage",
+            "objective_function": {
+                "function_type": "source"
+            },
+            "direction": "minimize",
+            "function_variables": [
+                {
+                    "name": "cpuRequest",
+                    "datasource": "prometheus",
+                    "value_type": "double",
+                    "kubernetes_object": "container",
+                    "aggregation_functions": {
+                        "avg": {
+                            "function": "avg",
+                            "query": "avg by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD ', pod!='', resource='cpu', unit='core' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                        },
+                        "min": {
+                            "function": "min",
+                            "query": "min by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='cpu', unit='core' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                        },
+                        "max": {
+                            "function": "max",
+                            "query": "max by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='cpu', unit='core' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                        },
+                        "sum": {
+                            "function": "sum",
+                            "query": "sum by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='cpu', unit='core' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                        }
+                    }
+                },
+                {
+                    "name": "cpuLimit",
+                    "datasource": "prometheus",
+                    "value_type": "double",
+                    "kubernetes_object": "container",
+                    "aggregation_functions": {
+                        "avg": {
+                            "function": "avg",
+                            "query": "avg by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='cpu', unit='core',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                        },
+                        "min": {
+                            "function": "min",
+                            "query": "min by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='cpu', unit='core',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                        },
+                        "max": {
+                            "function": "max",
+                            "query": "max by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='cpu', unit='core',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                        },
+                        "sum": {
+                            "function": "sum",
+                            "query": "sum by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='cpu', unit='core',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                        }
+                    }
+                },
+                {
+                    "name": "cpuUsage",
+                    "datasource": "prometheus",
+                    "value_type": "double",
+                    "kubernetes_object": "container",
+                    "aggregation_functions": {
+                        "avg": {
+                            "function": "avg",
+                            "query": "avg by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))"
+                        },
+                        "min": {
+                            "function": "min",
+                            "query": "min by(container, namespace)(min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))"
+                        },
+                        "max": {
+                            "function": "max",
+                            "query": "max by(container, namespace)(max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))"
+                        },
+                        "sum": {
+                            "function": "sum",
+                            "query": "sum by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))"
+                        }
+                    }
+                },
+                {
+                    "name": "cpuThrottle",
+                    "datasource": "prometheus",
+                    "value_type": "double",
+                    "kubernetes_object": "container",
+                    "aggregation_functions": {
+                        "avg": {
+                            "function": "avg",
+                            "query": "avg by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+                        },
+                        "min": {
+                            "function": "min",
+                            "query": "min by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+                        },
+                        "max": {
+                            "function": "max",
+                            "query": "max by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+                        },
+                        "sum": {
+                            "function": "sum",
+                            "query": "sum by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+                        }
+                    }
+                },
+                {
+                    "name": "memoryRequest",
+                    "datasource": "prometheus",
+                    "value_type": "double",
+                    "kubernetes_object": "container",
+                    "aggregation_functions": {
+                        "avg": {
+                            "function": "avg",
+                            "query": "avg by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='memory', unit='byte' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                        },
+                        "min": {
+                            "function": "min",
+                            "query": "min by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='memory', unit='byte' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                        },
+                        "max": {
+                            "function": "max",
+                            "query": "max by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='memory', unit='byte' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                        },
+                        "sum": {
+                            "function": "sum",
+                            "query": "sum by(container, namespace) (kube_pod_container_resource_requests{container!='', container!='POD', pod!='', resource='memory', unit='byte' ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                        }
+                    }
+                },
+                {
+                    "name": "memoryLimit",
+                    "datasource": "prometheus",
+                    "value_type": "double",
+                    "kubernetes_object": "container",
+                    "aggregation_functions": {
+                        "avg": {
+                            "function": "avg",
+                            "query": "avg by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='memory', unit='byte',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                        },
+                        "min": {
+                            "function": "min",
+                            "query": "min by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='memory', unit='byte',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                        },
+                        "max": {
+                            "function": "max",
+                            "query": "max by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='memory', unit='byte',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                        },
+                        "sum": {
+                            "function": "sum",
+                            "query": "sum by(container,namespace) (kube_pod_container_resource_limits{container!='', container!='POD', pod!='', resource='memory', unit='byte',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+                        }
+                    }
+                },
+                {
+                    "name": "memoryUsage",
+                    "datasource": "prometheus",
+                    "value_type": "double",
+                    "kubernetes_object": "container",
+                    "aggregation_functions": {
+                        "avg": {
+                            "function": "avg",
+                            "query": "avg by(container, namespace) (avg_over_time(container_memory_working_set_bytes{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+                        },
+                        "min": {
+                            "function": "min",
+                            "query": "min by(container, namespace) (min_over_time(container_memory_working_set_bytes{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))"
+                        },
+                        "max": {
+                            "function": "max",
+                            "query": "max by(container, namespace) (max_over_time(container_memory_working_set_bytes{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+                        },
+                        "sum": {
+                            "function": "sum",
+                            "query": "sum by(container, namespace) (avg_over_time(container_memory_working_set_bytes{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+                        }
+                    }
+                },
+                {
+                    "name": "memoryRSS",
+                    "datasource": "prometheus",
+                    "value_type": "double",
+                    "kubernetes_object": "container",
+                    "aggregation_functions": {
+                        "avg": {
+                            "function": "avg",
+                            "query": "avg by(container, namespace) (avg_over_time(container_memory_rss{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+                        },
+                        "min": {
+                            "function": "min",
+                            "query": "min by(container, namespace) (min_over_time(container_memory_rss{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+                        },
+                        "max": {
+                            "function": "max",
+                            "query": "max by(container, namespace) (max_over_time(container_memory_rss{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+                        },
+                        "sum": {
+                            "function": "sum",
+                            "query": "sum by(container, namespace) (avg_over_time(container_memory_rss{container!='', container!='POD', pod!='',namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+                        }
+                    }
+                },
+                {
+                    "name": "maxDate",
+                    "datasource": "prometheus",
+                    "value_type": "double",
+                    "kubernetes_object": "container",
+                    "aggregation_functions": {
+                        "max": {
+                            "function": "max",
+                            "query": "max by(namespace,container) (last_over_time((timestamp(container_cpu_usage_seconds_total{namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"} > 0))[15d:]))"
+                        }
+                    }
+                },
+                {
+                    "name": "namespaceCpuRequest",
+                    "datasource": "prometheus",
+                    "value_type": "double",
+                    "kubernetes_object": "namespace",
+                    "aggregation_functions": {
+                        "sum": {
+                            "function": "sum",
+                            "query": "sum by (namespace) (kube_resourcequota{namespace=\"$NAMESPACE$\", resource=\"requests.cpu\", type=\"hard\"})",
+                            "version": ""
+                        }
+                    }
+                },
+                {
+                    "name": "namespaceCpuLimit",
+                    "datasource": "prometheus",
+                    "value_type": "double",
+                    "kubernetes_object": "namespace",
+                    "aggregation_functions": {
+                        "sum": {
+                            "function": "sum",
+                            "query": "sum by (namespace) (kube_resourcequota{namespace=\"$NAMESPACE$\", resource=\"limits.cpu\", type=\"hard\"})",
+                            "version": ""
+                        }
+                    }
+                },
+                {
+                    "name": "namespaceMemoryRequest",
+                    "datasource": "prometheus",
+                    "value_type": "double",
+                    "kubernetes_object": "namespace",
+                    "aggregation_functions": {
+                        "sum": {
+                            "function": "sum",
+                            "query": "sum by (namespace) (kube_resourcequota{namespace=\"$NAMESPACE$\", resource=\"requests.memory\", type=\"hard\"})",
+                            "version": ""
+                        }
+                    }
+                },
+                {
+                    "name": "namespaceMemoryLimit",
+                    "datasource": "prometheus",
+                    "value_type": "double",
+                    "kubernetes_object": "namespace",
+                    "aggregation_functions": {
+                        "sum": {
+                            "function": "sum",
+                            "query": "sum by (namespace) (kube_resourcequota{namespace=\"$NAMESPACE$\", resource=\"limits.memory\", type=\"hard\"})",
+                            "version": ""
+                        }
+                    }
+                },
+                {
+                    "name": "namespaceCpuUsage",
+                    "datasource": "prometheus",
+                    "value_type": "double",
+                    "kubernetes_object": "namespace",
+                    "aggregation_functions": {
+                        "avg": {
+                            "function": "avg",
+                            "query": "avg_over_time(sum by(namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''})[$MEASUREMENT_DURATION_IN_MIN$m:])",
+                            "version": ""
+                        },
+                        "min": {
+                            "function": "min",
+                            "query": "min_over_time(sum by(namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''})[$MEASUREMENT_DURATION_IN_MIN$m:])",
+                            "version": ""
+                        },
+                        "max": {
+                            "function": "max",
+                            "query": "max_over_time(sum by(namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''})[$MEASUREMENT_DURATION_IN_MIN$m:])",
+                            "version": ""
+                        }
+                    }
+                },
+                {
+                    "name": "namespaceCpuThrottle",
+                    "datasource": "prometheus",
+                    "value_type": "double",
+                    "kubernetes_object": "namespace",
+                    "aggregation_functions": {
+                        "avg": {
+                            "function": "avg",
+                            "query": "avg_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''}[5m]))[$MEASUREMENT_DURATION_IN_MIN$m:])",
+                            "version": ""
+                        },
+                        "min": {
+                            "function": "min",
+                            "query": "min_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''}[5m]))[$MEASUREMENT_DURATION_IN_MIN$m:])",
+                            "version": ""
+                        },
+                        "max": {
+                            "function": "max",
+                            "query": "max_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''}[5m]))[$MEASUREMENT_DURATION_IN_MIN$m:])",
+                            "version": ""
+                        }
+                    }
+                },
+                {
+                    "name": "namespaceMemoryUsage",
+                    "datasource": "prometheus",
+                    "value_type": "double",
+                    "kubernetes_object": "namespace",
+                    "aggregation_functions": {
+                        "avg": {
+                            "function": "avg",
+                            "query": "avg_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''})[$MEASUREMENT_DURATION_IN_MIN$m:])",
+                            "version": ""
+                        },
+                        "min": {
+                            "function": "min",
+                            "query": "min_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''})[$MEASUREMENT_DURATION_IN_MIN$m:])",
+                            "version": ""
+                        },
+                        "max": {
+                            "function": "max",
+                            "query": "max_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''})[$MEASUREMENT_DURATION_IN_MIN$m:])",
+                            "version": ""
+                        }
+                    }
+                },
+                {
+                    "name": "namespaceMemoryRSS",
+                    "datasource": "prometheus",
+                    "value_type": "double",
+                    "kubernetes_object": "namespace",
+                    "aggregation_functions": {
+                        "avg": {
+                            "function": "avg",
+                            "query": "avg_over_time(sum by(namespace) (container_memory_rss{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''})[$MEASUREMENT_DURATION_IN_MIN$m:])",
+                            "version": ""
+                        },
+                        "min": {
+                            "function": "min",
+                            "query": "min_over_time(sum by(namespace) (container_memory_rss{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''})[$MEASUREMENT_DURATION_IN_MIN$m:])",
+                            "version": ""
+                        },
+                        "max": {
+                            "function": "max",
+                            "query": "max_over_time(sum by(namespace) (container_memory_rss{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''})[$MEASUREMENT_DURATION_IN_MIN$m:])",
+                            "version": ""
+                        }
+                    }
+                },
+                {
+                    "name": "namespaceTotalPods",
+                    "datasource": "prometheus",
+                    "value_type": "double",
+                    "kubernetes_object": "namespace",
+                    "aggregation_functions": {
+                        "sum": {
+                            "function": "sum",
+                            "query": "sum(count(kube_pod_status_phase{namespace=\"$NAMESPACE$\"}))",
+                            "version": ""
+                        }
+                    }
+                },
+                {
+                    "name": "namespaceRunningPods",
+                    "datasource": "prometheus",
+                    "value_type": "double",
+                    "kubernetes_object": "namespace",
+                    "aggregation_functions": {
+                        "sum": {
+                            "function": "sum",
+                            "query": "sum(count(kube_pod_status_phase{namespace=\"$NAMESPACE$\", phase=\"Running\"}))",
+                            "version": ""
+                        }
+                    }
+                },
+                {
+                    "name": "gpuCoreUsage",
+                    "datasource": "prometheus",
+                    "value_type": "double",
+                    "kubernetes_object": "container",
+                    "aggregation_functions": {
+                        "avg": {
+                            "function": "avg",
+                            "query": "avg by (Hostname,device,modelName,UUID,exported_container,exported_namespace) (avg_over_time(DCGM_FI_DEV_GPU_UTIL{exported_namespace=\"$NAMESPACE$\",exported_container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))",
+                            "version": ""
+                        },
+                        "min": {
+                            "function": "min",
+                            "query": "min by (Hostname,device,modelName,UUID,exported_container,exported_namespace) (min_over_time(DCGM_FI_DEV_GPU_UTIL{exported_namespace=\"$NAMESPACE$\",exported_container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))",
+                            "version": ""
+                        },
+                        "max": {
+                            "function": "max",
+                            "query": "max by (Hostname,device,modelName,UUID,exported_container,exported_namespace) (max_over_time(DCGM_FI_DEV_GPU_UTIL{exported_namespace=\"$NAMESPACE$\",exported_container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))",
+                            "version": ""
+                        }
+                    }
+                },
+                {
+                    "name": "gpuMemoryUsage",
+                    "datasource": "prometheus",
+                    "value_type": "double",
+                    "kubernetes_object": "container",
+                    "aggregation_functions": {
+                        "avg": {
+                            "function": "avg",
+                            "query": "avg by (Hostname,device,modelName,UUID,exported_container,exported_namespace) (avg_over_time(DCGM_FI_DEV_MEM_COPY_UTIL{exported_namespace=\"$NAMESPACE$\",exported_container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))",
+                            "version": ""
+                        },
+                        "min": {
+                            "function": "min",
+                            "query": "min by (Hostname,device,modelName,UUID,exported_container,exported_namespace) (min_over_time(DCGM_FI_DEV_MEM_COPY_UTIL{exported_namespace=\"$NAMESPACE$\",exported_container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))",
+                            "version": ""
+                        },
+                        "max": {
+                            "function": "max",
+                            "query": "max by (Hostname,device,modelName,UUID,exported_container,exported_namespace) (max_over_time(DCGM_FI_DEV_MEM_COPY_UTIL{exported_namespace=\"$NAMESPACE$\",exported_container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))",
+                            "version": ""
+                        }
+                    }
+                }
+            ]
+        }
+    }
+]
+```

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.yaml
@@ -23,12 +23,17 @@ slo:
 
       aggregation_functions:
         - function: 'avg'
-          query: 'avg(kube_pod_container_resource_requests{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", container="$CONTAINER_NAME$", namespace="$NAMESPACE", resource="cpu", unit="core"})'
+          query: 'avg by(container, namespace) (kube_pod_container_resource_requests{container!='', container!="", container!="POD", pod!="", resource="cpu", unit="core" ,namespace="$NAMESPACE$",container="$CONTAINER_NAME$"})'
 
         # Show sum of cpu requests in bytes for a container in a deployment
         - function: 'sum'
-          query: 'sum(kube_pod_container_resource_requests{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", container="$CONTAINER_NAME$", namespace="$NAMESPACE", resource="cpu", unit="core"})'
+          query: 'sum by(container, namespace) (kube_pod_container_resource_requests{container!='', container!="", container!="POD", pod!="", resource="cpu", unit="core" ,namespace="$NAMESPACE$",container="$CONTAINER_NAME$"})'
 
+        - function: 'min'
+          query: 'min by(container, namespace) (kube_pod_container_resource_requests{container!='', container!="", container!="POD", pod!="", resource="cpu", unit="core" ,namespace="$NAMESPACE$",container="$CONTAINER_NAME$"})'
+
+        - function: 'max'
+          query: 'max by(container, namespace) (kube_pod_container_resource_requests{container!='', container!="", container!="POD", pod!="", resource="cpu", unit="core" ,namespace="$NAMESPACE$",container="$CONTAINER_NAME$"})'
 
     # CPU Limit
     # Show cpu limits in bytes for a container in a deployment
@@ -39,11 +44,17 @@ slo:
 
       aggregation_functions:
         - function: avg
-          query: 'avg(kube_pod_container_resource_limits{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", container="$CONTAINER_NAME$", namespace="$NAMESPACE", resource="cpu", unit="core"})'
+          query: 'avg by(container,namespace) (kube_pod_container_resource_limits{container!='', container!="", container!="POD", pod!="", resource="cpu", unit="core",namespace="$NAMESPACE$",container="$CONTAINER_NAME$"})'
 
         # Show sum of cpu limits in bytes for a container in a deployment
         - function: sum
-          query: 'sum(kube_pod_container_resource_limits{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", container="$CONTAINER_NAME$", namespace="$NAMESPACE$", resource="cpu", unit="core"})'
+          query: 'sum by(container,namespace) (kube_pod_container_resource_limits{container!='',container!="", container!="POD", pod!="", resource="cpu", unit="core",namespace="$NAMESPACE$",container="$CONTAINER_NAME$"})'
+
+        - function: 'max'
+          query: 'max by(container,namespace) (kube_pod_container_resource_limits{container!='', container!="", container!="POD", pod!="", resource="cpu", unit="core",namespace="$NAMESPACE$",container="$CONTAINER_NAME$"})'
+
+        - function: 'max'
+          query: 'min by(container,namespace) (kube_pod_container_resource_limits{container!='', container!="", container!="POD", pod!="", resource="cpu", unit="core",namespace="$NAMESPACE$",container="$CONTAINER_NAME$"})'
 
 
     # CPU Usage
@@ -65,45 +76,45 @@ slo:
       # For openshift versions <=4.8
       aggregation_functions:
         - function: avg
-          query: 'avg(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace="$NAMESPACE$", container=”$CONTAINER_NAME$”}[15m]))'
+          query: 'avg by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!='', container!="POD", pod!="",namespace="$NAMESPACE$",container="$CONTAINER_NAME$" }[$MEASUREMENT_DURATION_IN_MIN$m]))'
           versions: "<=4.8"
 
         # For openshift versions >=4.9
         - function: avg
-          query: 'avg(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace="$NAMESPACE$", container=”$CONTAINER_NAME$”}[15m]))'
+          query: 'avg by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!='', container!="POD", pod!="",namespace="$NAMESPACE$",container="$CONTAINER_NAME$" }[$MEASUREMENT_DURATION_IN_MIN$m]))'
           versions: ">4.9"
 
         # Approx minimum CPU per container in a deployment
         # For openshift versions <=4.8
         - function: min
-          query: 'min(min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[15m]))'
+          query: 'min by(container, namespace)(min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!='', container!="POD", pod!="",namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))'
           versions: "<=4.8"
 
         # For openshift versions >=4.9
         - function: min
-          query: 'min(min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[15m]))'
+          query: 'min by(container, namespace)(min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!='', container!="POD", pod!="",namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
           versions: ">4.9"
 
         # Approx maximum CPU per container in a deployment
         # For openshift versions <=4.8
         - function: max
-          query: 'max(max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[15m]))'
+          query: 'max by(container, namespace)(max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!='', container!="POD", pod!="",namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))'
           versions: "<=4.8"
 
         # For openshift versions >=4.9
         - function: max
-          query: 'max(max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[15m]))'
+          query: 'max by(container, namespace)(max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!='', container!="POD", pod!="",namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))'
           versions: ">4.9"
 
         # Sum of CPU usage for a container in all pods of a deployment
         # For openshift versions <=4.8
         - function: sum
-          query: 'sum(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[15m]))'
+          query: 'sum by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!='', container!="POD", pod!="",namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))'
           versions: "<=4.8"
 
         # For openshift versions >=4.9
         - function: sum
-          query: 'sum(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[15m]))'
+          query: 'sum by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!='', container!="POD", pod!="",namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))'
           versions: ">4.9"
 
 
@@ -116,15 +127,19 @@ slo:
       aggregation_functions:
         # Average CPU throttling per container in a deployment
         - function: avg
-          query: 'avg(rate(container_cpu_cfs_throttled_seconds_total{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace="$NAMESPACE$", container=”$CONTAINER_NAME$”}[15m]))'
+          query: 'avg by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!='', container!="POD", pod!="",namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
         # Maximum CPU throttling per container in a deployment
         - function: max
-          query: 'max(rate(container_cpu_cfs_throttled_seconds_total{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace="$NAMESPACE$", container=”$CONTAINER_NAME$”}[15m]))'
+          query: 'max by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!='', container!="POD", pod!="",namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m])))'
+
+        # Min of CPU throttling for a container in all pods of a deployment
+        - function: min
+          query: 'min by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!='', container!="POD", pod!="",namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m])'
 
         # Sum of CPU throttling for a container in all pods of a deployment
         - function: sum
-          query: 'sum(rate(container_cpu_cfs_throttled_seconds_total{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace="$NAMESPACE$", container=”$CONTAINER_NAME$”}[15m]))'
+          query: 'sum by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!='', container!="POD", pod!="",namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
 
 
@@ -139,11 +154,17 @@ slo:
 
       aggregation_functions:
         - function: avg
-          query: 'avg(kube_pod_container_resource_requests{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", container=”$CONTAINER_NAME$”, namespace=”$NAMESPACE”, resource="memory", unit="byte"})'
+          query: 'avg by(container, namespace) (kube_pod_container_resource_requests{container!='', container!="POD", pod!="", resource="memory", unit="byte" ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})'
 
         # Show sum of memory requests in bytes for a container in a deployment
         - function: sum
-          query: 'sum(kube_pod_container_resource_requests{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", container=”$CONTAINER_NAME$”, namespace=”$NAMESPACE”, resource="memory", unit="byte"})'
+          query: 'sum by(container, namespace) (kube_pod_container_resource_requests{container!='', container!="POD", pod!="", resource="memory", unit="byte" ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})'
+
+        - function: max
+          query: 'max by(container, namespace) (kube_pod_container_resource_requests{container!='', container!="POD", pod!="", resource="memory", unit="byte" ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})'
+
+        - function: min
+          query: 'min by(container, namespace) (kube_pod_container_resource_requests{container!='', container!="POD", pod!="", resource="memory", unit="byte" ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})'
 
 
     # Memory Limit
@@ -155,12 +176,17 @@ slo:
 
       aggregation_functions:
         - function: avg
-          query: 'avg(kube_pod_container_resource_limits{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", container="$CONTAINER_NAME$", namespace="$NAMESPACE", resource="memory", unit="byte"})'
+          query: 'avg by(container,namespace) (kube_pod_container_resource_limits{container!='', container!="POD", pod!="", resource="memory", unit="byte" ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})'
 
         # Show sum of memory limits in bytes for a container in a deployment
         - function: sum
-          query: 'sum(kube_pod_container_resource_limits{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", container=”$CONTAINER_NAME$”, namespace=”$NAMESPACE”, resource="memory", unit="byte"})'
+          query: 'sum by(container,namespace) (kube_pod_container_resource_limits{container!='', container!="POD", pod!="", resource="memory", unit="byte" ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})'
 
+        - function: max
+          query: 'max by(container,namespace) (kube_pod_container_resource_limits{container!='', container!="POD", pod!="", resource="memory", unit="byte" ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})'
+
+        - function: min
+          query: 'min by(container,namespace) (kube_pod_container_resource_limits{container!='', container!="POD", pod!="", resource="memory", unit="byte" ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})'
 
     # Memory Usage
     # Average memory per container in a deployment
@@ -171,19 +197,19 @@ slo:
 
       aggregation_functions:
         - function: avg
-          query: 'avg(avg_over_time(container_memory_working_set_bytes{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace=$NAMESPACE$, container=”$CONTAINER_NAME$”}[15m]))'
+          query: 'avg by(container, namespace) (avg_over_time(container_memory_working_set_bytes{container!='', container!="POD", pod!="", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
         # Approx minimum memory per container in a deployment
         - function: min
-          query: 'min(min_over_time(container_memory_working_set_bytes{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace=$NAMESPACE$, container="$CONTAINER_NAME$"}[15m]))'
+          query: 'min by(container, namespace) (min_over_time(container_memory_working_set_bytes{container!='', container!="POD", pod!="", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m])'
 
         # Approx maximum memory per container in a deployment
         - function: max
-          query: 'max(max_over_time(container_memory_working_set_bytes{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace=$NAMESPACE$, container="$CONTAINER_NAME$"}[15m]))'
+          query: 'max by(container, namespace) (max_over_time(container_memory_working_set_bytes{container!='', container!="POD", pod!="", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
         # Sum of memory usage for a contianer in all pods of a deployment
         - function: sum
-          query: 'sum(avg_over_time(container_memory_working_set_bytes{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace=$NAMESPACE$, container="$CONTAINER_NAME$"}[15m]))'
+          query: 'sum by(container, namespace) (avg_over_time(container_memory_working_set_bytes{container!='', container!="POD", pod!="", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
 
     # 2.4 Memory RSS
@@ -195,17 +221,28 @@ slo:
       aggregation_functions:
         # Average memory RSS per container in a deployment
         - function: avg
-          query: 'avg(avg_over_time(container_memory_rss{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace=$NAMESPACE$, container=”$CONTAINER_NAME$”}[15m]))'
+          query: 'avg by(container, namespace) (avg_over_time(container_memory_rss{container!='', container!="POD", pod!="" ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
         # Approx minimum memory RSS per container in a deployment
         - function: min
-          query: 'min(min_over_time(container_memory_rss{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace=$NAMESPACE$, container="$CONTAINER_NAME$"}[15m]))'
+          query: 'min by(container, namespace) (min_over_time(container_memory_rss{container!='', container!="POD", pod!="" ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m])'
 
 
         # Approx maximum memory RSS per container in a deployment
         - function: max
-          query: 'max(max_over_time(container_memory_rss{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace=$NAMESPACE$, container="$CONTAINER_NAME$"}[15m]))'
+          query: 'max by(container, namespace) (max_over_time(container_memory_rss{container!='', container!="POD", pod!="" ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
         # Sum of memory RSS for a contianer in all pods of a deployment
         - function: sum
-          query: 'sum(avg_over_time(container_memory_rss{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace=$NAMESPACE$, container=”$CONTAINER_NAME$”}[15m]))'
+          query: 'sum by(container, namespace) (avg_over_time(container_memory_rss{container!='', container!="POD", pod!="" ,namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+
+
+    # Container Last Active Timestamp
+    - name: maxDate
+      datasource: prometheus
+      value_type: "double"
+      kubernetes_object: "container"
+
+      aggregation_functions:
+        - function: max
+          query: 'max by(namespace,container) (last_over_time((timestamp(container_cpu_usage_seconds_total{namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"} > 0))[15d:]))'

--- a/migrations/kruize_local_ddl.sql
+++ b/migrations/kruize_local_ddl.sql
@@ -1,3 +1,4 @@
 create table IF NOT EXISTS kruize_datasources (version varchar(255), name varchar(255), provider varchar(255), serviceName varchar(255), namespace varchar(255), url varchar(255), primary key (name));
 create table IF NOT EXISTS kruize_dsmetadata (id serial, version varchar(255), datasource_name varchar(255), cluster_name varchar(255), namespace varchar(255), workload_type varchar(255), workload_name varchar(255), container_name varchar(255), container_image_name varchar(255), primary key (id));
 alter table kruize_experiments add column metadata_id bigint references kruize_dsmetadata(id), alter column datasource type varchar(255);
+create table IF NOT EXISTS kruize_metric_profiles (api_version varchar(255), kind varchar(255), metadata jsonb, name varchar(255) not null, k8s_type varchar(255), profile_version float(53) not null, slo jsonb, primary key (name));

--- a/src/main/java/com/autotune/Autotune.java
+++ b/src/main/java/com/autotune/Autotune.java
@@ -20,6 +20,7 @@ import com.autotune.analyzer.exceptions.K8sTypeNotSupportedException;
 import com.autotune.analyzer.exceptions.KruizeErrorHandler;
 import com.autotune.analyzer.exceptions.MonitoringAgentNotFoundException;
 import com.autotune.analyzer.exceptions.MonitoringAgentNotSupportedException;
+import com.autotune.analyzer.performanceProfiles.MetricProfileCollection;
 import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.common.datasource.DataSourceCollection;
 import com.autotune.common.datasource.DataSourceInfo;
@@ -114,6 +115,8 @@ public class Autotune {
                 setUpDataSources();
                 // checking available DataSources
                 checkAvailableDataSources();
+                // load available metric profiles from db
+                loadMetricProfilesFromDB();
 
             }
             // close the existing session factory before recreating
@@ -193,6 +196,14 @@ public class Autotune {
             String url = dataSource.getUrl().toString();
             LOGGER.info(KruizeConstants.DataSourceConstants.DataSourceSuccessMsgs.DATASOURCE_FOUND + dataSourceName + ", " + url);
         }
+    }
+
+    /**
+     * loads metric profiles from database
+     */
+    private static void loadMetricProfilesFromDB() {
+        MetricProfileCollection metricProfileCollection = MetricProfileCollection.getInstance();
+        metricProfileCollection.loadMetricProfilesFromDB();
     }
 
     private static void addAutotuneServlets(ServletContextHandler context) {

--- a/src/main/java/com/autotune/analyzer/Analyzer.java
+++ b/src/main/java/com/autotune/analyzer/Analyzer.java
@@ -53,6 +53,8 @@ public class Analyzer {
         context.addServlet(ListRecommendations.class, ServerContext.RECOMMEND_RESULTS);
         context.addServlet(PerformanceProfileService.class, ServerContext.CREATE_PERF_PROFILE);
         context.addServlet(PerformanceProfileService.class, ServerContext.LIST_PERF_PROFILES);
+        context.addServlet(MetricProfileService.class, ServerContext.CREATE_METRIC_PROFILE);
+        context.addServlet(MetricProfileService.class, ServerContext.LIST_METRIC_PROFILES);
         context.addServlet(ListDatasources.class, ServerContext.LIST_DATASOURCES);
         context.addServlet(DSMetadataService.class, ServerContext.DATASOURCE_METADATA);
 

--- a/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
+++ b/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
@@ -122,6 +122,7 @@ public class ExperimentValidation {
                             errorMsg = AnalyzerErrorConstants.AutotuneObjectErrors.MISSING_SLO_DATA;
                             validationOutputData.setErrorCode(HttpServletResponse.SC_BAD_REQUEST);
                         } else {
+                            // TODO - set metric profile when local=true
                             String perfProfileName = KruizeOperator.setDefaultPerformanceProfile(kruizeObject.getSloInfo(), mode, target_cluster);
                             kruizeObject.setPerformanceProfile(perfProfileName);
                             proceed = true;

--- a/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
+++ b/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Red Hat, IBM Corporation and others.
+ * Copyright (c) 2022, 2024 Red Hat, IBM Corporation and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import com.autotune.common.data.metrics.Metric;
 import com.autotune.common.data.result.ContainerData;
 import com.autotune.common.k8sObjects.K8sObject;
 import com.autotune.database.service.ExperimentDBService;
+import com.autotune.operator.KruizeDeploymentInfo;
 import com.autotune.operator.KruizeOperator;
 import com.autotune.utils.KruizeConstants;
 import org.slf4j.Logger;
@@ -105,9 +106,13 @@ public class ExperimentValidation {
                             errorMsg = AnalyzerErrorConstants.AutotuneObjectErrors.SLO_REDUNDANCY_ERROR;
                             validationOutputData.setErrorCode(HttpServletResponse.SC_BAD_REQUEST);
                         } else {
-                            // fetch the Performance Profile from the DB
+                            // fetch the Performance / Metric Profile from the DB
                             try {
-                                new ExperimentDBService().loadPerformanceProfileFromDBByName(performanceProfilesMap, kruizeObject.getPerformanceProfile());
+                                if (!KruizeDeploymentInfo.local) {
+                                    new ExperimentDBService().loadPerformanceProfileFromDBByName(performanceProfilesMap, kruizeObject.getPerformanceProfile());
+                                } else {
+                                    new ExperimentDBService().loadMetricProfileFromDBByName(performanceProfilesMap, kruizeObject.getPerformanceProfile());
+                                }
                             } catch (Exception e) {
                                 LOGGER.error("Loading saved Performance Profile {} failed: {} ", expName, e.getMessage());
                             }
@@ -123,7 +128,12 @@ public class ExperimentValidation {
                             validationOutputData.setErrorCode(HttpServletResponse.SC_BAD_REQUEST);
                         } else {
                             // TODO - set metric profile when local=true
-                            String perfProfileName = KruizeOperator.setDefaultPerformanceProfile(kruizeObject.getSloInfo(), mode, target_cluster);
+                            String perfProfileName;
+                            if (!KruizeDeploymentInfo.local) {
+                                perfProfileName = KruizeOperator.setDefaultPerformanceProfile(kruizeObject.getSloInfo(), mode, target_cluster);
+                            } else {
+                                perfProfileName = KruizeOperator.setDefaultMetricProfile(kruizeObject.getSloInfo(), mode, target_cluster);
+                            }
                             kruizeObject.setPerformanceProfile(perfProfileName);
                             proceed = true;
                         }

--- a/src/main/java/com/autotune/analyzer/performanceProfiles/MetricProfileCollection.java
+++ b/src/main/java/com/autotune/analyzer/performanceProfiles/MetricProfileCollection.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2024 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.autotune.analyzer.performanceProfiles;
+
+import com.autotune.database.service.ExperimentDBService;
+import com.autotune.utils.KruizeConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MetricProfileCollection {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MetricProfileCollection.class);
+    private static MetricProfileCollection metricProfileCollectionInstance = new MetricProfileCollection();
+    private HashMap<String, PerformanceProfile> metricProfileCollection;
+
+    private MetricProfileCollection() {
+        this.metricProfileCollection = new HashMap<>();
+    }
+
+    public static MetricProfileCollection getInstance() {
+        return metricProfileCollectionInstance;
+    }
+
+    public HashMap<String, PerformanceProfile> getMetricProfileCollection() {
+        return metricProfileCollection;
+    }
+
+    public void loadMetricProfilesFromDB() {
+        try {
+            LOGGER.info(KruizeConstants.MetricProfileConstants.CHECKING_AVAILABLE_METRIC_PROFILE_FROM_DB);
+            Map<String, PerformanceProfile> availableMetricProfiles = new HashMap<>();
+            new ExperimentDBService().loadAllMetricProfiles(availableMetricProfiles);
+            if (availableMetricProfiles.isEmpty()) {
+                LOGGER.info(KruizeConstants.MetricProfileConstants.NO_METRIC_PROFILE_FOUND_IN_DB);
+            }else {
+                for (Map.Entry<String, PerformanceProfile> metricProfile : availableMetricProfiles.entrySet()) {
+                    LOGGER.info(KruizeConstants.MetricProfileConstants.METRIC_PROFILE_FOUND, metricProfile.getKey());
+                    metricProfileCollection.put(metricProfile.getKey(), metricProfile.getValue());
+                }
+            }
+
+        } catch (Exception e) {
+            LOGGER.error(e.getMessage());
+        }
+    }
+
+
+    public void addMetricProfile(PerformanceProfile metricProfile) {
+        String metricProfileName = metricProfile.getMetadata().get("name").asText();
+
+        LOGGER.info(KruizeConstants.MetricProfileConstants.ADDING_METRIC_PROFILE + "{}", metricProfileName);
+
+        if(metricProfileCollection.containsKey(metricProfileName)) {
+            LOGGER.error(KruizeConstants.MetricProfileConstants.METRIC_PROFILE_ALREADY_EXISTS + "{}", metricProfileName);
+        } else {
+            LOGGER.info(KruizeConstants.MetricProfileConstants.METRIC_PROFILE_ADDED + "{}", metricProfileName);
+            metricProfileCollection.put(metricProfileName, metricProfile);
+        }
+    }
+}

--- a/src/main/java/com/autotune/analyzer/performanceProfiles/PerformanceProfile.java
+++ b/src/main/java/com/autotune/analyzer/performanceProfiles/PerformanceProfile.java
@@ -17,6 +17,7 @@ package com.autotune.analyzer.performanceProfiles;
 
 import com.autotune.analyzer.kruizeObject.SloInfo;
 import com.autotune.analyzer.recommendations.term.Terms;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.Map;
@@ -25,9 +26,17 @@ import java.util.Map;
  * Container class for the PerformanceProfile kubernetes kind, which is used to define
  * a profile
  *
+ * This class provides a direct representation of MetricProfile CRD in JSON format,
+ * corresponding to the structure of PerformanceProfile YAML file. It includes mandatory fields
+ * for API version, kind, metadata and additional custom fields - profile_version, k8s_type and sloInfo
  */
 
 public class PerformanceProfile {
+    private String apiVersion;
+
+    private String kind;
+
+    private JsonNode metadata;
 
     private String name;
 
@@ -40,6 +49,30 @@ public class PerformanceProfile {
     private SloInfo sloInfo;
 
     private Map<String, Terms> terms;
+
+    public String getApiVersion() {
+        return apiVersion;
+    }
+
+    public void setApiVersion(String apiVersion) {
+        this.apiVersion = apiVersion;
+    }
+
+    public String getKind() {
+        return kind;
+    }
+
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    public JsonNode getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(JsonNode metadata) {
+        this.metadata = metadata;
+    }
 
     public void setName(String name) {
         this.name = name;
@@ -63,6 +96,17 @@ public class PerformanceProfile {
 
     public PerformanceProfile(String name, double profile_version, String k8s_type, SloInfo sloInfo) {
         this.name = name;
+        this.profile_version = profile_version;
+        this.k8s_type = k8s_type;
+        this.sloInfo = sloInfo;
+    }
+
+    // Constructor for MetricProfile
+    public PerformanceProfile(String apiVersion, String kind, JsonNode metadata,
+                              double profile_version, String k8s_type, SloInfo sloInfo) {
+        this.apiVersion = apiVersion;
+        this.kind = kind;
+        this.metadata = metadata;
         this.profile_version = profile_version;
         this.k8s_type = k8s_type;
         this.sloInfo = sloInfo;
@@ -95,7 +139,10 @@ public class PerformanceProfile {
     @Override
     public String toString() {
         return "PerformanceProfile{" +
-                "name='" + name + '\'' +
+                "apiVersion='" + apiVersion + '\'' +
+                ", kind='" + kind + '\'' +
+                ", metadata=" + metadata +
+                " name='" + name + '\'' +
                 ", profile_version=" + profile_version +
                 ", k8s_type='" + k8s_type + '\'' +
                 ", sloInfo=" + sloInfo +

--- a/src/main/java/com/autotune/analyzer/performanceProfiles/PerformanceProfileValidation.java
+++ b/src/main/java/com/autotune/analyzer/performanceProfiles/PerformanceProfileValidation.java
@@ -26,6 +26,7 @@ import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.analyzer.utils.AnalyzerErrorConstants;
 import com.autotune.utils.KruizeConstants;
 import com.autotune.utils.KruizeSupportedTypes;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,9 +47,17 @@ public class PerformanceProfileValidation {
     private String errorMessage;
     private final Map<String, PerformanceProfile> performanceProfilesMap;
 
-    //Mandatory fields
+    //Mandatory fields for PerformanceProfile
     private final List<String> mandatoryFields = new ArrayList<>(Arrays.asList(
             AnalyzerConstants.PerformanceProfileConstants.PERF_PROFILE_NAME,
+            AnalyzerConstants.SLO
+    ));
+
+    //Mandatory fields for MetricProfile
+    private final List<String> mandatoryMetricFields = new ArrayList<>(Arrays.asList(
+            AnalyzerConstants.API_VERSION,
+            AnalyzerConstants.KIND,
+            AnalyzerConstants.AutotuneObjectConstants.METADATA,
             AnalyzerConstants.SLO
     ));
 
@@ -81,6 +90,17 @@ public class PerformanceProfileValidation {
     }
 
     /**
+     * Validates function variables
+     *
+     * @param metricProfile Metric Profile Object to be validated
+     * @return Returns the ValidationOutputData containing the response based on the validation
+     */
+    public ValidationOutputData validateMetricProfile(PerformanceProfile metricProfile) {
+
+        return validateMetricProfileData(metricProfile);
+    }
+
+    /**
      * Validates the data present in the performance profile object before adding it to the map
      * @param performanceProfile
      * @return
@@ -102,118 +122,17 @@ public class PerformanceProfileValidation {
                 errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.DUPLICATE_PERF_PROFILE).append(performanceProfile.getName());
                 return new ValidationOutputData(false, errorString.toString(), HttpServletResponse.SC_CONFLICT);
             }
-            // Check if k8s type is supported
-            String k8sType = performanceProfile.getK8S_TYPE();
-            if (!KruizeSupportedTypes.K8S_TYPES_SUPPORTED.contains(k8sType)) {
-                errorString.append(AnalyzerConstants.PerformanceProfileConstants.K8S_TYPE).append(k8sType)
-                        .append(AnalyzerErrorConstants.AutotuneObjectErrors.UNSUPPORTED);
-            }
 
-            SloInfo sloInfo = performanceProfile.getSloInfo();
-            // Check if direction is supported
-            if (!KruizeSupportedTypes.DIRECTIONS_SUPPORTED.contains(sloInfo.getDirection()))
-                errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.DIRECTION_NOT_SUPPORTED);
-            // if slo_class is present, do further validations
-            if (sloInfo.getSloClass() != null) {
-                // Check if slo_class is supported
-                if (!KruizeSupportedTypes.SLO_CLASSES_SUPPORTED.contains(sloInfo.getSloClass()))
-                    errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.SLO_CLASS_NOT_SUPPORTED);
-
-                //check if slo_class is 'response_time' and direction is 'minimize'
-                if (sloInfo.getSloClass().equalsIgnoreCase(EMConstants.StandardDefaults.RESPONSE_TIME) && !sloInfo.getDirection()
-                        .equalsIgnoreCase(AnalyzerConstants.AutotuneObjectConstants.MINIMIZE)) {
-                    errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.INVALID_DIRECTION_FOR_SLO_CLASS);
-                }
-
-                //check if slo_class is 'throughput' and direction is 'maximize'
-                if (sloInfo.getSloClass().equalsIgnoreCase(EMConstants.StandardDefaults.THROUGHPUT) && !sloInfo.getDirection()
-                        .equalsIgnoreCase(AnalyzerConstants.AutotuneObjectConstants.MAXIMIZE)) {
-                    errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.INVALID_DIRECTION_FOR_SLO_CLASS);
-                }
-            }
-            // Check if function_variables is empty
-            if (sloInfo.getFunctionVariables().isEmpty())
-                errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.FUNCTION_VARIABLES_EMPTY);
-
-            // Check if objective_function and it's type exists
-            if (sloInfo.getObjectiveFunction() == null)
-                errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.OBJECTIVE_FUNCTION_MISSING);
-
-            // Get the objective_function type
-            String objFunctionType = sloInfo.getObjectiveFunction().getFunction_type();
-            String expression = null;
-            for (Metric functionVariable : sloInfo.getFunctionVariables()) {
-                // Check if datasource is supported
-                if (!KruizeSupportedTypes.MONITORING_AGENTS_SUPPORTED.contains(functionVariable.getDatasource().toLowerCase())) {
-                    errorString.append(AnalyzerConstants.AutotuneObjectConstants.FUNCTION_VARIABLE)
-                            .append(functionVariable.getName())
-                            .append(AnalyzerErrorConstants.AutotuneObjectErrors.DATASOURCE_NOT_SUPPORTED);
-                }
-
-                // Check if value_type is supported
-                if (!KruizeSupportedTypes.VALUE_TYPES_SUPPORTED.contains(functionVariable.getValueType().toLowerCase())) {
-                    errorString.append(AnalyzerConstants.AutotuneObjectConstants.FUNCTION_VARIABLE)
-                            .append(functionVariable.getName())
-                            .append(AnalyzerErrorConstants.AutotuneObjectErrors.VALUE_TYPE_NOT_SUPPORTED);
-                }
-
-                // Check if kubernetes_object type is supported, set default to 'container' if it's absent.
-                String kubernetes_object = functionVariable.getKubernetesObject();
-                if (null == kubernetes_object)
-                    functionVariable.setKubernetesObject(KruizeConstants.JSONKeys.CONTAINER);
-                else {
-                    if (!KruizeSupportedTypes.KUBERNETES_OBJECTS_SUPPORTED.contains(kubernetes_object.toLowerCase()))
-                        errorString.append(AnalyzerConstants.KUBERNETES_OBJECTS).append(kubernetes_object)
-                                .append(AnalyzerErrorConstants.AutotuneObjectErrors.UNSUPPORTED);
-                }
-
-                // Validate Objective Function
-                try {
-                    if (objFunctionType.equals(AnalyzerConstants.AutotuneObjectConstants.EXPRESSION)) {
-
-                        expression = sloInfo.getObjectiveFunction().getExpression();
-                        if (null == expression || expression.equals(AnalyzerConstants.NULL)) {
-                            throw new NullPointerException(AnalyzerErrorConstants.AutotuneObjectErrors.MISSING_EXPRESSION);
-                        }
-
-                    } else if (objFunctionType.equals(AnalyzerConstants.PerformanceProfileConstants.SOURCE)) {
-                        if (null != sloInfo.getObjectiveFunction().getExpression()) {
-                            errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.MISPLACED_EXPRESSION);
-                            throw new InvalidValueException(errorString.toString());
-                        }
-                    } else {
-                        errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.INVALID_TYPE);
-                        throw new InvalidValueException(errorString.toString());
-                    }
-                } catch (NullPointerException | InvalidValueException npe) {
-                    errorString.append(npe.getMessage());
-                    validationOutputData.setSuccess(false);
-                    validationOutputData.setMessage(errorString.toString());
-                }
-
-                // Check if function_variable is part of objective_function
-                if (objFunctionType.equals(AnalyzerConstants.AutotuneObjectConstants.EXPRESSION)) {
-                    if (!expression.contains(functionVariable.getName())) {
-                        errorString.append(AnalyzerConstants.AutotuneObjectConstants.FUNCTION_VARIABLE)
-                                .append(functionVariable.getName()).append(" ")
-                                .append(AnalyzerErrorConstants.AutotuneObjectErrors.FUNCTION_VARIABLE_ERROR);
-                    }
-                }
-            }
-
-            // Check if objective_function is correctly formatted
-            if (objFunctionType.equals(AnalyzerConstants.AutotuneObjectConstants.EXPRESSION)) {
-                if (expression.equals(AnalyzerConstants.NULL) || !new EvalExParser().validate(sloInfo.getObjectiveFunction().getExpression(), sloInfo.getFunctionVariables())) {
-                    errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.INVALID_OBJECTIVE_FUNCTION);
-                }
-            }
+            // Validates fields like k8s_type and slo object
+            validateCommonProfileFields(performanceProfile, errorString, validationOutputData);
 
             if (!errorString.toString().isEmpty()) {
                 validationOutputData.setSuccess(false);
                 validationOutputData.setMessage(errorString.toString());
                 validationOutputData.setErrorCode(HttpServletResponse.SC_BAD_REQUEST);
-            } else
+            } else {
                 validationOutputData.setSuccess(true);
+            }
         }
         return validationOutputData;
     }
@@ -302,6 +221,278 @@ public class PerformanceProfileValidation {
 
         return validationOutputData;
     }
+
+    /**
+     * Validates the data present in the metric profile object before adding it to the map
+     * @param metricProfile Metric Profile Object to be validated
+     * @return Returns the ValidationOutputData containing the response based on the validation
+     */
+    private ValidationOutputData validateMetricProfileData(PerformanceProfile metricProfile) {
+        ValidationOutputData validationOutputData = new ValidationOutputData(false, null, null);
+        StringBuilder errorString = new StringBuilder();
+        try {
+            // validate the mandatory values first
+            validationOutputData = validateMandatoryMetricProfileFieldsAndData(metricProfile);
+
+            // If the mandatory values are present,proceed for further validation else return the validation object directly
+            if (validationOutputData.isSuccess()) {
+                try {
+                    new ExperimentDBService().loadAllMetricProfiles(performanceProfilesMap);
+                } catch (Exception e) {
+                    LOGGER.error("Loading saved metric profiles failed: {} ", e.getMessage());
+                }
+
+                // Check if metadata exists
+                JsonNode metadata = metricProfile.getMetadata();
+                if (null == metadata) {
+                    errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.MISSING_METRIC_PROFILE_METADATA);
+                }
+                // check if the performance profile already exists
+                if (null != performanceProfilesMap.get(metricProfile.getMetadata().get("name").asText())) {
+                    errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.DUPLICATE_METRIC_PROFILE).append(metricProfile.getMetadata().get("name").asText());
+                    return new ValidationOutputData(false, errorString.toString(), HttpServletResponse.SC_CONFLICT);
+                }
+
+                // Validates fields like k8s_type and slo object
+                validateCommonProfileFields(metricProfile, errorString, validationOutputData);
+
+                if (!errorString.toString().isEmpty()) {
+                    validationOutputData.setSuccess(false);
+                    validationOutputData.setMessage(errorString.toString());
+                    validationOutputData.setErrorCode(HttpServletResponse.SC_BAD_REQUEST);
+                } else {
+                    validationOutputData.setSuccess(true);
+                }
+            }
+        } catch (Exception e){
+            validationOutputData.setSuccess(false);
+            validationOutputData.setMessage(errorString.toString());
+            validationOutputData.setErrorCode(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        }
+        return validationOutputData;
+    }
+
+    /**
+     * Check if all mandatory values are present.
+     *
+     * @param metricObj Mandatory fields of this Metric Profile Object will be validated
+     * @return ValidationOutputData object containing status of the validations
+     */
+    public ValidationOutputData validateMandatoryMetricProfileFieldsAndData(PerformanceProfile metricObj) {
+        List<String> missingMandatoryFields = new ArrayList<>();
+        ValidationOutputData validationOutputData = new ValidationOutputData(false, null, null);
+        String errorMsg;
+        errorMsg = "";
+        mandatoryMetricFields.forEach(
+                mField -> {
+                    String methodName = "get" + mField.substring(0, 1).toUpperCase() + mField.substring(1);
+                    try {
+                        LOGGER.debug("MethodName = {}",methodName);
+                        Method getNameMethod = metricObj.getClass().getMethod(methodName);
+                        if (null == getNameMethod.invoke(metricObj) || getNameMethod.invoke(metricObj).toString().isEmpty())
+                            missingMandatoryFields.add(mField);
+                    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+                        LOGGER.error("Method name {} doesn't exist!", mField);
+                    }
+                }
+        );
+        if (missingMandatoryFields.size() == 0) {
+            try {
+                String mandatoryMetadataPerf = AnalyzerConstants.PerformanceProfileConstants.PERF_PROFILE_NAME;
+                try {
+                    JsonNode metadata = metricObj.getMetadata();
+                    String metricProfileName = metadata.get(mandatoryMetadataPerf).asText();
+                    if (null == metricProfileName || metricProfileName.isEmpty() || metricProfileName.equals("null")) {
+                        missingMandatoryFields.add(mandatoryMetadataPerf);
+                    }
+                } catch (Exception e) {
+                    LOGGER.error("Method name doesn't exist for: {}!", mandatoryMetadataPerf);
+                }
+
+                if (missingMandatoryFields.size() == 0) {
+                    mandatorySLOPerf.forEach(
+                            mField -> {
+                                String methodName = "get" + mField.substring(0, 1).toUpperCase() + mField.substring(1);
+                                try {
+                                    LOGGER.debug("MethodName = {}", methodName);
+                                    Method getNameMethod = metricObj.getSloInfo().getClass().getMethod(methodName);
+                                    if (getNameMethod.invoke(metricObj.getSloInfo()) == null)
+                                        missingMandatoryFields.add(mField);
+                                } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+                                    LOGGER.error("Method name {} doesn't exist!", mField);
+                                }
+
+                            });
+                    if (missingMandatoryFields.size() == 0) {
+                        mandatoryFuncVariables.forEach(
+                                mField -> {
+                                    String methodName = "get" + mField.substring(0, 1).toUpperCase() + mField.substring(1);
+                                    try {
+                                        LOGGER.debug("MethodName = {}", methodName);
+                                        Method getNameMethod = metricObj.getSloInfo().getFunctionVariables().get(0)
+                                                .getClass().getMethod(methodName);
+                                        if (getNameMethod.invoke(metricObj.getSloInfo().getFunctionVariables().get(0)) == null)
+                                            missingMandatoryFields.add(mField);
+                                    } catch (NoSuchMethodException | IllegalAccessException |
+                                             InvocationTargetException e) {
+                                        LOGGER.error("Method name {} doesn't exist!", mField);
+                                    }
+
+                                });
+                        String mandatoryObjFuncData = AnalyzerConstants.AutotuneObjectConstants.OBJ_FUNCTION_TYPE;
+                        String methodName = "get" + mandatoryObjFuncData.substring(0, 1).toUpperCase() +
+                                mandatoryObjFuncData.substring(1);
+                        try {
+                            LOGGER.debug("MethodName = {}", methodName);
+                            Method getNameMethod = metricObj.getSloInfo().getObjectiveFunction()
+                                    .getClass().getMethod(methodName);
+                            if (getNameMethod.invoke(metricObj.getSloInfo().getObjectiveFunction()) == null)
+                                missingMandatoryFields.add(mandatoryObjFuncData);
+                        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+                            LOGGER.error("Method name {} doesn't exist!", mandatoryObjFuncData);
+                        }
+                        validationOutputData.setSuccess(true);
+                    }
+                }
+
+                if (!missingMandatoryFields.isEmpty()) {
+                    errorMsg = errorMsg.concat(String.format("Missing mandatory parameters: %s ", missingMandatoryFields));
+                    validationOutputData.setSuccess(false);
+                    validationOutputData.setMessage(errorMsg);
+                    validationOutputData.setErrorCode(HttpServletResponse.SC_BAD_REQUEST);
+                    LOGGER.error("Validation error message :{}", errorMsg);
+                }
+            } catch (Exception e) {
+                validationOutputData.setSuccess(false);
+                errorMsg = errorMsg.concat(e.getMessage());
+                validationOutputData.setMessage(errorMsg);
+                validationOutputData.setErrorCode(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            }
+        } else {
+            errorMsg = errorMsg.concat(String.format("Missing mandatory parameters: %s ", missingMandatoryFields));
+            validationOutputData.setSuccess(false);
+            validationOutputData.setMessage(errorMsg);
+            validationOutputData.setErrorCode(HttpServletResponse.SC_BAD_REQUEST);
+            LOGGER.error("Validation error message :{}", errorMsg);
+        }
+
+        return validationOutputData;
+    }
+
+    /**
+     *  Validates fields like k8s_type and slo object common to both Metric and Performance Profile
+     * @param metricProfile Metric/Performance Profile object to be validated
+     * @param errorString   StringBuilder to collect error messages during validation of multiple fields
+     * @param validationOutputData ValidationOutputData containing the response based on the validation
+     */
+    private void validateCommonProfileFields(PerformanceProfile metricProfile, StringBuilder errorString, ValidationOutputData validationOutputData){
+        // Check if k8s type is supported
+        String k8sType = metricProfile.getK8S_TYPE();
+        if (!KruizeSupportedTypes.K8S_TYPES_SUPPORTED.contains(k8sType)) {
+            errorString.append(AnalyzerConstants.PerformanceProfileConstants.K8S_TYPE).append(k8sType)
+                    .append(AnalyzerErrorConstants.AutotuneObjectErrors.UNSUPPORTED);
+        }
+
+        SloInfo sloInfo = metricProfile.getSloInfo();
+        // Check if direction is supported
+        if (!KruizeSupportedTypes.DIRECTIONS_SUPPORTED.contains(sloInfo.getDirection()))
+            errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.DIRECTION_NOT_SUPPORTED);
+        // if slo_class is present, do further validations
+        if (sloInfo.getSloClass() != null) {
+            // Check if slo_class is supported
+            if (!KruizeSupportedTypes.SLO_CLASSES_SUPPORTED.contains(sloInfo.getSloClass()))
+                errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.SLO_CLASS_NOT_SUPPORTED);
+
+            //check if slo_class is 'response_time' and direction is 'minimize'
+            if (sloInfo.getSloClass().equalsIgnoreCase(EMConstants.StandardDefaults.RESPONSE_TIME) && !sloInfo.getDirection()
+                    .equalsIgnoreCase(AnalyzerConstants.AutotuneObjectConstants.MINIMIZE)) {
+                errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.INVALID_DIRECTION_FOR_SLO_CLASS);
+            }
+
+            //check if slo_class is 'throughput' and direction is 'maximize'
+            if (sloInfo.getSloClass().equalsIgnoreCase(EMConstants.StandardDefaults.THROUGHPUT) && !sloInfo.getDirection()
+                    .equalsIgnoreCase(AnalyzerConstants.AutotuneObjectConstants.MAXIMIZE)) {
+                errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.INVALID_DIRECTION_FOR_SLO_CLASS);
+            }
+        }
+        // Check if function_variables is empty
+        if (sloInfo.getFunctionVariables().isEmpty())
+            errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.FUNCTION_VARIABLES_EMPTY);
+
+        // Check if objective_function and it's type exists
+        if (sloInfo.getObjectiveFunction() == null)
+            errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.OBJECTIVE_FUNCTION_MISSING);
+
+        // Get the objective_function type
+        String objFunctionType = sloInfo.getObjectiveFunction().getFunction_type();
+        String expression = null;
+        for (Metric functionVariable : sloInfo.getFunctionVariables()) {
+            // Check if datasource is supported
+            if (!KruizeSupportedTypes.MONITORING_AGENTS_SUPPORTED.contains(functionVariable.getDatasource().toLowerCase())) {
+                errorString.append(AnalyzerConstants.AutotuneObjectConstants.FUNCTION_VARIABLE)
+                        .append(functionVariable.getName())
+                        .append(AnalyzerErrorConstants.AutotuneObjectErrors.DATASOURCE_NOT_SUPPORTED);
+            }
+
+            // Check if value_type is supported
+            if (!KruizeSupportedTypes.VALUE_TYPES_SUPPORTED.contains(functionVariable.getValueType().toLowerCase())) {
+                errorString.append(AnalyzerConstants.AutotuneObjectConstants.FUNCTION_VARIABLE)
+                        .append(functionVariable.getName())
+                        .append(AnalyzerErrorConstants.AutotuneObjectErrors.VALUE_TYPE_NOT_SUPPORTED);
+            }
+
+            // Check if kubernetes_object type is supported, set default to 'container' if it's absent.
+            String kubernetes_object = functionVariable.getKubernetesObject();
+            if (null == kubernetes_object)
+                functionVariable.setKubernetesObject(KruizeConstants.JSONKeys.CONTAINER);
+            else {
+                if (!KruizeSupportedTypes.KUBERNETES_OBJECTS_SUPPORTED.contains(kubernetes_object.toLowerCase()))
+                    errorString.append(AnalyzerConstants.KUBERNETES_OBJECTS).append(kubernetes_object)
+                            .append(AnalyzerErrorConstants.AutotuneObjectErrors.UNSUPPORTED);
+            }
+
+            // Validate Objective Function
+            try {
+                if (objFunctionType.equals(AnalyzerConstants.AutotuneObjectConstants.EXPRESSION)) {
+
+                    expression = sloInfo.getObjectiveFunction().getExpression();
+                    if (null == expression || expression.equals(AnalyzerConstants.NULL)) {
+                        throw new NullPointerException(AnalyzerErrorConstants.AutotuneObjectErrors.MISSING_EXPRESSION);
+                    }
+
+                } else if (objFunctionType.equals(AnalyzerConstants.PerformanceProfileConstants.SOURCE)) {
+                    if (null != sloInfo.getObjectiveFunction().getExpression()) {
+                        errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.MISPLACED_EXPRESSION);
+                        throw new InvalidValueException(errorString.toString());
+                    }
+                } else {
+                    errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.INVALID_TYPE);
+                    throw new InvalidValueException(errorString.toString());
+                }
+            } catch (NullPointerException | InvalidValueException npe) {
+                errorString.append(npe.getMessage());
+                validationOutputData.setSuccess(false);
+                validationOutputData.setMessage(errorString.toString());
+            }
+
+            // Check if function_variable is part of objective_function
+            if (objFunctionType.equals(AnalyzerConstants.AutotuneObjectConstants.EXPRESSION)) {
+                if (!expression.contains(functionVariable.getName())) {
+                    errorString.append(AnalyzerConstants.AutotuneObjectConstants.FUNCTION_VARIABLE)
+                            .append(functionVariable.getName()).append(" ")
+                            .append(AnalyzerErrorConstants.AutotuneObjectErrors.FUNCTION_VARIABLE_ERROR);
+                }
+            }
+        }
+
+        // Check if objective_function is correctly formatted
+        if (objFunctionType.equals(AnalyzerConstants.AutotuneObjectConstants.EXPRESSION)) {
+            if (expression.equals(AnalyzerConstants.NULL) || !new EvalExParser().validate(sloInfo.getObjectiveFunction().getExpression(), sloInfo.getFunctionVariables())) {
+                errorString.append(AnalyzerErrorConstants.AutotuneObjectErrors.INVALID_OBJECTIVE_FUNCTION);
+            }
+        }
+    }
+
     public boolean isSuccess() {
         return success;
     }

--- a/src/main/java/com/autotune/analyzer/performanceProfiles/utils/PerformanceProfileUtil.java
+++ b/src/main/java/com/autotune/analyzer/performanceProfiles/utils/PerformanceProfileUtil.java
@@ -62,6 +62,28 @@ public class PerformanceProfileUtil {
     }
 
     /**
+     * validates the metric profile fields and the data and then adds it to the map
+     * @param metricProfilesMap
+     * @param metricProfile     Metric profile to be validated
+     * @return ValidationOutputData object
+     */
+    public static ValidationOutputData validateAndAddMetricProfile(Map<String, PerformanceProfile> metricProfilesMap, PerformanceProfile metricProfile) {
+        ValidationOutputData validationOutputData;
+        try {
+            validationOutputData = new PerformanceProfileValidation(metricProfilesMap).validateMetricProfile(metricProfile);
+            if (validationOutputData.isSuccess()) {
+                addMetricProfile(metricProfilesMap, metricProfile);
+            } else {
+                validationOutputData.setMessage("Validation failed: " + validationOutputData.getMessage());
+            }
+        } catch (Exception e) {
+            LOGGER.error("Validate and add metric profile failed: {}", e.getMessage());
+            validationOutputData = new ValidationOutputData(false, "Validation failed: " + e.getMessage(), HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        }
+        return validationOutputData;
+    }
+
+    /**
      * @param performanceProfile
      * @param updateResultsAPIObject
      * @return
@@ -160,6 +182,11 @@ public class PerformanceProfileUtil {
     public static void addPerformanceProfile(Map<String, PerformanceProfile> performanceProfileMap, PerformanceProfile performanceProfile) {
         performanceProfileMap.put(performanceProfile.getName(), performanceProfile);
         LOGGER.debug("Added PerformanceProfile: {} ",performanceProfile.getName());
+    }
+
+    public static void addMetricProfile(Map<String, PerformanceProfile> performanceProfileMap, PerformanceProfile performanceProfile) {
+        performanceProfileMap.put(performanceProfile.getMetadata().get("name").asText(), performanceProfile);
+        LOGGER.debug("Added MetricProfile: {} ",performanceProfile.getMetadata().get("name"));
     }
 
     /**

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -2,6 +2,8 @@ package com.autotune.analyzer.recommendations.engine;
 
 import com.autotune.analyzer.kruizeObject.KruizeObject;
 import com.autotune.analyzer.kruizeObject.RecommendationSettings;
+import com.autotune.analyzer.performanceProfiles.MetricProfileCollection;
+import com.autotune.analyzer.performanceProfiles.PerformanceProfile;
 import com.autotune.analyzer.plots.PlotManager;
 import com.autotune.analyzer.recommendations.ContainerRecommendations;
 import com.autotune.analyzer.recommendations.RecommendationConfigItem;
@@ -19,6 +21,8 @@ import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.analyzer.utils.AnalyzerErrorConstants;
 import com.autotune.common.data.ValidationOutputData;
 import com.autotune.common.data.dataSourceQueries.PromQLDataSourceQueries;
+import com.autotune.common.data.metrics.AggregationFunctions;
+import com.autotune.common.data.metrics.Metric;
 import com.autotune.common.data.metrics.MetricAggregationInfoResults;
 import com.autotune.common.data.metrics.MetricResults;
 import com.autotune.common.data.result.ContainerData;
@@ -1423,8 +1427,8 @@ public class RecommendationEngine {
             if (dataSourceInfo == null) {
                 throw new DataSourceNotExist(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.MISSING_DATASOURCE_INFO);
             }
-            // Fetch metrics based on the datasource
-            fetchMetricsBasedOnDatasource(kruizeObject, interval_end_time, intervalStartTime, dataSourceInfo);
+            // Fetch metrics dynamically from Metric Profile based on the datasource
+            fetchMetricsBasedOnProfileAndDatasource(kruizeObject, interval_end_time, intervalStartTime, dataSourceInfo);
         }
         return errorMsg;
     }
@@ -1601,6 +1605,217 @@ public class RecommendationEngine {
                     containerData.setResults(containerDataResults);
                     if (!containerDataResults.isEmpty())
                         setInterval_end_time(Collections.max(containerDataResults.keySet()));    //TODO Temp fix invalid date is set if experiment having two container with different last seen date
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new Exception(AnalyzerErrorConstants.APIErrors.UpdateRecommendationsAPI.METRIC_EXCEPTION + e.getMessage());
+        }
+    }
+
+    /**
+     * Fetches metrics based on the specified datasource using queries from the metricProfile for the given time interval.
+     *
+     * @param kruizeObject
+     * @param interval_end_time
+     * @param interval_start_time
+     * @param dataSourceInfo
+     * @throws Exception
+     */
+    public void fetchMetricsBasedOnProfileAndDatasource(KruizeObject kruizeObject, Timestamp interval_end_time, Timestamp interval_start_time, DataSourceInfo dataSourceInfo) throws Exception {
+        try {
+            long interval_end_time_epoc = 0;
+            long interval_start_time_epoc = 0;
+            SimpleDateFormat sdf = new SimpleDateFormat(KruizeConstants.DateFormats.STANDARD_JSON_DATE_FORMAT, Locale.ROOT);
+
+            String metricProfileName = kruizeObject.getPerformanceProfile();
+            PerformanceProfile metricProfile = MetricProfileCollection.getInstance().getMetricProfileCollection().get(metricProfileName);
+            if (null == metricProfile) {
+                LOGGER.error("MetricProfile does not exist or is not valid: {}", metricProfileName);
+                return;
+            }
+
+            String maxDateQuery = null;
+            List<Metric>metrics = metricProfile.getSloInfo().getFunctionVariables();
+            for (Metric metric: metrics) {
+                String name = metric.getName();
+                if(name.equals("maxDate")){
+                    String query = metric.getAggregationFunctionsMap().get("max").getQuery();
+                    maxDateQuery = query;
+                    break;
+                }
+            }
+
+            Double measurementDurationMinutesInDouble = kruizeObject.getTrial_settings().getMeasurement_durationMinutes_inDouble();
+            List<K8sObject> kubernetes_objects = kruizeObject.getKubernetes_objects();
+
+            // Iterate over Kubernetes objects
+            for (K8sObject k8sObject : kubernetes_objects) {
+                String namespace = k8sObject.getNamespace();
+                String workload = k8sObject.getName();
+                String workload_type = k8sObject.getType();
+                HashMap<String, ContainerData> containerDataMap = k8sObject.getContainerDataMap();
+                // Iterate over containers
+                for (Map.Entry<String, ContainerData> entry : containerDataMap.entrySet()) {
+                    ContainerData containerData = entry.getValue();
+                    String containerName = containerData.getContainer_name();
+                    if (null == interval_end_time) {
+                        LOGGER.info(KruizeConstants.APIMessages.CONTAINER_USAGE_INFO);
+                        String queryToEncode;
+                        if (null != maxDateQuery) {
+                            LOGGER.info("maxDateQuery: {}", maxDateQuery);
+                            queryToEncode =  maxDateQuery
+                                    .replace(AnalyzerConstants.NAMESPACE_VARIABLE, namespace)
+                                    .replace(AnalyzerConstants.CONTAINER_VARIABLE, containerName)
+                                    .replace(AnalyzerConstants.WORKLOAD_VARIABLE, workload)
+                                    .replace(AnalyzerConstants.WORKLOAD_TYPE_VARIABLE, workload_type);
+                        } else {
+                            queryToEncode =  String.format(PromQLDataSourceQueries.MAX_DATE, containerName, namespace);
+                        }
+                        String dateMetricsUrl = String.format(KruizeConstants.DataSourceConstants.DATE_ENDPOINT_WITH_QUERY,
+                                dataSourceInfo.getUrl(),
+                                URLEncoder.encode(queryToEncode, CHARACTER_ENCODING)
+                        );
+                        LOGGER.info(dateMetricsUrl);
+                        JSONObject genericJsonObject = new GenericRestApiClient(dateMetricsUrl).fetchMetricsJson(KruizeConstants.APIMessages.GET, "");
+                        JsonObject jsonObject = new Gson().fromJson(genericJsonObject.toString(), JsonObject.class);
+                        JsonArray resultArray = jsonObject.getAsJsonObject(KruizeConstants.JSONKeys.DATA).getAsJsonArray(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.RESULT);
+                        // Process fetched metrics
+                        if (null != resultArray && !resultArray.isEmpty()) {
+                            resultArray = resultArray.get(0)
+                                    .getAsJsonObject().getAsJsonArray(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.VALUE);
+                            long epochTime = resultArray.get(0).getAsLong();
+                            String timestamp = sdf.format(new Date(epochTime * KruizeConstants.TimeConv.NO_OF_MSECS_IN_SEC));
+                            Date date = sdf.parse(timestamp);
+                            Timestamp dateTS = new Timestamp(date.getTime());
+                            interval_end_time_epoc = dateTS.getTime() / KruizeConstants.TimeConv.NO_OF_MSECS_IN_SEC
+                                    - ((long) dateTS.getTimezoneOffset() * KruizeConstants.TimeConv.NO_OF_SECONDS_PER_MINUTE);
+                            int maxDay = Terms.getMaxDays(kruizeObject.getTerms());
+                            LOGGER.info(KruizeConstants.APIMessages.MAX_DAY, maxDay);
+                            Timestamp startDateTS = Timestamp.valueOf(Objects.requireNonNull(dateTS).toLocalDateTime().minusDays(maxDay));
+                            interval_start_time_epoc = startDateTS.getTime() / KruizeConstants.TimeConv.NO_OF_MSECS_IN_SEC
+                                    - ((long) startDateTS.getTimezoneOffset() * KruizeConstants.TimeConv.NO_OF_MSECS_IN_SEC);
+                        }
+                    } else {
+                        // Convert timestamps to epoch time
+                        interval_end_time_epoc = interval_end_time.getTime() / KruizeConstants.TimeConv.NO_OF_MSECS_IN_SEC
+                                - ((long) interval_end_time.getTimezoneOffset() * KruizeConstants.TimeConv.NO_OF_SECONDS_PER_MINUTE);
+                        interval_start_time_epoc = interval_start_time.getTime() / KruizeConstants.TimeConv.NO_OF_MSECS_IN_SEC
+                                - ((long) interval_start_time.getTimezoneOffset() * KruizeConstants.TimeConv.NO_OF_MSECS_IN_SEC);
+                    }
+                    HashMap<Timestamp, IntervalResults> containerDataResults = new HashMap<>();
+                    IntervalResults intervalResults;
+                    HashMap<AnalyzerConstants.MetricName, MetricResults> resMap;
+                    HashMap<String, MetricResults> resultMap;
+                    MetricResults metricResults;
+                    MetricAggregationInfoResults metricAggregationInfoResults;
+
+                    List<Metric> metricList = metricProfile.getSloInfo().getFunctionVariables();
+
+                    // Iterate over metrics and aggregation functions
+                    for (Metric metricEntry : metricList) {
+                        HashMap<String, AggregationFunctions> aggregationFunctions = metricEntry.getAggregationFunctionsMap();
+                        for (Map.Entry<String, AggregationFunctions> aggregationFunctionsEntry: aggregationFunctions.entrySet()) {
+                            // Determine promQL query on metric type
+                            String metricQuery = aggregationFunctionsEntry.getValue().getQuery();
+                            String promQL = metricQuery;
+                            String format = null;
+
+
+                            // Determine format based on metric type - Todo move this metric profile
+                            List<String> cpuFunction = Arrays.asList(AnalyzerConstants.MetricName.cpuUsage.toString(), AnalyzerConstants.MetricName.cpuThrottle.toString(), AnalyzerConstants.MetricName.cpuLimit.toString(), AnalyzerConstants.MetricName.cpuRequest.toString());
+                            List<String> memFunction = Arrays.asList(AnalyzerConstants.MetricName.memoryLimit.toString(), AnalyzerConstants.MetricName.memoryRequest.toString(), AnalyzerConstants.MetricName.memoryRSS.toString(), AnalyzerConstants.MetricName.memoryUsage.toString());
+                            if (cpuFunction.contains(metricEntry.getName())) {
+                                format = KruizeConstants.JSONKeys.CORES;
+                            } else if (memFunction.contains(metricEntry.getName())) {
+                                format = KruizeConstants.JSONKeys.BYTES;
+                            }
+
+                            promQL = promQL
+                                    .replace(AnalyzerConstants.NAMESPACE_VARIABLE, namespace)
+                                    .replace(AnalyzerConstants.CONTAINER_VARIABLE, containerName)
+                                    .replace(AnalyzerConstants.MEASUREMENT_DURATION_IN_MIN_VARAIBLE, Integer.toString(measurementDurationMinutesInDouble.intValue()))
+                                    .replace(AnalyzerConstants.WORKLOAD_VARIABLE, workload)
+                                    .replace(AnalyzerConstants.WORKLOAD_TYPE_VARIABLE, workload_type);
+
+                            // If promQL is determined, fetch metrics from the datasource
+                            if (promQL != null) {
+                                LOGGER.info(promQL);
+                                String podMetricsUrl;
+                                try {
+                                    podMetricsUrl = String.format(KruizeConstants.DataSourceConstants.DATASOURCE_ENDPOINT_WITH_QUERY,
+                                            dataSourceInfo.getUrl(),
+                                            URLEncoder.encode(promQL, CHARACTER_ENCODING),
+                                            interval_start_time_epoc,
+                                            interval_end_time_epoc,
+                                            measurementDurationMinutesInDouble.intValue() * KruizeConstants.TimeConv.NO_OF_SECONDS_PER_MINUTE);
+                                    LOGGER.info(podMetricsUrl);
+                                    JSONObject genericJsonObject = new GenericRestApiClient(podMetricsUrl).fetchMetricsJson(KruizeConstants.APIMessages.GET, "");
+                                    JsonObject jsonObject = new Gson().fromJson(genericJsonObject.toString(), JsonObject.class);
+                                    JsonArray resultArray = jsonObject.getAsJsonObject(KruizeConstants.JSONKeys.DATA).getAsJsonArray(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.RESULT);
+                                    // Process fetched metrics
+                                    if (null != resultArray && !resultArray.isEmpty()) {
+                                        resultArray = jsonObject.getAsJsonObject(KruizeConstants.JSONKeys.DATA).getAsJsonArray(
+                                                        KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.RESULT).get(0)
+                                                .getAsJsonObject().getAsJsonArray(KruizeConstants.DataSourceConstants
+                                                        .DataSourceQueryJSONKeys.VALUES);
+                                        sdf.setTimeZone(TimeZone.getTimeZone(KruizeConstants.TimeUnitsExt.TimeZones.UTC));
+
+                                        // Iterate over fetched metrics
+                                        Timestamp sTime = new Timestamp(interval_start_time_epoc);
+                                        for (JsonElement element : resultArray) {
+                                            JsonArray valueArray = element.getAsJsonArray();
+                                            long epochTime = valueArray.get(0).getAsLong();
+                                            double value = valueArray.get(1).getAsDouble();
+                                            String timestamp = sdf.format(new Date(epochTime * KruizeConstants.TimeConv.NO_OF_MSECS_IN_SEC));
+                                            Date date = sdf.parse(timestamp);
+                                            Timestamp eTime = new Timestamp(date.getTime());
+
+                                            // Prepare interval results
+                                            if (containerDataResults.containsKey(eTime)) {
+                                                intervalResults = containerDataResults.get(eTime);
+                                                resMap = intervalResults.getMetricResultsMap();
+                                            } else {
+                                                intervalResults = new IntervalResults();
+                                                resMap = new HashMap<>();
+                                            }
+                                            AnalyzerConstants.MetricName metricName = AnalyzerConstants.MetricName.valueOf(metricEntry.getName());
+                                            if (resMap.containsKey(metricName)) {
+                                                metricResults = resMap.get(metricName);
+                                                metricAggregationInfoResults = metricResults.getAggregationInfoResult();
+                                            } else {
+                                                metricResults = new MetricResults();
+                                                metricAggregationInfoResults = new MetricAggregationInfoResults();
+                                            }
+
+                                            Method method = MetricAggregationInfoResults.class.getDeclaredMethod(KruizeConstants.APIMessages.SET + aggregationFunctionsEntry.getKey().substring(0, 1).toUpperCase() + aggregationFunctionsEntry.getKey().substring(1), Double.class);
+                                            method.invoke(metricAggregationInfoResults, value);
+                                            metricAggregationInfoResults.setFormat(format);
+                                            metricResults.setAggregationInfoResult(metricAggregationInfoResults);
+                                            metricResults.setName(metricEntry.getName());
+                                            metricResults.setFormat(format);
+                                            resMap.put(metricName, metricResults);
+                                            intervalResults.setMetricResultsMap(resMap);
+                                            intervalResults.setIntervalStartTime(sTime);  //Todo this will change
+                                            intervalResults.setIntervalEndTime(eTime);
+                                            intervalResults.setDurationInMinutes((double) ((eTime.getTime() - sTime.getTime())
+                                                    / ((long) KruizeConstants.TimeConv.NO_OF_SECONDS_PER_MINUTE
+                                                    * KruizeConstants.TimeConv.NO_OF_MSECS_IN_SEC)));
+                                            containerDataResults.put(eTime, intervalResults);
+                                            sTime = eTime;
+                                        }
+                                    }
+                                } catch (Exception e) {
+                                    throw new RuntimeException(e);
+                                }
+                            }
+                        }
+                    }
+
+                    containerData.setResults(containerDataResults);
+                    if (!containerDataResults.isEmpty())
+                        setInterval_end_time(Collections.max(containerDataResults.keySet()));    //TODO Temp fix invalid date is set if experiment having two container with different last seen date
+
                 }
             }
         } catch (Exception e) {

--- a/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
@@ -318,16 +318,16 @@ public class Converters {
                     String kubeObject = functionVarObj.has(AnalyzerConstants.KUBERNETES_OBJECT) ? functionVarObj.getString(AnalyzerConstants.KUBERNETES_OBJECT) : null;
                     Metric metric = new Metric(name, query, datasource, valueType, kubeObject);
                     JSONArray aggrFunctionArray = functionVarObj.has(AnalyzerConstants.AGGREGATION_FUNCTIONS) ? functionVarObj.getJSONArray(AnalyzerConstants.AGGREGATION_FUNCTIONS) : null;
+                    HashMap<String, AggregationFunctions> aggregationFunctionsMap = new HashMap<>();
                     for (Object innerObject : aggrFunctionArray) {
                         JSONObject aggrFuncJsonObject = (JSONObject) innerObject;
-                        HashMap<String, AggregationFunctions> aggregationFunctionsMap = new HashMap<>();
                         String function = aggrFuncJsonObject.getString(AnalyzerConstants.FUNCTION);
                         String aggrFuncQuery = aggrFuncJsonObject.getString(KruizeConstants.JSONKeys.QUERY);
                         String version = aggrFuncJsonObject.has(KruizeConstants.JSONKeys.VERSION) ? aggrFuncJsonObject.getString(KruizeConstants.JSONKeys.VERSION) : null;
                         AggregationFunctions aggregationFunctions = new AggregationFunctions(function, aggrFuncQuery, version);
                         aggregationFunctionsMap.put(function, aggregationFunctions);
-                        metric.setAggregationFunctionsMap(aggregationFunctionsMap);
                     }
+                    metric.setAggregationFunctionsMap(aggregationFunctionsMap);
                     functionVariablesList.add(metric);
                 }
                 String sloClass = sloJsonObject.has(AnalyzerConstants.AutotuneObjectConstants.SLO_CLASS) ? sloJsonObject.get(AnalyzerConstants.AutotuneObjectConstants.SLO_CLASS).toString() : null;

--- a/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
@@ -31,6 +31,8 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class Converters {
     private Converters() {
@@ -288,6 +290,53 @@ public class Converters {
                 performanceProfile = new PerformanceProfile(perfProfileName, profileVersion, k8sType, sloInfo);
             }
             return performanceProfile;
+        }
+
+        public static PerformanceProfile convertInputJSONToCreateMetricProfile(String inputData) throws InvalidValueException, Exception {
+            PerformanceProfile metricProfile = null;
+            if (inputData != null) {
+                JSONObject jsonObject = new JSONObject(inputData);
+                String apiVersion = jsonObject.getString(AnalyzerConstants.API_VERSION);
+                String kind = jsonObject.getString(AnalyzerConstants.KIND);
+
+                JSONObject metadataObject = jsonObject.getJSONObject(AnalyzerConstants.AutotuneObjectConstants.METADATA);
+                ObjectMapper objectMapper = new ObjectMapper();
+                ObjectNode metadata = objectMapper.readValue(metadataObject.toString(), ObjectNode.class);
+                metadata.put("name", metadataObject.getString("name"));
+
+                Double profileVersion = jsonObject.has(AnalyzerConstants.PROFILE_VERSION) ? jsonObject.getDouble(AnalyzerConstants.PROFILE_VERSION) : null;
+                String k8sType = jsonObject.has(AnalyzerConstants.PerformanceProfileConstants.K8S_TYPE) ? jsonObject.getString(AnalyzerConstants.PerformanceProfileConstants.K8S_TYPE) : null;
+                JSONObject sloJsonObject = jsonObject.getJSONObject(AnalyzerConstants.AutotuneObjectConstants.SLO);
+                JSONArray functionVariableArray = sloJsonObject.getJSONArray(AnalyzerConstants.AutotuneObjectConstants.FUNCTION_VARIABLES);
+                ArrayList<Metric> functionVariablesList = new ArrayList<>();
+                for (Object object : functionVariableArray) {
+                    JSONObject functionVarObj = (JSONObject) object;
+                    String name = functionVarObj.getString(AnalyzerConstants.AutotuneObjectConstants.NAME);
+                    String datasource = functionVarObj.getString(AnalyzerConstants.AutotuneObjectConstants.DATASOURCE);
+                    String query = functionVarObj.has(AnalyzerConstants.AutotuneObjectConstants.QUERY) ? functionVarObj.getString(AnalyzerConstants.AutotuneObjectConstants.QUERY) : null;
+                    String valueType = functionVarObj.getString(AnalyzerConstants.AutotuneObjectConstants.VALUE_TYPE);
+                    String kubeObject = functionVarObj.has(AnalyzerConstants.KUBERNETES_OBJECT) ? functionVarObj.getString(AnalyzerConstants.KUBERNETES_OBJECT) : null;
+                    Metric metric = new Metric(name, query, datasource, valueType, kubeObject);
+                    JSONArray aggrFunctionArray = functionVarObj.has(AnalyzerConstants.AGGREGATION_FUNCTIONS) ? functionVarObj.getJSONArray(AnalyzerConstants.AGGREGATION_FUNCTIONS) : null;
+                    for (Object innerObject : aggrFunctionArray) {
+                        JSONObject aggrFuncJsonObject = (JSONObject) innerObject;
+                        HashMap<String, AggregationFunctions> aggregationFunctionsMap = new HashMap<>();
+                        String function = aggrFuncJsonObject.getString(AnalyzerConstants.FUNCTION);
+                        String aggrFuncQuery = aggrFuncJsonObject.getString(KruizeConstants.JSONKeys.QUERY);
+                        String version = aggrFuncJsonObject.has(KruizeConstants.JSONKeys.VERSION) ? aggrFuncJsonObject.getString(KruizeConstants.JSONKeys.VERSION) : null;
+                        AggregationFunctions aggregationFunctions = new AggregationFunctions(function, aggrFuncQuery, version);
+                        aggregationFunctionsMap.put(function, aggregationFunctions);
+                        metric.setAggregationFunctionsMap(aggregationFunctionsMap);
+                    }
+                    functionVariablesList.add(metric);
+                }
+                String sloClass = sloJsonObject.has(AnalyzerConstants.AutotuneObjectConstants.SLO_CLASS) ? sloJsonObject.get(AnalyzerConstants.AutotuneObjectConstants.SLO_CLASS).toString() : null;
+                String direction = sloJsonObject.has(AnalyzerConstants.AutotuneObjectConstants.DIRECTION) ? sloJsonObject.get(AnalyzerConstants.AutotuneObjectConstants.DIRECTION).toString() : null;
+                ObjectiveFunction objectiveFunction = new Gson().fromJson(sloJsonObject.getJSONObject(AnalyzerConstants.AutotuneObjectConstants.OBJECTIVE_FUNCTION).toString(), ObjectiveFunction.class);
+                SloInfo sloInfo = new SloInfo(sloClass, objectiveFunction, direction, functionVariablesList);
+                metricProfile = new PerformanceProfile(apiVersion, kind, metadata, profileVersion, k8sType, sloInfo);
+            }
+            return metricProfile;
         }
 
         public static ConcurrentHashMap<String, KruizeObject> ConvertUpdateResultDataToAPIResponse(ConcurrentHashMap<String, KruizeObject> mainKruizeExperimentMap) {

--- a/src/main/java/com/autotune/analyzer/services/MetricProfileService.java
+++ b/src/main/java/com/autotune/analyzer/services/MetricProfileService.java
@@ -1,0 +1,243 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package com.autotune.analyzer.services;
+
+import com.autotune.analyzer.exceptions.InvalidValueException;
+import com.autotune.analyzer.exceptions.PerformanceProfileResponse;
+import com.autotune.analyzer.performanceProfiles.PerformanceProfile;
+import com.autotune.analyzer.performanceProfiles.utils.PerformanceProfileUtil;
+import com.autotune.analyzer.serviceObjects.Converters;
+import com.autotune.analyzer.utils.AnalyzerConstants;
+import com.autotune.analyzer.utils.AnalyzerErrorConstants;
+import com.autotune.analyzer.utils.GsonUTCDateAdapter;
+import com.autotune.common.data.ValidationOutputData;
+import com.autotune.common.data.metrics.Metric;
+import com.autotune.database.service.ExperimentDBService;
+import com.autotune.utils.KruizeConstants;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.gson.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.Serial;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import static com.autotune.analyzer.utils.AnalyzerConstants.ServiceConstants.CHARACTER_ENCODING;
+import static com.autotune.analyzer.utils.AnalyzerConstants.ServiceConstants.JSON_CONTENT_TYPE;
+
+/**
+ * REST API to create metric profile .
+ */
+@WebServlet(asyncSupported = true)
+public class MetricProfileService extends HttpServlet {
+    @Serial
+    private static final long serialVersionUID = 1L;
+    private static final Logger LOGGER = LoggerFactory.getLogger(MetricProfileService.class);
+    private ConcurrentHashMap<String, PerformanceProfile> metricProfilesMap;
+
+    @Override
+    public void init(ServletConfig config) throws ServletException {
+        super.init(config);
+        metricProfilesMap = (ConcurrentHashMap<String, PerformanceProfile>) getServletContext()
+                .getAttribute(AnalyzerConstants.PerformanceProfileConstants.METRIC_PROFILE_MAP);
+    }
+
+    /**
+     * Validate and create new Metric Profile.
+     *
+     * @param request
+     * @param response
+     * @throws IOException
+     */
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        try {
+            Map<String, PerformanceProfile> metricProfilesMap = new ConcurrentHashMap<>();
+            String inputData = request.getReader().lines().collect(Collectors.joining());
+            PerformanceProfile metricProfile = Converters.KruizeObjectConverters.convertInputJSONToCreateMetricProfile(inputData);
+            ValidationOutputData validationOutputData = PerformanceProfileUtil.validateAndAddMetricProfile(metricProfilesMap, metricProfile);
+            if (validationOutputData.isSuccess()) {
+                ValidationOutputData addedToDB = new ExperimentDBService().addMetricProfileToDB(metricProfile);
+                if (addedToDB.isSuccess()) {
+                    metricProfilesMap.put(String.valueOf(metricProfile.getMetadata().get("name")), metricProfile);
+                    getServletContext().setAttribute(AnalyzerConstants.PerformanceProfileConstants.METRIC_PROFILE_MAP, metricProfilesMap);
+                    LOGGER.debug(KruizeConstants.MetricProfileAPIMessages.ADD_METRIC_PROFILE_TO_DB_WITH_VERSION,
+                            metricProfile.getMetadata().get("name").asText(), metricProfile.getProfile_version());
+                    sendSuccessResponse(response, String.format(KruizeConstants.MetricProfileAPIMessages.CREATE_METRIC_PROFILE_SUCCESS_MSG, metricProfile.getMetadata().get("name").asText()));
+                } else {
+                    sendErrorResponse(response, null, HttpServletResponse.SC_BAD_REQUEST, addedToDB.getMessage());
+                }
+            } else
+                sendErrorResponse(response, null, validationOutputData.getErrorCode(), validationOutputData.getMessage());
+        } catch (Exception e) {
+            sendErrorResponse(response, e, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Validation failed: " + e.getMessage());
+        } catch (InvalidValueException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Get List of Metric Profiles
+     *
+     * @param req
+     * @param response
+     * @throws ServletException
+     * @throws IOException
+     */
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse response) throws ServletException, IOException {
+        response.setContentType(JSON_CONTENT_TYPE);
+        response.setCharacterEncoding(CHARACTER_ENCODING);
+        response.setStatus(HttpServletResponse.SC_OK);
+        String gsonStr = "[]";
+        // Fetch all metric profiles from the DB
+        try {
+            new ExperimentDBService().loadAllMetricProfiles(metricProfilesMap);
+        } catch (Exception e) {
+            LOGGER.error(KruizeConstants.MetricProfileAPIMessages.LOAD_METRIC_PROFILE_FAILURE, e.getMessage());
+        }
+        if (metricProfilesMap.size() > 0) {
+            Collection<PerformanceProfile> values = metricProfilesMap.values();
+            Gson gsonObj = new GsonBuilder()
+                    .disableHtmlEscaping()
+                    .setPrettyPrinting()
+                    .enableComplexMapKeySerialization()
+                    .registerTypeAdapter(Date.class, new GsonUTCDateAdapter())
+                    // a custom serializer for serializing metadata of JsonNode type.
+                    .registerTypeAdapter(JsonNode.class, new JsonSerializer<JsonNode>() {
+                        @Override
+                        public JsonElement serialize(JsonNode jsonNode, Type typeOfSrc, JsonSerializationContext context) {
+                            if (jsonNode instanceof ObjectNode) {
+                                ObjectNode objectNode = (ObjectNode) jsonNode;
+                                JsonObject metadataJson = new JsonObject();
+
+                                // Extract the "name" field directly if it exists
+                                if (objectNode.has("name")) {
+                                    metadataJson.addProperty("name", objectNode.get("name").asText());
+                                }
+
+                                return metadataJson;
+                            }
+                            return context.serialize(jsonNode);
+                        }
+                    })
+                    .setExclusionStrategies(new ExclusionStrategy() {
+                        @Override
+                        public boolean shouldSkipField(FieldAttributes f) {
+                            return f.getDeclaringClass() == Metric.class && (
+                                    f.getName().equals("trialSummaryResult")
+                                            || f.getName().equals("cycleDataMap")
+                            );
+                        }
+
+                        @Override
+                        public boolean shouldSkipClass(Class<?> aClass) {
+                            return false;
+                        }
+                    })
+                    .create();
+            gsonStr = gsonObj.toJson(values);
+        } else {
+            LOGGER.debug(AnalyzerErrorConstants.AutotuneObjectErrors.NO_PERF_PROFILE);
+        }
+        response.getWriter().println(gsonStr);
+        response.getWriter().close();
+    }
+
+    /**
+     * TODO: Need to implement
+     * Update Metric Profile
+     *
+     * @param req
+     * @param resp
+     * @throws ServletException
+     * @throws IOException
+     */
+    @Override
+    protected void doPut(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        super.doPut(req, resp);
+    }
+
+    /**
+     * TODO: Need to implement
+     * Delete Metric profile
+     *
+     * @param req
+     * @param resp
+     * @throws ServletException
+     * @throws IOException
+     */
+    @Override
+    protected void doDelete(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        super.doDelete(req, resp);
+    }
+
+    /**
+     * Send success response in case of no errors or exceptions.
+     *
+     * @param response
+     * @param message
+     * @throws IOException
+     */
+    private void sendSuccessResponse(HttpServletResponse response, String message) throws IOException {
+        response.setContentType(JSON_CONTENT_TYPE);
+        response.setCharacterEncoding(CHARACTER_ENCODING);
+        response.setStatus(HttpServletResponse.SC_CREATED);
+        PrintWriter out = response.getWriter();
+        out.append(
+                new Gson().toJson(
+                        new PerformanceProfileResponse(message +
+                                KruizeConstants.MetricProfileAPIMessages.VIEW_METRIC_PROFILES_MSG,
+                                HttpServletResponse.SC_CREATED, "", "SUCCESS")
+                )
+        );
+        out.flush();
+    }
+
+    /**
+     * Send response containing corresponding error message in case of failures and exceptions
+     *
+     * @param response
+     * @param e
+     * @param httpStatusCode
+     * @param errorMsg
+     * @throws IOException
+     */
+    public void sendErrorResponse(HttpServletResponse response, Exception e, int httpStatusCode, String errorMsg) throws
+            IOException {
+        if (null != e) {
+            LOGGER.error(e.toString());
+            if (null == errorMsg)
+                errorMsg = e.getMessage();
+        }
+        response.sendError(httpStatusCode, errorMsg);
+    }
+}

--- a/src/main/java/com/autotune/analyzer/services/MetricProfileService.java
+++ b/src/main/java/com/autotune/analyzer/services/MetricProfileService.java
@@ -18,6 +18,7 @@ package com.autotune.analyzer.services;
 
 import com.autotune.analyzer.exceptions.InvalidValueException;
 import com.autotune.analyzer.exceptions.PerformanceProfileResponse;
+import com.autotune.analyzer.performanceProfiles.MetricProfileCollection;
 import com.autotune.analyzer.performanceProfiles.PerformanceProfile;
 import com.autotune.analyzer.performanceProfiles.utils.PerformanceProfileUtil;
 import com.autotune.analyzer.serviceObjects.Converters;
@@ -91,6 +92,10 @@ public class MetricProfileService extends HttpServlet {
                     getServletContext().setAttribute(AnalyzerConstants.PerformanceProfileConstants.METRIC_PROFILE_MAP, metricProfilesMap);
                     LOGGER.debug(KruizeConstants.MetricProfileAPIMessages.ADD_METRIC_PROFILE_TO_DB_WITH_VERSION,
                             metricProfile.getMetadata().get("name").asText(), metricProfile.getProfile_version());
+                    // Store metric profile in-memory collection
+                    MetricProfileCollection metricProfileCollection = MetricProfileCollection.getInstance();
+                    metricProfileCollection.addMetricProfile(metricProfile);
+
                     sendSuccessResponse(response, String.format(KruizeConstants.MetricProfileAPIMessages.CREATE_METRIC_PROFILE_SUCCESS_MSG, metricProfile.getMetadata().get("name").asText()));
                 } else {
                     sendErrorResponse(response, null, HttpServletResponse.SC_BAD_REQUEST, addedToDB.getMessage());

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -63,6 +63,10 @@ public class AnalyzerConstants {
     public static final String NONE = "none";
     public static final String POD_VARIABLE = "$POD$";
     public static final String NAMESPACE_VARIABLE = "$NAMESPACE$";
+    public static final String CONTAINER_VARIABLE = "$CONTAINER_NAME$";
+    public static final String MEASUREMENT_DURATION_IN_MIN_VARAIBLE = "$MEASUREMENT_DURATION_IN_MIN$";
+    public static final String WORKLOAD_VARIABLE = "$WORKLOAD$";
+    public static final String WORKLOAD_TYPE_VARIABLE = "$WORKLOAD_TYPE$";
     public static final String API_VERSION = "apiVersion";
     public static final String KIND = "kind";
     public static final String RESOURCE_VERSION = "resourceVersion";
@@ -159,7 +163,8 @@ public class AnalyzerConstants {
         memoryRequest,
         memoryLimit,
         memoryUsage,
-        memoryRSS
+        memoryRSS,
+        maxDate
     }
 
     public enum K8S_OBJECT_TYPES {

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -453,6 +453,7 @@ public class AnalyzerConstants {
         public static final String K8S_TYPE = "k8s_type";
         public static final String PERF_PROFILE = "performanceProfile";
         public static final String PERF_PROFILE_MAP = "performanceProfileMap";
+        public static final String METRIC_PROFILE_MAP = "metricProfileMap";
         public static final String PERF_PROFILE_NAME = "name";
         public static final String OBJECTIVE_FUNCTION = "objectiveFunction";
         public static final String FUNCTION_VARIABLES = "functionVariables";

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -463,6 +463,10 @@ public class AnalyzerConstants {
         public static final String PERFORMANCE_PROFILE_PKG = "com.autotune.analyzer.performanceProfiles.PerformanceProfileInterface.";
         public static final String DEFAULT_PROFILE = "default";
 
+        //Metric profile constants
+        public static final String DEFAULT_API_VERSION = "recommender.com/v1";
+        public static final String DEFAULT_KIND = "KruizePerformanceProfile";
+
         // Perf profile names
         public static final String RESOURCE_OPT_OPENSHIFT_PROFILE = "resource-optimization-openshift";
         public static final String RESOURCE_OPT_LOCAL_MON_PROFILE = "resource-optimization-local-monitoring";

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -164,7 +164,19 @@ public class AnalyzerConstants {
         memoryLimit,
         memoryUsage,
         memoryRSS,
-        maxDate
+        maxDate,
+        namespaceCpuRequest,
+        namespaceCpuLimit,
+        namespaceCpuUsage,
+        namespaceCpuThrottle,
+        namespaceMemoryRequest,
+        namespaceMemoryLimit,
+        namespaceMemoryUsage,
+        namespaceMemoryRSS,
+        namespaceTotalPods,
+        namespaceRunningPods,
+        gpuCoreUsage,
+        gpuMemoryUsage,
     }
 
     public enum K8S_OBJECT_TYPES {

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -457,6 +457,7 @@ public class AnalyzerConstants {
         public static final String PERF_PROFILE_NAME = "name";
         public static final String OBJECTIVE_FUNCTION = "objectiveFunction";
         public static final String FUNCTION_VARIABLES = "functionVariables";
+        public static final String METRIC_PROFILE_NAME = "name";
         public static final String VALUE_TYPE = "valueType";
         public static final String SOURCE = "source";
         public static final String PERFORMANCE_PROFILE_PKG = "com.autotune.analyzer.performanceProfiles.PerformanceProfileInterface.";

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
@@ -223,6 +223,17 @@ public class AnalyzerErrorConstants {
             public static final String DATASOURCE_METADATA_MISSING_REQUEST_INPUT_EXCPTN = "Request input data cannot be null or empty";
             public static final String DATASOURCE_METADATA_CONNECTION_FAILED = "Metadata cannot be imported, datasource connection refused or timed out";
         }
+
+        public static final class ListMetricProfileAPI {
+            public ListMetricProfileAPI() {
+            }
+            public static final String INVALID_QUERY_PARAM = "The query param(s) - %s is/are invalid";
+            public static final String INVALID_QUERY_PARAM_VALUE = "The query param value(s) is/are invalid";
+            public static final String INVALID_METRIC_PROFILE_NAME_EXCPTN = "Invalid Metric Profile Name";
+            public static final String INVALID_METRIC_PROFILE_NAME_MSG = "Given metric profile name - %s either does not exist or is not valid";
+            public static final String NO_METRIC_PROFILES_EXCPTN = "No metric profile";
+            public static final String NO_METRIC_PROFILES = "No metric profiles found!";
+        }
     }
 
     public static final class ConversionErrors {

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
@@ -79,6 +79,8 @@ public class AnalyzerErrorConstants {
         public static final String SLO_REDUNDANCY_ERROR = "SLO Data and Performance Profile cannot exist simultaneously!";
         public static final String DUPLICATE_PERF_PROFILE = "Performance Profile already exists: ";
         public static final String MISSING_PERF_PROFILE = "Not Found: performance_profile does not exist: ";
+        public static final String MISSING_METRIC_PROFILE_METADATA= "metadata missing\n";
+        public static final String DUPLICATE_METRIC_PROFILE = "Metric Profile already exists: ";
         public static final String MISSING_EXPERIMENT_NAME = "Not Found: experiment_name does not exist: ";
         public static final String NO_METRICS_AVAILABLE = "No metrics available from %s to %s";
         public static final String UNSUPPORTED_EXPERIMENT = String.format("At present, the system does not support bulk entries!");

--- a/src/main/java/com/autotune/database/dao/ExperimentDAO.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAO.java
@@ -25,6 +25,9 @@ public interface ExperimentDAO {
     // Add Performance Profile  to DB
     public ValidationOutputData addPerformanceProfileToDB(KruizePerformanceProfileEntry kruizePerformanceProfileEntry);
 
+    // Add Metric Profile  to DB
+    public ValidationOutputData addMetricProfileToDB(KruizeMetricProfileEntry kruizeMetricProfileEntry);
+
     // Add DataSource to DB
     ValidationOutputData addDataSourceToDB(KruizeDataSourceEntry kruizeDataSourceEntry);
 
@@ -45,6 +48,9 @@ public interface ExperimentDAO {
 
     // If Kruize restarts load all performance profiles
     List<KruizePerformanceProfileEntry> loadAllPerformanceProfiles() throws Exception;
+
+    // If Kruize restarts load all metric profiles
+    List<KruizeMetricProfileEntry> loadAllMetricProfiles() throws Exception;
 
     // Load a single experiment based on experimentName
     List<KruizeExperimentEntry> loadExperimentByName(String experimentName) throws Exception;

--- a/src/main/java/com/autotune/database/dao/ExperimentDAO.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAO.java
@@ -69,6 +69,8 @@ public interface ExperimentDAO {
     // Load a single Performance Profile based on name
     List<KruizePerformanceProfileEntry> loadPerformanceProfileByName(String performanceProfileName) throws Exception;
 
+    // Load a single Metric Profile based on name
+    List<KruizeMetricProfileEntry> loadMetricProfileByName(String metricProfileName) throws Exception;
 
     // Load all recommendations of a particular experiment and interval end Time
     KruizeRecommendationEntry loadRecommendationsByExperimentNameAndDate(String experimentName, String cluster_name, Timestamp interval_end_time) throws Exception;

--- a/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
@@ -850,7 +850,7 @@ public class ExperimentDAOImpl implements ExperimentDAO {
     }
 
     /**
-     * Fetched Metric Profile by name from KruizeMetricProfileEntry database table
+     * Fetches Metric Profile by name from KruizeMetricProfileEntry database table
      * @param metricProfileName Metric profile name
      * @return List of KruizeMetricProfileEntry objects
      * @throws Exception

--- a/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
@@ -385,6 +385,38 @@ public class ExperimentDAOImpl implements ExperimentDAO {
     }
 
     /**
+     * Adds MetricProfile to database
+     * @param kruizeMetricProfileEntry Metric Profile Database object to be added
+     * @return validationOutputData contains the status of the DB insert operation
+     */
+    public ValidationOutputData addMetricProfileToDB(KruizeMetricProfileEntry kruizeMetricProfileEntry) {
+        ValidationOutputData validationOutputData = new ValidationOutputData(false, null, null);
+        String statusValue = "failure";
+        Timer.Sample timerAddMetricProfileDB = Timer.start(MetricsConfig.meterRegistry());
+        Transaction tx = null;
+        try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
+            try {
+                tx = session.beginTransaction();
+                session.persist(kruizeMetricProfileEntry);
+                tx.commit();
+                validationOutputData.setSuccess(true);
+                statusValue = "success";
+            } catch (HibernateException e) {
+                LOGGER.error("Not able to save metric profile due to {}", e.getMessage());
+                if (tx != null) tx.rollback();
+                e.printStackTrace();
+                validationOutputData.setSuccess(false);
+                validationOutputData.setMessage(e.getMessage());
+                //todo save error to API_ERROR_LOG
+            }
+        } catch (Exception e) {
+            LOGGER.error("Not able to save metric profile due to {}", e.getMessage());
+            validationOutputData.setMessage(e.getMessage());
+        }
+        return validationOutputData;
+    }
+
+    /**
      * @param kruizeDataSourceEntry
      * @return validationOutputData contains the status of the DB insert operation
      */
@@ -622,6 +654,25 @@ public class ExperimentDAOImpl implements ExperimentDAO {
         return entries;
     }
 
+    /**
+     * Fetches all the Metric Profile records from KruizeMetricProfileEntry database table
+     * @return List of all KruizeMetricProfileEntry database objects
+     * @throws Exception
+     */
+    @Override
+    public List<KruizeMetricProfileEntry> loadAllMetricProfiles() throws Exception {
+        String statusValue = "failure";
+        Timer.Sample timerLoadAllMetricProfiles = Timer.start(MetricsConfig.meterRegistry());
+        List<KruizeMetricProfileEntry> entries = null;
+        try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
+            entries = session.createQuery(DBConstants.SQLQUERY.SELECT_FROM_METRIC_PROFILE, KruizeMetricProfileEntry.class).list();
+        } catch (Exception e) {
+            LOGGER.error("Not able to load Metric Profile  due to {}", e.getMessage());
+            throw new Exception("Error while loading existing Metric Profile from database due to : " + e.getMessage());
+        }
+        return entries;
+    }
+
     @Override
     public List<KruizeExperimentEntry> loadExperimentByName(String experimentName) throws Exception {
         //todo load only experimentStatus=inprogress , playback may not require completed experiments
@@ -794,6 +845,26 @@ public class ExperimentDAOImpl implements ExperimentDAO {
                 MetricsConfig.timerLoadPerfProfileName = MetricsConfig.timerBLoadPerfProfileName.tag("status", statusValue).register(MetricsConfig.meterRegistry());
                 timerLoadPerfProfileName.stop(MetricsConfig.timerLoadPerfProfileName);
             }
+        }
+        return entries;
+    }
+
+    /**
+     * Fetched Metric Profile by name from KruizeMetricProfileEntry database table
+     * @param metricProfileName Metric profile name
+     * @return List of KruizeMetricProfileEntry objects
+     * @throws Exception
+     */
+    public List<KruizeMetricProfileEntry> loadMetricProfileByName(String metricProfileName) throws Exception {
+        String statusValue = "failure";
+        Timer.Sample timerLoadMetricProfileName = Timer.start(MetricsConfig.meterRegistry());
+        List<KruizeMetricProfileEntry> entries = null;
+        try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
+            entries = session.createQuery(DBConstants.SQLQUERY.SELECT_FROM_METRIC_PROFILE_BY_NAME, KruizeMetricProfileEntry.class)
+                    .setParameter("name", metricProfileName).list();
+        } catch (Exception e) {
+            LOGGER.error("Not able to load Metric Profile {} due to {}", metricProfileName, e.getMessage());
+            throw new Exception("Error while loading existing metric profile from database due to : " + e.getMessage());
         }
         return entries;
     }

--- a/src/main/java/com/autotune/database/helper/DBConstants.java
+++ b/src/main/java/com/autotune/database/helper/DBConstants.java
@@ -57,6 +57,8 @@ public class DBConstants {
         public static final String SELECT_FROM_RECOMMENDATIONS = "from KruizeRecommendationEntry";
         public static final String SELECT_FROM_PERFORMANCE_PROFILE = "from KruizePerformanceProfileEntry";
         public static final String SELECT_FROM_PERFORMANCE_PROFILE_BY_NAME = "from KruizePerformanceProfileEntry k WHERE k.name = :name";
+        public static final String SELECT_FROM_METRIC_PROFILE = "from KruizeMetricProfileEntry";
+        public static final String SELECT_FROM_METRIC_PROFILE_BY_NAME = "from KruizeMetricProfileEntry k WHERE k.name = :name";
         public static final String DELETE_FROM_EXPERIMENTS_BY_EXP_NAME = "DELETE FROM KruizeExperimentEntry k WHERE k.experiment_name = :experimentName";
         public static final String DELETE_FROM_RESULTS_BY_EXP_NAME = "DELETE FROM KruizeResultsEntry k WHERE k.experiment_name = :experimentName";
         public static final String DELETE_FROM_RECOMMENDATIONS_BY_EXP_NAME = "DELETE FROM KruizeRecommendationEntry k WHERE k.experiment_name = :experimentName";

--- a/src/main/java/com/autotune/database/init/KruizeHibernateUtil.java
+++ b/src/main/java/com/autotune/database/init/KruizeHibernateUtil.java
@@ -59,6 +59,7 @@ public class KruizeHibernateUtil {
             if (KruizeDeploymentInfo.local) {
                 configuration.addAnnotatedClass(KruizeDataSourceEntry.class);
                 configuration.addAnnotatedClass(KruizeDSMetadataEntry.class);
+                configuration.addAnnotatedClass(KruizeMetricProfileEntry.class);
             }
             LOGGER.info("DB is trying to connect to {}", connectionURL);
             sfTemp = configuration.buildSessionFactory();

--- a/src/main/java/com/autotune/database/service/ExperimentDBService.java
+++ b/src/main/java/com/autotune/database/service/ExperimentDBService.java
@@ -388,6 +388,27 @@ public class ExperimentDBService {
         }
     }
 
+    /**
+     * Fetches Metric Profile by name from kruizeMetricProfileEntry
+     * @param metricProfileMap Map to store metric profile loaded from the database
+     * @param metricProfileName Metric profile name to be fetched
+     * @return ValidationOutputData object
+     */
+    public void loadMetricProfileFromDBByName(Map<String, PerformanceProfile> metricProfileMap, String metricProfileName) throws Exception {
+        List<KruizeMetricProfileEntry> entries = experimentDAO.loadMetricProfileByName(metricProfileName);
+        if (null != entries && !entries.isEmpty()) {
+            List<PerformanceProfile> metricProfiles = DBHelpers.Converters.KruizeObjectConverters
+                    .convertMetricProfileEntryToMetricProfileObject(entries);
+            if (!metricProfiles.isEmpty()) {
+                for (PerformanceProfile performanceProfile : metricProfiles) {
+                    if (null != performanceProfile) {
+                        PerformanceProfileUtil.addMetricProfile(metricProfileMap, performanceProfile);
+                    }
+                }
+            }
+        }
+    }
+
     public void loadAllExperimentsAndRecommendations(Map<String, KruizeObject> mainKruizeExperimentMap) throws Exception {
 
         loadAllExperiments(mainKruizeExperimentMap);

--- a/src/main/java/com/autotune/database/service/ExperimentDBService.java
+++ b/src/main/java/com/autotune/database/service/ExperimentDBService.java
@@ -140,6 +140,17 @@ public class ExperimentDBService {
         }
     }
 
+    public void loadAllMetricProfiles(Map<String, PerformanceProfile> metricProfileMap) throws Exception {
+        List<KruizeMetricProfileEntry> entries = experimentDAO.loadAllMetricProfiles();
+        if (null != entries && !entries.isEmpty()) {
+            List<PerformanceProfile> performanceProfiles = DBHelpers.Converters.KruizeObjectConverters.convertMetricProfileEntryToMetricProfileObject(entries);
+            if (!performanceProfiles.isEmpty()) {
+                performanceProfiles.forEach(performanceProfile ->
+                        PerformanceProfileUtil.addMetricProfile(metricProfileMap, performanceProfile));
+            }
+        }
+    }
+
     public boolean loadResultsFromDBByName(Map<String, KruizeObject> mainKruizeExperimentMap, String experimentName, Timestamp calculated_start_time, Timestamp interval_end_time) throws Exception {
         ExperimentInterface experimentInterface = new ExperimentInterfaceImpl();
         KruizeObject kruizeObject = mainKruizeExperimentMap.get(experimentName);
@@ -267,6 +278,22 @@ public class ExperimentDBService {
             validationOutputData = this.experimentDAO.addPerformanceProfileToDB(kruizePerformanceProfileEntry);
         } catch (Exception e) {
             LOGGER.error("Not able to save Performance Profile due to {}", e.getMessage());
+        }
+        return validationOutputData;
+    }
+
+    /**
+     * Adds Metric Profile to kruizeMetricProfileEntry
+     * @param metricProfile Metric profile object to be added
+     * @return ValidationOutputData object
+     */
+    public ValidationOutputData addMetricProfileToDB(PerformanceProfile metricProfile) {
+        ValidationOutputData validationOutputData = new ValidationOutputData(false, null, null);
+        try {
+            KruizeMetricProfileEntry kruizeMetricProfileEntry = DBHelpers.Converters.KruizeObjectConverters.convertMetricProfileObjToMetricProfileDBObj(metricProfile);
+            validationOutputData = this.experimentDAO.addMetricProfileToDB(kruizeMetricProfileEntry);
+        } catch (Exception e) {
+            LOGGER.error("Not able to save Metric Profile due to {}", e.getMessage());
         }
         return validationOutputData;
     }

--- a/src/main/java/com/autotune/database/table/KruizeMetricProfileEntry.java
+++ b/src/main/java/com/autotune/database/table/KruizeMetricProfileEntry.java
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.autotune.database.table;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.persistence.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+/**
+ * This is a Java class named KruizeMetricProfileEntry annotated with JPA annotations.
+ * It represents a table named kruize_metric_profiles in a relational database.
+ * <p>
+ * The class has the following fields:
+ * <p>
+ * id: A unique identifier for each metric profile detail.
+ * apiVersion: A string representing version of the Kubernetes API to create this object
+ * kind: A string representing type of kubernetes object
+ * metadata: A JSON object containing the metadata of the CRD, including name field
+ * name: A string representing the name of the metric profile.
+ * profile_version: A string representing the version of the metric profile.
+ * k8s_type: A string representing kubernetes type.
+ * SLO: A string representing the slo class, direction, Objective function and function variables.
+ */
+@Entity
+@Table(name = "kruize_metric_profiles")
+public class KruizeMetricProfileEntry {
+    private String api_version;
+    private String kind;
+    @JdbcTypeCode(SqlTypes.JSON)
+    private JsonNode metadata;
+    @Id
+    private String name;
+    private double profile_version;
+    private String k8s_type;
+    @JdbcTypeCode(SqlTypes.JSON)
+    private JsonNode slo;
+
+    public String getApi_version() {
+        return api_version;
+    }
+
+    public void setApi_version(String api_version) {
+        this.api_version = api_version;
+    }
+
+    public String getKind() {
+        return kind;
+    }
+
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    public JsonNode getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(JsonNode metadata) {
+        this.metadata = metadata;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public double getProfile_version() {
+        return profile_version;
+    }
+
+    public void setProfile_version(double profile_version) {
+        this.profile_version = profile_version;
+    }
+
+    public String getK8s_type() {
+        return k8s_type;
+    }
+
+    public void setK8s_type(String k8s_type) {
+        this.k8s_type = k8s_type;
+    }
+
+    public JsonNode getSlo() {
+        return slo;
+    }
+
+    public void setSlo(JsonNode slo) {
+        this.slo = slo;
+    }
+}

--- a/src/main/java/com/autotune/operator/KruizeOperator.java
+++ b/src/main/java/com/autotune/operator/KruizeOperator.java
@@ -40,6 +40,8 @@ import com.autotune.common.target.kubernetes.service.impl.KubernetesServicesImpl
 import com.autotune.common.variables.Variables;
 import com.autotune.utils.EventLogger;
 import com.autotune.utils.KubeEventLogger;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.gson.Gson;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
@@ -449,6 +451,39 @@ public class KruizeOperator {
             return null;
         }
         return performanceProfile.getName();
+    }
+
+    public static String setDefaultMetricProfile(SloInfo sloInfo, String mode, String targetCluster) {
+        PerformanceProfile metricProfile = null;
+        try {
+            String apiVersion = AnalyzerConstants.PerformanceProfileConstants.DEFAULT_API_VERSION;
+            String kind = AnalyzerConstants.PerformanceProfileConstants.DEFAULT_KIND;
+            String name = AnalyzerConstants.PerformanceProfileConstants.DEFAULT_PROFILE;
+            ObjectMapper objectMapper = new ObjectMapper();
+            ObjectNode metadataNode = objectMapper.createObjectNode();
+            metadataNode.put("name",name);
+
+            double profile_version = AnalyzerConstants.DEFAULT_PROFILE_VERSION;
+            String k8s_type = AnalyzerConstants.DEFAULT_K8S_TYPE;
+            metricProfile = new PerformanceProfile(apiVersion, kind, metadataNode, profile_version, k8s_type, sloInfo);
+
+            if (null != metricProfile) {
+                ValidationOutputData validationOutputData = PerformanceProfileUtil.validateAndAddMetricProfile(PerformanceProfilesDeployment.performanceProfilesMap, metricProfile);
+                if (validationOutputData.isSuccess()) {
+                    LOGGER.info("Added metric Profile : {} into the map with version: {}",
+                            metricProfile.getName(), metricProfile.getProfile_version());
+                } else {
+                    new KubeEventLogger(Clock.systemUTC()).log("Failed", validationOutputData.getMessage(), EventLogger.Type.Warning, null, null, null, null);
+                }
+            } else {
+                new KubeEventLogger(Clock.systemUTC()).log("Failed", "Unable to create metric profile ", EventLogger.Type.Warning, null, null, null, null);
+            }
+        } catch (Exception e) {
+            LOGGER.error("Exception while adding Metric profile with message: {} ", e.getMessage());
+            new KubeEventLogger(Clock.systemUTC()).log("Failed", e.getMessage(), EventLogger.Type.Warning, null, null, null, null);
+            return null;
+        }
+        return metricProfile.getName();
     }
 
     /**

--- a/src/main/java/com/autotune/service/InitiateListener.java
+++ b/src/main/java/com/autotune/service/InitiateListener.java
@@ -25,6 +25,7 @@ import com.autotune.experimentManager.data.ExperimentDetailsMap;
 import com.autotune.experimentManager.utils.EMConstants;
 import com.autotune.experimentManager.utils.EMConstants.ParallelEngineConfigs;
 import com.autotune.experimentManager.workerimpl.IterationManager;
+import com.autotune.operator.KruizeDeploymentInfo;
 import com.autotune.operator.KruizeOperator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -156,6 +157,19 @@ public class InitiateListener implements ServletContextListener {
             LOGGER.error("Failed to load performance profile: {} ", e.getMessage());
         }
         sce.getServletContext().setAttribute(AnalyzerConstants.PerformanceProfileConstants.PERF_PROFILE_MAP, performanceProfilesMap);
+
+        if(KruizeDeploymentInfo.local == true) {
+            /*
+            Kruize Metric Profile configuration
+            */
+            ConcurrentHashMap<String, PerformanceProfile> metricProfilesMap = new ConcurrentHashMap<>();
+            try {
+                new ExperimentDBService().loadAllMetricProfiles(metricProfilesMap);
+            } catch (Exception e) {
+                LOGGER.error("Failed to load metric profile: {} ", e.getMessage());
+            }
+            sce.getServletContext().setAttribute(AnalyzerConstants.PerformanceProfileConstants.METRIC_PROFILE_MAP, metricProfilesMap);
+        }
     }
 
     @Override

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -73,6 +73,15 @@ public class KruizeConstants {
         public static final String ADD_METRIC_PROFILE_TO_DB_WITH_VERSION = "Added Metric Profile : {} into the DB with version: {}";
     }
 
+    public static class MetricProfileConstants {
+        public static final String CHECKING_AVAILABLE_METRIC_PROFILE_FROM_DB = "Checking available metric profiles from database: ";
+        public static final String NO_METRIC_PROFILE_FOUND_IN_DB = "No metric profile found in database.";
+        public static final String METRIC_PROFILE_FOUND = "MetricProfile found: ";
+        public static final String ADDING_METRIC_PROFILE = "Trying to add the metric profile to collection: ";
+        public static final String METRIC_PROFILE_ALREADY_EXISTS = "MetricProfile already exists: ";
+        public static final String METRIC_PROFILE_ADDED = "MetricProfile added to the collection successfully: ";
+    }
+
     /**
      * Holds the constants of env vars and values to start Autotune in different Modes
      */

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -66,6 +66,13 @@ public class KruizeConstants {
         public static final String UPDATE_RECOMMENDATIONS_FAILURE_MSG = "UpdateRecommendations API failed for experiment_name: %s and intervalEndTimeStr : %s due to %s";
     }
 
+    public static class MetricProfileAPIMessages {
+        public static final String CREATE_METRIC_PROFILE_SUCCESS_MSG = "Metric Profile : %s created successfully.";
+        public static final String VIEW_METRIC_PROFILES_MSG = " View Metric Profiles at /listMetricProfiles";
+        public static final String LOAD_METRIC_PROFILE_FAILURE = "Failed to load saved metric profile data: {}";
+        public static final String ADD_METRIC_PROFILE_TO_DB_WITH_VERSION = "Added Metric Profile : {} into the DB with version: {}";
+    }
+
     /**
      * Holds the constants of env vars and values to start Autotune in different Modes
      */

--- a/src/main/java/com/autotune/utils/KruizeSupportedTypes.java
+++ b/src/main/java/com/autotune/utils/KruizeSupportedTypes.java
@@ -81,10 +81,14 @@ public class KruizeSupportedTypes
 			"datasource", "cluster_name", "namespace", "verbose"
 	));
 	
-  public static final Set<String> SUPPORTED_FORMATS =
+  	public static final Set<String> SUPPORTED_FORMATS =
 			new HashSet<>(Arrays.asList("cores", "m", "Bytes", "bytes", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "kB", "KB", "MB", "GB", "TB", "PB", "EB", "K", "k", "M", "G", "T", "P", "E"));
 
 	public static final Set<String> QUERY_PARAMS_SUPPORTED = new HashSet<>(Arrays.asList(
 			"experiment_name", "results", "recommendations", "latest"
+	));
+
+	public static final Set<String> LIST_METRIC_PROFILES_QUERY_PARAMS_SUPPORTED = new HashSet<>(Arrays.asList(
+			"name", "verbose"
 	));
 }

--- a/src/main/java/com/autotune/utils/KruizeSupportedTypes.java
+++ b/src/main/java/com/autotune/utils/KruizeSupportedTypes.java
@@ -75,7 +75,7 @@ public class KruizeSupportedTypes
 					"((request_count / (request_sum / request_count)) / request_max) * 100"));
 
 	public static final Set<String> KUBERNETES_OBJECTS_SUPPORTED =
-			new HashSet<>(Arrays.asList("deployment", "pod", "container"));
+			new HashSet<>(Arrays.asList("deployment", "pod", "container", "namespace"));
 
 	public static final Set<String> DSMETADATA_QUERY_PARAMS_SUPPORTED = new HashSet<>(Arrays.asList(
 			"datasource", "cluster_name", "namespace", "verbose"

--- a/src/main/java/com/autotune/utils/ServerContext.java
+++ b/src/main/java/com/autotune/utils/ServerContext.java
@@ -43,6 +43,8 @@ public class ServerContext {
     public static final String RECOMMEND_RESULTS = ROOT_CONTEXT + "listRecommendations";
     public static final String CREATE_PERF_PROFILE = ROOT_CONTEXT + "createPerformanceProfile";
     public static final String LIST_PERF_PROFILES = ROOT_CONTEXT + "listPerformanceProfiles";
+    public static final String CREATE_METRIC_PROFILE = ROOT_CONTEXT + "createMetricProfile";
+    public static final String LIST_METRIC_PROFILES = ROOT_CONTEXT + "listMetricProfiles";
 
     public static final String KRUIZE_SERVER_URL = "http://localhost:" + KRUIZE_SERVER_PORT;
     public static final String SEARCH_SPACE_END_POINT = KRUIZE_SERVER_URL + SEARCH_SPACE;


### PR DESCRIPTION
## Description

This PR has the following changes:

- Integrates `MetricProfile` with `local_monitoring` experiments
- Generates recommendations by fetching metric queries dynamically from `MetricProfile` instead of constant values from Java source
- Add MetricName placeholders for `namespace` and `GPU` related queries

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Tested using local monitoring demo script

**Test Configuration**
* Kubernetes clusters tested on: openshift, ResourceHub cluster

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Image - quay.io/shbirada/mvp_demo:genRecomm-using-metricprofile