### PR TITLE
Configure Openshift port for Prometheus service

### DIFF
--- a/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
@@ -3,6 +3,19 @@ kind: Namespace
 metadata:
   name: openshift-tuning
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kruize-monitoring-view
+subjects:
+  - kind: ServiceAccount
+    name: kruize-sa
+    namespace: openshift-tuning
+roleRef:
+  kind: ClusterRole
+  name: cluster-monitoring-view
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -233,16 +246,4 @@ spec:
     - name: nginx-config-volume
       configMap:
         name: nginx-config
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: kruize-monitoring-view
-subjects:
-  - kind: ServiceAccount
-    name: kruize-sa
-    namespace: openshift-tuning
-roleRef:
-  kind: ClusterRole
-  name: cluster-monitoring-view
-  apiGroup: rbac.authorization.k8s.io
+

--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -12,6 +12,19 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  name: kruize-monitoring-view
+subjects:
+  - kind: ServiceAccount
+    name: kruize-sa
+    namespace: openshift-tuning
+roleRef:
+  kind: ClusterRole
+  name: cluster-monitoring-view
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
   name: autotune-scc-crb
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -450,16 +463,3 @@ spec:
     - name: nginx-config-volume
       configMap:
         name: nginx-config
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: kruize-monitoring-view
-subjects:
-  - kind: ServiceAccount
-    name: kruize-sa
-    namespace: openshift-tuning
-roleRef:
-  kind: ClusterRole
-  name: cluster-monitoring-view
-  apiGroup: rbac.authorization.k8s.io

--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -119,9 +119,9 @@ data:
         {
           "name": "prometheus-1",
           "provider": "prometheus",
-          "serviceName": "",
-          "namespace": "",
-          "url": "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
+          "serviceName": "prometheus-k8s",
+          "namespace": "openshift-monitoring",
+          "url": ""
         }
       ]
     }

--- a/src/main/java/com/autotune/common/datasource/prometheus/PrometheusDataOperatorImpl.java
+++ b/src/main/java/com/autotune/common/datasource/prometheus/PrometheusDataOperatorImpl.java
@@ -18,6 +18,7 @@ package com.autotune.common.datasource.prometheus;
 import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.common.datasource.DataSourceOperatorImpl;
 import com.autotune.common.utils.CommonUtils;
+import com.autotune.operator.KruizeDeploymentInfo;
 import com.autotune.utils.KruizeConstants;
 import com.autotune.utils.GenericRestApiClient;
 import com.google.gson.*;
@@ -61,6 +62,9 @@ public class PrometheusDataOperatorImpl extends DataSourceOperatorImpl {
      */
     @Override
     public String getDefaultServicePortForProvider() {
+        if (KruizeDeploymentInfo.k8s_type.equalsIgnoreCase(KruizeConstants.OPENSHIFT)) {
+            return KruizeConstants.DataSourceConstants.OPENSHIFT_MONITORING_PROMETHEUS_DEFAULT_SERVICE_PORT;
+        }
         return KruizeConstants.DataSourceConstants.PROMETHEUS_DEFAULT_SERVICE_PORT;
     }
 

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -393,6 +393,7 @@ public class KruizeConstants {
         public static final String KRUIZE_DATASOURCE = "datasource";
         public static final String SERVICE_DNS = ".svc.cluster.local";
         public static final String PROMETHEUS_DEFAULT_SERVICE_PORT = "9090";
+        public static final String OPENSHIFT_MONITORING_PROMETHEUS_DEFAULT_SERVICE_PORT = "9091";
         public static final String PROMETHEUS_REACHABILITY_QUERY = "up";
         public static final String DATASOURCE_ENDPOINT_WITH_QUERY = "%s/api/v1/query_range?query=%s&start=%s&end=%s&step=%s";
         public static final String DATE_ENDPOINT_WITH_QUERY = "%s/api/v1/query?query=%s";


### PR DESCRIPTION
## Description

This PR adds `9091` port for Prometheus service in Openshift to help populate the DNS url using `serviceName` and `namespace` instead of just supporting `url` through the datasource manifest.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

In `kruize-crc-openshift.yaml` under `kruizeconfigjson` pass `serviceName` and `namespace` instead of the `url` 
```
"datasource": [
        {
          "name": "prometheus-1",
          "provider": "prometheus",
          "serviceName": "prometheus-k8s",
          "namespace": "openshift-monitoring",
          "url": ""
        }
      ]
```
Kruize pod logs:

```
2024-09-0208:52:54.586 INFO [main][DataSourceCollection.java(47)]-Checking available datasources from database:
2024-09-0208:52:54.797 INFO [main][DataSourceCollection.java(50)]-No datasource found in database.
2024-09-0208:52:54.866 INFO [main][DataSourceCollection.java(89)]-Trying to add the datasource to collection: prometheus-1
2024-09-0208:52:54.866 INFO [main][DataSourceCollection.java(97)]-Verifying datasource reachability status: prometheus-1
2024-09-0208:52:56.244 INFO [main][DataSourceCollection.java(100)]-Datasource is serviceable.
2024-09-0208:52:56.269 INFO [main][DataSourceCollection.java(104)]-Datasource added to the DB successfully.
2024-09-0208:52:56.269 INFO [main][DataSourceCollection.java(109)]-Datasource added to the collection successfully.
2024-09-0208:52:56.269 INFO [main][Autotune.java(191)]-Checking available datasources:
2024-09-0208:52:56.270 INFO [main][Autotune.java(197)]-Datasource found: prometheus-1, https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091

```
**Test Configuration**
* Kubernetes clusters tested on: Openshift ResourceHub cluster

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Image - quay.io/shbirada/port-configuration:openshift
