### PR TITLE
experiment_name format

### DIFF
--- a/design/BulkAPI.md
+++ b/design/BulkAPI.md
@@ -310,3 +310,58 @@ kruizeconfigjson: |
 
 - **Control Mechanism:** The number of threads used for bulk API operations can be controlled using the environment
   variable `bulkThreadPoolSize`.
+
+## Experiment_name
+
+# Experiment Name Format Configuration
+
+## **experimentNameFormat**
+
+The `experimentNameFormat` environment variable is used to define the format for experiment names. For example, if the
+experiment name should follow the structure:
+
+```
+org_id|source_id|cluster_id|namespace|k8s_object_type|k8s_object_name
+```
+
+then set or define the `experimentNameFormat` as follows:
+
+```json
+"experimentNameFormat": "%label:org_id%|%label:source_id%|%label:cluster_id%|%namespace%|%workloadtype%|%workloadname%|%containername%"
+```
+
+When making a /bulk call, ensure the label values used in the experiment name format are passed in the payload's filter
+and include sections, matching the format above.
+
+```angular2html
+ "filter": {
+        "exclude": {
+            "namespace": [],
+            "workload": [],
+            "containers": [],
+            "labels": {
+                "key1": "value1",
+        "key2": "value2"
+    }
+},
+        "include": {
+                "namespace": [],
+                        "workload": [],
+                        "containers": [],
+                        "labels": {
+                        "org_id":"ABCOrga",  "source_id":"ZZZ" ,"cluster_id" : "ABG"
+                                }
+                }
+        }
+```
+
+With the above configuration, the experiment name generated will be:
+
+ABCOrga|ZZZ|ABG|kube-system|deployment|coredns|coredns
+
+If the filter is not specified, it will display as Unknown.
+
+```
+ABCOrga|ZZZ|unknowncluster_id|prometheus-1|default|kube-system|coredns(deployment)|coredns
+```
+    

--- a/design/BulkAPI.md
+++ b/design/BulkAPI.md
@@ -311,14 +311,11 @@ kruizeconfigjson: |
 - **Control Mechanism:** The number of threads used for bulk API operations can be controlled using the environment
   variable `bulkThreadPoolSize`.
 
-## Experiment_name
+## Experiment Name Format Configuration
 
-# Experiment Name Format Configuration
-
-## **experimentNameFormat**
-
-The `experimentNameFormat` environment variable is used to define the format for experiment names. For example, if the
-experiment name should follow the structure:
+- **experimentNameFormat:** The `experimentNameFormat` environment variable is used to define the format for experiment
+  names. For example, if the
+  experiment name should follow the structure:
 
 ```
 org_id|source_id|cluster_id|namespace|k8s_object_type|k8s_object_name
@@ -326,33 +323,37 @@ org_id|source_id|cluster_id|namespace|k8s_object_type|k8s_object_name
 
 then set or define the `experimentNameFormat` as follows:
 
-```json
+```
 "experimentNameFormat": "%label:org_id%|%label:source_id%|%label:cluster_id%|%namespace%|%workloadtype%|%workloadname%|%containername%"
 ```
 
 When making a /bulk call, ensure the label values used in the experiment name format are passed in the payload's filter
 and include sections, matching the format above.
 
-```angular2html
- "filter": {
-        "exclude": {
-            "namespace": [],
-            "workload": [],
-            "containers": [],
-            "labels": {
-                "key1": "value1",
+```json
+{
+  "filter": {
+    "exclude": {
+      "namespace": [],
+      "workload": [],
+      "containers": [],
+      "labels": {
+        "key1": "value1",
         "key2": "value2"
+      }
+    },
+    "include": {
+      "namespace": [],
+      "workload": [],
+      "containers": [],
+      "labels": {
+        "org_id": "ABCOrga",
+        "source_id": "ZZZ",
+        "cluster_id": "ABG"
+      }
     }
-},
-        "include": {
-                "namespace": [],
-                        "workload": [],
-                        "containers": [],
-                        "labels": {
-                        "org_id":"ABCOrga",  "source_id":"ZZZ" ,"cluster_id" : "ABG"
-                                }
-                }
-        }
+  }
+}
 ```
 
 With the above configuration, the experiment name generated will be:

--- a/design/BulkAPI.md
+++ b/design/BulkAPI.md
@@ -365,4 +365,11 @@ If the filter is not specified, it will display as Unknown.
 ```
 ABCOrga|ZZZ|unknowncluster_id|prometheus-1|default|kube-system|coredns(deployment)|coredns
 ```
-    
+
+**Note**:Specifying labels in envirnoment varable `experimentNameFormat` is optional and flexible; there can be any
+number of labels, or none at all. Here are some examples:
+
+- "%datasource%|%clustername%|%namespace%|%workloadname%(%workloadtype%)|%containername%"    -> Default
+- "%label:org_id%|%label:source_id%|%label:cluster_id%|%namespace%|%workloadtype%|%workloadname%|%containername%"
+- "%label:org_id%|%namespace%|%workloadtype%|%workloadname%|%containername%"
+- "%label:org_id%|%label:cluster_id%|%namespace%|%workloadtype%|%workloadname%"

--- a/manifests/crc/default-db-included-installation/aks/kruize-crc-aks.yaml
+++ b/manifests/crc/default-db-included-installation/aks/kruize-crc-aks.yaml
@@ -101,7 +101,8 @@ data:
       "logAllHttpReqAndResp": "true",
       "recommendationsURL" : "http://kruize.monitoring.svc.cluster.local:8080/generateRecommendations?experiment_name=%s",    
       "experimentsURL" : "http://kruize.monitoring.svc.cluster.local:8080/createExperiment", 
-      "experimentNameFormat" : "%label:org_id%|%label:source_id%|%label:cluster_id%|%namespace%|%workloadtype%|%workloadname%",
+      "experimentNameFormat" : "%datasource%|%clustername%|%namespace%|%workloadname%(%workloadtype%)|%containername%",
+      "bulkapilimit" : 1000,
       "hibernate": {
         "dialect": "org.hibernate.dialect.PostgreSQLDialect",
         "driver": "org.postgresql.Driver",

--- a/manifests/crc/default-db-included-installation/aks/kruize-crc-aks.yaml
+++ b/manifests/crc/default-db-included-installation/aks/kruize-crc-aks.yaml
@@ -100,7 +100,8 @@ data:
       "local": "true",
       "logAllHttpReqAndResp": "true",
       "recommendationsURL" : "http://kruize.monitoring.svc.cluster.local:8080/generateRecommendations?experiment_name=%s",    
-      "experimentsURL" : "http://kruize.monitoring.svc.cluster.local:8080/createExperiment",    
+      "experimentsURL" : "http://kruize.monitoring.svc.cluster.local:8080/createExperiment", 
+      "experimentNameFormat" : "%label:org_id%|%label:source_id%|%label:cluster_id%|%namespace%|%workloadtype%|%workloadname%",
       "hibernate": {
         "dialect": "org.hibernate.dialect.PostgreSQLDialect",
         "driver": "org.postgresql.Driver",

--- a/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
@@ -114,7 +114,8 @@ data:
       "local": "true",
       "logAllHttpReqAndResp": "true",
       "recommendationsURL" : "http://kruize.monitoring.svc.cluster.local:8080/generateRecommendations?experiment_name=%s",    
-      "experimentsURL" : "http://kruize.monitoring.svc.cluster.local:8080/createExperiment",    
+      "experimentsURL" : "http://kruize.monitoring.svc.cluster.local:8080/createExperiment",   
+      "experimentNameFormat" : "%label:org_id%|%label:source_id%|%label:cluster_id%|%namespace%|%workloadtype%|%workloadname%",
       "hibernate": {
         "dialect": "org.hibernate.dialect.PostgreSQLDialect",
         "driver": "org.postgresql.Driver",

--- a/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
@@ -115,7 +115,8 @@ data:
       "logAllHttpReqAndResp": "true",
       "recommendationsURL" : "http://kruize.monitoring.svc.cluster.local:8080/generateRecommendations?experiment_name=%s",    
       "experimentsURL" : "http://kruize.monitoring.svc.cluster.local:8080/createExperiment",   
-      "experimentNameFormat" : "%label:org_id%|%label:source_id%|%label:cluster_id%|%namespace%|%workloadtype%|%workloadname%",
+      "experimentNameFormat" : "%datasource%|%clustername%|%namespace%|%workloadname%(%workloadtype%)|%containername%",
+      "bulkapilimit" : 1000,
       "hibernate": {
         "dialect": "org.hibernate.dialect.PostgreSQLDialect",
         "driver": "org.postgresql.Driver",

--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -109,6 +109,7 @@ data:
       "logAllHttpReqAndResp": "true",
       "recommendationsURL" : "http://kruize.openshift-tuning.svc.cluster.local:8080/generateRecommendations?experiment_name=%s",
       "experimentsURL" : "http://kruize.openshift-tuning.svc.cluster.local:8080/createExperiment",
+      "experimentNameFormat" : "%label:org_id%|%label:source_id%|%label:cluster_id%|%namespace%|%workloadtype%|%workloadname%",
       "hibernate": {
         "dialect": "org.hibernate.dialect.PostgreSQLDialect",
         "driver": "org.postgresql.Driver",

--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -109,7 +109,8 @@ data:
       "logAllHttpReqAndResp": "true",
       "recommendationsURL" : "http://kruize.openshift-tuning.svc.cluster.local:8080/generateRecommendations?experiment_name=%s",
       "experimentsURL" : "http://kruize.openshift-tuning.svc.cluster.local:8080/createExperiment",
-      "experimentNameFormat" : "%label:org_id%|%label:source_id%|%label:cluster_id%|%namespace%|%workloadtype%|%workloadname%",
+      "experimentNameFormat" : "%datasource%|%clustername%|%namespace%|%workloadname%(%workloadtype%)|%containername%",
+      "bulkapilimit" : 1000,
       "hibernate": {
         "dialect": "org.hibernate.dialect.PostgreSQLDialect",
         "driver": "org.postgresql.Driver",

--- a/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
+++ b/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
@@ -130,7 +130,7 @@ public class BulkJobManager implements Runnable {
             if (null != daterange)
                 metadataInfo = dataSourceManager.importMetadataFromDataSource(datasource, labelString, (Long) daterange.get("start_time"), (Long) daterange.get("end_time"), (Integer) daterange.get("steps"));
             else {
-                metadataInfo = dataSourceManager.importMetadataFromDataSource(datasource, null, 0, 0, 0);
+                metadataInfo = dataSourceManager.importMetadataFromDataSource(datasource, labelString, 0, 0, 0);
             }
             if (null == metadataInfo) {
                 jobData.setStatus(COMPLETED);

--- a/src/main/java/com/autotune/operator/KruizeDeploymentInfo.java
+++ b/src/main/java/com/autotune/operator/KruizeDeploymentInfo.java
@@ -86,6 +86,7 @@ public class KruizeDeploymentInfo {
     public static Integer bulk_thread_pool_size = 3;
     public static int generate_recommendations_date_range_limit_in_days = 15;
     public static Integer delete_partition_threshold_in_days = DELETE_PARTITION_THRESHOLD_IN_DAYS;
+    public static String experiment_name_format = "%datasource%|%clustername%|%namespace%|%workloadname%(%workloadtype%)|%containername%";
     private static Hashtable<String, Class> tunableLayerPair;
     //private static KubernetesClient kubernetesClient;
     private static KubeEventLogger kubeEventLogger;

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -682,6 +682,7 @@ public class KruizeConstants {
         public static final String BULK_API_LIMIT = "bulkapilimit";
         public static final String BULK_API_CHUNK_SIZE = "bulkapichunksize";
         public static final String BULK_THREAD_POOL_SIZE = "bulkThreadPoolSize";
+        public static final String EXPERIMENT_NAME_FORMAT = "experimentNameFormat";
     }
 
     public static final class RecommendationEngineConstants {


### PR DESCRIPTION
## Description



For ROS, the experiment_name format should follow the structure shown below:

org_id|source_id|cluster_id|namespace|k8s_object_type|k8s_object_name

Here, source_id and cluster_id are UUIDs.

It would also be beneficial if this format could be configurable.


Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
