### PR TITLE
Fix missing datasource issue on pod restart

### DIFF
--- a/src/main/java/com/autotune/common/datasource/DataSourceCollection.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceCollection.java
@@ -144,6 +144,10 @@ public class DataSourceCollection {
                     DataSourceInfo dataSourceInfo = new ExperimentDBService().loadDataSourceFromDBByName(name);
                     if (null != dataSourceInfo) {
                         LOGGER.error("Datasource: {} already exists!", name);
+                        // add the auth details to local object
+                        AuthenticationConfig authConfig = getAuthenticationDetails(dataSourceObject, name);
+                        dataSourceInfo.setAuthenticationConfig(authConfig);
+                        dataSourceCollection.put(name, dataSourceInfo);
                         continue;
                     }
                 } catch (Exception e) {
@@ -153,16 +157,7 @@ public class DataSourceCollection {
                 String serviceName = dataSourceObject.getString(KruizeConstants.DataSourceConstants.DATASOURCE_SERVICE_NAME);
                 String namespace = dataSourceObject.getString(KruizeConstants.DataSourceConstants.DATASOURCE_SERVICE_NAMESPACE);
                 String dataSourceURL = dataSourceObject.getString(KruizeConstants.DataSourceConstants.DATASOURCE_URL);
-                AuthenticationConfig authConfig;
-                try {
-                    JSONObject authenticationObj = dataSourceObject.optJSONObject(KruizeConstants.AuthenticationConstants.AUTHENTICATION);
-                    // create the corresponding authentication object
-                    authConfig = AuthenticationConfig.createAuthenticationConfigObject(authenticationObj);
-                } catch (Exception e) {
-                    LOGGER.warn("Auth details are missing for datasource: {}", name);
-                    authConfig = AuthenticationConfig.noAuth();
-                }
-
+                AuthenticationConfig authConfig = getAuthenticationDetails(dataSourceObject, name);
                 DataSourceInfo datasource;
                 // Validate input
                 if (!validateInput(name, provider, serviceName, dataSourceURL, namespace)) {
@@ -180,6 +175,19 @@ public class DataSourceCollection {
         } catch (IOException e) {
             LOGGER.error(e.getMessage());
         }
+    }
+
+    private AuthenticationConfig getAuthenticationDetails(JSONObject dataSourceObject, String name) {
+        AuthenticationConfig authConfig;
+        try {
+            JSONObject authenticationObj = dataSourceObject.optJSONObject(KruizeConstants.AuthenticationConstants.AUTHENTICATION);
+            // create the corresponding authentication object
+            authConfig = AuthenticationConfig.createAuthenticationConfigObject(authenticationObj);
+        } catch (Exception e) {
+            LOGGER.warn("Auth details are missing for datasource: {}", name);
+            authConfig = AuthenticationConfig.noAuth();
+        }
+        return authConfig;
     }
 
     /**

--- a/src/main/java/com/autotune/common/utils/CommonUtils.java
+++ b/src/main/java/com/autotune/common/utils/CommonUtils.java
@@ -307,7 +307,7 @@ public class CommonUtils {
             // fetch the datasource from the DB
             datasource = dataSourceManager.fetchDataSourceFromDBByName(dataSourceName);
             if (isInvalidDataSource(datasource)) {
-                throw new Exception(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.INVALID_DATASOURCE_INFO);
+                throw new Exception(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.INVALID_DATASOURCE_INFO + dataSourceName);
             }
         }
         return datasource;

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -456,7 +456,7 @@ public class KruizeConstants {
             public static final String SERVICE_NOT_FOUND = "Can not find service with specified name.";
             public static final String ENDPOINT_NOT_FOUND = "Service endpoint not found.";
             public static final String MISSING_DATASOURCE_INFO = "Datasource is missing, add a valid Datasource";
-            public static final String INVALID_DATASOURCE_INFO = "Datasource is either missing or is invalid";
+            public static final String INVALID_DATASOURCE_INFO = "Datasource is either missing or is invalid: ";
 
             private DataSourceErrorMsgs() {
             }


### PR DESCRIPTION
## Description

This PR fixes the issue with datasource which is causing a `missing or invalid datasource`  exception. Details for the same are mentioned in Issue [1356](https://github.com/kruize/autotune/issues/1356)

Fixes  [1356](https://github.com/kruize/autotune/issues/1356)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [x] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: Openshift

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [x] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
