### PR TITLE
Kruize Notification prod fix

### DIFF
--- a/src/main/java/com/autotune/metrics/KruizeNotificationCollectionRegistry.java
+++ b/src/main/java/com/autotune/metrics/KruizeNotificationCollectionRegistry.java
@@ -82,9 +82,9 @@ public class KruizeNotificationCollectionRegistry {
         for (RecommendationNotification recommendationNotification : recommendationNotificationList) {
             Tags additionalTags = Tags.empty();
             if (("|" + KruizeDeploymentInfo.log_recommendation_metrics_level + "|").contains("|" + recommendationNotification.getType() + "|") == true) {
-                String kibanaLog =  String.format(KruizeConstants.KRUIZE_RECOMMENDATION_METRICS.notification_format_for_KIBANA, this.experiment_name, this.container_name, KruizeConstants.DateFormats.simpleDateFormatForUTC.format(this.interval_end_time), level, term, model, String.valueOf(recommendationNotification.getCode()), recommendationNotification.getType(), recommendationNotification.getMessage());
+                String notificationLog =  String.format(KruizeConstants.KRUIZE_RECOMMENDATION_METRICS.notification_format_for_KIBANA, this.experiment_name, this.container_name, KruizeConstants.DateFormats.simpleDateFormatForUTC.format(this.interval_end_time), level, term, model, String.valueOf(recommendationNotification.getCode()), recommendationNotification.getType(), recommendationNotification.getMessage());
                 String metricEntry =  String.format(KruizeConstants.KRUIZE_RECOMMENDATION_METRICS.notification_format_for_METRICS,  term, model, recommendationNotification.getType());
-                LOGGER.info(kibanaLog);
+                LOGGER.info(notificationLog);
                 additionalTags = additionalTags.and(KruizeConstants.KRUIZE_RECOMMENDATION_METRICS.TAG_NAME,metricEntry); // A metric entry with only three tags, which are unlikely to have many unique values, will therefore help reduce cardinality.
                 Counter counterNotifications = MetricsConfig.meterRegistry().find(KruizeConstants.KRUIZE_RECOMMENDATION_METRICS.METRIC_NAME).tags(additionalTags).counter();
                 if (counterNotifications == null) {

--- a/src/main/java/com/autotune/metrics/KruizeNotificationCollectionRegistry.java
+++ b/src/main/java/com/autotune/metrics/KruizeNotificationCollectionRegistry.java
@@ -5,7 +5,6 @@ import com.autotune.analyzer.recommendations.objects.MappedRecommendationForMode
 import com.autotune.analyzer.recommendations.objects.MappedRecommendationForTimestamp;
 import com.autotune.analyzer.recommendations.objects.TermRecommendations;
 import com.autotune.common.data.result.ContainerData;
-import com.autotune.operator.InitializeDeployment;
 import com.autotune.operator.KruizeDeploymentInfo;
 import com.autotune.utils.KruizeConstants;
 import com.autotune.utils.MetricsConfig;
@@ -82,7 +81,7 @@ public class KruizeNotificationCollectionRegistry {
         for (RecommendationNotification recommendationNotification : recommendationNotificationList) {
             Tags additionalTags = Tags.empty();
             if (("|" + KruizeDeploymentInfo.log_recommendation_metrics_level + "|").contains("|" + recommendationNotification.getType() + "|") == true) {
-                String notificationLog =  String.format(KruizeConstants.KRUIZE_RECOMMENDATION_METRICS.notification_format_for_KIBANA, this.experiment_name, this.container_name, KruizeConstants.DateFormats.simpleDateFormatForUTC.format(this.interval_end_time), level, term, model, String.valueOf(recommendationNotification.getCode()), recommendationNotification.getType(), recommendationNotification.getMessage());
+                String notificationLog =  String.format(KruizeConstants.KRUIZE_RECOMMENDATION_METRICS.notification_format_for_LOG, this.experiment_name, this.container_name, KruizeConstants.DateFormats.simpleDateFormatForUTC.format(this.interval_end_time), level, term, model, String.valueOf(recommendationNotification.getCode()), recommendationNotification.getType(), recommendationNotification.getMessage());
                 String metricEntry =  String.format(KruizeConstants.KRUIZE_RECOMMENDATION_METRICS.notification_format_for_METRICS,  term, model, recommendationNotification.getType());
                 LOGGER.info(notificationLog);
                 additionalTags = additionalTags.and(KruizeConstants.KRUIZE_RECOMMENDATION_METRICS.TAG_NAME,metricEntry); // A metric entry with only three tags, which are unlikely to have many unique values, will therefore help reduce cardinality.

--- a/src/main/java/com/autotune/metrics/KruizeNotificationCollectionRegistry.java
+++ b/src/main/java/com/autotune/metrics/KruizeNotificationCollectionRegistry.java
@@ -5,11 +5,14 @@ import com.autotune.analyzer.recommendations.objects.MappedRecommendationForMode
 import com.autotune.analyzer.recommendations.objects.MappedRecommendationForTimestamp;
 import com.autotune.analyzer.recommendations.objects.TermRecommendations;
 import com.autotune.common.data.result.ContainerData;
+import com.autotune.operator.InitializeDeployment;
 import com.autotune.operator.KruizeDeploymentInfo;
 import com.autotune.utils.KruizeConstants;
 import com.autotune.utils.MetricsConfig;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Tags;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.sql.Timestamp;
 import java.util.Collection;
@@ -24,6 +27,7 @@ public class KruizeNotificationCollectionRegistry {
     private String experiment_name;
     private Timestamp interval_end_time;
     private String container_name;
+    private static final Logger LOGGER = LoggerFactory.getLogger(KruizeNotificationCollectionRegistry.class);
 
     /**
      * Constructor to initialize KruizeNotificationCollectionRegistry with experiment name, interval end time, and container name.
@@ -78,7 +82,10 @@ public class KruizeNotificationCollectionRegistry {
         for (RecommendationNotification recommendationNotification : recommendationNotificationList) {
             Tags additionalTags = Tags.empty();
             if (("|" + KruizeDeploymentInfo.log_recommendation_metrics_level + "|").contains("|" + recommendationNotification.getType() + "|") == true) {
-                additionalTags = additionalTags.and(KruizeConstants.KRUIZE_RECOMMENDATION_METRICS.TAG_NAME, String.format(KruizeConstants.KRUIZE_RECOMMENDATION_METRICS.notification_format, this.experiment_name, this.container_name, KruizeConstants.DateFormats.simpleDateFormatForUTC.format(this.interval_end_time), level, term, model, String.valueOf(recommendationNotification.getCode()), recommendationNotification.getType(), recommendationNotification.getMessage()));
+                String kibanaLog =  String.format(KruizeConstants.KRUIZE_RECOMMENDATION_METRICS.notification_format_for_KIBANA, this.experiment_name, this.container_name, KruizeConstants.DateFormats.simpleDateFormatForUTC.format(this.interval_end_time), level, term, model, String.valueOf(recommendationNotification.getCode()), recommendationNotification.getType(), recommendationNotification.getMessage());
+                String metricEntry =  String.format(KruizeConstants.KRUIZE_RECOMMENDATION_METRICS.notification_format_for_METRICS,  term, model, recommendationNotification.getType());
+                LOGGER.info(kibanaLog);
+                additionalTags = additionalTags.and(KruizeConstants.KRUIZE_RECOMMENDATION_METRICS.TAG_NAME,metricEntry); // A metric entry with only three tags, which are unlikely to have many unique values, will therefore help reduce cardinality.
                 Counter counterNotifications = MetricsConfig.meterRegistry().find(KruizeConstants.KRUIZE_RECOMMENDATION_METRICS.METRIC_NAME).tags(additionalTags).counter();
                 if (counterNotifications == null) {
                     counterNotifications = MetricsConfig.timerBKruizeNotifications.tags(additionalTags).register(MetricsConfig.meterRegistry);

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -697,8 +697,9 @@ public class KruizeConstants {
 
     public static final class KRUIZE_RECOMMENDATION_METRICS {
         public static final String METRIC_NAME = "KruizeRecommendationsNotification";
-        public static final String TAG_NAME = "experiment_details";
-        public static final String notification_format = "%s|%s|%s|%s|%s|%s|%s|%s|%s"; //experiment_name,container_name,endtime,level,termname,modelname,code,type,message
+        public static final String TAG_NAME = "recommendations_notifications";
+        public static final String notification_format_for_KIBANA = "%s|%s|%s|%s|%s|%s|%s|%s|%s"; //experiment_name,container_name,endtime,level,termname,modelname,code,type,message
+        public static final String notification_format_for_METRICS = "%s|%s|%s"; //termname,modelname,type
 
     }
 }

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -698,7 +698,7 @@ public class KruizeConstants {
     public static final class KRUIZE_RECOMMENDATION_METRICS {
         public static final String METRIC_NAME = "KruizeRecommendationsNotification";
         public static final String TAG_NAME = "recommendations_notifications";
-        public static final String notification_format_for_KIBANA = "%s|%s|%s|%s|%s|%s|%s|%s|%s"; //experiment_name,container_name,endtime,level,termname,modelname,code,type,message
+        public static final String notification_format_for_LOG = "%s|%s|%s|%s|%s|%s|%s|%s|%s"; //experiment_name,container_name,endtime,level,termname,modelname,code,type,message
         public static final String notification_format_for_METRICS = "%s|%s|%s"; //termname,modelname,type
 
     }


### PR DESCRIPTION
## Description

Previously, we had too many variables in the set, such as experiment_name, container_name, endtime, level, termname, modelname, code, type, and message, which significantly increased cardinality. Now, we've reduced it to just a few variables, like termname, modelname, and type, which has decreased the cardinality, resulting in no more than 10 entries, whereas before, it generated millions.

there will be one follow up MR .. to unblock kruize_recommendations entry at ros side

A metric entry with only three tags, which are unlikely to have many unique values, will therefore help reduce cardinality.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?


A metric entry with only three tags, which are unlikely to have many unique values, will therefore help reduce cardinality.


- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information


