### PR TITLE
Resolve issue where error is not being returned to the caller.

### DIFF
--- a/src/main/java/com/autotune/common/datasource/DataSourceManager.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceManager.java
@@ -54,7 +54,7 @@ public class DataSourceManager {
      * @param steps         the interval between data points in a range query
      * @return
      */
-    public DataSourceMetadataInfo importMetadataFromDataSource(DataSourceInfo dataSourceInfo,String uniqueKey,long startTime,long endTime,int steps) {
+    public DataSourceMetadataInfo importMetadataFromDataSource(DataSourceInfo dataSourceInfo,String uniqueKey,long startTime,long endTime,int steps) throws Exception {
         try {
             if (null == dataSourceInfo) {
                 throw new DataSourceDoesNotExist(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.MISSING_DATASOURCE_INFO);
@@ -67,8 +67,9 @@ public class DataSourceManager {
             return dataSourceMetadataInfo;
         } catch (Exception e) {
             LOGGER.error(e.getMessage());
+            throw e;
         }
-        return null;
+
     }
 
     /**

--- a/src/main/java/com/autotune/common/datasource/prometheus/PrometheusDataOperatorImpl.java
+++ b/src/main/java/com/autotune/common/datasource/prometheus/PrometheusDataOperatorImpl.java
@@ -235,8 +235,10 @@ public class PrometheusDataOperatorImpl extends DataSourceOperatorImpl {
             }
         } catch (JsonParseException e) {
             LOGGER.error(e.getMessage());
+            throw e;
         } catch (NullPointerException e) {
             LOGGER.error(e.getMessage());
+            throw e;
         }
         return null;
     }


### PR DESCRIPTION
## Description

Execution errors in PromQL queries or query exceptions are being suppressed without passing error details back to the caller.

Fixes # (issue)
Add thows and throw so errors are not suppressed and error details passed backed to caller.
### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [x] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
