### PR TITLE
Bump mvp_demo images to UI 0.0.6 and aks to 0.0.24_rm

### DIFF
--- a/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
@@ -213,7 +213,7 @@ metadata:
 spec:
   containers:
     - name: kruize-ui-nginx-container
-      image: quay.io/kruize/kruize-ui:0.0.5
+      image: quay.io/kruize/kruize-ui:0.0.6
       imagePullPolicy: Always
       env:
         - name: KRUIZE_UI_ENV

--- a/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
@@ -220,7 +220,7 @@ metadata:
 spec:
   containers:
     - name: kruize-ui-nginx-container
-      image: quay.io/kruize/kruize-ui:0.0.5
+      image: quay.io/kruize/kruize-ui:0.0.6
       imagePullPolicy: Always
       env:
         - name: KRUIZE_UI_ENV

--- a/manifests/crc/default-db-included-installation/aks/kruize-crc-aks.yaml
+++ b/manifests/crc/default-db-included-installation/aks/kruize-crc-aks.yaml
@@ -151,7 +151,7 @@ spec:
     spec:
       containers:
         - name: kruize
-          image: quay.io/kruize/autotune_operator:0.0.22_rm
+          image: quay.io/kruize/autotune_operator:0.0.24_rm
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume
@@ -216,7 +216,7 @@ spec:
         spec:
           containers:
             - name: kruizecronjob
-              image: quay.io/kruize/autotune_operator:0.0.22_rm
+              image: quay.io/kruize/autotune_operator:0.0.24_rm
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume
@@ -315,7 +315,7 @@ metadata:
 spec:
   containers:
     - name: kruize-ui-nginx-container
-      image: quay.io/kruize/kruize-ui:0.0.3
+      image: quay.io/kruize/kruize-ui:0.0.6
       imagePullPolicy: Always
       env:
         - name: KRUIZE_UI_ENV
@@ -342,7 +342,7 @@ spec:
         spec:
           containers:
             - name: kruizedeletejob
-              image: quay.io/kruize/autotune_operator:0.0.22_rm
+              image: quay.io/kruize/autotune_operator:0.0.24_rm
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume

--- a/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
@@ -341,7 +341,7 @@ metadata:
 spec:
   containers:
     - name: kruize-ui-nginx-container
-      image: quay.io/kruize/kruize-ui:0.0.5
+      image: quay.io/kruize/kruize-ui:0.0.6
       imagePullPolicy: Always
       env:
         - name: KRUIZE_UI_ENV

--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -437,7 +437,7 @@ metadata:
 spec:
   containers:
     - name: kruize-ui-nginx-container
-      image: quay.io/kruize/kruize-ui:0.0.5
+      image: quay.io/kruize/kruize-ui:0.0.6
       imagePullPolicy: Always
       env:
         - name: KRUIZE_UI_ENV


### PR DESCRIPTION
Bump manifest files to point to latest release images