### PR TITLE
Update Container Metric Queries

### DIFF
--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.json
@@ -21,19 +21,19 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg by(container, namespace) (kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            "query": "avg by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           },
           {
             "function": "sum",
-            "query": "sum by(container, namespace) (kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            "query": "sum by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           },
           {
             "function": "min",
-            "query": "min by(container, namespace) (kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            "query": "min by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           },
           {
             "function": "max",
-            "query": "max by(container, namespace) (kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            "query": "max by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           }
         ]
       },
@@ -45,19 +45,19 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg by(container,namespace) (kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            "query": "avg by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           },
           {
             "function": "sum",
-            "query": "sum by(container,namespace) (kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            "query": "sum by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           },
           {
             "function": "max",
-            "query": "max by(container,namespace) (kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            "query": "min by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           },
           {
             "function": "min",
-            "query": "min by(container,namespace) (kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            "query": "max by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           }
         ]
       },
@@ -69,43 +69,43 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!=\"\", container!=\"POD\", pod!=\"\",namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\" }[$MEASUREMENT_DURATION_IN_MIN$m]))",
-            "versions": "<=4.8"
+            "query": "avg by(container, pod, namespace) (avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))",
+            "version": "<=4.8"
           },
           {
             "function": "avg",
-            "query": "avg by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))",
-            "versions": ">4.9"
+            "query": "avg by(container, pod, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))",
+            "version": ">4.9"
           },
           {
             "function": "min",
-            "query": "min by(container, namespace)(min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))",
-            "versions": "<=4.8"
+            "query": "min by(container, pod, namespace) (min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))",
+            "version": "<=4.8"
           },
           {
             "function": "min",
-            "query": "min by(container, namespace)(min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))",
-            "versions": ">4.9"
+            "query": "min by(container, pod, namespace) (min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))",
+            "version": ">4.9"
           },
           {
             "function": "max",
-            "query": "max by(container, namespace)(max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))",
-            "versions": "<=4.8"
+            "query": "max by(container, pod, namespace) (max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))",
+            "version": "<=4.8"
           },
           {
             "function": "max",
-            "query": "max by(container, namespace)(max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))",
-            "versions": ">4.9"
+            "query": "max by(container, pod, namespace) (max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))",
+            "version": ">4.9"
           },
           {
             "function": "sum",
-            "query": "sum by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))",
-            "versions": "<=4.8"
+            "query": "sum by(container, pod, namespace) (avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))",
+            "version": "<=4.8"
           },
           {
             "function": "sum",
-            "query": "sum by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))",
-            "versions": ">4.9"
+            "query": "sum by(container, pod, namespace) (avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))",
+            "version": ">4.9"
           }
         ]
       },
@@ -117,19 +117,19 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
-          },
-          {
-            "function": "max",
-            "query": "max by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
-          },
-          {
-            "function": "min",
-            "query": "min by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            "query": "avg by(container, pod, namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           },
           {
             "function": "sum",
-            "query": "sum by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            "query": "sum by(container, pod, namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          },
+          {
+            "function": "min",
+            "query": "min by(container, pod, namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          },
+          {
+            "function": "max",
+            "query": "max by(container, pod, namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           }
         ]
       },
@@ -141,19 +141,19 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg by(container, namespace) (kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            "query": "avg by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           },
           {
             "function": "sum",
-            "query": "sum by(container, namespace) (kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
-          },
-          {
-            "function": "max",
-            "query": "max by(container, namespace) (kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            "query": "sum by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           },
           {
             "function": "min",
-            "query": "min by(container, namespace) (kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            "query": "min by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+          },
+          {
+            "function": "max",
+            "query": "max by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           }
         ]
       },
@@ -165,19 +165,19 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg by(container,namespace) (kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            "query": "avg by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           },
           {
             "function": "sum",
-            "query": "sum by(container,namespace) (kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
-          },
-          {
-            "function": "max",
-            "query": "max by(container,namespace) (kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            "query": "sum by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           },
           {
             "function": "min",
-            "query": "min by(container,namespace) (kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            "query": "min by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+          },
+          {
+            "function": "max",
+            "query": "max by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           }
         ]
       },
@@ -189,19 +189,19 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg by(container, namespace) (avg_over_time(container_memory_working_set_bytes{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            "query": "avg by(container, pod, namespace) (avg_over_time(container_memory_working_set_bytes{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           },
           {
             "function": "min",
-            "query": "min by(container, namespace) (min_over_time(container_memory_working_set_bytes{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            "query": "min by(container, pod, namespace) (min_over_time(container_memory_working_set_bytes{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           },
           {
             "function": "max",
-            "query": "max by(container, namespace) (max_over_time(container_memory_working_set_bytes{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            "query": "max by(container, pod, namespace) (max_over_time(container_memory_working_set_bytes{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           },
           {
             "function": "sum",
-            "query": "sum by(container, namespace) (avg_over_time(container_memory_working_set_bytes{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            "query": "sum by(container, pod, namespace) (avg_over_time(container_memory_working_set_bytes{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           }
         ]
       },
@@ -213,19 +213,19 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg by(container, namespace) (avg_over_time(container_memory_rss{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            "query": "avg by(container, pod, namespace) (avg_over_time(container_memory_rss{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           },
           {
             "function": "min",
-            "query": "min by(container, namespace) (min_over_time(container_memory_rss{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            "query": "min by(container, pod, namespace) (min_over_time(container_memory_rss{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           },
           {
             "function": "max",
-            "query": "max by(container, namespace) (max_over_time(container_memory_rss{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            "query": "max by(container, pod, namespace) (max_over_time(container_memory_rss{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           },
           {
             "function": "sum",
-            "query": "sum by(container, namespace) (avg_over_time(container_memory_rss{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            "query": "sum by(container, pod, namespace) (avg_over_time(container_memory_rss{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           }
         ]
       },
@@ -238,6 +238,30 @@
           {
             "function": "max",
             "query": "max by(namespace,container) (last_over_time((timestamp(container_cpu_usage_seconds_total{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"} > 0))[15d:]))"
+          }
+        ]
+      },
+      {
+        "name": "imageOwners",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "max",
+            "query": "(max_over_time(kube_pod_container_info{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m])) * on(pod, namespace) group_left(owner_kind, owner_name) max by(pod, namespace, owner_kind, owner_name) (max_over_time(kube_pod_owner{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          }
+        ]
+      },
+      {
+        "name": "imageWorkloads",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "max",
+            "query": "(max_over_time(kube_pod_container_info{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m])) * on(pod, namespace) group_left(workload, workload_type) max by(pod, namespace, workload, workload_type) (max_over_time(namespace_workload_pod:kube_pod_owner:relabel{pod!=\"\", namespace=\"$NAMESPACE$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           }
         ]
       },

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.json
@@ -21,19 +21,19 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "avg by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           },
           {
             "function": "sum",
-            "query": "sum by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "sum by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           },
           {
             "function": "min",
-            "query": "min by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "min by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           },
           {
             "function": "max",
-            "query": "max by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "max by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           }
         ]
       },
@@ -45,19 +45,19 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "avg by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           },
           {
             "function": "sum",
-            "query": "sum by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "sum by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           },
           {
             "function": "min",
-            "query": "min by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "min by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           },
           {
             "function": "max",
-            "query": "max by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "max by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           }
         ]
       },
@@ -141,19 +141,19 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "avg by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           },
           {
             "function": "sum",
-            "query": "sum by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "sum by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           },
           {
             "function": "min",
-            "query": "min by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "min by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           },
           {
             "function": "max",
-            "query": "max by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "max by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           }
         ]
       },
@@ -165,19 +165,19 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "avg by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           },
           {
             "function": "sum",
-            "query": "sum by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "sum by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           },
           {
             "function": "min",
-            "query": "min by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "min by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           },
           {
             "function": "max",
-            "query": "max by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "max by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           }
         ]
       },

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.json
@@ -52,11 +52,11 @@
             "query": "sum by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           },
           {
-            "function": "max",
+            "function": "min",
             "query": "min by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           },
           {
-            "function": "min",
+            "function": "max",
             "query": "max by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           }
         ]

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.yaml
@@ -23,17 +23,17 @@ slo:
 
     aggregation_functions:
     - function: avg
-      query: 'avg by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'avg by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
     # Show sum of cpu requests in bytes for a container in a deployment
     - function: sum
-      query: 'sum by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'sum by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
     - function: min
-      query: 'min by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'min by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
     - function: max
-      query: 'max by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'max by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
   # CPU Limit
   # Show cpu limits in bytes for a container in a deployment
@@ -44,17 +44,17 @@ slo:
 
     aggregation_functions:
     - function: avg
-      query: 'avg by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'avg by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
     # Show sum of cpu limits in bytes for a container in a deployment
     - function: sum
-      query: 'sum by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'sum by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
     - function: min
-      query: 'min by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'min by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
     - function: max
-      query: 'max by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'max by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
   # CPU Usage
   # CPU Usage query uses recording rule to get the data. Recording rule has changed
@@ -153,17 +153,17 @@ slo:
 
     aggregation_functions:
     - function: avg
-      query: 'avg by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'avg by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
     # Show sum of memory requests in bytes for a container in a deployment
     - function: sum
-      query: 'sum by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'sum by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
     - function: max
-      query: 'max by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'max by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
     - function: min
-      query: 'min by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'min by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
 
   # Memory Limit
@@ -175,17 +175,17 @@ slo:
 
     aggregation_functions:
     - function: avg
-      query: 'avg by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'avg by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
     # Show sum of memory limits in bytes for a container in a deployment
     - function: sum
-      query: 'sum by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'sum by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
     - function: max
-      query: 'max by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'max by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
     - function: min
-      query: 'min by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'min by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
   # Memory Usage
   # Average memory per container in a deployment

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.yaml
@@ -23,17 +23,17 @@ slo:
 
     aggregation_functions:
     - function: avg
-      query: 'avg by(container, namespace) (kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'avg by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
     # Show sum of cpu requests in bytes for a container in a deployment
     - function: sum
-      query: 'sum by(container, namespace) (kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'sum by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
     - function: min
-      query: 'min by(container, namespace) (kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'min by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
     - function: max
-      query: 'max by(container, namespace) (kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'max by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
   # CPU Limit
   # Show cpu limits in bytes for a container in a deployment
@@ -44,18 +44,17 @@ slo:
 
     aggregation_functions:
     - function: avg
-      query: 'avg by(container,namespace) (kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'avg by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
     # Show sum of cpu limits in bytes for a container in a deployment
     - function: sum
-      query: 'sum by(container,namespace) (kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
-
-    - function: max
-      query: 'max by(container,namespace) (kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'sum by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
     - function: min
-      query: 'min by(container,namespace) (kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'min by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
+    - function: max
+      query: 'max by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
   # CPU Usage
   # CPU Usage query uses recording rule to get the data. Recording rule has changed
@@ -76,46 +75,46 @@ slo:
     # For openshift versions <=4.8
     aggregation_functions:
     - function: avg
-      query: 'avg by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
-      versions: "<=4.8"
+      query: 'avg by(container, pod, namespace) (avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      version: "<=4.8"
 
     # For openshift versions >=4.9
     - function: avg
-      query: 'avg by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
-      versions: ">4.9"
+      query: 'avg by(container, pod, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      version: ">4.9"
 
     # Approx minimum CPU per container in a deployment
     # For openshift versions <=4.8
     - function: min
-      query: 'min by(container, namespace)(min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
-      versions: "<=4.8"
+      query: 'min by(container, pod, namespace) (min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      version: "<=4.8"
 
     # For openshift versions >=4.9
     - function: min
-      query: 'min by(container, namespace)(min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
-      versions: ">4.9"
+      query: 'min by(container, pod, namespace) (min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      version: ">4.9"
 
     # Approx maximum CPU per container in a deployment
     # For openshift versions <=4.8
     - function: max
-      query: 'max by(container, namespace)(max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
-      versions: "<=4.8"
+      query: 'max by(container, pod, namespace) (max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      version: "<=4.8"
 
     # For openshift versions >=4.9
     - function: max
-      query: 'max by(container, namespace)(max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
-      versions: ">4.9"
+      query: 'max by(container, pod, namespace) (max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      version: ">4.9"
 
     # Sum of CPU usage for a container in all pods of a deployment
     # For openshift versions <=4.8
     - function: sum
-      query: 'sum by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
-      versions: "<=4.8"
+      query: 'sum by(container, pod, namespace) (avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      version: "<=4.8"
 
     # For openshift versions >=4.9
     - function: sum
-      query: 'sum by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
-      versions: ">4.9"
+      query: 'sum by(container, pod, namespace) (avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      version: ">4.9"
 
 
   # CPU Throttling
@@ -127,19 +126,19 @@ slo:
     aggregation_functions:
     # Average CPU throttling per container in a deployment
     - function: avg
-      query: 'avg by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="",namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      query: 'avg by(container, pod, namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="",namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
     # Maximum CPU throttling per container in a deployment
     - function: max
-      query: 'max by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="",namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      query: 'max by(container, pod, namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="",namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
     # Min of CPU throttling for a container in all pods of a deployment
     - function: min
-      query: 'min by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="",namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      query: 'min by(container, pod, namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="",namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
     # Sum of CPU throttling for a container in all pods of a deployment
     - function: sum
-      query: 'sum by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="",namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      query: 'sum by(container, pod, namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="",namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
 
 
@@ -154,17 +153,17 @@ slo:
 
     aggregation_functions:
     - function: avg
-      query: 'avg by(container, namespace) (kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'avg by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
     # Show sum of memory requests in bytes for a container in a deployment
     - function: sum
-      query: 'sum by(container, namespace) (kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'sum by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
     - function: max
-      query: 'max by(container, namespace) (kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'max by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
     - function: min
-      query: 'min by(container, namespace) (kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'min by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
 
   # Memory Limit
@@ -176,17 +175,17 @@ slo:
 
     aggregation_functions:
     - function: avg
-      query: 'avg by(container,namespace) (kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'avg by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
     # Show sum of memory limits in bytes for a container in a deployment
     - function: sum
-      query: 'sum by(container,namespace) (kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'sum by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
     - function: max
-      query: 'max by(container,namespace) (kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'max by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
     - function: min
-      query: 'min by(container,namespace) (kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'min by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
   # Memory Usage
   # Average memory per container in a deployment
@@ -197,19 +196,19 @@ slo:
 
     aggregation_functions:
     - function: avg
-      query: 'avg by(container, namespace) (avg_over_time(container_memory_working_set_bytes{container!="", container!="POD", pod!="", namespace="$NAMESPACE$",container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      query: 'avg by(container, pod, namespace) (avg_over_time(container_memory_working_set_bytes{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
     # Approx minimum memory per container in a deployment
     - function: min
-      query: 'min by(container, namespace) (min_over_time(container_memory_working_set_bytes{container!="", container!="POD", pod!="", namespace="$NAMESPACE$",container="$CONTAINER_NAME$" }[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      query: 'min by(container, pod, namespace) (min_over_time(container_memory_working_set_bytes{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
     # Approx maximum memory per container in a deployment
     - function: max
-      query: 'max by(container, namespace) (max_over_time(container_memory_working_set_bytes{container!="", container!="POD", pod!="", namespace="$NAMESPACE$",container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      query: 'max by(container, pod, namespace) (max_over_time(container_memory_working_set_bytes{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
     # Sum of memory usage for a contianer in all pods of a deployment
     - function: sum
-      query: 'sum by(container, namespace) (avg_over_time(container_memory_working_set_bytes{container!="", container!="POD", pod!="", namespace="$NAMESPACE$",container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      query: 'sum by(container, pod, namespace) (avg_over_time(container_memory_working_set_bytes{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
 
   # 2.4 Memory RSS
@@ -221,20 +220,20 @@ slo:
     aggregation_functions:
     # Average memory RSS per container in a deployment
     - function: avg
-      query: 'avg by(container, namespace) (avg_over_time(container_memory_rss{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      query: 'avg by(container, pod, namespace) (avg_over_time(container_memory_rss{container!="", container!="POD", pod!="",namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
     # Approx minimum memory RSS per container in a deployment
     - function: min
-      query: 'min by(container, namespace) (min_over_time(container_memory_rss{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      query: 'min by(container, pod, namespace) (min_over_time(container_memory_rss{container!="", container!="POD", pod!="",namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
 
     # Approx maximum memory RSS per container in a deployment
     - function: max
-      query: 'max by(container, namespace) (max_over_time(container_memory_rss{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      query: 'max by(container, pod, namespace) (max_over_time(container_memory_rss{container!="", container!="POD", pod!="",namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
     # Sum of memory RSS for a contianer in all pods of a deployment
     - function: sum
-      query: 'sum by(container, namespace) (avg_over_time(container_memory_rss{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      query: 'sum by(container, pod, namespace) (avg_over_time(container_memory_rss{container!="", container!="POD", pod!="",namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
 
   # Container Last Active Timestamp
@@ -246,6 +245,26 @@ slo:
     aggregation_functions:
     - function: max
       query: 'max by(namespace,container) (last_over_time((timestamp(container_cpu_usage_seconds_total{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"} > 0))[15d:]))'
+
+  # Pod containers owner_kind and owner_kind info
+  - name: imageOwners
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "container"
+
+    aggregation_functions:
+    - function: max
+      query: '(max_over_time(kube_pod_container_info{container!="", container!="POD", pod!="", namespace="$NAMESPACE$",container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m])) * on(pod, namespace) group_left(owner_kind, owner_name) max by(pod, namespace, owner_kind, owner_name) (max_over_time(kube_pod_owner{container!="", container!="POD", pod!="", namespace="$NAMESPACE$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+
+  # Pod containers workload and workload_type info
+  - name: imageWorkloads
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "container"
+
+    aggregation_functions:
+    - function: max
+      query: '(max_over_time(kube_pod_container_info{container!="", container!="POD", pod!="", namespace="$NAMESPACE$",container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m])) * on(pod, namespace) group_left(workload, workload_type) max by(pod, namespace, workload, workload_type) (max_over_time(namespace_workload_pod:kube_pod_owner:relabel{pod!="", namespace="$NAMESPACE$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
   ## namespace related queries
 

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.json
@@ -21,19 +21,19 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "avg by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           },
           {
             "function": "sum",
-            "query": "sum by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "sum by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           },
           {
             "function": "min",
-            "query": "min by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "min by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           },
           {
             "function": "max",
-            "query": "max by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "max by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           }
         ]
       },
@@ -45,19 +45,19 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "avg by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           },
           {
             "function": "sum",
-            "query": "sum by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "sum by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           },
           {
             "function": "max",
-            "query": "max by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "max by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           },
           {
             "function": "min",
-            "query": "min by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "min by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           }
         ]
       },
@@ -117,19 +117,19 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "avg by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           },
           {
             "function": "sum",
-            "query": "sum by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "sum by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           },
           {
             "function": "max",
-            "query": "max by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "max by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           },
           {
             "function": "min",
-            "query": "min by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "min by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           }
         ]
       },
@@ -141,19 +141,19 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "avg by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           },
           {
             "function": "sum",
-            "query": "sum by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "sum by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           },
           {
             "function": "max",
-            "query": "max by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "max by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           },
           {
             "function": "min",
-            "query": "min by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
+            "query": "min by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}))"
           }
         ]
       },

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.json
@@ -21,19 +21,19 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg by(container, namespace) (kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            "query": "avg by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           },
           {
             "function": "sum",
-            "query": "sum by(container, namespace) (kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            "query": "sum by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           },
           {
             "function": "min",
-            "query": "min by(container, namespace) (kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            "query": "min by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           },
           {
             "function": "max",
-            "query": "max by(container, namespace) (kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            "query": "max by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           }
         ]
       },
@@ -45,19 +45,19 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg by(container,namespace) (kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            "query": "avg by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           },
           {
             "function": "sum",
-            "query": "sum by(container,namespace) (kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            "query": "sum by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           },
           {
             "function": "max",
-            "query": "max by(container,namespace) (kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            "query": "max by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           },
           {
             "function": "min",
-            "query": "min by(container,namespace) (kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            "query": "min by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"cpu\", unit=\"core\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           }
         ]
       },
@@ -69,19 +69,19 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg by(container, namespace)(avg_over_time(rate(container_cpu_usage_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[5m])[$MEASUREMENT_DURATION_IN_MIN$m:]))"
+            "query": "avg by(container, pod, namespace) (avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           },
           {
             "function": "min",
-            "query": "min by(container, namespace)(min_over_time(rate(container_cpu_usage_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[5m])[$MEASUREMENT_DURATION_IN_MIN$m:]))"
+            "query": "max by(container, pod, namespace) (max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           },
           {
             "function": "max",
-            "query": "max by(container, namespace)(max_over_time(rate(container_cpu_usage_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[5m])[$MEASUREMENT_DURATION_IN_MIN$m:]))"
+            "query": "sum by(container, pod, namespace) (avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           },
           {
             "function": "sum",
-            "query": "sum by(container, namespace)(avg_over_time(rate(container_cpu_usage_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[5m])[$MEASUREMENT_DURATION_IN_MIN$m:]))"
+            "query": "min by(container, pod, namespace) (min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           }
         ]
       },
@@ -93,19 +93,19 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            "query": "avg by(container, pod, namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\",namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           },
           {
             "function": "max",
-            "query": "max by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            "query": "max by(container, pod, namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\",namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           },
           {
             "function": "min",
-            "query": "min by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            "query": "min by(container, pod, namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\",namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           },
           {
             "function": "sum",
-            "query": "sum by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            "query": "sum by(container, pod, namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\",namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           }
         ]
       },
@@ -117,19 +117,19 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg by(container, namespace) (kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            "query": "avg by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           },
           {
             "function": "sum",
-            "query": "sum by(container, namespace) (kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            "query": "sum by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           },
           {
             "function": "max",
-            "query": "max by(container, namespace) (kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            "query": "max by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           },
           {
             "function": "min",
-            "query": "min by(container, namespace) (kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            "query": "min by(container, pod, namespace) ((kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           }
         ]
       },
@@ -141,19 +141,19 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg by(container,namespace) (kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            "query": "avg by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           },
           {
             "function": "sum",
-            "query": "sum by(container,namespace) (kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            "query": "sum by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           },
           {
             "function": "max",
-            "query": "max by(container,namespace) (kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            "query": "max by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           },
           {
             "function": "min",
-            "query": "min by(container,namespace) (kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\",container=\"$CONTAINER_NAME$\"})"
+            "query": "min by(container, pod, namespace) ((kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", resource=\"memory\", unit=\"byte\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase=\"Running\"}))"
           }
         ]
       },
@@ -165,19 +165,19 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg by(container, namespace) (avg_over_time(container_memory_working_set_bytes{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            "query": "avg by(container, pod, namespace) (avg_over_time(container_memory_working_set_bytes{container!=\"\", container!=\"POD\", pod!=\"\",namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           },
           {
             "function": "min",
-            "query": "min by(container, namespace) (min_over_time(container_memory_working_set_bytes{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            "query": "min by(container, pod, namespace) (min_over_time(container_memory_working_set_bytes{container!=\"\", container!=\"POD\", pod!=\"\",namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           },
           {
             "function": "max",
-            "query": "max by(container, namespace) (max_over_time(container_memory_working_set_bytes{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            "query": "max by(container, pod, namespace) (max_over_time(container_memory_working_set_bytes{container!=\"\", container!=\"POD\", pod!=\"\",namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           },
           {
             "function": "sum",
-            "query": "sum by(container, namespace) (avg_over_time(container_memory_working_set_bytes{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            "query": "sum by(container, pod, namespace) (avg_over_time(container_memory_working_set_bytes{container!=\"\", container!=\"POD\", pod!=\"\",namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           }
         ]
       },
@@ -189,19 +189,19 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg by(container, namespace) (avg_over_time(container_memory_rss{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            "query": "avg by(container, pod, namespace) (avg_over_time(container_memory_rss{container!=\"\", container!=\"POD\", pod!=\"\",namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           },
           {
             "function": "min",
-            "query": "min by(container, namespace) (min_over_time(container_memory_rss{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            "query": "min by(container, pod, namespace) (min_over_time(container_memory_rss{container!=\"\", container!=\"POD\", pod!=\"\",namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           },
           {
             "function": "max",
-            "query": "max by(container, namespace) (max_over_time(container_memory_rss{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            "query": "max by(container, pod, namespace) (max_over_time(container_memory_rss{container!=\"\", container!=\"POD\", pod!=\"\",namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           },
           {
             "function": "sum",
-            "query": "sum by(container, namespace) (avg_over_time(container_memory_rss{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+            "query": "sum by(container, pod, namespace) (avg_over_time(container_memory_rss{container!=\"\", container!=\"POD\", pod!=\"\",namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           }
         ]
       },
@@ -214,6 +214,30 @@
           {
             "function": "max",
             "query": "max by(namespace,container) (last_over_time((timestamp(container_cpu_usage_seconds_total{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"} > 0))[15d:]))"
+          }
+        ]
+      },
+      {
+        "name": "imageOwners",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "max",
+            "query": "(max_over_time(kube_pod_container_info{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m])) * on(pod, namespace) group_left(owner_kind, owner_name) max by(pod, namespace, owner_kind, owner_name) (max_over_time(kube_pod_owner{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          }
+        ]
+      },
+      {
+        "name": "imageWorkloads",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "max",
+            "query": "(max_over_time(kube_pod_container_info{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m])) * on(pod, namespace) group_left(workload, workload_type) max by(pod, namespace, workload, workload_type) (max_over_time(namespace_workload_pod:kube_pod_owner:relabel{pod!=\"\", namespace=\"$NAMESPACE$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           }
         ]
       },

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.json
@@ -72,15 +72,15 @@
             "query": "avg by(container, pod, namespace) (avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           },
           {
-            "function": "min",
+            "function": "max",
             "query": "max by(container, pod, namespace) (max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           },
           {
-            "function": "max",
+            "function": "sum",
             "query": "sum by(container, pod, namespace) (avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           },
           {
-            "function": "sum",
+            "function": "min",
             "query": "min by(container, pod, namespace) (min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           }
         ]

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.yaml
@@ -23,17 +23,17 @@ slo:
 
     aggregation_functions:
     - function: avg
-      query: 'avg by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'avg by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
     # Show sum of cpu requests in bytes for a container in a deployment
     - function: sum
-      query: 'sum by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'sum by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
     - function: min
-      query: 'min by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'min by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
     - function: max
-      query: 'max by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'max by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
   # CPU Limit
   # Show cpu limits in bytes for a container in a deployment
@@ -44,17 +44,17 @@ slo:
 
     aggregation_functions:
     - function: avg
-      query: 'avg by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'avg by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
     # Show sum of cpu limits in bytes for a container in a deployment
     - function: sum
-      query: 'sum by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'sum by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
     - function: max
-      query: 'max by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'max by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
     - function: min
-      query: 'min by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'min by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
 
   # CPU Usage
@@ -117,17 +117,17 @@ slo:
 
     aggregation_functions:
     - function: avg
-      query: 'avg by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'avg by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
     # Show sum of memory requests in bytes for a container in a deployment
     - function: sum
-      query: 'sum by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'sum by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
     - function: max
-      query: 'max by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'max by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
     - function: min
-      query: 'min by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'min by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
 
   # Memory Limit
@@ -139,17 +139,17 @@ slo:
 
     aggregation_functions:
     - function: avg
-      query: 'avg by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'avg by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
     # Show sum of memory limits in bytes for a container in a deployment
     - function: sum
-      query: 'sum by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'sum by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
     - function: max
-      query: 'max by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'max by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
     - function: min
-      query: 'min by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
+      query: 'min by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}))'
 
   # Memory Usage
   # Average memory per container in a deployment

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.yaml
@@ -70,15 +70,15 @@ slo:
       query: 'avg by(container, pod, namespace) (avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
     # Approx minimum CPU per container in a deployment
-    - function: min
+    - function: max
       query: 'max by(container, pod, namespace) (max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
       
     # Approx maximum CPU per container in a deployment
-    - function: max
+    - function: sum
       query: 'sum by(container, pod, namespace) (avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
       
     # Sum of CPU usage for a container in all pods of a deployment
-    - function: sum
+    - function: min
       query: 'min by(container, pod, namespace) (min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
       
   # CPU Throttling

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.yaml
@@ -23,17 +23,17 @@ slo:
 
     aggregation_functions:
     - function: avg
-      query: 'avg by(container, namespace) (kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'avg by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
     # Show sum of cpu requests in bytes for a container in a deployment
     - function: sum
-      query: 'sum by(container, namespace) (kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'sum by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
     - function: min
-      query: 'min by(container, namespace) (kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'min by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
     - function: max
-      query: 'max by(container, namespace) (kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'max by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
   # CPU Limit
   # Show cpu limits in bytes for a container in a deployment
@@ -44,17 +44,17 @@ slo:
 
     aggregation_functions:
     - function: avg
-      query: 'avg by(container,namespace) (kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'avg by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
     # Show sum of cpu limits in bytes for a container in a deployment
     - function: sum
-      query: 'sum by(container,namespace) (kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'sum by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
     - function: max
-      query: 'max by(container,namespace) (kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'max by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
     - function: min
-      query: 'min by(container,namespace) (kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'min by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
 
   # CPU Usage
@@ -67,19 +67,19 @@ slo:
 
     aggregation_functions:
     - function: avg
-      query: 'avg by(container, namespace)(avg_over_time(rate(container_cpu_usage_seconds_total{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[5m])[$MEASUREMENT_DURATION_IN_MIN$m:]))'
+      query: 'avg by(container, pod, namespace) (avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
     # Approx minimum CPU per container in a deployment
     - function: min
-      query: 'min by(container, namespace)(min_over_time(rate(container_cpu_usage_seconds_total{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[5m])[$MEASUREMENT_DURATION_IN_MIN$m:]))'
+      query: 'max by(container, pod, namespace) (max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
       
     # Approx maximum CPU per container in a deployment
     - function: max
-      query: 'max by(container, namespace)(max_over_time(rate(container_cpu_usage_seconds_total{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[5m])[$MEASUREMENT_DURATION_IN_MIN$m:]))'
+      query: 'sum by(container, pod, namespace) (avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
       
     # Sum of CPU usage for a container in all pods of a deployment
     - function: sum
-      query: 'sum by(container, namespace)(avg_over_time(rate(container_cpu_usage_seconds_total{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[5m])[$MEASUREMENT_DURATION_IN_MIN$m:]))'
+      query: 'min by(container, pod, namespace) (min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
       
   # CPU Throttling
   - name: cpuThrottle
@@ -90,19 +90,19 @@ slo:
     aggregation_functions:
     # Average CPU throttling per container in a deployment
     - function: avg
-      query: 'avg by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="",namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      query: 'avg by(container, pod, namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="",namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
     # Maximum CPU throttling per container in a deployment
     - function: max
-      query: 'max by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="",namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      query: 'max by(container, pod, namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="",namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
     # Min of CPU throttling for a container in all pods of a deployment
     - function: min
-      query: 'min by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="",namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      query: 'min by(container, pod, namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="",namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
     # Sum of CPU throttling for a container in all pods of a deployment
     - function: sum
-      query: 'sum by(container,namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="",namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      query: 'sum by(container, pod, namespace) (rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="",namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
 
 
@@ -117,17 +117,17 @@ slo:
 
     aggregation_functions:
     - function: avg
-      query: 'avg by(container, namespace) (kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'avg by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
     # Show sum of memory requests in bytes for a container in a deployment
     - function: sum
-      query: 'sum by(container, namespace) (kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'sum by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
     - function: max
-      query: 'max by(container, namespace) (kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'max by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
     - function: min
-      query: 'min by(container, namespace) (kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'min by(container, pod, namespace) ((kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
 
   # Memory Limit
@@ -139,17 +139,17 @@ slo:
 
     aggregation_functions:
     - function: avg
-      query: 'avg by(container,namespace) (kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'avg by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
     # Show sum of memory limits in bytes for a container in a deployment
     - function: sum
-      query: 'sum by(container,namespace) (kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'sum by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
     - function: max
-      query: 'max by(container,namespace) (kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'max by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
     - function: min
-      query: 'min by(container,namespace) (kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'min by(container, pod, namespace) ((kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}) * on(pod, namespace) group_left max by (container, pod, namespace) (kube_pod_status_phase{phase="Running"}))'
 
   # Memory Usage
   # Average memory per container in a deployment
@@ -160,19 +160,19 @@ slo:
 
     aggregation_functions:
     - function: avg
-      query: 'avg by(container, namespace) (avg_over_time(container_memory_working_set_bytes{container!="", container!="POD", pod!="", namespace="$NAMESPACE$",container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      query: 'avg by(container, pod, namespace) (avg_over_time(container_memory_working_set_bytes{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
     # Approx minimum memory per container in a deployment
     - function: min
-      query: 'min by(container, namespace) (min_over_time(container_memory_working_set_bytes{container!="", container!="POD", pod!="", namespace="$NAMESPACE$",container="$CONTAINER_NAME$" }[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      query: 'min by(container, pod, namespace) (min_over_time(container_memory_working_set_bytes{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
     # Approx maximum memory per container in a deployment
     - function: max
-      query: 'max by(container, namespace) (max_over_time(container_memory_working_set_bytes{container!="", container!="POD", pod!="", namespace="$NAMESPACE$",container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      query: 'max by(container, pod, namespace) (max_over_time(container_memory_working_set_bytes{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
     # Sum of memory usage for a contianer in all pods of a deployment
     - function: sum
-      query: 'sum by(container, namespace) (avg_over_time(container_memory_working_set_bytes{container!="", container!="POD", pod!="", namespace="$NAMESPACE$",container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      query: 'sum by(container, pod, namespace) (avg_over_time(container_memory_working_set_bytes{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
 
   # 2.4 Memory RSS
@@ -184,20 +184,20 @@ slo:
     aggregation_functions:
     # Average memory RSS per container in a deployment
     - function: avg
-      query: 'avg by(container, namespace) (avg_over_time(container_memory_rss{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      query: 'avg by(container, pod, namespace) (avg_over_time(container_memory_rss{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
     # Approx minimum memory RSS per container in a deployment
     - function: min
-      query: 'min by(container, namespace) (min_over_time(container_memory_rss{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      query: 'min by(container, pod, namespace) (min_over_time(container_memory_rss{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
 
     # Approx maximum memory RSS per container in a deployment
     - function: max
-      query: 'max by(container, namespace) (max_over_time(container_memory_rss{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      query: 'max by(container, pod, namespace) (max_over_time(container_memory_rss{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
     # Sum of memory RSS for a contianer in all pods of a deployment
     - function: sum
-      query: 'sum by(container, namespace) (avg_over_time(container_memory_rss{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+      query: 'sum by(container, pod, namespace) (avg_over_time(container_memory_rss{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
 
   # Container Last Active Timestamp
@@ -209,6 +209,26 @@ slo:
     aggregation_functions:
     - function: max
       query: 'max by(namespace,container) (last_over_time((timestamp(container_cpu_usage_seconds_total{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"} > 0))[15d:]))'
+
+  # Pod containers owner_kind and owner_kind info
+  - name: imageOwners
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "container"
+
+    aggregation_functions:
+      - function: max
+        query: '(max_over_time(kube_pod_container_info{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m])) * on(pod, namespace) group_left(owner_kind, owner_name) max by(pod, namespace, owner_kind, owner_name) (max_over_time(kube_pod_owner{container!="", container!="POD", pod!="", namespace="$NAMESPACE$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+
+  # Pod containers workload and workload_type info
+  - name: imageWorkloads
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "container"
+
+    aggregation_functions:
+      - function: max
+        query: '(max_over_time(kube_pod_container_info{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m])) * on(pod, namespace) group_left(workload, workload_type) max by(pod, namespace, workload, workload_type) (max_over_time(namespace_workload_pod:kube_pod_owner:relabel{pod!="", namespace="$NAMESPACE$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
   ## namespace related queries
 

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -188,6 +188,8 @@ public class AnalyzerConstants {
         memoryUsage,
         memoryRSS,
         maxDate,
+        imageOwners,
+        imageWorkloads,
         namespaceCpuRequest,
         namespaceCpuLimit,
         namespaceCpuUsage,


### PR DESCRIPTION
## Description

This PR has the following changes:

-  Updates existing container metric queries similar to the cost operator [koku-metrics](https://github.com/project-koku/koku-metrics-operator/blob/main/internal/collector/queries.go#L34)
- Add additional metric queries - `imageOwners` and `imageWorkloads`  to fetch pod owner and workload details

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: Tested manually on OpenShift (ResourceHub) cluster 

## Checklist :dart:

- [ ] Followed coding guidelines
- [x] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

.
