### PR TITLE
Update datasource metadata queries 

### DIFF
--- a/src/main/java/com/autotune/common/data/dataSourceQueries/DataSourceQueries.java
+++ b/src/main/java/com/autotune/common/data/dataSourceQueries/DataSourceQueries.java
@@ -7,9 +7,9 @@ package com.autotune.common.data.dataSourceQueries;
  */
 public class DataSourceQueries {
     public enum PromQLQuery {
-        NAMESPACE_QUERY("sum by (namespace) (kube_namespace_status_phase{phase=\"Active\" ADDITIONAL_LABEL })"),
-        WORKLOAD_INFO_QUERY("sum by (namespace, workload, workload_type) (namespace_workload_pod:kube_pod_owner:relabel{ ADDITIONAL_LABEL })"),
-        CONTAINER_INFO_QUERY("sum by (container, image, workload) (kube_pod_container_info{ ADDITIONAL_LABEL } * on(pod) group_left(workload, workload_type) (namespace_workload_pod:kube_pod_owner:relabel{ ADDITIONAL_LABEL }))");
+        NAMESPACE_QUERY("sum by (namespace) ( avg_over_time(kube_namespace_status_phase{namespace!=\"\" ADDITIONAL_LABEL}[15d]))"),
+        WORKLOAD_INFO_QUERY("sum by (namespace, workload, workload_type) ( avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!=\"\" ADDITIONAL_LABEL}[15d]))"),
+        CONTAINER_INFO_QUERY("sum by (container, image, workload, workload_type, namespace) ( avg_over_time(kube_pod_container_info{container!=\"\" ADDITIONAL_LABEL}[15d]) * on (pod, namespace) group_left(workload, workload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!=\"\" ADDITIONAL_LABEL}[15d]))");
         private final String query;
 
         PromQLQuery(String query) {

--- a/src/main/java/com/autotune/database/helper/DBHelpers.java
+++ b/src/main/java/com/autotune/database/helper/DBHelpers.java
@@ -895,6 +895,11 @@ public class DBHelpers {
                             continue;
                         }
                         dataSourceNamespace.getDataSourceWorkloadHashMap().put(kruizeMetadata.getWorkloadName(), dataSourceWorkload);
+
+                        if (null == dataSourceContainer) {
+                            dataSourceWorkload.setDataSourceContainerHashMap(null);
+                            continue;
+                        }
                         dataSourceWorkload.getDataSourceContainerHashMap().put(kruizeMetadata.getContainerName(), dataSourceContainer);
                     } catch (Exception e) {
                         LOGGER.error("Error occurred while converting to dataSourceMetadataInfo from DB object : {}", e.getMessage());
@@ -1028,6 +1033,23 @@ public class DBHelpers {
                                 }
 
                                 for (DataSourceWorkload dataSourceWorkload : dataSourceNamespace.getDataSourceWorkloadHashMap().values()) {
+                                    // handles 'job' workload type with no containers
+                                    if(null == dataSourceWorkload.getDataSourceContainerHashMap()) {
+                                        KruizeDSMetadataEntry kruizeMetadata = new KruizeDSMetadataEntry();
+                                        kruizeMetadata.setVersion(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoConstants.version);
+
+                                        kruizeMetadata.setDataSourceName(dataSourceName);
+                                        kruizeMetadata.setClusterName(dataSourceClusterName);
+                                        kruizeMetadata.setNamespace(namespaceName);
+                                        kruizeMetadata.setWorkloadType(dataSourceWorkload.getDataSourceWorkloadType());
+                                        kruizeMetadata.setWorkloadName(dataSourceWorkload.getDataSourceWorkloadName());
+
+                                        kruizeMetadata.setContainerName(null);
+                                        kruizeMetadata.setContainerImageName(null);
+
+                                        kruizeMetadataList.add(kruizeMetadata);
+                                        continue;
+                                    }
 
                                     for (DataSourceContainer dataSourceContainer : dataSourceWorkload.getDataSourceContainerHashMap().values()) {
                                         KruizeDSMetadataEntry kruizeMetadata = new KruizeDSMetadataEntry();

--- a/tests/scripts/helpers/list_metadata_json_verbose_true_schema.py
+++ b/tests/scripts/helpers/list_metadata_json_verbose_true_schema.py
@@ -64,7 +64,7 @@ list_metadata_json_verbose_true_schema = {
                                                                             }
                                                                         }
                                                                     },
-                                                                    "required": ["workload_name", "workload_type", "containers"]
+                                                                    "required": ["workload_name", "workload_type"]
                                                                 }
                                                             }
                                                         }


### PR DESCRIPTION
## Description

This PR has the following changes: 

- Updates `NAMESPACE_QUERY`, `WORKLOAD_INFO_QUERY`, `CONTAINER_INFO_QUERY` dsmetadata queries to provide the average namespace, workload and container status over the past 15 days.

- Also includes `namespace` label in `CONTAINER_INFO` query to perform the join operation `on (pod, namespace)` with the pod to handle the case where same workloads are present in different namespaces.
- Handles an edge case - wherein for workload type `job` with no containers was earlier resulting in `NullPointerException`, which is now fixed.

Fixes # [(1316)](https://github.com/kruize/autotune/issues/1316)

### Type of change

- [x] Bug fix
- [x] Enhancement
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

Tested by running local monitoring demos on ResourceHub cluster - ./local_monitoring_demo.sh -c openshift -i quay.io/shbirada/update_dsmetadata_queries:v1 

Fixed the NullPointerException seen before: 
```
Error while converting DataSourceMetadata Object to KruizeDSMetadataEntry table due to Cannot invoke "java.util.HashMap.values()" because the return value of "com.autotune.common.data.dataSourceMetadata.DataSourceWorkload.getDataSourceContainerHashMap()" is null

java.lang.NullPointerException: Cannot invoke "java.util.HashMap.values()" because the return value of "com.autotune.common.data.dataSourceMetadata.DataSourceWorkload.getDataSourceContainerHashMap()" is null
```

pod logs after handling the edge case: https://privatebin.corp.redhat.com/?87922ed8fdb9df55#D6FBWxRYbKHTYEsTEcts1D3aNGtmb3jgEe3eXhf5FU2F 

pod logs with Exception - https://privatebin.corp.redhat.com/?527498b097f364ac#F93EzwiZG121QPcc73FKk8NU9bCTqzLMgSsbPsHuoFVS

**Test Configuration**
* Kubernetes clusters tested on: ResourceHub OpenShift cluster

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

docker image - `quay.io/shbirada/update_dsmetadata_queries:v1`
