### PR TITLE
changed Up metrics to look for just Success response

### DIFF
--- a/src/main/java/com/autotune/common/datasource/prometheus/PrometheusDataOperatorImpl.java
+++ b/src/main/java/com/autotune/common/datasource/prometheus/PrometheusDataOperatorImpl.java
@@ -117,16 +117,11 @@ public class PrometheusDataOperatorImpl extends DataSourceOperatorImpl {
 
             if (null == jsonObject) {
                 return null;
+            } else {
+                return "1";   //if it returns HTTP STATUS_OK  200
             }
 
-            JSONArray result = jsonObject.getJSONObject(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.DATA).getJSONArray(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.RESULT);
-            for (Object result_obj : result) {
-                JSONObject result_json = (JSONObject) result_obj;
-                if (result_json.has(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.VALUE)
-                        && !result_json.getJSONArray(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.VALUE).isEmpty()) {
-                    return result_json.getJSONArray(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.VALUE).getString(1);
-                }
-            }
+
         } catch (JSONException e) {
             LOGGER.error(e.getMessage());
         } catch (NullPointerException e) {
@@ -159,6 +154,7 @@ public class PrometheusDataOperatorImpl extends DataSourceOperatorImpl {
             JSONObject jsonObject = apiClient.fetchMetricsJson(
                     KruizeConstants.HttpConstants.MethodType.GET,
                     query);
+            /*  TODO need to separate it out this logic form here
             if (!jsonObject.has(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.STATUS))
                 return null;
             if (!jsonObject.getString(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.STATUS).equalsIgnoreCase(KruizeConstants.DataSourceConstants.DataSourceQueryStatus.SUCCESS))
@@ -169,6 +165,8 @@ public class PrometheusDataOperatorImpl extends DataSourceOperatorImpl {
                 return null;
             if (jsonObject.getJSONObject(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.DATA).getJSONArray(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.RESULT).isEmpty())
                 return  null;
+
+             */
 
             return jsonObject;
 


### PR DESCRIPTION
## Description

Kruize checks if the datasource is reachable by querying the following metric:
http://127.0.0.1:9090/api/v1/query?query=up.

Prometheus/Thanos typically returns the current status of the targets (such as services or jobs) it monitors. However, in this case, Thanos was unable to provide those details, even though the response status was 200 OK.

Kruize only needs to confirm that the response is 200 OK to proceed, and currently, it's not concerned with the actual content of the response. Therefore, the fix will focus on simply checking for a 200 OK status and moving forward based on that

`{
  "status": "success",
  "data": {
    "resultType": "vector",
    "result": [
      {
        "metric": {
          "__name__": "up",
          "instance": "localhost:9090",
          "job": "prometheus"
        },
        "value": [1696841450.278, "1"]
      },
      {
        "metric": {
          "__name__": "up",
          "instance": "localhost:9100",
          "job": "node"
        },
        "value": [1696841450.278, "1"]
      }
    ]
  }
}
`

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
