### PR TITLE
Removed the autotune job from the PR check workflow

### DIFF
--- a/.github/workflows/test-on-pr.yaml
+++ b/.github/workflows/test-on-pr.yaml
@@ -13,68 +13,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  # This workflow contains two jobs called "build autotune" and "build crc"
-  build_autotune:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
 
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.3.0
-        with:
-          minikube version: 'v1.16.0'
-          kubernetes version: 'v1.19.2'
-      - name: Build autotune
-        run: |
-          echo Build autotune
-          pr_number=${{ github.event.pull_request.number }}
-          echo "pr_number=${pr_number}" >> "$GITHUB_ENV"
-          ./build.sh -i autotune_operator:pr_${pr_number}
-          docker images | grep autotune     
-      - name: Check cluster info on minikube
-        run: |
-          kubectl cluster-info
-          kubectl get pods -n kube-system
-      - name: Install Prometheus on minikube
-        run: |
-          echo Install Prometheus on minikube
-          cd scripts
-          ./prometheus_on_minikube.sh -as
-      - name: Deploy kruize in experiment mode
-        run: |
-          echo Deploy kruize in experiment mode
-          cp ./manifests/autotune/autotune-operator-deployment.yaml_template ./manifests/autotune/autotune-operator-deployment.yaml_template.old
-          sed -e "s/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g" ./manifests/autotune/autotune-operator-deployment.yaml_template.old > ./manifests/autotune/autotune-operator-deployment.yaml_template
-          echo "***************************************************************"
-          cat ./manifests/autotune/autotune-operator-deployment.yaml_template
-          echo "***************************************************************"
-          
-          echo "PR_NUMBER = ${{ env.pr_number }}"
-          ./deploy.sh -c minikube -i autotune_operator:pr_${{ env.pr_number }}
-
-          sleep 20
-      - name: Capture ffdc logs
-        if: always()
-        run: |
-          echo "Capturing ffdc logs"
-          ./scripts/ffdc.sh -d ${GITHUB_WORKSPACE}
-      - name: Archive results
-        if: always()
-        run: |
-          cd ${GITHUB_WORKSPACE}
-          tar cvf autotune_results.tar kruize_*log.txt
-
-      - name: Upload results
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: autotune-results
-          path: ./autotune_results.tar
-          retention-days: 2
-
-
+  # This workflow builds the kruize image and runs an end-to-end test to validate the remote monitoring workflow
   build_crc:
     # The type of runner that the job will run on
     runs-on: ubuntu-20.04


### PR DESCRIPTION
## Description

This PR removes the build-autotune job from the PR check workflow as we do not support the autotune use case as of now. 

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

This will be tested using the PR check workflow itself

- [ ] New Test X
- [ ] Functional testsuite
- [X] PR check tests

**Test Configuration**
* Kubernetes clusters tested on:  minikube

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated
- [X] PR check updated

## Additional information

Include any additional information such as links, test results, screenshots here
