### PR TITLE
Bump mvp_demo to Kruize version 0.1!

### DIFF
--- a/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
@@ -90,7 +90,7 @@ spec:
               done
       containers:
         - name: kruize
-          image: kruize/autotune_operator:0.0.25_rm
+          image: kruize/autotune_operator:0.1
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume
@@ -213,7 +213,7 @@ metadata:
 spec:
   containers:
     - name: kruize-ui-nginx-container
-      image: quay.io/kruize/kruize-ui:0.0.6
+      image: quay.io/kruize/kruize-ui:0.0.7
       imagePullPolicy: Always
       env:
         - name: KRUIZE_UI_ENV

--- a/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
@@ -118,7 +118,7 @@ spec:
               done
       containers:
         - name: kruize
-          image: kruize/autotune_operator:0.0.25_rm
+          image: kruize/autotune_operator:0.1
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume
@@ -248,7 +248,7 @@ metadata:
 spec:
   containers:
     - name: kruize-ui-nginx-container
-      image: quay.io/kruize/kruize-ui:0.0.6
+      image: quay.io/kruize/kruize-ui:0.0.7
       imagePullPolicy: Always
       env:
         - name: KRUIZE_UI_ENV

--- a/manifests/crc/default-db-included-installation/aks/kruize-crc-aks.yaml
+++ b/manifests/crc/default-db-included-installation/aks/kruize-crc-aks.yaml
@@ -151,7 +151,7 @@ spec:
     spec:
       containers:
         - name: kruize
-          image: quay.io/kruize/autotune_operator:0.0.25_rm
+          image: quay.io/kruize/autotune_operator:0.1
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume
@@ -216,7 +216,7 @@ spec:
         spec:
           containers:
             - name: kruizecronjob
-              image: quay.io/kruize/autotune_operator:0.0.25_rm
+              image: quay.io/kruize/autotune_operator:0.1
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume
@@ -315,7 +315,7 @@ metadata:
 spec:
   containers:
     - name: kruize-ui-nginx-container
-      image: quay.io/kruize/kruize-ui:0.0.6
+      image: quay.io/kruize/kruize-ui:0.0.7
       imagePullPolicy: Always
       env:
         - name: KRUIZE_UI_ENV
@@ -342,7 +342,7 @@ spec:
         spec:
           containers:
             - name: kruizedeletejob
-              image: quay.io/kruize/autotune_operator:0.0.25_rm
+              image: quay.io/kruize/autotune_operator:0.1
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume

--- a/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
@@ -177,7 +177,7 @@ spec:
               done
       containers:
         - name: kruize
-          image: quay.io/kruize/autotune_operator:0.0.25_rm
+          image: quay.io/kruize/autotune_operator:0.1
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume
@@ -242,7 +242,7 @@ spec:
         spec:
           containers:
             - name: kruizecronjob
-              image: kruize/autotune_operator:0.0.25_rm
+              image: kruize/autotune_operator:0.1
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume
@@ -341,7 +341,7 @@ metadata:
 spec:
   containers:
     - name: kruize-ui-nginx-container
-      image: quay.io/kruize/kruize-ui:0.0.6
+      image: quay.io/kruize/kruize-ui:0.0.7
       imagePullPolicy: Always
       env:
         - name: KRUIZE_UI_ENV
@@ -368,7 +368,7 @@ spec:
         spec:
           containers:
             - name: kruizedeletejob
-              image: kruize/autotune_operator:0.0.25_rm
+              image: kruize/autotune_operator:0.1
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume

--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -242,7 +242,7 @@ spec:
               done
       containers:
         - name: kruize
-          image: kruize/autotune_operator:0.0.25_rm
+          image: kruize/autotune_operator:0.1
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume
@@ -314,7 +314,7 @@ spec:
         spec:
           containers:
             - name: kruizecronjob
-              image: kruize/autotune_operator:0.0.25_rm
+              image: kruize/autotune_operator:0.1
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume
@@ -355,7 +355,7 @@ spec:
         spec:
           containers:
             - name: kruizedeletejob
-              image: kruize/autotune_operator:0.0.25_rm
+              image: kruize/autotune_operator:0.1
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume
@@ -456,7 +456,7 @@ metadata:
 spec:
   containers:
     - name: kruize-ui-nginx-container
-      image: quay.io/kruize/kruize-ui:0.0.6
+      image: quay.io/kruize/kruize-ui:0.0.7
       imagePullPolicy: Always
       env:
         - name: KRUIZE_UI_ENV

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.autotune</groupId>
     <artifactId>autotune</artifactId>
-    <version>0.0.25_mvp</version>
+    <version>0.1</version>
     <properties>
         <fabric8-version>4.13.2</fabric8-version>
         <org-json-version>20240303</org-json-version>


### PR DESCRIPTION
This is a big milestone for the project as we now have BULK API, GPU recommendations and along with the recently released namespace recommendations.

This means that going forward we will be using the 0.x naming convention for the releases. The biggest change is that Kruize now defaults to "local" monitoring instead of "remote".