### PR TITLE
Refactor Bulk Job Manager to call createExperiments API

### DIFF
--- a/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
@@ -36,6 +36,7 @@ data:
       "local": "false",
       "logAllHttpReqAndResp": "true",
       "recommendationsURL" : "http://kruize.monitoring.svc.cluster.local:8080/generateRecommendations?experiment_name=%s",    
+      "experimentsURL" : "http://kruize.monitoring.svc.cluster.local:8080/createExperiment",    
       "hibernate": {
         "dialect": "org.hibernate.dialect.PostgreSQLDialect",
         "driver": "org.postgresql.Driver",

--- a/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
@@ -49,6 +49,7 @@ data:
       "local": "false",
       "logAllHttpReqAndResp": "true",
       "recommendationsURL" : "http://kruize.openshift-tuning.svc.cluster.local:8080/generateRecommendations?experiment_name=%s",
+      "experimentsURL" : "http://kruize.openshift-tuning.svc.cluster.local:8080/createExperiment",
       "hibernate": {
         "dialect": "org.hibernate.dialect.PostgreSQLDialect",
         "driver": "org.postgresql.Driver",

--- a/manifests/crc/default-db-included-installation/aks/kruize-crc-aks.yaml
+++ b/manifests/crc/default-db-included-installation/aks/kruize-crc-aks.yaml
@@ -100,6 +100,7 @@ data:
       "local": "false",
       "logAllHttpReqAndResp": "true",
       "recommendationsURL" : "http://kruize.monitoring.svc.cluster.local:8080/generateRecommendations?experiment_name=%s",    
+      "experimentsURL" : "http://kruize.monitoring.svc.cluster.local:8080/createExperiment",    
       "hibernate": {
         "dialect": "org.hibernate.dialect.PostgreSQLDialect",
         "driver": "org.postgresql.Driver",

--- a/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
@@ -114,6 +114,7 @@ data:
       "local": "false",
       "logAllHttpReqAndResp": "true",
       "recommendationsURL" : "http://kruize.monitoring.svc.cluster.local:8080/generateRecommendations?experiment_name=%s",    
+      "experimentsURL" : "http://kruize.monitoring.svc.cluster.local:8080/createExperiment",    
       "hibernate": {
         "dialect": "org.hibernate.dialect.PostgreSQLDialect",
         "driver": "org.postgresql.Driver",

--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -108,6 +108,7 @@ data:
       "local": "false",
       "logAllHttpReqAndResp": "true",
       "recommendationsURL" : "http://kruize.openshift-tuning.svc.cluster.local:8080/generateRecommendations?experiment_name=%s",
+      "experimentsURL" : "http://kruize.openshift-tuning.svc.cluster.local:8080/createExperiment",
       "hibernate": {
         "dialect": "org.hibernate.dialect.PostgreSQLDialect",
         "driver": "org.postgresql.Driver",

--- a/src/main/java/com/autotune/analyzer/kruizeObject/CreateExperimentConfigBean.java
+++ b/src/main/java/com/autotune/analyzer/kruizeObject/CreateExperimentConfigBean.java
@@ -15,12 +15,19 @@
  *******************************************************************************/
 package com.autotune.analyzer.kruizeObject;
 
+import com.autotune.analyzer.serviceObjects.KubernetesAPIObject;
+
+import java.util.List;
+
 /**
  * THis is a placeholder class for bulkAPI createExperiment template to store defaults
  */
 public class CreateExperimentConfigBean {
 
     // Private fields
+    private String experimentName;
+    private String clusterName;
+    private List<KubernetesAPIObject> kubernetesAPIObjects;
     private String mode;
     private String target;
     private String version;
@@ -31,6 +38,30 @@ public class CreateExperimentConfigBean {
     private int measurementDuration;
 
     // Getters and Setters
+    public String getExperimentName() {
+        return experimentName;
+    }
+
+    public void setExperimentName(String experimentName) {
+        this.experimentName = experimentName;
+    }
+
+    public String getClusterName() {
+        return clusterName;
+    }
+
+    public void setClusterName(String clusterName) {
+        this.clusterName = clusterName;
+    }
+
+    public List<KubernetesAPIObject> getKubernetesAPIObjects() {
+        return kubernetesAPIObjects;
+    }
+
+    public void setKubernetesAPIObjects(List<KubernetesAPIObject> kubernetesAPIObjects) {
+        this.kubernetesAPIObjects = kubernetesAPIObjects;
+    }
+
     public String getMode() {
         return mode;
     }
@@ -97,8 +128,11 @@ public class CreateExperimentConfigBean {
 
     @Override
     public String toString() {
-        return "MonitoringConfigBean{" +
-                "mode='" + mode + '\'' +
+        return "CreateExperimentConfigBean{" +
+                "experimentName='" + experimentName + '\'' +
+                ", clusterName='" + clusterName + '\'' +
+                ", kubernetesAPIObjects=" + kubernetesAPIObjects +
+                ", mode='" + mode + '\'' +
                 ", target='" + target + '\'' +
                 ", version='" + version + '\'' +
                 ", datasourceName='" + datasourceName + '\'' +

--- a/src/main/java/com/autotune/analyzer/kruizeObject/CreateExperimentConfigBean.java
+++ b/src/main/java/com/autotune/analyzer/kruizeObject/CreateExperimentConfigBean.java
@@ -15,59 +15,22 @@
  *******************************************************************************/
 package com.autotune.analyzer.kruizeObject;
 
-import com.autotune.analyzer.serviceObjects.KubernetesAPIObject;
-import com.autotune.common.k8sObjects.TrialSettings;
-import com.fasterxml.jackson.annotation.JsonGetter;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 /**
  * THis is a placeholder class for bulkAPI createExperiment template to store defaults
  */
 public class CreateExperimentConfigBean {
 
     // Private fields
-    private String experiment_name;
-    private String cluster_name;
-    private List<KubernetesAPIObject> kubernetes_objects;
     private String mode;
-    private String target_cluster;
+    private String target;
     private String version;
-    private String datasource;
-    private String performance_profile;
+    private String datasourceName;
+    private String performanceProfile;
     private double threshold;
     private String measurementDurationStr;
     private int measurementDuration;
-    private TrialSettings trial_settings;
-    private RecommendationSettings recommendation_settings;
 
     // Getters and Setters
-    public String getExperiment_name() {
-        return experiment_name;
-    }
-
-    public void setExperiment_name(String experiment_name) {
-        this.experiment_name = experiment_name;
-    }
-
-    public String getCluster_name() {
-        return cluster_name;
-    }
-
-    public void setCluster_name(String cluster_name) {
-        this.cluster_name = cluster_name;
-    }
-
-    public List<KubernetesAPIObject> getKubernetes_objects() {
-        return kubernetes_objects;
-    }
-
-    public void setKubernetes_objects(List<KubernetesAPIObject> kubernetes_objects) {
-        this.kubernetes_objects = kubernetes_objects;
-    }
-
     public String getMode() {
         return mode;
     }
@@ -76,12 +39,12 @@ public class CreateExperimentConfigBean {
         this.mode = mode;
     }
 
-    public String getTarget_cluster() {
-        return target_cluster;
+    public String getTarget() {
+        return target;
     }
 
-    public void setTarget_cluster(String target_cluster) {
-        this.target_cluster = target_cluster;
+    public void setTarget(String target) {
+        this.target = target;
     }
 
     public String getVersion() {
@@ -92,28 +55,20 @@ public class CreateExperimentConfigBean {
         this.version = version;
     }
 
-    public String getDatasource() {
-        return datasource;
+    public String getDatasourceName() {
+        return datasourceName;
     }
 
-    public void setDatasource(String datasource) {
-        this.datasource = datasource;
+    public void setDatasourceName(String datasourceName) {
+        this.datasourceName = datasourceName;
     }
 
-    public String getPerformance_profile() {
-        return performance_profile;
+    public String getPerformanceProfile() {
+        return performanceProfile;
     }
 
-    public void setPerformance_profile(String performance_profile) {
-        this.performance_profile = performance_profile;
-    }
-
-    public void setTrial_settings(TrialSettings trial_settings) {
-        this.trial_settings = trial_settings;
-    }
-
-    public void setRecommendation_settings(RecommendationSettings recommendation_settings) {
-        this.recommendation_settings = recommendation_settings;
+    public void setPerformanceProfile(String performanceProfile) {
+        this.performanceProfile = performanceProfile;
     }
 
     public double getThreshold() {
@@ -140,34 +95,17 @@ public class CreateExperimentConfigBean {
         this.measurementDuration = measurementDuration;
     }
 
-    @JsonGetter("trial_settings")
-    public Map<String, String> getTrialSettings() {
-        Map<String, String> trialSettingsMap = new HashMap<>();
-        trialSettingsMap.put("measurement_duration", this.measurementDurationStr);
-        return trialSettingsMap;
-    }
-
-    @JsonGetter("recommendation_settings")
-    public Map<String, Double> getRecommendationSettings() {
-        Map<String, Double> recommendationSettingsMap = new HashMap<>();
-        recommendationSettingsMap.put("threshold", this.threshold);
-        return recommendationSettingsMap;
-    }
-
     @Override
     public String toString() {
         return "CreateExperimentConfigBean{" +
-                "experiment_name='" + experiment_name + '\'' +
-                ", cluster_name='" + cluster_name + '\'' +
-                ", kubernetes_objects=" + kubernetes_objects +
-                ", mode='" + mode + '\'' +
-                ", target_cluster='" + target_cluster + '\'' +
+                "mode='" + mode + '\'' +
+                ", target='" + target + '\'' +
                 ", version='" + version + '\'' +
-                ", datasource='" + datasource + '\'' +
-                ", performance_profile='" + performance_profile + '\'' +
+                ", datasourceName='" + datasourceName + '\'' +
+                ", performanceProfile='" + performanceProfile + '\'' +
+                ", threshold=" + threshold +
                 ", measurementDurationStr='" + measurementDurationStr + '\'' +
-                ", trial_settings=" + trial_settings +
-                ", recommendation_settings=" + recommendation_settings +
+                ", measurementDuration=" + measurementDuration +
                 '}';
     }
 }

--- a/src/main/java/com/autotune/analyzer/kruizeObject/CreateExperimentConfigBean.java
+++ b/src/main/java/com/autotune/analyzer/kruizeObject/CreateExperimentConfigBean.java
@@ -16,8 +16,12 @@
 package com.autotune.analyzer.kruizeObject;
 
 import com.autotune.analyzer.serviceObjects.KubernetesAPIObject;
+import com.autotune.common.k8sObjects.TrialSettings;
+import com.fasterxml.jackson.annotation.JsonGetter;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * THis is a placeholder class for bulkAPI createExperiment template to store defaults
@@ -25,41 +29,43 @@ import java.util.List;
 public class CreateExperimentConfigBean {
 
     // Private fields
-    private String experimentName;
-    private String clusterName;
-    private List<KubernetesAPIObject> kubernetesAPIObjects;
+    private String experiment_name;
+    private String cluster_name;
+    private List<KubernetesAPIObject> kubernetes_objects;
     private String mode;
-    private String target;
+    private String target_cluster;
     private String version;
-    private String datasourceName;
-    private String performanceProfile;
+    private String datasource;
+    private String performance_profile;
     private double threshold;
     private String measurementDurationStr;
     private int measurementDuration;
+    private TrialSettings trial_settings;
+    private RecommendationSettings recommendation_settings;
 
     // Getters and Setters
-    public String getExperimentName() {
-        return experimentName;
+    public String getExperiment_name() {
+        return experiment_name;
     }
 
-    public void setExperimentName(String experimentName) {
-        this.experimentName = experimentName;
+    public void setExperiment_name(String experiment_name) {
+        this.experiment_name = experiment_name;
     }
 
-    public String getClusterName() {
-        return clusterName;
+    public String getCluster_name() {
+        return cluster_name;
     }
 
-    public void setClusterName(String clusterName) {
-        this.clusterName = clusterName;
+    public void setCluster_name(String cluster_name) {
+        this.cluster_name = cluster_name;
     }
 
-    public List<KubernetesAPIObject> getKubernetesAPIObjects() {
-        return kubernetesAPIObjects;
+    public List<KubernetesAPIObject> getKubernetes_objects() {
+        return kubernetes_objects;
     }
 
-    public void setKubernetesAPIObjects(List<KubernetesAPIObject> kubernetesAPIObjects) {
-        this.kubernetesAPIObjects = kubernetesAPIObjects;
+    public void setKubernetes_objects(List<KubernetesAPIObject> kubernetes_objects) {
+        this.kubernetes_objects = kubernetes_objects;
     }
 
     public String getMode() {
@@ -70,12 +76,12 @@ public class CreateExperimentConfigBean {
         this.mode = mode;
     }
 
-    public String getTarget() {
-        return target;
+    public String getTarget_cluster() {
+        return target_cluster;
     }
 
-    public void setTarget(String target) {
-        this.target = target;
+    public void setTarget_cluster(String target_cluster) {
+        this.target_cluster = target_cluster;
     }
 
     public String getVersion() {
@@ -86,20 +92,28 @@ public class CreateExperimentConfigBean {
         this.version = version;
     }
 
-    public String getDatasourceName() {
-        return datasourceName;
+    public String getDatasource() {
+        return datasource;
     }
 
-    public void setDatasourceName(String datasourceName) {
-        this.datasourceName = datasourceName;
+    public void setDatasource(String datasource) {
+        this.datasource = datasource;
     }
 
-    public String getPerformanceProfile() {
-        return performanceProfile;
+    public String getPerformance_profile() {
+        return performance_profile;
     }
 
-    public void setPerformanceProfile(String performanceProfile) {
-        this.performanceProfile = performanceProfile;
+    public void setPerformance_profile(String performance_profile) {
+        this.performance_profile = performance_profile;
+    }
+
+    public void setTrial_settings(TrialSettings trial_settings) {
+        this.trial_settings = trial_settings;
+    }
+
+    public void setRecommendation_settings(RecommendationSettings recommendation_settings) {
+        this.recommendation_settings = recommendation_settings;
     }
 
     public double getThreshold() {
@@ -126,20 +140,34 @@ public class CreateExperimentConfigBean {
         this.measurementDuration = measurementDuration;
     }
 
+    @JsonGetter("trial_settings")
+    public Map<String, String> getTrialSettings() {
+        Map<String, String> trialSettingsMap = new HashMap<>();
+        trialSettingsMap.put("measurement_duration", this.measurementDurationStr);
+        return trialSettingsMap;
+    }
+
+    @JsonGetter("recommendation_settings")
+    public Map<String, Double> getRecommendationSettings() {
+        Map<String, Double> recommendationSettingsMap = new HashMap<>();
+        recommendationSettingsMap.put("threshold", this.threshold);
+        return recommendationSettingsMap;
+    }
+
     @Override
     public String toString() {
         return "CreateExperimentConfigBean{" +
-                "experimentName='" + experimentName + '\'' +
-                ", clusterName='" + clusterName + '\'' +
-                ", kubernetesAPIObjects=" + kubernetesAPIObjects +
+                "experiment_name='" + experiment_name + '\'' +
+                ", cluster_name='" + cluster_name + '\'' +
+                ", kubernetes_objects=" + kubernetes_objects +
                 ", mode='" + mode + '\'' +
-                ", target='" + target + '\'' +
+                ", target_cluster='" + target_cluster + '\'' +
                 ", version='" + version + '\'' +
-                ", datasourceName='" + datasourceName + '\'' +
-                ", performanceProfile='" + performanceProfile + '\'' +
-                ", threshold=" + threshold +
+                ", datasource='" + datasource + '\'' +
+                ", performance_profile='" + performance_profile + '\'' +
                 ", measurementDurationStr='" + measurementDurationStr + '\'' +
-                ", measurementDuration=" + measurementDuration +
+                ", trial_settings=" + trial_settings +
+                ", recommendation_settings=" + recommendation_settings +
                 '}';
     }
 }

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -1866,7 +1866,7 @@ public class RecommendationEngine {
                 String namespaceMaxDateQuery = maxDateQuery.replace(AnalyzerConstants.NAMESPACE_VARIABLE, namespace);
 
                 if (null == interval_end_time) {
-                    LOGGER.info(KruizeConstants.APIMessages.NAMESPACE_USAGE_INFO);
+                    LOGGER.debug(KruizeConstants.APIMessages.NAMESPACE_USAGE_INFO);
                     String dateMetricsUrl = String.format(KruizeConstants.DataSourceConstants.DATE_ENDPOINT_WITH_QUERY,
                             dataSourceInfo.getUrl(),
                             URLEncoder.encode(namespaceMaxDateQuery, CHARACTER_ENCODING)
@@ -1887,7 +1887,7 @@ public class RecommendationEngine {
                         interval_end_time_epoc = dateTS.getTime() / KruizeConstants.TimeConv.NO_OF_MSECS_IN_SEC
                                 - ((long) dateTS.getTimezoneOffset() * KruizeConstants.TimeConv.NO_OF_SECONDS_PER_MINUTE);
                         int maxDay = Terms.getMaxDays(kruizeObject.getTerms());
-                        LOGGER.info(KruizeConstants.APIMessages.MAX_DAY, maxDay);
+                        LOGGER.debug(KruizeConstants.APIMessages.MAX_DAY, maxDay);
                         Timestamp startDateTS = Timestamp.valueOf(Objects.requireNonNull(dateTS).toLocalDateTime().minusDays(maxDay));
                         interval_start_time_epoc = startDateTS.getTime() / KruizeConstants.TimeConv.NO_OF_MSECS_IN_SEC
                                 - ((long) startDateTS.getTimezoneOffset() * KruizeConstants.TimeConv.NO_OF_MSECS_IN_SEC);
@@ -2044,7 +2044,7 @@ public class RecommendationEngine {
 
                     String containerName = containerData.getContainer_name();
                     if (null == interval_end_time) {
-                        LOGGER.info(KruizeConstants.APIMessages.CONTAINER_USAGE_INFO);
+                        LOGGER.debug(KruizeConstants.APIMessages.CONTAINER_USAGE_INFO);
                         String queryToEncode = null;
                         if (null == maxDateQuery || maxDateQuery.isEmpty()) {
                             throw new NullPointerException("maxDate query cannot be empty or null");
@@ -2078,7 +2078,7 @@ public class RecommendationEngine {
                             interval_end_time_epoc = dateTS.getTime() / KruizeConstants.TimeConv.NO_OF_MSECS_IN_SEC
                                     - ((long) dateTS.getTimezoneOffset() * KruizeConstants.TimeConv.NO_OF_SECONDS_PER_MINUTE);
                             int maxDay = Terms.getMaxDays(kruizeObject.getTerms());
-                            LOGGER.info(KruizeConstants.APIMessages.MAX_DAY, maxDay);
+                            LOGGER.debug(KruizeConstants.APIMessages.MAX_DAY, maxDay);
                             Timestamp startDateTS = Timestamp.valueOf(Objects.requireNonNull(dateTS).toLocalDateTime().minusDays(maxDay));
                             interval_start_time_epoc = startDateTS.getTime() / KruizeConstants.TimeConv.NO_OF_MSECS_IN_SEC
                                     - ((long) startDateTS.getTimezoneOffset() * KruizeConstants.TimeConv.NO_OF_MSECS_IN_SEC);
@@ -2154,7 +2154,7 @@ public class RecommendationEngine {
                                     .replace(AnalyzerConstants.WORKLOAD_VARIABLE, workload)
                                     .replace(AnalyzerConstants.WORKLOAD_TYPE_VARIABLE, workload_type);
 
-                            LOGGER.info(promQL);
+                            LOGGER.debug(promQL);
                             String podMetricsUrl;
                             try {
                                 podMetricsUrl = String.format(KruizeConstants.DataSourceConstants.DATASOURCE_ENDPOINT_WITH_QUERY,

--- a/src/main/java/com/autotune/analyzer/serviceObjects/BulkJobStatus.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/BulkJobStatus.java
@@ -164,9 +164,10 @@ public class BulkJobStatus {
         @JsonProperty("failed")
         private List<String> failedExperiments;
 
-        public Experiments(List<String> newExperiments, List<String> updatedExperiments) {
+        public Experiments(List<String> newExperiments, List<String> updatedExperiments, List<String> failedExperiments) {
             this.newExperiments = newExperiments;
             this.updatedExperiments = updatedExperiments;
+            this.failedExperiments = failedExperiments;
         }
 
         public List<String> getNewExperiments() {
@@ -183,6 +184,14 @@ public class BulkJobStatus {
 
         public void setUpdatedExperiments(List<String> updatedExperiments) {
             this.updatedExperiments = updatedExperiments;
+        }
+
+        public List<String> getFailedExperiments() {
+            return failedExperiments;
+        }
+
+        public void setFailedExperiments(List<String> failedExperiments) {
+            this.failedExperiments = failedExperiments;
         }
     }
 

--- a/src/main/java/com/autotune/analyzer/services/BulkService.java
+++ b/src/main/java/com/autotune/analyzer/services/BulkService.java
@@ -122,7 +122,7 @@ public class BulkService extends HttpServlet {
         // Generate a unique jobID
         String jobID = UUID.randomUUID().toString();
         BulkJobStatus.Data data = new BulkJobStatus.Data(
-                new BulkJobStatus.Experiments(new ArrayList<>(), new ArrayList<>()),
+                new BulkJobStatus.Experiments(new ArrayList<>(), new ArrayList<>(), new ArrayList<>()),
                 new BulkJobStatus.Recommendations(new BulkJobStatus.RecommendationData(
                         new ArrayList<>(),
                         new ArrayList<>(),

--- a/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
+++ b/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
@@ -133,6 +133,7 @@ public class BulkJobManager implements Runnable {
                             BulkJobStatus.Experiments failedExperiments = jobData.getData().getExperiments();
                             BulkJobStatus.RecommendationData recommendationData = jobData.getData().getRecommendations().getData();
                             try {
+                                // skip appending the experiments of type - job for now until the 'job' workload is fully supported
                                 if (experiment_name.contains(AnalyzerConstants.K8sObjectConstants.Types.JOB)) {
                                     jobData.getData().getExperiments().setFailedExperiments(
                                             appendExperiments(failedExperiments.getFailedExperiments(), experiment_name));

--- a/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
+++ b/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
@@ -100,7 +100,7 @@ public class BulkJobManager implements Runnable {
             BulkJobStatus jobData = jobStatusMap.get(jobID);
             String uniqueKey = getLabels(this.bulkInput.getFilter());
             if (null == this.bulkInput.getDatasource()) {
-                this.bulkInput.setDatasource(CREATE_EXPERIMENT_CONFIG_BEAN.getDatasourceName());
+                this.bulkInput.setDatasource(CREATE_EXPERIMENT_CONFIG_BEAN.getDatasource());
             }
             DataSourceMetadataInfo metadataInfo = null;
             DataSourceManager dataSourceManager = new DataSourceManager();
@@ -315,11 +315,11 @@ public class BulkJobManager implements Runnable {
 
         CreateExperimentConfigBean createExperimentConfigBean = CREATE_EXPERIMENT_CONFIG_BEAN;
         // Experiment name
-        createExperimentConfigBean.setExperimentName(experiment_name);
+        createExperimentConfigBean.setExperiment_name(experiment_name);
         // Datasource
-        createExperimentConfigBean.setDatasourceName(datasource);
+        createExperimentConfigBean.setDatasource(datasource);
         // Cluster name
-        createExperimentConfigBean.setClusterName(dsc.getDataSourceClusterName());
+        createExperimentConfigBean.setCluster_name(dsc.getDataSourceClusterName());
         // Kubernetes objects
         List<KubernetesAPIObject> kubernetesAPIObjectList = new ArrayList<>();
         KubernetesAPIObject kubernetesAPIObject = new KubernetesAPIObject();
@@ -333,12 +333,18 @@ public class BulkJobManager implements Runnable {
         kubernetesAPIObject.setContainerAPIObjects(Arrays.asList(containerAPIObject));
         kubernetesAPIObjectList.add(kubernetesAPIObject);
         // Add the Kubernetes objects to the createExperimentConfigBean
-        createExperimentConfigBean.setKubernetesAPIObjects(kubernetesAPIObjectList);
+        createExperimentConfigBean.setKubernetes_objects(kubernetesAPIObjectList);
+
+        // list to hold CreateExperimentConfigBean objects
+        List<CreateExperimentConfigBean> createExperimentConfigBeanList = new ArrayList<>();
+
+        // Add CreateExperimentConfigBean object to the list
+        createExperimentConfigBeanList.add(createExperimentConfigBean);
 
         // Convert to JSON
         ObjectMapper mapper = new ObjectMapper();
-        String json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(createExperimentConfigBean);
-        LOGGER.info("CreateExp JSON: {}", json);
+        String json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(createExperimentConfigBeanList);
+        LOGGER.debug("CreateExp JSON: {}", json);
         return json;
     }
 
@@ -361,6 +367,7 @@ public class BulkJobManager implements Runnable {
             connection.setRequestMethod("POST");
             connection.setRequestProperty("Content-Type", "application/json; utf-8");
             connection.setRequestProperty("Accept", "application/json");
+            connection.setDoOutput(true);
         } catch (ProtocolException e) {
             LOGGER.error(e.getMessage());
             throw new RuntimeException(e);

--- a/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
@@ -157,7 +157,7 @@ public class DataSourceMetadataOperator {
             String workloadQuery = PromQLDataSourceQueries.WORKLOAD_QUERY;
             String containerQuery = PromQLDataSourceQueries.CONTAINER_QUERY;
             if (null != uniqueKey && !uniqueKey.isEmpty()) {
-                LOGGER.info("uniquekey: {}", uniqueKey);
+                LOGGER.debug("uniquekey: {}", uniqueKey);
                 namespaceQuery = namespaceQuery.replace("ADDITIONAL_LABEL", "," + uniqueKey);
                 workloadQuery = workloadQuery.replace("ADDITIONAL_LABEL", "," + uniqueKey);
                 containerQuery = containerQuery.replace("ADDITIONAL_LABEL", "," + uniqueKey);

--- a/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
@@ -156,7 +156,7 @@ public class DataSourceMetadataOperator {
             String namespaceQuery = PromQLDataSourceQueries.NAMESPACE_QUERY;
             String workloadQuery = PromQLDataSourceQueries.WORKLOAD_QUERY;
             String containerQuery = PromQLDataSourceQueries.CONTAINER_QUERY;
-            if (null != uniqueKey) {
+            if (null != uniqueKey && !uniqueKey.isEmpty()) {
                 LOGGER.info("uniquekey: {}", uniqueKey);
                 namespaceQuery = namespaceQuery.replace("ADDITIONAL_LABEL", "," + uniqueKey);
                 workloadQuery = workloadQuery.replace("ADDITIONAL_LABEL", "," + uniqueKey);
@@ -171,7 +171,7 @@ public class DataSourceMetadataOperator {
             LOGGER.info("containerQuery: {}", containerQuery);
 
             JsonArray namespacesDataResultArray = op.getResultArrayForQuery(dataSourceInfo, namespaceQuery);
-            if (false == op.validateResultArray(namespacesDataResultArray)) {
+            if (!op.validateResultArray(namespacesDataResultArray)) {
                 dataSourceMetadataInfo = dataSourceDetailsHelper.createDataSourceMetadataInfoObject(dataSourceName, null);
                 throw new Exception(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.NAMESPACE_QUERY_VALIDATION_FAILED);
             }

--- a/src/main/java/com/autotune/operator/KruizeDeploymentInfo.java
+++ b/src/main/java/com/autotune/operator/KruizeDeploymentInfo.java
@@ -80,6 +80,7 @@ public class KruizeDeploymentInfo {
     public static Boolean local = false;
     public static Boolean log_http_req_resp = false;
     public static String recommendations_url;
+    public static String experiments_url;
     public static int BULK_API_LIMIT = 1000;
     public static int BULK_API_MAX_BATCH_SIZE = 100;
     public static Integer bulk_thread_pool_size = 3;

--- a/src/main/java/com/autotune/utils/GenericRestApiClient.java
+++ b/src/main/java/com/autotune/utils/GenericRestApiClient.java
@@ -93,7 +93,7 @@ public class GenericRestApiClient {
             // Apply authentication
             applyAuthentication(httpRequestBase);
 
-            LOGGER.info("Executing Prometheus metrics request: {}", httpRequestBase.getRequestLine());
+            LOGGER.debug("Executing Prometheus metrics request: {}", httpRequestBase.getRequestLine());
 
             // Execute the request
             jsonResponse = httpclient.execute(httpRequestBase, new StringResponseHandler());
@@ -149,7 +149,7 @@ public class GenericRestApiClient {
             try (CloseableHttpResponse response = httpclient.execute(httpPost)) {
                 // Get the status code from the response
                 int responseCode = response.getStatusLine().getStatusCode();
-                LOGGER.info("Response code: {}", responseCode);
+                LOGGER.debug("Response code: {}", responseCode);
                 return responseCode;
             } catch (Exception e) {
                 LOGGER.error("Error occurred while calling Kruize API: {}", e.getMessage());

--- a/src/main/java/com/autotune/utils/GenericRestApiClient.java
+++ b/src/main/java/com/autotune/utils/GenericRestApiClient.java
@@ -26,10 +26,13 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.ssl.SSLContexts;
@@ -70,38 +73,91 @@ public class GenericRestApiClient {
     }
 
     /**
-     * This method appends aueryString with baseURL and returns response in JSON using specified authentication.
+     * This method appends queryString with baseURL and returns response in JSON using specified authentication.
      * @param methodType    Http methods like GET,POST,PATCH etc
      * @param queryString
      * @return Json object which contains API response.
      * @throws IOException
      */
     public JSONObject fetchMetricsJson(String methodType, String queryString) throws IOException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException, FetchMetricsError {
-        System.setProperty("https.protocols", "TLSv1.2");
-        String jsonOutputInString = "";
-        SSLContext sslContext = SSLContexts.custom().loadTrustMaterial((chain, authType) -> true).build();  // Trust all certificates
-        SSLConnectionSocketFactory sslConnectionSocketFactory =
-                new SSLConnectionSocketFactory(sslContext, new String[]{"TLSv1.2"}, null, NoopHostnameVerifier.INSTANCE);
-        try (CloseableHttpClient httpclient = HttpClients.custom().setSSLSocketFactory(sslConnectionSocketFactory).build()) {
+        String jsonResponse;
+        try (CloseableHttpClient httpclient = setupHttpClient()) {
+
             HttpRequestBase httpRequestBase;
             if (methodType.equalsIgnoreCase("GET")) {
                 httpRequestBase = new HttpGet(baseURL + URLEncoder.encode(queryString, StandardCharsets.UTF_8));
             } else {
                 throw new UnsupportedOperationException("Unsupported method type: " + methodType);
             }
-            // Apply authentication
-            if (authenticationStrategy != null) {
-                String authHeader = authenticationStrategy.applyAuthentication();
-                httpRequestBase.setHeader(KruizeConstants.AuthenticationConstants.AUTHORIZATION, authHeader);
-            }
-            LOGGER.info("Executing request: {}", httpRequestBase.getRequestLine());
-            jsonOutputInString = httpclient.execute(httpRequestBase, new StringResponseHandler());
 
-        } catch (Exception e) {
-            throw new FetchMetricsError(e.getMessage());
+            // Apply authentication
+            applyAuthentication(httpRequestBase);
+
+            LOGGER.info("Executing Prometheus metrics request: {}", httpRequestBase.getRequestLine());
+
+            // Execute the request
+            jsonResponse = httpclient.execute(httpRequestBase, new StringResponseHandler());
         }
-        return new JSONObject(jsonOutputInString);
+        return new JSONObject(jsonResponse);
     }
+
+
+    /**
+     * Common method to setup SSL context for trust-all certificates.
+     * @return CloseableHttpClient
+     */
+    private CloseableHttpClient setupHttpClient() throws NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
+        SSLContext sslContext = SSLContexts.custom().loadTrustMaterial((chain, authType) -> true).build();  // Trust all certificates
+        SSLConnectionSocketFactory sslConnectionSocketFactory =
+                new SSLConnectionSocketFactory(sslContext, new String[]{"TLSv1.2"}, null, NoopHostnameVerifier.INSTANCE);
+        return HttpClients.custom().setSSLSocketFactory(sslConnectionSocketFactory).build();
+    }
+
+    /**
+     * Common method to apply authentication to the HTTP request.
+     * @param httpRequestBase the HTTP request (GET, POST, etc.)
+     */
+    private void applyAuthentication(HttpRequestBase httpRequestBase) {
+        if (authenticationStrategy != null) {
+            String authHeader = authenticationStrategy.applyAuthentication();
+            httpRequestBase.setHeader(KruizeConstants.AuthenticationConstants.AUTHORIZATION, authHeader);
+        }
+    }
+
+    /**
+     * Method to call the Experiment API (e.g., to create an experiment) using POST request.
+     * @param payload JSON payload containing the experiment details
+     * @return API response code
+     * @throws IOException
+     */
+    public int callKruizeAPI(String payload) throws IOException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException, FetchMetricsError {
+
+        // Create an HTTP client
+        try (CloseableHttpClient httpclient = setupHttpClient()) {
+            // Prepare the HTTP POST request
+            HttpPost httpPost = new HttpPost(baseURL);
+            httpPost.setHeader("Content-Type", "application/json");
+            httpPost.setHeader("Accept", "application/json");
+
+            // If payload is present, set it in the request body
+            if (payload != null) {
+                StringEntity entity = new StringEntity(payload, StandardCharsets.UTF_8);
+                httpPost.setEntity(entity);
+            }
+
+            // Execute the request and return the response code
+            try (CloseableHttpResponse response = httpclient.execute(httpPost)) {
+                // Get the status code from the response
+                int responseCode = response.getStatusLine().getStatusCode();
+                LOGGER.info("Response code: {}", responseCode);
+                return responseCode;
+            } catch (Exception e) {
+                LOGGER.error("Error occurred while calling Kruize API: {}", e.getMessage());
+                throw new FetchMetricsError(e.getMessage());
+            }
+        }
+    }
+
 
     private static class StringResponseHandler implements ResponseHandler<String> {
         @Override

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -786,10 +786,10 @@ public class KruizeConstants {
         static {
             CREATE_EXPERIMENT_CONFIG_BEAN = new CreateExperimentConfigBean();
             CREATE_EXPERIMENT_CONFIG_BEAN.setMode(AnalyzerConstants.MONITOR);
-            CREATE_EXPERIMENT_CONFIG_BEAN.setTarget_cluster(AnalyzerConstants.LOCAL);
+            CREATE_EXPERIMENT_CONFIG_BEAN.setTarget(AnalyzerConstants.LOCAL);
             CREATE_EXPERIMENT_CONFIG_BEAN.setVersion(AnalyzerConstants.VersionConstants.CURRENT_KRUIZE_OBJECT_VERSION);
-            CREATE_EXPERIMENT_CONFIG_BEAN.setDatasource("prometheus-1");
-            CREATE_EXPERIMENT_CONFIG_BEAN.setPerformance_profile(AnalyzerConstants.PerformanceProfileConstants.RESOURCE_OPT_LOCAL_MON_PROFILE);
+            CREATE_EXPERIMENT_CONFIG_BEAN.setDatasourceName("prometheus-1");
+            CREATE_EXPERIMENT_CONFIG_BEAN.setPerformanceProfile(AnalyzerConstants.PerformanceProfileConstants.RESOURCE_OPT_LOCAL_MON_PROFILE);
             CREATE_EXPERIMENT_CONFIG_BEAN.setThreshold(0.1);
             CREATE_EXPERIMENT_CONFIG_BEAN.setMeasurementDurationStr("15min");
             CREATE_EXPERIMENT_CONFIG_BEAN.setMeasurementDuration(15);

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -18,6 +18,7 @@
 package com.autotune.utils;
 
 import com.autotune.analyzer.kruizeObject.CreateExperimentConfigBean;
+import com.autotune.analyzer.utils.AnalyzerConstants;
 
 import java.text.SimpleDateFormat;
 import java.util.Locale;
@@ -784,11 +785,11 @@ public class KruizeConstants {
         // Static block to initialize the Bean
         static {
             CREATE_EXPERIMENT_CONFIG_BEAN = new CreateExperimentConfigBean();
-            CREATE_EXPERIMENT_CONFIG_BEAN.setMode("monitor");
-            CREATE_EXPERIMENT_CONFIG_BEAN.setTarget("local");
-            CREATE_EXPERIMENT_CONFIG_BEAN.setVersion("v2.0");
-            CREATE_EXPERIMENT_CONFIG_BEAN.setDatasourceName("prometheus-1");
-            CREATE_EXPERIMENT_CONFIG_BEAN.setPerformanceProfile("resource-optimization-local-monitoring");
+            CREATE_EXPERIMENT_CONFIG_BEAN.setMode(AnalyzerConstants.MONITOR);
+            CREATE_EXPERIMENT_CONFIG_BEAN.setTarget_cluster(AnalyzerConstants.LOCAL);
+            CREATE_EXPERIMENT_CONFIG_BEAN.setVersion(AnalyzerConstants.VersionConstants.CURRENT_KRUIZE_OBJECT_VERSION);
+            CREATE_EXPERIMENT_CONFIG_BEAN.setDatasource("prometheus-1");
+            CREATE_EXPERIMENT_CONFIG_BEAN.setPerformance_profile(AnalyzerConstants.PerformanceProfileConstants.RESOURCE_OPT_LOCAL_MON_PROFILE);
             CREATE_EXPERIMENT_CONFIG_BEAN.setThreshold(0.1);
             CREATE_EXPERIMENT_CONFIG_BEAN.setMeasurementDurationStr("15min");
             CREATE_EXPERIMENT_CONFIG_BEAN.setMeasurementDuration(15);

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -677,6 +677,7 @@ public class KruizeConstants {
         public static final String LOCAL = "local";
         public static final String LOG_HTTP_REQ_RESP = "logAllHttpReqAndResp";
         public static final String RECOMMENDATIONS_URL = "recommendationsURL";
+        public static final String EXPERIMENTS_URL = "experimentsURL";
         public static final String BULK_API_LIMIT = "bulkapilimit";
         public static final String BULK_API_CHUNK_SIZE = "bulkapichunksize";
         public static final String BULK_THREAD_POOL_SIZE = "bulkThreadPoolSize";


### PR DESCRIPTION
## Description

This PR refactors the bulk job manager to call the createExperiments API for experiment creation replacing redundant code for adding new experiments.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: Testing is in-progress

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [x] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Test image: quay.io/khansaad/autotune_operator:bulk-api-fix