### PR TITLE
Include non-recording cpu usage queries into separate yaml

### DIFF
--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.json
@@ -1,0 +1,395 @@
+{
+  "apiVersion": "recommender.com/v1",
+  "kind": "KruizePerformanceProfile",
+  "metadata": {
+    "name": "resource-optimization-local-monitoring"
+  },
+  "profile_version": 1,
+  "k8s_type": "openshift",
+  "slo": {
+    "slo_class": "resource_usage",
+    "direction": "minimize",
+    "objective_function": {
+      "function_type": "source"
+    },
+    "function_variables": [
+      {
+        "name": "cpuRequest",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg by(container, namespace) (kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          },
+          {
+            "function": "sum",
+            "query": "sum by(container, namespace) (kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          },
+          {
+            "function": "min",
+            "query": "min by(container, namespace) (kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          },
+          {
+            "function": "max",
+            "query": "max by(container, namespace) (kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          }
+        ]
+      },
+      {
+        "name": "cpuLimit",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg by(container,namespace) (kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          },
+          {
+            "function": "sum",
+            "query": "sum by(container,namespace) (kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          },
+          {
+            "function": "max",
+            "query": "max by(container,namespace) (kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          },
+          {
+            "function": "min",
+            "query": "min by(container,namespace) (kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          }
+        ]
+      },
+      {
+        "name": "cpuUsage",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg by(container, namespace)(avg_over_time(rate(container_cpu_usage_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[5m])[$MEASUREMENT_DURATION_IN_MIN$m:]))"
+          },
+          {
+            "function": "min",
+            "query": "min by(container, namespace)(min_over_time(rate(container_cpu_usage_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[5m])[$MEASUREMENT_DURATION_IN_MIN$m:]))"
+          },
+          {
+            "function": "max",
+            "query": "max by(container, namespace)(max_over_time(rate(container_cpu_usage_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[5m])[$MEASUREMENT_DURATION_IN_MIN$m:]))"
+          },
+          {
+            "function": "sum",
+            "query": "sum by(container, namespace)(avg_over_time(rate(container_cpu_usage_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[5m])[$MEASUREMENT_DURATION_IN_MIN$m:]))"
+          }
+        ]
+      },
+      {
+        "name": "cpuThrottle",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          },
+          {
+            "function": "max",
+            "query": "max by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          },
+          {
+            "function": "min",
+            "query": "min by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          },
+          {
+            "function": "sum",
+            "query": "sum by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          }
+        ]
+      },
+      {
+        "name": "memoryRequest",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg by(container, namespace) (kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          },
+          {
+            "function": "sum",
+            "query": "sum by(container, namespace) (kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          },
+          {
+            "function": "max",
+            "query": "max by(container, namespace) (kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          },
+          {
+            "function": "min",
+            "query": "min by(container, namespace) (kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          }
+        ]
+      },
+      {
+        "name": "memoryLimit",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg by(container,namespace) (kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          },
+          {
+            "function": "sum",
+            "query": "sum by(container,namespace) (kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          },
+          {
+            "function": "max",
+            "query": "max by(container,namespace) (kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          },
+          {
+            "function": "min",
+            "query": "min by(container,namespace) (kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+          }
+        ]
+      },
+      {
+        "name": "memoryUsage",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg by(container, namespace) (avg_over_time(container_memory_working_set_bytes{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          },
+          {
+            "function": "min",
+            "query": "min by(container, namespace) (min_over_time(container_memory_working_set_bytes{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          },
+          {
+            "function": "max",
+            "query": "max by(container, namespace) (max_over_time(container_memory_working_set_bytes{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          },
+          {
+            "function": "sum",
+            "query": "sum by(container, namespace) (avg_over_time(container_memory_working_set_bytes{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          }
+        ]
+      },
+      {
+        "name": "memoryRSS",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg by(container, namespace) (avg_over_time(container_memory_rss{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          },
+          {
+            "function": "min",
+            "query": "min by(container, namespace) (min_over_time(container_memory_rss{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          },
+          {
+            "function": "max",
+            "query": "max by(container, namespace) (max_over_time(container_memory_rss{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          },
+          {
+            "function": "sum",
+            "query": "sum by(container, namespace) (avg_over_time(container_memory_rss{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          }
+        ]
+      },
+      {
+        "name": "maxDate",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "max",
+            "query": "max by(namespace,container) (last_over_time((timestamp(container_cpu_usage_seconds_total{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"} > 0))[15d:]))"
+          }
+        ]
+      },
+      {
+        "name": "namespaceCpuRequest",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "sum",
+            "query": "sum by (namespace) (kube_resourcequota{namespace=\"$NAMESPACE$\", resource=\"requests.cpu\", type=\"hard\"})"
+          }
+        ]
+      },
+      {
+        "name": "namespaceCpuLimit",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "sum",
+            "query": "sum by (namespace) (kube_resourcequota{namespace=\"$NAMESPACE$\", resource=\"limits.cpu\", type=\"hard\"})"
+          }
+        ]
+      },
+      {
+        "name": "namespaceMemoryRequest",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "sum",
+            "query": "sum by (namespace) (kube_resourcequota{namespace=\"$NAMESPACE$\", resource=\"requests.memory\", type=\"hard\"})"
+          }
+        ]
+      },
+      {
+        "name": "namespaceMemoryLimit",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "sum",
+            "query": "sum by (namespace) (kube_resourcequota{namespace=\"$NAMESPACE$\", resource=\"limits.memory\", type=\"hard\"})"
+          }
+        ]
+      },
+      {
+        "name": "namespaceCpuUsage",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg_over_time(sum by(namespace) (rate(container_cpu_usage_seconds_total{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''}[5m]))[$MEASUREMENT_DURATION_IN_MIN$m:])"
+            
+          },
+          {
+            "function": "max",
+            "query": "max_over_time(sum by(namespace) (rate(container_cpu_usage_seconds_total{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''}[5m]))[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          },
+          {
+            "function": "min",
+            "query": "min_over_time(sum by(namespace) (rate(container_cpu_usage_seconds_total{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''}[5m]))[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          }
+        ]
+      },
+      {
+        "name": "namespaceCpuThrottle",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''}[5m]))[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          },
+          {
+            "function": "max",
+            "query": "max_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''}[5m]))[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          },
+          {
+            "function": "min",
+            "query": "min_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''}[5m]))[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          }
+        ]
+      },
+      {
+        "name": "namespaceMemoryUsage",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          },
+          {
+            "function": "max",
+            "query": "max_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          },
+          {
+            "function": "min",
+            "query": "min_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          }
+        ]
+      },
+      {
+        "name": "namespaceMemoryRSS",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg_over_time(sum by(namespace) (container_memory_rss{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          },
+          {
+            "function": "max",
+            "query": "max_over_time(sum by(namespace) (container_memory_rss{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          },
+          {
+            "function": "min",
+            "query": "min_over_time(sum by(namespace) (container_memory_rss{namespace=\"$NAMESPACE$\", container!='', container!='POD', pod!=''})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          }
+        ]
+      },
+      {
+        "name": "namespaceTotalPods",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "max",
+            "query": "max_over_time(sum by(namespace) ((kube_pod_info{namespace=\"$NAMESPACE$\"}))[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          },
+          {
+            "function": "avg",
+            "query": "avg_over_time(sum by(namespace) ((kube_pod_info{namespace=\"$NAMESPACE$\"}))[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          }
+        ]
+      },
+      {
+        "name": "namespaceRunningPods",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "max",
+            "query": "max_over_time(sum by(namespace) ((kube_pod_status_phase{phase=\"Running\", namespace=\"$NAMESPACE$\"}))[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          },
+          {
+            "function": "avg",
+            "query": "avg_over_time(sum by(namespace) ((kube_pod_status_phase{phase=\"Running\", namespace=\"$NAMESPACE$\"}))[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          }
+        ]
+      },
+      {
+        "name": "namespaceMaxDate",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "max",
+            "query": "max(last_over_time(timestamp((sum by (namespace) (container_cpu_usage_seconds_total{namespace=\"$NAMESPACE$\"})) > 0 )[15d:]))"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.yaml
@@ -1,0 +1,377 @@
+apiVersion: "recommender.com/v1"
+kind: "KruizePerformanceProfile"
+metadata:
+  name: "resource-optimization-local-monitoring"
+profile_version: 1.0
+k8s_type: openshift
+
+slo:
+  slo_class: "resource_usage"
+  direction: "minimize"
+
+  # Refer to src/.../performanceProfiles/PerformanceProfileInterface/RemoteMonitoringOpenShiftImpl.java
+  objective_function:
+    function_type: source
+
+  function_variables:
+  # CPU Request
+  # Show cpu requests in cores for a container in a deployment
+  - name: cpuRequest
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "container"
+
+    aggregation_functions:
+    - function: avg
+      query: 'avg by(container, namespace) (kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+
+    # Show sum of cpu requests in bytes for a container in a deployment
+    - function: sum
+      query: 'sum by(container, namespace) (kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+
+    - function: min
+      query: 'min by(container, namespace) (kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+
+    - function: max
+      query: 'max by(container, namespace) (kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+
+  # CPU Limit
+  # Show cpu limits in bytes for a container in a deployment
+  - name: cpuLimit
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "container"
+
+    aggregation_functions:
+    - function: avg
+      query: 'avg by(container,namespace) (kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+
+    # Show sum of cpu limits in bytes for a container in a deployment
+    - function: sum
+      query: 'sum by(container,namespace) (kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+
+    - function: max
+      query: 'max by(container,namespace) (kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+
+    - function: min
+      query: 'min by(container,namespace) (kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+
+
+  # CPU Usage
+  
+  # Average CPU per container in a deployment
+  - name: cpuUsage
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "container"
+
+    aggregation_functions:
+    - function: avg
+      query: 'avg by(container, namespace)(avg_over_time(rate(container_cpu_usage_seconds_total{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[5m])[$MEASUREMENT_DURATION_IN_MIN$m:]))'
+
+    # Approx minimum CPU per container in a deployment
+    - function: min
+      query: 'min by(container, namespace)(min_over_time(rate(container_cpu_usage_seconds_total{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[5m])[$MEASUREMENT_DURATION_IN_MIN$m:]))'
+      
+    # Approx maximum CPU per container in a deployment
+    - function: max
+      query: 'max by(container, namespace)(max_over_time(rate(container_cpu_usage_seconds_total{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[5m])[$MEASUREMENT_DURATION_IN_MIN$m:]))'
+      
+    # Sum of CPU usage for a container in all pods of a deployment
+    - function: sum
+      query: 'sum by(container, namespace)(avg_over_time(rate(container_cpu_usage_seconds_total{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[5m])[$MEASUREMENT_DURATION_IN_MIN$m:]))'
+      
+  # CPU Throttling
+  - name: cpuThrottle
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "container"
+
+    aggregation_functions:
+    # Average CPU throttling per container in a deployment
+    - function: avg
+      query: 'avg by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="",namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+
+    # Maximum CPU throttling per container in a deployment
+    - function: max
+      query: 'max by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="",namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+
+    # Min of CPU throttling for a container in all pods of a deployment
+    - function: min
+      query: 'min by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="",namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+
+    # Sum of CPU throttling for a container in all pods of a deployment
+    - function: sum
+      query: 'sum by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="",namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+
+
+
+  ######################
+
+  # Memory Request
+  # Show memory requests in bytes for a container in a deployment
+  - name: memoryRequest
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "container"
+
+    aggregation_functions:
+    - function: avg
+      query: 'avg by(container, namespace) (kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+
+    # Show sum of memory requests in bytes for a container in a deployment
+    - function: sum
+      query: 'sum by(container, namespace) (kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+
+    - function: max
+      query: 'max by(container, namespace) (kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+
+    - function: min
+      query: 'min by(container, namespace) (kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+
+
+  # Memory Limit
+  # Show memory limits in bytes for a container in a deployment
+  - name: memoryLimit
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "container"
+
+    aggregation_functions:
+    - function: avg
+      query: 'avg by(container,namespace) (kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+
+    # Show sum of memory limits in bytes for a container in a deployment
+    - function: sum
+      query: 'sum by(container,namespace) (kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+
+    - function: max
+      query: 'max by(container,namespace) (kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+
+    - function: min
+      query: 'min by(container,namespace) (kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+
+  # Memory Usage
+  # Average memory per container in a deployment
+  - name: memoryUsage
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "container"
+
+    aggregation_functions:
+    - function: avg
+      query: 'avg by(container, namespace) (avg_over_time(container_memory_working_set_bytes{container!="", container!="POD", pod!="", namespace="$NAMESPACE$",container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+
+    # Approx minimum memory per container in a deployment
+    - function: min
+      query: 'min by(container, namespace) (min_over_time(container_memory_working_set_bytes{container!="", container!="POD", pod!="", namespace="$NAMESPACE$",container="$CONTAINER_NAME$" }[$MEASUREMENT_DURATION_IN_MIN$m]))'
+
+    # Approx maximum memory per container in a deployment
+    - function: max
+      query: 'max by(container, namespace) (max_over_time(container_memory_working_set_bytes{container!="", container!="POD", pod!="", namespace="$NAMESPACE$",container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+
+    # Sum of memory usage for a contianer in all pods of a deployment
+    - function: sum
+      query: 'sum by(container, namespace) (avg_over_time(container_memory_working_set_bytes{container!="", container!="POD", pod!="", namespace="$NAMESPACE$",container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+
+
+  # 2.4 Memory RSS
+  - name: memoryRSS
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "container"
+
+    aggregation_functions:
+    # Average memory RSS per container in a deployment
+    - function: avg
+      query: 'avg by(container, namespace) (avg_over_time(container_memory_rss{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+
+    # Approx minimum memory RSS per container in a deployment
+    - function: min
+      query: 'min by(container, namespace) (min_over_time(container_memory_rss{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+
+
+    # Approx maximum memory RSS per container in a deployment
+    - function: max
+      query: 'max by(container, namespace) (max_over_time(container_memory_rss{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+
+    # Sum of memory RSS for a contianer in all pods of a deployment
+    - function: sum
+      query: 'sum by(container, namespace) (avg_over_time(container_memory_rss{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+
+
+  # Container Last Active Timestamp
+  - name: maxDate
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "container"
+
+    aggregation_functions:
+    - function: max
+      query: 'max by(namespace,container) (last_over_time((timestamp(container_cpu_usage_seconds_total{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"} > 0))[15d:]))'
+
+    ## namespace related queries
+
+    # Namespace quota for CPU requests
+    # Show namespace quota for CPU requests in cores for a namespace
+    - name: namespaceCpuRequest
+      datasource: prometheus
+      value_type: "double"
+      kubernetes_object: "namespace"
+      aggregation_functions:
+      # sum of all cpu request quotas for a namespace in cores
+      - function: sum
+        query: 'sum by (namespace) (kube_resourcequota{namespace="$NAMESPACE$", resource="requests.cpu", type="hard"})'
+
+    # Namespace quota for CPU limits
+    # Show namespace quota for CPU limits in cores for a namespace
+    - name: namespaceCpuLimit
+      datasource: prometheus
+      value_type: "double"
+      kubernetes_object: "namespace"
+      aggregation_functions:
+      # sum of all cpu limits quotas for a namespace in cores
+      - function: sum
+        query: 'sum by (namespace) (kube_resourcequota{namespace="$NAMESPACE$", resource="limits.cpu", type="hard"})'
+
+
+    # Namespace quota for memory requests
+    # Show namespace quota for memory requests in bytes for a namespace
+    - name: namespaceMemoryRequest
+      datasource: prometheus
+      value_type: "double"
+      kubernetes_object: "namespace"
+      aggregation_functions:
+      # sum of all memory requests quotas for a namespace in bytes
+      - function: sum
+        query: 'sum by (namespace) (kube_resourcequota{namespace="$NAMESPACE$", resource="requests.memory", type="hard"})'
+
+
+    # Namespace quota for memory limits
+    # Show namespace quota for memory limits in bytes for a namespace
+    - name: namespaceMemoryLimit
+      datasource: prometheus
+      value_type: "double"
+      kubernetes_object: "namespace"
+      aggregation_functions:
+      # sum of all memory limits quotas for a namespace in bytes
+      - function: sum
+        query: 'sum by (namespace) (kube_resourcequota{namespace="$NAMESPACE$", resource="limits.memory", type="hard"})'
+
+
+    # Namespace CPU usage
+    # Show cpu usages in cores for a namespace
+    - name: namespaceCpuUsage
+      datasource: prometheus
+      value_type: "double"
+      kubernetes_object: "namespace"
+      aggregation_functions:
+      # average cpu usages in cores for a namespace
+      - function: avg
+        query: 'avg_over_time(sum by(namespace) (rate(container_cpu_usage_seconds_total{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""}[5m]) )[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+      # maximum cpu usages in cores for a namespace
+      - function: max
+        query: 'max_over_time(sum by(namespace) (rate(container_cpu_usage_seconds_total{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""}[5m]) )[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+      # minimum cpu usages in cores for a namespace
+      - function: min
+        query: 'min_over_time(sum by(namespace) (rate(container_cpu_usage_seconds_total{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""}[5m]) )[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+
+    # Namespace CPU Throttle
+    # Show cpu throttle in cores for a namespace
+    - name: namespaceCpuThrottle
+      datasource: prometheus
+      value_type: "double"
+      kubernetes_object: "namespace"
+      aggregation_functions:
+      # average cpu throttle in cores for a namespace
+      - function: avg
+        query: 'avg_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""}[5m]))[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+      # maximum cpu throttle in cores for a namespace
+      - function: max
+        query: 'max_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""}[5m]))[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+      # minimum cpu throttle in cores for a namespace
+      - function: min
+        query: 'min_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""}[5m]))[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+
+    # Namespace memory usage
+    # Show memory usages in bytes for a namespace
+    - name: namespaceMemoryUsage
+      datasource: prometheus
+      value_type: "double"
+      kubernetes_object: "namespace"
+      aggregation_functions:
+      # average memory usage in bytes for a namespace
+      - function: avg
+        query: 'avg_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+      # maximum memory usage in bytes for a namespace
+      - function: max
+        query: 'max_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+      # minimum memory usage in bytes for a namespace
+      - function: min
+        query: 'min_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+
+    # Namespace memory rss value
+    # Show memory rss in bytes for a namespace
+    - name: namespaceMemoryRSS
+      datasource: prometheus
+      value_type: "double"
+      kubernetes_object: "namespace"
+      aggregation_functions:
+      # average memory rss in bytes for a namespace
+      - function: avg
+        query: 'avg_over_time(sum by(namespace) (container_memory_rss{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+      # maximum memory rss in bytes for a namespace
+      - function: max
+        query: 'max_over_time(sum by(namespace) (container_memory_rss{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+      # minimum memory rss in bytes for a namespace
+      - function: min
+        query: 'min_over_time(sum by(namespace) (container_memory_rss{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+
+    # Show total pods in a namespace
+    - name: namespaceTotalPods
+      datasource: prometheus
+      value_type: "double"
+      kubernetes_object: "namespace"
+      aggregation_functions:
+      # maximum total pods in a namespace
+      - function: max
+        query: 'max_over_time(sum by(namespace) ((kube_pod_info{namespace="$NAMESPACE$"}))[$MEASUREMENT_DURATION_IN_MIN$m:])'
+      # average total pods in a namespace
+      - function: avg
+        query: 'avg_over_time(sum by(namespace) ((kube_pod_info{namespace="$NAMESPACE$"}))[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+
+    # Show total running pods in a namespace
+    - name: namespaceRunningPods
+      datasource: prometheus
+      value_type: "double"
+      kubernetes_object: "namespace"
+      aggregation_functions:
+      # maximum total pods in a namespace
+      - function: max
+        query: 'max_over_time(sum by(namespace) ((kube_pod_status_phase{phase="Running"}))[$MEASUREMENT_DURATION_IN_MIN$m:])'
+      # average total pods in a namespace
+      - function: avg
+        query: 'avg_over_time(sum by(namespace) ((kube_pod_status_phase{phase="Running"}))[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+    # Show last activity for a namespace
+    - name: namespaceMaxDate
+      datasource: prometheus
+      value_type: "double"
+      kubernetes_object: "namespace"
+      aggregation_functions:
+      - function: max
+        query: 'max(last_over_time(timestamp((sum by (namespace) (container_cpu_usage_seconds_total{namespace="$NAMESPACE$"})) > 0 )[15d:]))'
+      


### PR DESCRIPTION
## Description

Please describe the issue or feature and the summary of changes made to fix this. 
Include non-recording cpu usage queries into separate yaml and jsons to run the local monitoring APIs with any version of prometheus.  

Fixes # (issue)

### Type of change

- [ X] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Run the kruize-demos script by using the `resource_optimization_local_monitoring_norecordingrules` yaml.

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
- Testing is yet to complete.

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
