### PR TITLE
Fixing List Recommendations API Error

### DIFF
--- a/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
@@ -1113,6 +1113,7 @@ public class ExperimentDAOImpl implements ExperimentDAO {
                 try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
                     String sql = DBConstants.SQLQUERY.SELECT_RECOMMENDATIONS_EXP_TYPE;
                     Query query = session.createNativeQuery(sql);
+                    // set experiment_type parameter in sql query
                     query.setParameter("experiment_name", recomEntry.getExperiment_name());
                     List<String> exType = query.getResultList();
                     if (null != exType && !exType.isEmpty()) {


### PR DESCRIPTION
## Description

This PR fixes the error caused by incorrect setting of parameters while updating experiment type in Recommendations Entry.

We encountered an issue while updating the `experiment_type` in `RecommendationEntry` when handling local monitoring experiments with dynamic SQL queries. Since `experiment_type` is a `transient` field, we have to update it manually.

The original SELECT query is:

```sql
SELECT experiment_type FROM kruize_recommendations WHERE experiment_name = :experiment_name
```

Previously, the query was mistakenly modified to include:
```java
query.setParameter("experiment_type", recomEntry.getExperimentType());
query.setParameter("experiment_name", recomEntry.getExperiment_name());
```

However, the `experiment_type` parameter should not be set in this case as it is not part of the SQL query. We want to fetch this column. This led to the following error while executing the query:
```bash
[ExperimentDAOImpl.java(833)] - Not able to load recommendations due to Error while updating experiment type to recommendation: Could not locate named parameter [experiment_type], expecting one of [experiment_name].
```
To resolve this, I have removed the `experiment_type` parameter setting, and now only `experiment_name` is set. The query executes successfully with this correction.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

On Openshift: kruize-lm

**Test Configuration**
* Kubernetes clusters tested on: Openshift (kruize-lm)

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

quay.io/rh-ee-shesaxen/autotune:ns-extype-change
