### PR TITLE
Upgraded jetty version to fix a security vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <fabric8-version>4.13.2</fabric8-version>
         <org-json-version>20240303</org-json-version>
-        <jetty-version>9.4.56.v20240826</jetty-version>
+        <jetty-version>10.0.24</jetty-version>
         <slf4j-version>2.17.1</slf4j-version>
         <java-version>17</java-version>
         <prometheus-simpleclient>0.14.1</prometheus-simpleclient>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <fabric8-version>4.13.2</fabric8-version>
         <org-json-version>20240303</org-json-version>
-        <jetty-version>9.4.55.v20240627</jetty-version>
+        <jetty-version>9.4.56.v20240826</jetty-version>
         <slf4j-version>2.17.1</slf4j-version>
         <java-version>17</java-version>
         <prometheus-simpleclient>0.14.1</prometheus-simpleclient>


### PR DESCRIPTION
## Description

Upgraded the jetty version to fix [this](https://github.com/jetty/jetty.project/security/advisories/GHSA-g8m5-722r-8whq) vulnerability

Fixes # (issue)

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Tested this manually by building the docker image and pushing it to quay. Verified that this advisory is not listed by the quay security scanner

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on:  NA

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
