### PR TITLE
Refactor end-to-end local monitoring test 

### DIFF
--- a/tests/scripts/helpers/utils.py
+++ b/tests/scripts/helpers/utils.py
@@ -1117,19 +1117,19 @@ def get_urls(namespace, cluster_type):
     elif cluster_type == "openshift":
         # expose service kruize
         subprocess.run(['oc -n openshift-tuning expose service kruize'], shell=True, stdout=subprocess.PIPE,
-                       stderr=subprocess.PIPE, text=True)
+                       stderr=subprocess.PIPE)
 
         # annotate kruize route
         subprocess.run(['oc -n openshift-tuning annotate route kruize --overwrite haproxy.router.openshift.io/timeout=60s'],
-                       shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+                       shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         # expose service tfb-qrh-service
         subprocess.run([f'oc -n {namespace} expose service tfb-qrh-service'], shell=True, stdout=subprocess.PIPE,
-                       stderr=subprocess.PIPE, text=True)
+                       stderr=subprocess.PIPE)
 
         # get tfb-qrh-service route
         techempower_url = subprocess.run([f'oc -n {namespace} get route tfb-qrh-service --no-headers -o custom-columns=NODE:.spec.host'],
-                                         shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+                                         shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     else:
         raise ValueError("Unsupported CLUSTER_TYPE. Expected 'minikube' or 'openshift'.")
 
@@ -1190,8 +1190,9 @@ def wait_for_container_to_complete(container_id):
     print("##########################################################################################################\n")
     result = subprocess.run(
         ["docker", "wait", container_id],
-        capture_output=True,
-        text=True
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
     exit_code = result.stdout.strip()
     print(f"Container {container_id} has completed with exit code {exit_code}.")

--- a/tests/scripts/helpers/utils.py
+++ b/tests/scripts/helpers/utils.py
@@ -1190,7 +1190,6 @@ def wait_for_container_to_complete(container_id):
     print("##########################################################################################################\n")
     result = subprocess.run(
         ["docker", "wait", container_id],
-        shell=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )

--- a/tests/scripts/helpers/utils.py
+++ b/tests/scripts/helpers/utils.py
@@ -1124,7 +1124,7 @@ def get_urls(namespace, cluster_type):
                        shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
 
         # expose service tfb-qrh-service
-        subprocess.run(['oc -n default expose service tfb-qrh-service'], shell=True, stdout=subprocess.PIPE,
+        subprocess.run([f'oc -n {namespace} expose service tfb-qrh-service'], shell=True, stdout=subprocess.PIPE,
                        stderr=subprocess.PIPE, text=True)
 
         # get tfb-qrh-service route

--- a/tests/scripts/local_monitoring_tests/rest_apis/test_local_monitoring_e2e_workflow.py
+++ b/tests/scripts/local_monitoring_tests/rest_apis/test_local_monitoring_e2e_workflow.py
@@ -19,6 +19,7 @@ import json
 import pytest
 import sys
 import time
+import shutil
 sys.path.append("../../")
 
 from helpers.fixtures import *
@@ -226,3 +227,6 @@ def test_list_recommendations_multiple_exps_for_datasource_workloads(cluster_typ
     response = delete_metric_profile(metric_profile_json_file)
     print("delete metric profile = ", response.status_code)
     assert response.status_code == SUCCESS_STATUS_CODE
+
+    # Remove benchmarks directory
+    shutil.rmtree("benchmarks")

--- a/tests/scripts/local_monitoring_tests/rest_apis/test_local_monitoring_e2e_workflow.py
+++ b/tests/scripts/local_monitoring_tests/rest_apis/test_local_monitoring_e2e_workflow.py
@@ -185,8 +185,6 @@ def test_list_recommendations_multiple_exps_for_datasource_workloads(cluster_typ
 
 
     response = generate_recommendations(tfb_exp_name)
-    data = response.json()
-    print(data)
     assert response.status_code == SUCCESS_STATUS_CODE
 
     # Invoke list recommendations for the specified experiment
@@ -200,8 +198,6 @@ def test_list_recommendations_multiple_exps_for_datasource_workloads(cluster_typ
 
 
     response = generate_recommendations(tfb_db_exp_name)
-    data = response.json()
-    print(data)
     assert response.status_code == SUCCESS_STATUS_CODE
 
     # Invoke list recommendations for the specified experiment


### PR DESCRIPTION
## Description

This PR has following changes:

- Exposes `tfb-qrh-service` to retrieve `techempower_url` using the route in OpenShift
- Remove installed benchmarks at the end of the test script

Test results: 
- [0.0.24-openshift-local-monitoring-functional-tests.zip](https://github.com/user-attachments/files/16776433/0.0.24-openshift-local-monitoring-functional-tests.zip)
 - Jenkins functional tests: https://ci.app-svc-perf.corp.redhat.com/job/ExternalTeams/job/Autotune/job/kruize_functional_tests/123

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

Tested using kruize-lm cluster by running functional tests 

- [ ] New Test X
- [x] Functional testsuite: local_monitoring_tests

**Test Configuration**
* Kubernetes clusters tested on: openshift

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [x] Tests added or updated

## Additional information

.
