### PR TITLE
Exclude namespace queries to fetch container metric data

### DIFF
--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -2098,7 +2098,10 @@ public class RecommendationEngine {
                     MetricResults metricResults = null;
                     MetricAggregationInfoResults metricAggregationInfoResults = null;
 
-                    List<Metric> metricList = metricProfile.getSloInfo().getFunctionVariables();
+                    // Exclude maxDate and namespace queries to fetch container metric data
+                    List<Metric> metricList = metricProfile.getSloInfo().getFunctionVariables().stream()
+                            .filter(metricEntry -> !metricEntry.getName().startsWith(AnalyzerConstants.NAMESPACE) && !metricEntry.getName().equals(AnalyzerConstants.MetricName.maxDate.name()))
+                            .toList();
 
                     List<String> acceleratorFunctions = Arrays.asList(
                             AnalyzerConstants.MetricName.gpuCoreUsage.toString(),

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -1914,7 +1914,7 @@ public class RecommendationEngine {
                 }
 
                 List<Metric> namespaceMetricList = filterMetricsBasedOnExpType(metricProfile,
-                        AnalyzerConstants.MetricName.namespaceMaxDate.name(),AnalyzerConstants.ExperimentTypes.NAMESPACE_EXPERIMENT);
+                        AnalyzerConstants.MetricName.namespaceMaxDate.name(), kruizeObject.getExperimentType());
 
                 // Iterate over metrics and aggregation functions
                 for (Metric metricEntry : namespaceMetricList) {
@@ -2098,7 +2098,7 @@ public class RecommendationEngine {
                     MetricAggregationInfoResults metricAggregationInfoResults = null;
 
                     List<Metric> metricList = filterMetricsBasedOnExpType(metricProfile,
-                            AnalyzerConstants.MetricName.maxDate.name(),AnalyzerConstants.ExperimentTypes.CONTAINER_EXPERIMENT);
+                            AnalyzerConstants.MetricName.maxDate.name(), kruizeObject.getExperimentType());
 
                     List<String> acceleratorFunctions = Arrays.asList(
                             AnalyzerConstants.MetricName.gpuCoreUsage.toString(),
@@ -2386,10 +2386,10 @@ public class RecommendationEngine {
             .filter(Metric -> {
                 String name = Metric.getName();
                 if (experimentType.equals(AnalyzerConstants.ExperimentTypes.NAMESPACE_EXPERIMENT)) {
-                    // Include metrics that start with namespace and exclude namespaceMaxDate metric
+                    // Include metrics that start with prefix "namespace" and exclude namespaceMaxDate metric
                     return name.startsWith(namespace) && !name.equals(maxDateQuery);
                 } else {
-                    // Exclude metrics that start with namespace or maxDate metric
+                    // Exclude metrics that start with prefix "namespace" and maxDate metric
                     return !name.startsWith(namespace) && !name.equals(maxDateQuery);
                 }
             })


### PR DESCRIPTION
## Description

This PR filters out 

- namespace queries

- redundant `maxDate` query (already executed to fetch the interval start and end time before iterating through the list of metrics)

to fetch container metric data to generate recommendations for a `container` based experiment to run only the relevant queries and not overload the datasource while running multiple experiments.

Fixes #1308

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Tested by running local monitoring demos on ResourceHub cluster -  `./local_monitoring_demo.sh -c openshift -i quay.io/shbirada/autotune_operator:filter-namespace-for-container-reco
`

pod logs with queries run for `tfb-server` and `tfb-database` containers - https://privatebin.corp.redhat.com/?d50352a3d066c26b#4mGGpw7q2TXbrF1pN6C7yUykuphywPSwstMez2RkKWvB

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: Openshift (ResourceHub cluster)

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

docker image - `quay.io/shbirada/autotune_operator:filter-namespace-queries`
