### PR TITLE
Handling GatewayTimout 503 , ConnectionTimeout 502 and HttpHostConnection

### DIFF
--- a/src/main/java/com/autotune/Autotune.java
+++ b/src/main/java/com/autotune/Autotune.java
@@ -24,6 +24,9 @@ import com.autotune.analyzer.performanceProfiles.MetricProfileCollection;
 import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.common.datasource.DataSourceCollection;
 import com.autotune.common.datasource.DataSourceInfo;
+import com.autotune.common.exceptions.datasource.DataSourceAlreadyExist;
+import com.autotune.common.exceptions.datasource.DataSourceNotServiceable;
+import com.autotune.common.exceptions.datasource.UnsupportedDataSourceProvider;
 import com.autotune.database.helper.DBConstants;
 import com.autotune.database.init.KruizeHibernateUtil;
 import com.autotune.experimentManager.core.ExperimentManager;
@@ -31,7 +34,10 @@ import com.autotune.operator.InitializeDeployment;
 import com.autotune.operator.KruizeDeploymentInfo;
 import com.autotune.service.HealthService;
 import com.autotune.service.InitiateListener;
-import com.autotune.utils.*;
+import com.autotune.utils.CloudWatchAppender;
+import com.autotune.utils.KruizeConstants;
+import com.autotune.utils.MetricsConfig;
+import com.autotune.utils.ServerContext;
 import com.autotune.utils.filter.KruizeCORSFilter;
 import io.prometheus.client.exporter.MetricsServlet;
 import io.prometheus.client.hotspot.DefaultExports;
@@ -50,8 +56,12 @@ import org.slf4j.LoggerFactory;
 
 import javax.servlet.DispatcherType;
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Scanner;
@@ -112,7 +122,11 @@ public class Autotune {
                 // load available datasources from db
                 loadDataSourcesFromDB();
                 // setting up DataSources
-                setUpDataSources();
+                try {
+                    setUpDataSources();
+                } catch (Exception e) {
+                    LOGGER.error(e.getMessage());
+                }
                 // checking available DataSources
                 checkAvailableDataSources();
                 // load available metric profiles from db
@@ -124,7 +138,7 @@ public class Autotune {
             //Regenerate a Hibernate session following the creation of new tables
             KruizeHibernateUtil.buildSessionFactory();
         } catch (Exception | K8sTypeNotSupportedException | MonitoringAgentNotSupportedException |
-                MonitoringAgentNotFoundException e) {
+                 MonitoringAgentNotFoundException e) {
             e.printStackTrace();
             System.exit(1);
         }
@@ -170,7 +184,7 @@ public class Autotune {
     /**
      * Set up the data sources available at installation time from config file
      */
-    private static void setUpDataSources() {
+    private static void setUpDataSources() throws UnsupportedDataSourceProvider, DataSourceNotServiceable, DataSourceAlreadyExist, IOException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
         DataSourceCollection dataSourceCollection = DataSourceCollection.getInstance();
         dataSourceCollection.addDataSourcesFromConfigFile(KruizeConstants.CONFIG_FILE);
     }
@@ -190,7 +204,7 @@ public class Autotune {
         DataSourceCollection dataSourceCollection = DataSourceCollection.getInstance();
         LOGGER.info(KruizeConstants.DataSourceConstants.DataSourceInfoMsgs.CHECKING_AVAILABLE_DATASOURCE);
         HashMap<String, DataSourceInfo> dataSources = dataSourceCollection.getDataSourcesCollection();
-        for (String name: dataSources.keySet()) {
+        for (String name : dataSources.keySet()) {
             DataSourceInfo dataSource = dataSources.get(name);
             String dataSourceName = dataSource.getName();
             String url = dataSource.getUrl().toString();

--- a/src/main/java/com/autotune/common/datasource/DataSourceCollection.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceCollection.java
@@ -16,8 +16,8 @@
 package com.autotune.common.datasource;
 
 import com.autotune.common.auth.AuthenticationConfig;
-import com.autotune.common.exceptions.datasource.*;
 import com.autotune.common.data.ValidationOutputData;
+import com.autotune.common.exceptions.datasource.*;
 import com.autotune.common.utils.CommonUtils;
 import com.autotune.database.service.ExperimentDBService;
 import com.autotune.utils.KruizeConstants;
@@ -31,6 +31,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.List;
 
@@ -43,13 +46,22 @@ public class DataSourceCollection {
         this.dataSourceCollection = new HashMap<>();
     }
 
+    /**
+     * Returns the instance of dataSourceCollection class
+     *
+     * @return DataSourceCollection instance
+     */
+    public static DataSourceCollection getInstance() {
+        return dataSourceCollectionInstance;
+    }
+
     public void loadDataSourcesFromDB() {
         try {
             LOGGER.info(KruizeConstants.DataSourceConstants.DataSourceInfoMsgs.CHECKING_AVAILABLE_DATASOURCE_FROM_DB);
             List<DataSourceInfo> availableDataSources = new ExperimentDBService().loadAllDataSources();
             if (null == availableDataSources) {
                 LOGGER.info(KruizeConstants.DataSourceConstants.DataSourceInfoMsgs.NO_DATASOURCE_FOUND_IN_DB);
-            }else {
+            } else {
                 for (DataSourceInfo dataSourceInfo : availableDataSources) {
                     LOGGER.info(KruizeConstants.DataSourceConstants.DataSourceSuccessMsgs.DATASOURCE_FOUND + dataSourceInfo.getName());
                     dataSourceCollection.put(dataSourceInfo.getName(), dataSourceInfo);
@@ -61,16 +73,10 @@ public class DataSourceCollection {
         }
 
     }
-    /**
-     * Returns the instance of dataSourceCollection class
-     * @return DataSourceCollection instance
-     */
-    public static DataSourceCollection getInstance() {
-        return dataSourceCollectionInstance;
-    }
 
     /**
      * Returns the hashmap of data sources
+     *
      * @return HashMap containing dataSourceInfo objects
      */
     public HashMap<String, DataSourceInfo> getDataSourcesCollection() {
@@ -79,116 +85,111 @@ public class DataSourceCollection {
 
     /**
      * Adds datasource to collection
+     *
      * @param datasource DataSourceInfo object containing details of datasource
      */
-    public void addDataSource(DataSourceInfo datasource) {
+    public void addDataSource(DataSourceInfo datasource) throws DataSourceAlreadyExist, DataSourceNotServiceable, UnsupportedDataSourceProvider, IOException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
         final String name = datasource.getName();
         final String provider = datasource.getProvider();
         ValidationOutputData addedToDB = null;
 
         LOGGER.info(KruizeConstants.DataSourceConstants.DataSourceInfoMsgs.ADDING_DATASOURCE + name);
 
-        try {
-            if (dataSourceCollection.containsKey(name)) {
-                throw new DataSourceAlreadyExist(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.DATASOURCE_ALREADY_EXIST);
-            }
 
-            if (provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.PROMETHEUS)) {
-                LOGGER.info(KruizeConstants.DataSourceConstants.DataSourceInfoMsgs.VERIFYING_DATASOURCE_REACHABILITY + name);
-                DataSourceOperatorImpl op = DataSourceOperatorImpl.getInstance().getOperator(KruizeConstants.SupportedDatasources.PROMETHEUS);
-                if (op.isServiceable(datasource) == CommonUtils.DatasourceReachabilityStatus.REACHABLE) {
-                    LOGGER.info(KruizeConstants.DataSourceConstants.DataSourceSuccessMsgs.DATASOURCE_SERVICEABLE);
-                    // add the data source to DB
-                    addedToDB = new ExperimentDBService().addDataSourceToDB(datasource);
-                    if (addedToDB.isSuccess()) {
-                        LOGGER.info("Datasource added to the DB successfully.");
-                    } else {
-                        LOGGER.error("Failed to add datasource to DB: {}", addedToDB.getMessage());
-                    }
-                    dataSourceCollection.put(name, datasource);
-                    LOGGER.info(KruizeConstants.DataSourceConstants.DataSourceSuccessMsgs.DATASOURCE_ADDED);
-                } else {
-                    throw new DataSourceNotServiceable(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.DATASOURCE_NOT_SERVICEABLE);
-                }
-            } else {
-                throw new UnsupportedDataSourceProvider(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.UNSUPPORTED_DATASOURCE_PROVIDER);
-            }
-        } catch (UnsupportedDataSourceProvider e) {
-            LOGGER.error(e.getMessage());
-        } catch (DataSourceNotServiceable e) {
-            LOGGER.error(e.getMessage());
-        } catch (DataSourceAlreadyExist e) {
-            LOGGER.error(e.getMessage());
+        if (dataSourceCollection.containsKey(name)) {
+            throw new DataSourceAlreadyExist(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.DATASOURCE_ALREADY_EXIST);
         }
+
+        if (provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.PROMETHEUS)) {
+            LOGGER.info(KruizeConstants.DataSourceConstants.DataSourceInfoMsgs.VERIFYING_DATASOURCE_REACHABILITY + name);
+            DataSourceOperatorImpl op = DataSourceOperatorImpl.getInstance().getOperator(KruizeConstants.SupportedDatasources.PROMETHEUS);
+            if (op.isServiceable(datasource) == CommonUtils.DatasourceReachabilityStatus.REACHABLE) {
+                LOGGER.info(KruizeConstants.DataSourceConstants.DataSourceSuccessMsgs.DATASOURCE_SERVICEABLE);
+                // add the data source to DB
+                addedToDB = new ExperimentDBService().addDataSourceToDB(datasource);
+                if (addedToDB.isSuccess()) {
+                    LOGGER.info("Datasource added to the DB successfully.");
+                } else {
+                    LOGGER.error("Failed to add datasource to DB: {}", addedToDB.getMessage());
+                }
+                dataSourceCollection.put(name, datasource);
+                LOGGER.info(KruizeConstants.DataSourceConstants.DataSourceSuccessMsgs.DATASOURCE_ADDED);
+            } else {
+                throw new DataSourceNotServiceable(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.DATASOURCE_NOT_SERVICEABLE);
+            }
+        } else {
+            throw new UnsupportedDataSourceProvider(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.UNSUPPORTED_DATASOURCE_PROVIDER);
+        }
+
     }
 
     /**
      * Loads the data sources available at installation time
+     *
      * @param configFileName name of the config file mounted
      */
-    public void addDataSourcesFromConfigFile(String configFileName) {
-        try {
-            String configFile = System.getenv(configFileName);
-            JSONObject configObject = null;
+    public void addDataSourcesFromConfigFile(String configFileName) throws UnsupportedDataSourceProvider, DataSourceNotServiceable, DataSourceAlreadyExist, IOException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
 
-            InputStream is = new FileInputStream(configFile);
-            String jsonTxt = new String(is.readAllBytes(), StandardCharsets.UTF_8);
-            configObject = new JSONObject(jsonTxt);
-            JSONArray dataSourceArr = configObject.getJSONArray(KruizeConstants.DataSourceConstants.KRUIZE_DATASOURCE);
+        String configFile = System.getenv(configFileName);
+        JSONObject configObject = null;
 
-            for (Object dataSourceObj: dataSourceArr) {
-                JSONObject dataSourceObject = (JSONObject) dataSourceObj;
-                String name = dataSourceObject.getString(KruizeConstants.DataSourceConstants.DATASOURCE_NAME);
-                // check the DB if the datasource already exists
-                try {
-                    DataSourceInfo dataSourceInfo = new ExperimentDBService().loadDataSourceFromDBByName(name);
-                    if (null != dataSourceInfo) {
-                        LOGGER.error("Datasource: {} already exists!", name);
-                        continue;
-                    }
-                } catch (Exception e) {
-                    LOGGER.error("Loading saved datasource {} failed: {} ", name, e.getMessage());
-                }
-                String provider = dataSourceObject.getString(KruizeConstants.DataSourceConstants.DATASOURCE_PROVIDER);
-                String serviceName = dataSourceObject.getString(KruizeConstants.DataSourceConstants.DATASOURCE_SERVICE_NAME);
-                String namespace = dataSourceObject.getString(KruizeConstants.DataSourceConstants.DATASOURCE_SERVICE_NAMESPACE);
-                String dataSourceURL = dataSourceObject.getString(KruizeConstants.DataSourceConstants.DATASOURCE_URL);
-                AuthenticationConfig authConfig;
-                try {
-                    JSONObject authenticationObj = dataSourceObject.optJSONObject(KruizeConstants.AuthenticationConstants.AUTHENTICATION);
-                    // create the corresponding authentication object
-                    authConfig = AuthenticationConfig.createAuthenticationConfigObject(authenticationObj);
-                } catch (Exception e) {
-                    LOGGER.warn("Auth details are missing for datasource: {}", name);
-                    authConfig = AuthenticationConfig.noAuth();
-                }
+        InputStream is = new FileInputStream(configFile);
+        String jsonTxt = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+        configObject = new JSONObject(jsonTxt);
+        JSONArray dataSourceArr = configObject.getJSONArray(KruizeConstants.DataSourceConstants.KRUIZE_DATASOURCE);
 
-                DataSourceInfo datasource;
-                // Validate input
-                if (!validateInput(name, provider, serviceName, dataSourceURL, namespace)) {
+        for (Object dataSourceObj : dataSourceArr) {
+            JSONObject dataSourceObject = (JSONObject) dataSourceObj;
+            String name = dataSourceObject.getString(KruizeConstants.DataSourceConstants.DATASOURCE_NAME);
+            // check the DB if the datasource already exists
+            try {
+                DataSourceInfo dataSourceInfo = new ExperimentDBService().loadDataSourceFromDBByName(name);
+                if (null != dataSourceInfo) {
+                    LOGGER.error("Datasource: {} already exists!", name);
                     continue;
                 }
-                if (dataSourceURL.isEmpty()) {
-                    datasource = new DataSourceInfo(name, provider, serviceName, namespace, null);
-                } else {
-                    datasource = new DataSourceInfo(name, provider, serviceName, namespace, new URL(dataSourceURL));
-                }
-                // set the authentication config
-                datasource.setAuthenticationConfig(authConfig);
-                addDataSource(datasource);
+            } catch (Exception e) {
+                LOGGER.error("Loading saved datasource {} failed: {} ", name, e.getMessage());
             }
-        } catch (IOException e) {
-            LOGGER.error(e.getMessage());
+            String provider = dataSourceObject.getString(KruizeConstants.DataSourceConstants.DATASOURCE_PROVIDER);
+            String serviceName = dataSourceObject.getString(KruizeConstants.DataSourceConstants.DATASOURCE_SERVICE_NAME);
+            String namespace = dataSourceObject.getString(KruizeConstants.DataSourceConstants.DATASOURCE_SERVICE_NAMESPACE);
+            String dataSourceURL = dataSourceObject.getString(KruizeConstants.DataSourceConstants.DATASOURCE_URL);
+            AuthenticationConfig authConfig;
+            try {
+                JSONObject authenticationObj = dataSourceObject.optJSONObject(KruizeConstants.AuthenticationConstants.AUTHENTICATION);
+                // create the corresponding authentication object
+                authConfig = AuthenticationConfig.createAuthenticationConfigObject(authenticationObj);
+            } catch (Exception e) {
+                LOGGER.warn("Auth details are missing for datasource: {}", name);
+                authConfig = AuthenticationConfig.noAuth();
+            }
+
+            DataSourceInfo datasource;
+            // Validate input
+            if (!validateInput(name, provider, serviceName, dataSourceURL, namespace)) {
+                continue;
+            }
+            if (dataSourceURL.isEmpty()) {
+                datasource = new DataSourceInfo(name, provider, serviceName, namespace, null);
+            } else {
+                datasource = new DataSourceInfo(name, provider, serviceName, namespace, new URL(dataSourceURL));
+            }
+            // set the authentication config
+            datasource.setAuthenticationConfig(authConfig);
+            addDataSource(datasource);
         }
+
     }
 
     /**
      * validates the input parameters before creating dataSourceInfo objects
-     * @param name String containing name of the datasource
-     * @param provider String containing provider of the datasource
+     *
+     * @param name        String containing name of the datasource
+     * @param provider    String containing provider of the datasource
      * @param servicename String containing service name for the datasource
-     * @param url String containing URL of the data source
-     * @param namespace String containing namespace for the datasource service
+     * @param url         String containing URL of the data source
+     * @param namespace   String containing namespace for the datasource service
      * @return boolean returns true if validation is successful otherwise return false
      */
     public boolean validateInput(String name, String provider, String servicename, String url, String namespace) {
@@ -214,42 +215,38 @@ public class DataSourceCollection {
 
     /**
      * deletes the datasource from the Hashmap
+     *
      * @param name String containing the name of the datasource to be deleted
-     * TODO: add db related operations
+     *                                                             TODO: add db related operations
      */
-    public void deleteDataSource(String name) {
-        try {
-            if (name == null) {
-                throw new DataSourceMissingRequiredFiled(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.MISSING_DATASOURCE_NAME);
-            }
-            if (dataSourceCollection.containsKey(name)) {
-                dataSourceCollection.remove(name);
-            } else {
-                throw new DataSourceDoesNotExist(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.DATASOURCE_NOT_EXIST);
-            }
-        } catch (DataSourceMissingRequiredFiled e) {
-            LOGGER.error(e.getMessage());
-        } catch (DataSourceDoesNotExist e) {
-            LOGGER.error(e.getMessage());
+    public void deleteDataSource(String name) throws DataSourceMissingRequiredFiled, DataSourceDoesNotExist {
+
+        if (name == null) {
+            throw new DataSourceMissingRequiredFiled(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.MISSING_DATASOURCE_NAME);
         }
+        if (dataSourceCollection.containsKey(name)) {
+            dataSourceCollection.remove(name);
+        } else {
+            throw new DataSourceDoesNotExist(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.DATASOURCE_NOT_EXIST);
+        }
+
     }
 
     /**
      * updates the existing datasource in the Hashmap
-     * @param name String containing the name of the datasource to be updated
+     *
+     * @param name          String containing the name of the datasource to be updated
      * @param newDataSource DataSourceInfo object with updated values
-     * TODO: add db related operations
+     *                                                                                                          TODO: add db related operations
      */
-    public void updateDataSource(String name, DataSourceInfo newDataSource) {
-        try {
-            if (dataSourceCollection.containsKey(name)) {
-                dataSourceCollection.remove(name);
-                addDataSource(newDataSource);
-            } else {
-                throw new DataSourceDoesNotExist(name + ": " + KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.DATASOURCE_NOT_EXIST);
-            }
-        } catch (DataSourceDoesNotExist e) {
-            LOGGER.error(e.getMessage());
+    public void updateDataSource(String name, DataSourceInfo newDataSource) throws DataSourceDoesNotExist, UnsupportedDataSourceProvider, DataSourceNotServiceable, DataSourceAlreadyExist, IOException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
+
+        if (dataSourceCollection.containsKey(name)) {
+            dataSourceCollection.remove(name);
+            addDataSource(newDataSource);
+        } else {
+            throw new DataSourceDoesNotExist(name + ": " + KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.DATASOURCE_NOT_EXIST);
         }
+
     }
 }

--- a/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
@@ -55,7 +55,7 @@ public class DataSourceMetadataOperator {
      * @param startTime      Get metadata from starttime to endtime
      * @param endTime        Get metadata from starttime to endtime
      * @param steps          the interval between data points in a range query
-     *                       TODO - support multiple data sources
+     *                                                                                                               TODO - support multiple data sources
      */
     public DataSourceMetadataInfo createDataSourceMetadata(DataSourceInfo dataSourceInfo, String uniqueKey, long startTime, long endTime, int steps) throws Exception {
         return processQueriesAndPopulateDataSourceMetadataInfo(dataSourceInfo, uniqueKey, startTime, endTime, steps);
@@ -97,8 +97,8 @@ public class DataSourceMetadataOperator {
      * @param dataSourceInfo The DataSourceInfo object containing information about the
      *                       data source to be updated.
      *                       <p>
-     *                        TODO - Currently Create and Update functions have identical functionalities, based on UI workflow and requirements
-     *                               need to further enhance updateDataSourceMetadata() to support namespace, workload level granular updates
+     *                                                                                                                TODO - Currently Create and Update functions have identical functionalities, based on UI workflow and requirements
+     *                                                                                                                       need to further enhance updateDataSourceMetadata() to support namespace, workload level granular updates
      */
     public DataSourceMetadataInfo updateDataSourceMetadata(DataSourceInfo dataSourceInfo, String uniqueKey, long startTime, long endTime, int steps) throws Exception {
         return processQueriesAndPopulateDataSourceMetadataInfo(dataSourceInfo, uniqueKey, startTime, endTime, steps);
@@ -180,56 +180,56 @@ public class DataSourceMetadataOperator {
             JsonArray namespacesDataResultArray = op.getResultArrayForQuery(dataSourceInfo, namespaceQuery);
             if (!op.validateResultArray(namespacesDataResultArray)) {
                 dataSourceMetadataInfo = dataSourceDetailsHelper.createDataSourceMetadataInfoObject(dataSourceName, null);
-                throw new Exception(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.NAMESPACE_QUERY_VALIDATION_FAILED);
+            } else {
+                /**
+                 * Key: Name of namespace
+                 * Value: DataSourceNamespace object corresponding to a namespace
+                 */
+                HashMap<String, DataSourceNamespace> datasourceNamespaces = dataSourceDetailsHelper.getActiveNamespaces(namespacesDataResultArray);
+                dataSourceMetadataInfo = dataSourceDetailsHelper.createDataSourceMetadataInfoObject(dataSourceName, datasourceNamespaces);
+
+                /**
+                 * Outer map:
+                 * Key: Name of namespace
+                 * <p>
+                 * Inner map:
+                 * Key: Name of workload
+                 * Value: DataSourceWorkload object matching the name
+                 * TODO -  get workload metadata for a given namespace
+                 */
+                HashMap<String, HashMap<String, DataSourceWorkload>> datasourceWorkloads = new HashMap<>();
+                JsonArray workloadDataResultArray = op.getResultArrayForQuery(dataSourceInfo,
+                        workloadQuery);
+
+                if (op.validateResultArray(workloadDataResultArray)) {
+                    datasourceWorkloads = dataSourceDetailsHelper.getWorkloadInfo(workloadDataResultArray);
+                }
+                dataSourceDetailsHelper.updateWorkloadDataSourceMetadataInfoObject(dataSourceName, dataSourceMetadataInfo,
+                        datasourceWorkloads);
+
+                /**
+                 * Outer map:
+                 * Key: Name of workload
+                 * <p>
+                 * Inner map:
+                 * Key: Name of container
+                 * Value: DataSourceContainer object matching the name
+                 * TODO - get container metadata for a given workload
+                 */
+                HashMap<String, HashMap<String, DataSourceContainer>> datasourceContainers = new HashMap<>();
+                JsonArray containerDataResultArray = op.getResultArrayForQuery(dataSourceInfo,
+                        containerQuery);
+                LOGGER.debug("containerDataResultArray: {}", containerDataResultArray);
+
+                if (op.validateResultArray(containerDataResultArray)) {
+                    datasourceContainers = dataSourceDetailsHelper.getContainerInfo(containerDataResultArray);
+                }
+                dataSourceDetailsHelper.updateContainerDataSourceMetadataInfoObject(dataSourceName, dataSourceMetadataInfo,
+                        datasourceWorkloads, datasourceContainers);
+                return getDataSourceMetadataInfo(dataSourceInfo);
             }
 
-            /**
-             * Key: Name of namespace
-             * Value: DataSourceNamespace object corresponding to a namespace
-             */
-            HashMap<String, DataSourceNamespace> datasourceNamespaces = dataSourceDetailsHelper.getActiveNamespaces(namespacesDataResultArray);
-            dataSourceMetadataInfo = dataSourceDetailsHelper.createDataSourceMetadataInfoObject(dataSourceName, datasourceNamespaces);
-
-            /**
-             * Outer map:
-             * Key: Name of namespace
-             * <p>
-             * Inner map:
-             * Key: Name of workload
-             * Value: DataSourceWorkload object matching the name
-             * TODO -  get workload metadata for a given namespace
-             */
-            HashMap<String, HashMap<String, DataSourceWorkload>> datasourceWorkloads = new HashMap<>();
-            JsonArray workloadDataResultArray = op.getResultArrayForQuery(dataSourceInfo,
-                    workloadQuery);
-
-            if (op.validateResultArray(workloadDataResultArray)) {
-                datasourceWorkloads = dataSourceDetailsHelper.getWorkloadInfo(workloadDataResultArray);
-            }
-            dataSourceDetailsHelper.updateWorkloadDataSourceMetadataInfoObject(dataSourceName, dataSourceMetadataInfo,
-                    datasourceWorkloads);
-
-            /**
-             * Outer map:
-             * Key: Name of workload
-             * <p>
-             * Inner map:
-             * Key: Name of container
-             * Value: DataSourceContainer object matching the name
-             * TODO - get container metadata for a given workload
-             */
-            HashMap<String, HashMap<String, DataSourceContainer>> datasourceContainers = new HashMap<>();
-            JsonArray containerDataResultArray = op.getResultArrayForQuery(dataSourceInfo,
-                    containerQuery);
-            LOGGER.debug("containerDataResultArray: {}", containerDataResultArray);
-
-            if (op.validateResultArray(containerDataResultArray)) {
-                datasourceContainers = dataSourceDetailsHelper.getContainerInfo(containerDataResultArray);
-            }
-            dataSourceDetailsHelper.updateContainerDataSourceMetadataInfoObject(dataSourceName, dataSourceMetadataInfo,
-                    datasourceWorkloads, datasourceContainers);
-
-            return getDataSourceMetadataInfo(dataSourceInfo);
+            return null;
         } catch (Exception e) {
             LOGGER.error(e.getMessage());
             throw e;

--- a/src/main/java/com/autotune/common/datasource/DataSourceOperator.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceOperator.java
@@ -15,30 +15,38 @@
  *******************************************************************************/
 package com.autotune.common.datasource;
 
+import com.autotune.analyzer.exceptions.FetchMetricsError;
 import com.autotune.common.utils.CommonUtils;
 import com.google.gson.JsonArray;
 import org.json.JSONObject;
 
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+
 /**
  * DataSourceOperator is an abstraction which has a generic and implementation,
  * and it can also be implemented by each data source provider type.
- *
+ * <p>
  * Currently Supported Implementations:
- *  - Prometheus
- *
- *  The Implementation should have helper functions to perform operations related
- *  to datasource
+ * - Prometheus
+ * <p>
+ * The Implementation should have helper functions to perform operations related
+ * to datasource
  */
 
 public interface DataSourceOperator {
     /**
      * Returns the default service port for provider
+     *
      * @return String containing the port number
      */
     String getDefaultServicePortForProvider();
 
     /**
      * Returns the instance of specific operator class based on provider type
+     *
      * @param provider String containing the name of provider
      * @return instance of specific operator
      */
@@ -51,7 +59,7 @@ public interface DataSourceOperator {
      * @param dataSource DatasourceInfo object containing the datasource details
      * @return DatasourceReachabilityStatus
      */
-    CommonUtils.DatasourceReachabilityStatus isServiceable(DataSourceInfo dataSource);
+    CommonUtils.DatasourceReachabilityStatus isServiceable(DataSourceInfo dataSource) throws FetchMetricsError, Exception;
 
     /**
      * executes specified query on datasource and returns the result value
@@ -60,7 +68,7 @@ public interface DataSourceOperator {
      * @param query      String containing the query to be executed
      * @return Object containing the result value for the specified query
      */
-    Object getValueForQuery(DataSourceInfo dataSource, String query);
+    Object getValueForQuery(DataSourceInfo dataSource, String query) throws FetchMetricsError, Exception;
 
     /**
      * executes specified query on datasource and returns the JSON Object
@@ -69,7 +77,7 @@ public interface DataSourceOperator {
      * @param query      String containing the query to be executed
      * @return JSONObject for the specified query
      */
-    JSONObject getJsonObjectForQuery(DataSourceInfo dataSource, String query);
+    JSONObject getJsonObjectForQuery(DataSourceInfo dataSource, String query) throws Exception, FetchMetricsError;
 
     /**
      * executes specified query on datasource and returns the result array
@@ -78,7 +86,7 @@ public interface DataSourceOperator {
      * @param query      String containing the query to be executed
      * @return JsonArray containing the result array for the specified query
      */
-    public JsonArray getResultArrayForQuery(DataSourceInfo dataSource, String query);
+    public JsonArray getResultArrayForQuery(DataSourceInfo dataSource, String query) throws IOException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException;
 
     /**
      * Validates a JSON array to ensure it is not null, not a JSON null, and has at least one element.
@@ -90,6 +98,7 @@ public interface DataSourceOperator {
 
     /**
      * returns query endpoint for datasource
+     *
      * @return String containing query endpoint
      */
     String getQueryEndpoint();

--- a/src/main/java/com/autotune/common/datasource/DataSourceOperatorImpl.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceOperatorImpl.java
@@ -4,9 +4,6 @@ import com.autotune.analyzer.exceptions.FetchMetricsError;
 import com.autotune.analyzer.exceptions.MonitoringAgentNotFoundException;
 import com.autotune.analyzer.exceptions.TooManyRecursiveCallsException;
 import com.autotune.analyzer.utils.AnalyzerConstants;
-import com.autotune.common.auth.AuthenticationConfig;
-import com.autotune.common.auth.AuthenticationStrategy;
-import com.autotune.common.auth.AuthenticationStrategyFactory;
 import com.autotune.common.datasource.prometheus.PrometheusDataOperatorImpl;
 import com.autotune.common.exceptions.datasource.ServiceNotFound;
 import com.autotune.common.target.kubernetes.service.KubernetesServices;
@@ -20,6 +17,7 @@ import io.fabric8.kubernetes.api.model.Service;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -35,11 +33,13 @@ public class DataSourceOperatorImpl implements DataSourceOperator {
 
     private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(DataSourceOperatorImpl.class);
     private static DataSourceOperatorImpl dataSourceOperator = null;
+
     protected DataSourceOperatorImpl() {
     }
 
     /**
      * Returns the instance of DataSourceOperatorImpl class
+     *
      * @return DataSourceOperatorImpl instance
      */
     public static DataSourceOperatorImpl getInstance() {
@@ -50,142 +50,9 @@ public class DataSourceOperatorImpl implements DataSourceOperator {
     }
 
     /**
-     * Returns the instance of specific operator class based on provider type
-     * @param provider String containg the name of provider
-     * @return instance of specific operator
-     */
-    @Override
-    public DataSourceOperatorImpl getOperator(String provider) {
-        if (provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.PROMETHEUS)) {
-            return PrometheusDataOperatorImpl.getInstance();
-        }
-        return null;
-    }
-
-    /**
-     * Returns the default service port for prometheus
-     * @return String containing the port number
-     */
-    @Override
-    public String getDefaultServicePortForProvider() {
-        return "";
-    }
-
-    /**
-     * Check if a datasource is reachable, implementation of this function
-     * should check and return the reachability status (REACHABLE, NOT_REACHABLE)
-     *
-     * @param dataSource DatasourceInfo object containing the datasource details
-     * @return DatasourceReachabilityStatus
-     */
-    @Override
-    public CommonUtils.DatasourceReachabilityStatus isServiceable(DataSourceInfo dataSource) {
-        return null;
-    }
-
-    /**
-     * executes specified query on datasource and returns the result value
-     *
-     * @param dataSource DatasourceInfo object containing the datasource details
-     * @param query      String containing the query to be executed
-     * @return Object containing the result value for the specified query
-     */
-    @Override
-    public Object getValueForQuery(DataSourceInfo dataSource, String query) {
-        return null;
-    }
-
-    /**
-     * returns query endpoint for datasource
-     * @return String containing query endpoint
-     */
-    @Override
-    public String getQueryEndpoint() {
-        return null;
-    }
-    /**
-     * executes specified query on datasource and returns the JSON Object
-     *
-     * @param dataSource DatasourceInfo object containing the datasource details
-     * @param query      String containing the query to be executed
-     * @return JSONObject for the specified query
-     */
-    @Override
-    public JSONObject getJsonObjectForQuery(DataSourceInfo dataSource, String query) {
-        return null;
-    }
-
-    /**
-     * executes specified query on datasource and returns the result array
-     *
-     * @param dataSource DatasourceInfo object containing the datasource details
-     * @param query      String containing the query to be executed
-     * @return JsonArray containing the result array for the specified query
-     */
-    @Override
-    public JsonArray getResultArrayForQuery(DataSourceInfo dataSource, String query) {
-        return null;
-    }
-
-    /**
-     * Validates a JSON array to ensure it is not null, not a JSON null, and has at least one element.
-     *
-     * @param resultArray The JSON array to be validated.
-     * @return True if the JSON array is valid (not null, not a JSON null, and has at least one element), otherwise false.
-     */
-    @Override
-    public boolean validateResultArray(JsonArray resultArray) { return false;}
-
-    /**
-     * TODO: To find a suitable place for this function later
-     * returns authentication token for datasource
-     * @return String containing token
-     */
-    public String getToken() throws IOException {
-        String fileName = KruizeConstants.AUTH_MOUNT_PATH+"token";
-        String authToken = new String(Files.readAllBytes(Paths.get(fileName)));
-        return authToken;
-    }
-
-    /**
-     * TODO: To find a suitable place for this function later
-     * Run the getAppsForLayer and return the list of applications matching the layer.
-     * @param dataSource
-     * @param query getAppsForLayer query for the layer
-     * @param key The key to search for in the response
-     * @return ArrayList of all applications from the query
-     * @throws MalformedURLException
-     */
-    public ArrayList<String> getAppsForLayer(DataSourceInfo dataSource, String query, String key) throws MalformedURLException {
-        String dataSourceURL = dataSource.getUrl().toString();
-        String provider = dataSource.getProvider();
-        DataSourceOperator op = this.getOperator(provider);
-        String queryEndpoint = op.getQueryEndpoint();
-        String response = null;
-        ArrayList<String> valuesList = new ArrayList<>();
-        String queryURL = dataSourceURL + queryEndpoint + query;
-        LOGGER.debug("Query URL is: {}", queryURL);
-        try {
-            // Create the client
-            GenericRestApiClient genericRestApiClient = new GenericRestApiClient(dataSource);
-            genericRestApiClient.setBaseURL(dataSourceURL + queryEndpoint);
-            JSONObject responseJson = genericRestApiClient.fetchMetricsJson("GET", query);
-            int level = 0;
-            try {
-                parseJsonForKey(responseJson, key, valuesList, level);
-                LOGGER.debug("Applications for the query: {}", valuesList.toString());
-            } catch (TooManyRecursiveCallsException e) {
-                e.printStackTrace();
-            }
-        } catch (IOException | NoSuchAlgorithmException | KeyStoreException | KeyManagementException | FetchMetricsError e) {
-            LOGGER.error("Unable to proceed due to invalid connection to URL: "+ queryURL);
-        }
-        return valuesList;
-    }
-
-    /**
      * TODO: monitoring agent will be replaced by default datasource later
      * returns DataSourceInfo objects for default datasource which is currently monitoring agent
+     *
      * @return DataSourceInfo objects
      */
     public static DataSourceInfo getMonitoringAgent(String dataSource) throws MonitoringAgentNotFoundException, MalformedURLException {
@@ -214,6 +81,7 @@ public class DataSourceOperatorImpl implements DataSourceOperator {
      * TODO: To find a suitable place for this function later
      * Gets the service endpoint for the datasource service through the cluster IP
      * of the service.
+     *
      * @return Endpoint of the service.
      * @throws ServiceNotFound
      */
@@ -256,6 +124,7 @@ public class DataSourceOperatorImpl implements DataSourceOperator {
 
     /**
      * TODO: To find a suitable place for this function later
+     *
      * @param jsonObj The JSON that needs to be parsed
      * @param key     The key to search in the JSON
      * @param values  ArrayList to hold the key values in the JSON
@@ -288,5 +157,145 @@ public class DataSourceOperatorImpl implements DataSourceOperator {
                 }
             }
         }
+    }
+
+    /**
+     * Returns the instance of specific operator class based on provider type
+     *
+     * @param provider String containg the name of provider
+     * @return instance of specific operator
+     */
+    @Override
+    public DataSourceOperatorImpl getOperator(String provider) {
+        if (provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.PROMETHEUS)) {
+            return PrometheusDataOperatorImpl.getInstance();
+        }
+        return null;
+    }
+
+    /**
+     * Returns the default service port for prometheus
+     *
+     * @return String containing the port number
+     */
+    @Override
+    public String getDefaultServicePortForProvider() {
+        return "";
+    }
+
+    /**
+     * Check if a datasource is reachable, implementation of this function
+     * should check and return the reachability status (REACHABLE, NOT_REACHABLE)
+     *
+     * @param dataSource DatasourceInfo object containing the datasource details
+     * @return DatasourceReachabilityStatus
+     */
+    @Override
+    public CommonUtils.DatasourceReachabilityStatus isServiceable(DataSourceInfo dataSource) throws IOException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
+        return null;
+    }
+
+    /**
+     * executes specified query on datasource and returns the result value
+     *
+     * @param dataSource DatasourceInfo object containing the datasource details
+     * @param query      String containing the query to be executed
+     * @return Object containing the result value for the specified query
+     */
+    @Override
+    public Object getValueForQuery(DataSourceInfo dataSource, String query) throws FetchMetricsError, Exception {
+        return null;
+    }
+
+    /**
+     * returns query endpoint for datasource
+     *
+     * @return String containing query endpoint
+     */
+    @Override
+    public String getQueryEndpoint() {
+        return null;
+    }
+
+    /**
+     * executes specified query on datasource and returns the JSON Object
+     *
+     * @param dataSource DatasourceInfo object containing the datasource details
+     * @param query      String containing the query to be executed
+     * @return JSONObject for the specified query
+     */
+    @Override
+    public JSONObject getJsonObjectForQuery(DataSourceInfo dataSource, String query) throws Exception, FetchMetricsError {
+        return null;
+    }
+
+    /**
+     * executes specified query on datasource and returns the result array
+     *
+     * @param dataSource DatasourceInfo object containing the datasource details
+     * @param query      String containing the query to be executed
+     * @return JsonArray containing the result array for the specified query
+     */
+    @Override
+    public JsonArray getResultArrayForQuery(DataSourceInfo dataSource, String query) throws IOException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
+        return null;
+    }
+
+    /**
+     * Validates a JSON array to ensure it is not null, not a JSON null, and has at least one element.
+     *
+     * @param resultArray The JSON array to be validated.
+     * @return True if the JSON array is valid (not null, not a JSON null, and has at least one element), otherwise false.
+     */
+    @Override
+    public boolean validateResultArray(JsonArray resultArray) {
+        return false;
+    }
+
+    /**
+     * TODO: To find a suitable place for this function later
+     * returns authentication token for datasource
+     *
+     * @return String containing token
+     */
+    public String getToken() throws IOException {
+        String fileName = KruizeConstants.AUTH_MOUNT_PATH + "token";
+        String authToken = new String(Files.readAllBytes(Paths.get(fileName)));
+        return authToken;
+    }
+
+    /**
+     * TODO: To find a suitable place for this function later
+     * Run the getAppsForLayer and return the list of applications matching the layer.
+     *
+     * @param dataSource
+     * @param query      getAppsForLayer query for the layer
+     * @param key        The key to search for in the response
+     * @return ArrayList of all applications from the query
+     * @throws MalformedURLException
+     */
+    public ArrayList<String> getAppsForLayer(DataSourceInfo dataSource, String query, String key) throws IOException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
+        String dataSourceURL = dataSource.getUrl().toString();
+        String provider = dataSource.getProvider();
+        DataSourceOperator op = this.getOperator(provider);
+        String queryEndpoint = op.getQueryEndpoint();
+        String response = null;
+        ArrayList<String> valuesList = new ArrayList<>();
+        String queryURL = dataSourceURL + queryEndpoint + query;
+        LOGGER.debug("Query URL is: {}", queryURL);
+
+        // Create the client
+        GenericRestApiClient genericRestApiClient = new GenericRestApiClient(dataSource);
+        genericRestApiClient.setBaseURL(dataSourceURL + queryEndpoint);
+        JSONObject responseJson = genericRestApiClient.fetchMetricsJson("GET", query);
+        int level = 0;
+        try {
+            parseJsonForKey(responseJson, key, valuesList, level);
+            LOGGER.debug("Applications for the query: {}", valuesList.toString());
+        } catch (TooManyRecursiveCallsException e) {
+            e.printStackTrace();
+        }
+
+        return valuesList;
     }
 }

--- a/src/main/java/com/autotune/common/datasource/prometheus/PrometheusDataOperatorImpl.java
+++ b/src/main/java/com/autotune/common/datasource/prometheus/PrometheusDataOperatorImpl.java
@@ -15,20 +15,16 @@
  *******************************************************************************/
 package com.autotune.common.datasource.prometheus;
 
-import com.autotune.analyzer.exceptions.FetchMetricsError;
 import com.autotune.analyzer.utils.AnalyzerConstants;
-import com.autotune.common.auth.AuthenticationStrategy;
-import com.autotune.common.auth.AuthenticationStrategyFactory;
 import com.autotune.common.datasource.DataSourceInfo;
 import com.autotune.common.datasource.DataSourceOperatorImpl;
 import com.autotune.common.utils.CommonUtils;
 import com.autotune.operator.KruizeDeploymentInfo;
-import com.autotune.utils.KruizeConstants;
 import com.autotune.utils.GenericRestApiClient;
-import com.google.gson.*;
-import org.apache.http.conn.HttpHostConnectException;
-import org.json.JSONArray;
-import org.json.JSONException;
+import com.autotune.utils.KruizeConstants;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import org.json.JSONObject;
 import org.slf4j.LoggerFactory;
 
@@ -38,19 +34,22 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 
 /**
- *  PrometheusDataOperatorImpl extends DataSourceOperatorImpl class
- *  This class provides Prometheus specific implementation for DataSourceOperator functions
+ * PrometheusDataOperatorImpl extends DataSourceOperatorImpl class
+ * This class provides Prometheus specific implementation for DataSourceOperator functions
  */
 public class PrometheusDataOperatorImpl extends DataSourceOperatorImpl {
     private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(PrometheusDataOperatorImpl.class);
 
-    private static PrometheusDataOperatorImpl prometheusDataOperator = null;;
+    private static PrometheusDataOperatorImpl prometheusDataOperator = null;
+    ;
+
     private PrometheusDataOperatorImpl() {
         super();
     }
 
     /**
      * Returns the instance of PrometheusDataOperatorImpl class
+     *
      * @return PrometheusDataOperatorImpl instance
      */
     public static PrometheusDataOperatorImpl getInstance() {
@@ -62,6 +61,7 @@ public class PrometheusDataOperatorImpl extends DataSourceOperatorImpl {
 
     /**
      * Returns the default service port for prometheus
+     *
      * @return String containing the port number
      */
     @Override
@@ -80,7 +80,7 @@ public class PrometheusDataOperatorImpl extends DataSourceOperatorImpl {
      * @return DatasourceReachabilityStatus
      */
     @Override
-    public CommonUtils.DatasourceReachabilityStatus isServiceable(DataSourceInfo dataSource) {
+    public CommonUtils.DatasourceReachabilityStatus isServiceable(DataSourceInfo dataSource) throws IOException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
         String dataSourceStatus;
         Object queryResult;
 
@@ -89,13 +89,13 @@ public class PrometheusDataOperatorImpl extends DataSourceOperatorImpl {
 
         queryResult = this.getValueForQuery(dataSource, query);
 
-        if (queryResult != null){
+        if (queryResult != null) {
             dataSourceStatus = queryResult.toString();
         } else {
             dataSourceStatus = "0";
         }
 
-        if (dataSourceStatus.equalsIgnoreCase("1")){
+        if (dataSourceStatus.equalsIgnoreCase("1")) {
             reachabilityStatus = CommonUtils.DatasourceReachabilityStatus.REACHABLE;
         } else {
             reachabilityStatus = CommonUtils.DatasourceReachabilityStatus.NOT_REACHABLE;
@@ -111,23 +111,17 @@ public class PrometheusDataOperatorImpl extends DataSourceOperatorImpl {
      * @return Object containing the result value for the specified query
      */
     @Override
-    public Object getValueForQuery(DataSourceInfo dataSource, String query) {
-        try {
-            JSONObject jsonObject = getJsonObjectForQuery(dataSource, query);
+    public Object getValueForQuery(DataSourceInfo dataSource, String query) throws IOException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
 
-            if (null == jsonObject) {
-                return null;
-            } else {
-                return "1";   //if it returns HTTP STATUS_OK  200
-            }
+        JSONObject jsonObject = getJsonObjectForQuery(dataSource, query);
 
-
-        } catch (JSONException e) {
-            LOGGER.error(e.getMessage());
-        } catch (NullPointerException e) {
-            LOGGER.error(e.getMessage());
+        if (null == jsonObject) {
+            return null;
+        } else {
+            return "1";   //if it returns HTTP STATUS_OK  200
         }
-        return null;
+
+
     }
 
     /**
@@ -138,7 +132,7 @@ public class PrometheusDataOperatorImpl extends DataSourceOperatorImpl {
      * @return JSONObject for the specified query
      */
     @Override
-    public JSONObject getJsonObjectForQuery(DataSourceInfo dataSource, String query) {
+    public JSONObject getJsonObjectForQuery(DataSourceInfo dataSource, String query) throws IOException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
         // Create the client
         GenericRestApiClient apiClient = new GenericRestApiClient(dataSource);
         apiClient.setBaseURL(CommonUtils.getBaseDataSourceUrl(
@@ -150,10 +144,10 @@ public class PrometheusDataOperatorImpl extends DataSourceOperatorImpl {
             return null;
         }
 
-        try {
-            JSONObject jsonObject = apiClient.fetchMetricsJson(
-                    KruizeConstants.HttpConstants.MethodType.GET,
-                    query);
+
+        JSONObject jsonObject = apiClient.fetchMetricsJson(
+                KruizeConstants.HttpConstants.MethodType.GET,
+                query);
             /*  TODO need to separate it out this logic form here
             if (!jsonObject.has(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.STATUS))
                 return null;
@@ -168,26 +162,14 @@ public class PrometheusDataOperatorImpl extends DataSourceOperatorImpl {
 
              */
 
-            return jsonObject;
+        return jsonObject;
 
-        } catch (HttpHostConnectException e) {
-            LOGGER.error(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.DATASOURCE_CONNECTION_FAILED);
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (NoSuchAlgorithmException e) {
-            e.printStackTrace();
-        } catch (KeyStoreException e) {
-            e.printStackTrace();
-        } catch (KeyManagementException e) {
-            e.printStackTrace();
-        } catch (FetchMetricsError e) {
-            e.printStackTrace();
-        }
-        return null;
+
     }
 
     /**
      * returns query endpoint for prometheus datasource
+     *
      * @return String containing query endpoint
      */
     @Override
@@ -201,45 +183,37 @@ public class PrometheusDataOperatorImpl extends DataSourceOperatorImpl {
      * @param dataSource DatasourceInfo object containing the datasource details
      * @param query      String containing the query to be executed
      * @return JsonArray containing the result array for the specified query
-     *
+     * <p>
      * Example output JsonArray -
      * [
-     *   {
-     *     "metric": {
-     *       "__name__": "exampleMetric"
-     *     },
-     *     "value": [1642612628.987, "1"]
-     *   }
+     * {
+     * "metric": {
+     * "__name__": "exampleMetric"
+     * },
+     * "value": [1642612628.987, "1"]
+     * }
      * ]
      */
 
     @Override
-    public JsonArray getResultArrayForQuery(DataSourceInfo dataSource, String query) {
-        try {
-            JSONObject jsonObject = getJsonObjectForQuery(dataSource, query);
+    public JsonArray getResultArrayForQuery(DataSourceInfo dataSource, String query) throws IOException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
 
-            if (null == jsonObject) {
-                return null;
-            }
+        JSONObject jsonObject = getJsonObjectForQuery(dataSource, query);
 
+        if (null == jsonObject) {
+            return null;
+        } else {
             String jsonString = jsonObject.toString();
             JsonObject parsedJsonObject = JsonParser.parseString(jsonString).getAsJsonObject();
             JsonObject dataObject = parsedJsonObject.get(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.DATA).getAsJsonObject();
-
             if (dataObject.has(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.RESULT) && dataObject.get(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.RESULT).isJsonArray()) {
                 JsonArray resultArray = dataObject.getAsJsonArray(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.RESULT);
-
                 if (null != resultArray) {
                     return resultArray;
                 }
             }
-        } catch (JsonParseException e) {
-            LOGGER.error(e.getMessage());
-            throw e;
-        } catch (NullPointerException e) {
-            LOGGER.error(e.getMessage());
-            throw e;
         }
+
         return null;
     }
 

--- a/src/main/java/com/autotune/experimentManager/handler/MetricCollectionHandler.java
+++ b/src/main/java/com/autotune/experimentManager/handler/MetricCollectionHandler.java
@@ -15,6 +15,7 @@
  *******************************************************************************/
 package com.autotune.experimentManager.handler;
 
+import com.autotune.analyzer.exceptions.FetchMetricsError;
 import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.common.data.metrics.Metric;
 import com.autotune.common.data.metrics.MetricResults;
@@ -121,8 +122,15 @@ public class MetricCollectionHandler implements EMHandlerInterface {
                             if (null == ado) {
                                 // TODO: Return an error saying unsupported datasource
                             }
-                            String queryResult = (String) ado.getValueForQuery(experimentTrial.getDatasourceInfoHashMap()
-                                    .get(podMetric.getDatasource()), updatedPodQuery);
+                            String queryResult = null;
+                            try {
+                                queryResult = (String) ado.getValueForQuery(experimentTrial.getDatasourceInfoHashMap()
+                                        .get(podMetric.getDatasource()), updatedPodQuery);
+                            } catch (FetchMetricsError e) {
+                                throw new RuntimeException(e);
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            }
                             if (null != queryResult && !queryResult.isEmpty() && !queryResult.isBlank()) {
                                 try {
                                     queryResult = queryResult.trim();
@@ -159,8 +167,15 @@ public class MetricCollectionHandler implements EMHandlerInterface {
                                 }
                                 if (null != updatedContainerQuery) {
                                     LOGGER.debug("Updated Query - " + updatedContainerQuery);
-                                    String queryResult = (String) ado.getValueForQuery(experimentTrial.getDatasourceInfoHashMap()
-                                            .get(containerMetric.getDatasource()), updatedContainerQuery);
+                                    String queryResult = null;
+                                    try {
+                                        queryResult = (String) ado.getValueForQuery(experimentTrial.getDatasourceInfoHashMap()
+                                                .get(containerMetric.getDatasource()), updatedContainerQuery);
+                                    } catch (FetchMetricsError e) {
+                                        throw new RuntimeException(e);
+                                    } catch (Exception e) {
+                                        throw new RuntimeException(e);
+                                    }
                                     if (null != queryResult && !queryResult.isEmpty() && !queryResult.isBlank()) {
                                         try {
                                             queryResult = queryResult.trim();


### PR DESCRIPTION


## Description
This PR improves error handling for Datasource connections by addressing the suppression of exceptions like SocketTimeoutException and ConnectTimeoutException. These exceptions will now be rethrown, enabling the REST API to return appropriate HTTP status codes:

504 Gateway Timeout: For requests that time out while waiting for a response.
503 Service Unavailable: For connections that cannot be established to the Datasource.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [x] New Test X
- [x] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [x] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
