### PR TITLE
Integrate MetricProfile with local Experiments

### DIFF
--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -465,6 +465,10 @@ public class AnalyzerConstants {
         public static final String RESOURCE_OPT_OPENSHIFT_PROFILE = "resource-optimization-openshift";
         public static final String RESOURCE_OPT_LOCAL_MON_PROFILE = "resource-optimization-local-monitoring";
 
+        //Metric profile constants
+        public static final String DEFAULT_API_VERSION = "recommender.com/v1";
+        public static final String DEFAULT_KIND = "KruizePerformanceProfile";
+
         public static final Map<String, String> PerfProfileNames = Map.of(
                 RESOURCE_OPT_OPENSHIFT_PROFILE, "ResourceOptimizationOpenshiftImpl",
                 RESOURCE_OPT_LOCAL_MON_PROFILE, "ResourceOptimizationOpenshiftImpl"

--- a/src/main/java/com/autotune/database/dao/ExperimentDAO.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAO.java
@@ -63,6 +63,8 @@ public interface ExperimentDAO {
     // Load a single Performance Profile based on name
     List<KruizePerformanceProfileEntry> loadPerformanceProfileByName(String performanceProfileName) throws Exception;
 
+    // Load a single Metric Profile based on name
+    List<KruizeMetricProfileEntry> loadMetricProfileByName(String metricProfileName) throws Exception;
 
     // Load all recommendations of a particular experiment and interval end Time
     KruizeRecommendationEntry loadRecommendationsByExperimentNameAndDate(String experimentName, String cluster_name, Timestamp interval_end_time) throws Exception;

--- a/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
@@ -798,6 +798,25 @@ public class ExperimentDAOImpl implements ExperimentDAO {
         return entries;
     }
 
+    /**
+     * Fetches Metric Profile by name from KruizeMetricProfileEntry database table
+     * @param metricProfileName Metric profile name
+     * @return List of KruizeMetricProfileEntry objects
+     * @throws Exception
+     */
+    public List<KruizeMetricProfileEntry> loadMetricProfileByName(String metricProfileName) throws Exception {
+        String statusValue = "failure";
+        Timer.Sample timerLoadMetricProfileName = Timer.start(MetricsConfig.meterRegistry());
+        List<KruizeMetricProfileEntry> entries = null;
+        try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
+            entries = session.createQuery(DBConstants.SQLQUERY.SELECT_FROM_METRIC_PROFILE_BY_NAME, KruizeMetricProfileEntry.class)
+                    .setParameter("name", metricProfileName).list();
+        } catch (Exception e) {
+            LOGGER.error("Not able to load Metric Profile {} due to {}", metricProfileName, e.getMessage());
+            throw new Exception("Error while loading existing metric profile from database due to : " + e.getMessage());
+        }
+        return entries;
+    }
 
     @Override
     public List<KruizeResultsEntry> getKruizeResultsEntry(String experiment_name, String cluster_name, Timestamp interval_start_time, Timestamp interval_end_time) throws Exception {

--- a/src/main/java/com/autotune/database/service/ExperimentDBService.java
+++ b/src/main/java/com/autotune/database/service/ExperimentDBService.java
@@ -361,6 +361,27 @@ public class ExperimentDBService {
         }
     }
 
+    /**
+     * Fetches Metric Profile by name from kruizeMetricProfileEntry
+     * @param metricProfileMap Map to store metric profile loaded from the database
+     * @param metricProfileName Metric profile name to be fetched
+     * @return ValidationOutputData object
+     */
+    public void loadMetricProfileFromDBByName(Map<String, PerformanceProfile> metricProfileMap, String metricProfileName) throws Exception {
+        List<KruizeMetricProfileEntry> entries = experimentDAO.loadMetricProfileByName(metricProfileName);
+        if (null != entries && !entries.isEmpty()) {
+            List<PerformanceProfile> metricProfiles = DBHelpers.Converters.KruizeObjectConverters
+                    .convertMetricProfileEntryToMetricProfileObject(entries);
+            if (!metricProfiles.isEmpty()) {
+                for (PerformanceProfile performanceProfile : metricProfiles) {
+                    if (null != performanceProfile) {
+                        PerformanceProfileUtil.addMetricProfile(metricProfileMap, performanceProfile);
+                    }
+                }
+            }
+        }
+    }
+
     public void loadAllExperimentsAndRecommendations(Map<String, KruizeObject> mainKruizeExperimentMap) throws Exception {
 
         loadAllExperiments(mainKruizeExperimentMap);

--- a/src/main/java/com/autotune/operator/KruizeOperator.java
+++ b/src/main/java/com/autotune/operator/KruizeOperator.java
@@ -40,6 +40,8 @@ import com.autotune.common.target.kubernetes.service.impl.KubernetesServicesImpl
 import com.autotune.common.variables.Variables;
 import com.autotune.utils.EventLogger;
 import com.autotune.utils.KubeEventLogger;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.gson.Gson;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
@@ -449,6 +451,39 @@ public class KruizeOperator {
             return null;
         }
         return performanceProfile.getName();
+    }
+
+    public static String setDefaultMetricProfile(SloInfo sloInfo, String mode, String targetCluster) {
+        PerformanceProfile metricProfile = null;
+        try {
+            String apiVersion = AnalyzerConstants.PerformanceProfileConstants.DEFAULT_API_VERSION;
+            String kind = AnalyzerConstants.PerformanceProfileConstants.DEFAULT_KIND;
+            String name = AnalyzerConstants.PerformanceProfileConstants.DEFAULT_PROFILE;
+            ObjectMapper objectMapper = new ObjectMapper();
+            ObjectNode metadataNode = objectMapper.createObjectNode();
+            metadataNode.put("name",name);
+
+            double profile_version = AnalyzerConstants.DEFAULT_PROFILE_VERSION;
+            String k8s_type = AnalyzerConstants.DEFAULT_K8S_TYPE;
+            metricProfile = new PerformanceProfile(apiVersion, kind, metadataNode, profile_version, k8s_type, sloInfo);
+
+            if (null != metricProfile) {
+                ValidationOutputData validationOutputData = PerformanceProfileUtil.validateAndAddMetricProfile(PerformanceProfilesDeployment.performanceProfilesMap, metricProfile);
+                if (validationOutputData.isSuccess()) {
+                    LOGGER.info("Added metric Profile : {} into the map with version: {}",
+                            metricProfile.getName(), metricProfile.getProfile_version());
+                } else {
+                    new KubeEventLogger(Clock.systemUTC()).log("Failed", validationOutputData.getMessage(), EventLogger.Type.Warning, null, null, null, null);
+                }
+            } else {
+                new KubeEventLogger(Clock.systemUTC()).log("Failed", "Unable to create metric profile ", EventLogger.Type.Warning, null, null, null, null);
+            }
+        } catch (Exception e) {
+            LOGGER.error("Exception while adding Metric profile with message: {} ", e.getMessage());
+            new KubeEventLogger(Clock.systemUTC()).log("Failed", e.getMessage(), EventLogger.Type.Warning, null, null, null, null);
+            return null;
+        }
+        return metricProfile.getName();
     }
 
     /**


### PR DESCRIPTION
## Description

This PR integrates MetricProfile with CreateExperiments codeflow  to reference metric profile for the `performance_profile` field

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

.
