### PR TITLE
Updating Local Monitoring Test 

### DIFF
--- a/tests/scripts/helpers/utils.py
+++ b/tests/scripts/helpers/utils.py
@@ -1523,6 +1523,5 @@ def validate_local_monitoring_recommendation_data_present(recommendations_json):
 
         # Validate if all the containers are present
         for i in range(list_reco_containers_length):
-             assert recommendations_json[0]['kubernetes_objects'][0]['containers'][i]['recommendations']['data']
-
+             assert recommendations_json[0]['kubernetes_objects'][0]['containers'][i]['recommendations']['data'], "Recommendations data is expected, but not present."
 

--- a/tests/scripts/helpers/utils.py
+++ b/tests/scripts/helpers/utils.py
@@ -1514,3 +1514,15 @@ def get_metric_profile_dir():
     metric_profile_dir = base_dir / 'manifests' / 'autotune' / 'performance-profiles'
 
     return metric_profile_dir
+
+def validate_local_monitoring_recommendation_data_present(recommendations_json):
+    if recommendations_json[0]['experiment_type'] == NAMESPACE_EXPERIMENT_TYPE:
+        assert recommendations_json[0]['kubernetes_objects'][0]['namespaces']['recommendations']['data']
+    if recommendations_json[0]['experiment_type'] == CONTAINER_EXPERIMENT_TYPE:
+        list_reco_containers_length = len(recommendations_json[0]['kubernetes_objects'][0]['containers'])
+
+        # Validate if all the containers are present
+        for i in range(list_reco_containers_length):
+             assert recommendations_json[0]['kubernetes_objects'][0]['containers'][i]['recommendations']['data']
+
+

--- a/tests/scripts/helpers/utils.py
+++ b/tests/scripts/helpers/utils.py
@@ -1517,11 +1517,12 @@ def get_metric_profile_dir():
 
 def validate_local_monitoring_recommendation_data_present(recommendations_json):
     if recommendations_json[0]['experiment_type'] == NAMESPACE_EXPERIMENT_TYPE:
-        assert recommendations_json[0]['kubernetes_objects'][0]['namespaces']['recommendations']['data']
+        assert recommendations_json[0]['kubernetes_objects'][0]['namespaces']['recommendations']['data'], "Recommendations data is expected, but not present."
+        assert recommendations_json[0]['kubernetes_objects'][0]['namespaces']['recommendations']['notifications'][NOTIFICATION_CODE_FOR_RECOMMENDATIONS_AVAILABLE]['message'] == RECOMMENDATIONS_AVAILABLE, "Recommendations notification is expected, but not present."
     if recommendations_json[0]['experiment_type'] == CONTAINER_EXPERIMENT_TYPE:
         list_reco_containers_length = len(recommendations_json[0]['kubernetes_objects'][0]['containers'])
 
         # Validate if all the containers are present
         for i in range(list_reco_containers_length):
              assert recommendations_json[0]['kubernetes_objects'][0]['containers'][i]['recommendations']['data'], "Recommendations data is expected, but not present."
-
+             assert recommendations_json[0]['kubernetes_objects'][0]['containers'][i]['recommendations']['notifications'][NOTIFICATION_CODE_FOR_RECOMMENDATIONS_AVAILABLE]['message'] == RECOMMENDATIONS_AVAILABLE, "Recommendations notification is expected, but not present."

--- a/tests/scripts/local_monitoring_tests/rest_apis/test_list_recommendations.py
+++ b/tests/scripts/local_monitoring_tests/rest_apis/test_list_recommendations.py
@@ -164,6 +164,7 @@ def test_list_recommendations_namespace_single_result(test_name, expected_status
     assert errorMsg == ""
 
     # Validate the json values
+    validate_local_monitoring_recommendation_data_present(list_reco_json)
     namespace_exp_json = read_json_data_from_file(input_json_file)
     validate_local_monitoring_reco_json(namespace_exp_json[0], list_reco_json[0])
 

--- a/tests/scripts/local_monitoring_tests/rest_apis/test_local_monitoring_e2e_workflow.py
+++ b/tests/scripts/local_monitoring_tests/rest_apis/test_local_monitoring_e2e_workflow.py
@@ -253,6 +253,7 @@ def test_list_recommendations_multiple_exps_for_datasource_workloads(cluster_typ
     assert errorMsg == ""
 
     # Validate the json values
+    validate_local_monitoring_recommendation_data_present(list_reco_json)
     tfb_exp_json = read_json_data_from_file(tfb_exp_json_file)
     validate_local_monitoring_reco_json(tfb_exp_json[0], list_reco_json[0])
 
@@ -269,6 +270,7 @@ def test_list_recommendations_multiple_exps_for_datasource_workloads(cluster_typ
     assert errorMsg == ""
 
     # Validate the json values
+    validate_local_monitoring_recommendation_data_present(list_reco_json)
     tfb_db_exp_json = read_json_data_from_file(tfb_db_exp_json_file)
     validate_local_monitoring_reco_json(tfb_db_exp_json[0], list_reco_json[0])
 
@@ -285,6 +287,7 @@ def test_list_recommendations_multiple_exps_for_datasource_workloads(cluster_typ
     assert errorMsg == ""
 
     # Validate the json values
+    validate_local_monitoring_recommendation_data_present(list_reco_json)
     namespace_exp_json = read_json_data_from_file(namespace_exp_json_file)
     validate_local_monitoring_reco_json(namespace_exp_json[0], list_reco_json[0])
 

--- a/tests/scripts/local_monitoring_tests/rest_apis/test_namespace_reco_e2e_workflow.py
+++ b/tests/scripts/local_monitoring_tests/rest_apis/test_namespace_reco_e2e_workflow.py
@@ -286,6 +286,7 @@ def test_list_recommendations_namespace_exps(cluster_type):
     assert errorMsg == ""
 
     # Validate the json values
+    validate_local_monitoring_recommendation_data_present(list_reco_json)
     ns1_exp_json = read_json_data_from_file(ns1_exp_json_file)
     validate_local_monitoring_reco_json(ns1_exp_json[0], list_reco_json[0])
 
@@ -298,10 +299,12 @@ def test_list_recommendations_namespace_exps(cluster_type):
     list_reco_json = response.json()
 
     # Validate the json against the json schema
+    validate_local_monitoring_recommendation_data_present(list_reco_json)
     errorMsg = validate_list_reco_json(list_reco_json, list_reco_namespace_json_local_monitoring_schema)
     assert errorMsg == ""
 
     # Validate the json values
+    validate_local_monitoring_recommendation_data_present(list_reco_json)
     ns2_exp_json = read_json_data_from_file(ns2_exp_json_file)
     validate_local_monitoring_reco_json(ns2_exp_json[0], list_reco_json[0])
 
@@ -314,10 +317,12 @@ def test_list_recommendations_namespace_exps(cluster_type):
     list_reco_json = response.json()
 
     # Validate the json against the json schema
+    assert list_reco_json[0]['kubernetes_objects'][0]['namespaces']['recommendations']['data']
     errorMsg = validate_list_reco_json(list_reco_json, list_reco_namespace_json_local_monitoring_schema)
     assert errorMsg == ""
 
     # Validate the json values
+    validate_local_monitoring_recommendation_data_present(list_reco_json)
     ns3_exp_json = read_json_data_from_file(ns3_exp_json_file)
     validate_local_monitoring_reco_json(ns3_exp_json[0], list_reco_json[0])
 

--- a/tests/scripts/local_monitoring_tests/rest_apis/test_namespace_reco_e2e_workflow.py
+++ b/tests/scripts/local_monitoring_tests/rest_apis/test_namespace_reco_e2e_workflow.py
@@ -299,7 +299,6 @@ def test_list_recommendations_namespace_exps(cluster_type):
     list_reco_json = response.json()
 
     # Validate the json against the json schema
-    validate_local_monitoring_recommendation_data_present(list_reco_json)
     errorMsg = validate_list_reco_json(list_reco_json, list_reco_namespace_json_local_monitoring_schema)
     assert errorMsg == ""
 
@@ -317,7 +316,6 @@ def test_list_recommendations_namespace_exps(cluster_type):
     list_reco_json = response.json()
 
     # Validate the json against the json schema
-    assert list_reco_json[0]['kubernetes_objects'][0]['namespaces']['recommendations']['data']
     errorMsg = validate_list_reco_json(list_reco_json, list_reco_namespace_json_local_monitoring_schema)
     assert errorMsg == ""
 


### PR DESCRIPTION
## Description
This PR updates the test to verify whether recommendation `data` is available when calling the `listRecommendations` API. We've observed that if there’s an error related to the database or other error, the `listRecommendations` API still returns a 200 response code, with `no data is available` notification, with the error logged in the pod logs. This makes it challenging to determine whether the recommendations are being listed correctly.

To address this, I’m adding a check to ensure that `data` is present in all cases where we expect at least some short-term recommendations. This will guarantee that the `data` field is not empty when recommendations should be available.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

On kruize-lm cluster. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: kruize-lm

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [x] Dependent changes merged
- [ ] Documentation updated
- [x] Tests added or updated

## Additional information
Please test these changes with 1304 changes included.
docker.io/kruize/autotune_operator:0.0.25_mvp
