### PR TITLE
Add Time Range Filter for Bulk API

### DIFF
--- a/design/BulkAPI.md
+++ b/design/BulkAPI.md
@@ -237,25 +237,25 @@ resource optimization in Kubernetes environments. Below is a breakdown of the JS
 
     - Each object in the `experiments` array has the following structure:
 
-  | Field            | Type     | Description                                                                         |
-  |------------------|----------|-------------------------------------------------------------------------------------|
-  | `name`           | `string` | Name of the experiment, typically indicating a service name and deployment context. |
-  | `notification`   | `object` | Notifications specific to this experiment (if any).                                 |
-  | `recommendation` | `object` | Recommendation status and notifications specific to this experiment.                |
+  | Field             | Type     | Description                                                                         |
+  |-------------------|----------|-------------------------------------------------------------------------------------|
+  | `name`            | `string` | Name of the experiment, typically indicating a service name and deployment context. |
+  | `notifications`   | `object` | Notifications specific to this experiment (if any).                                 |
+  | `recommendations` | `object` | Recommendation status and notifications specific to this experiment.                |
 
   #### Recommendation Object
 
-  The `recommendation` field within each experiment provides information about recommendation processing status and
+  The `recommendations` field within each experiment provides information about recommendation processing status and
   errors (if any).
 
-  | Field          | Type     | Description                                                                                      |
-  |----------------|----------|--------------------------------------------------------------------------------------------------|
-  | `status`       | `string` | Status of the recommendation (e.g., `"unprocessed"`, `"processed"`, `"processing"`, `"failed"`). |
-  | `notification` | `object` | Notifications related to recommendation processing.                                              |
+  | Field           | Type     | Description                                                                                      |
+  |-----------------|----------|--------------------------------------------------------------------------------------------------|
+  | `status`        | `string` | Status of the recommendation (e.g., `"unprocessed"`, `"processed"`, `"processing"`, `"failed"`). |
+  | `notifications` | `object` | Notifications related to recommendation processing.                                              |
 
   #### Notification Object
 
-  Both the `notification` and `recommendation.notification` fields may contain error messages or warnings as follows:
+  Both the `notifications` and `recommendations.notifications` fields may contain error messages or warnings as follows:
 
   | Field                   | Type         | Description                                                                |
   |-------------------------|--------------|----------------------------------------------------------------------------|

--- a/design/BulkAPI.md
+++ b/design/BulkAPI.md
@@ -43,7 +43,10 @@ progress of the job.
       }
     }
   },
-  "time_range": {},
+  "time_range": {
+    "start": "2024-11-01T00:00:00.000Z",
+    "end": "2024-11-15T23:59:59.000Z"
+  },
   "datasource": "Cbank1Xyz",
   "experiment_types": [
     "container",
@@ -84,43 +87,21 @@ progress of the job.
 ```
 ### Different payload parameters examples
 
-#### 1. **Request Payload with `time range` specified (JSON):**
+#### 1. **Request Payload with `time_range` specified:**
 
-```json
-{
-  "filter": {
-    "exclude": {
-      "namespace": [],
-      "workload": [],
-      "containers": [],
-      "labels": {}
-    },
-    "include": {
-      "namespace": [],
-      "workload": [],
-      "containers": [],
-      "labels": {
-        "key1": "value1",
-        "key2": "value2"
-      }
-    }
-  },
-  "time_range": {
-    "start": "2024-11-01T00:00:00.000Z",
-    "end": "2024-11-15T23:59:59.000Z"
-  },
-  "datasource": "Cbank1Xyz",
-  "experiment_types": [
-    "container",
-    "namespace"
-  ]
-}
-```
+This object allows users to specify the duration for which they want to query data and receive recommendations. It consists of the following fields:
 
-#### 2. **Request Payload with `exclude` filter specified (JSON):**
+- **`start`**: The starting timestamp of the query duration in ISO 8601 format (`YYYY-MM-DDTHH:mm:ss.sssZ`).
+- **`end`**: The ending timestamp of the query duration in ISO 8601 format (`YYYY-MM-DDTHH:mm:ss.sssZ`).
+
+The specified time range determines the period over which the data is analyzed to provide recommendations at the container or namespace level. Ensure that:
+- Both `start` and `end` are valid timestamps.
+- The `start` timestamp precedes the `end` timestamp.
+
+#### 2. **Request Payload with `exclude` filter specified:**
 TBA
 
-#### 3. **Request Payload with `include` filter specified (JSON):**
+#### 3. **Request Payload with `include` filter specified:**
 TBA
 
 ### GET Request:
@@ -257,7 +238,7 @@ resource optimization in Kubernetes environments. Below is a breakdown of the JS
     - Each object in the `experiments` array has the following structure:
 
   | Field            | Type     | Description                                                                         |
-              |------------------|----------|-------------------------------------------------------------------------------------|
+  |------------------|----------|-------------------------------------------------------------------------------------|
   | `name`           | `string` | Name of the experiment, typically indicating a service name and deployment context. |
   | `notification`   | `object` | Notifications specific to this experiment (if any).                                 |
   | `recommendation` | `object` | Recommendation status and notifications specific to this experiment.                |
@@ -268,7 +249,7 @@ resource optimization in Kubernetes environments. Below is a breakdown of the JS
   errors (if any).
 
   | Field          | Type     | Description                                                                                      |
-              |----------------|----------|--------------------------------------------------------------------------------------------------|
+  |----------------|----------|--------------------------------------------------------------------------------------------------|
   | `status`       | `string` | Status of the recommendation (e.g., `"unprocessed"`, `"processed"`, `"processing"`, `"failed"`). |
   | `notification` | `object` | Notifications related to recommendation processing.                                              |
 
@@ -277,7 +258,7 @@ resource optimization in Kubernetes environments. Below is a breakdown of the JS
   Both the `notification` and `recommendation.notification` fields may contain error messages or warnings as follows:
 
   | Field                   | Type         | Description                                                                |
-              |-------------------------|--------------|----------------------------------------------------------------------------|
+  |-------------------------|--------------|----------------------------------------------------------------------------|
   | `type`                  | `string`     | Type of notification (e.g., `"info"`,`"error"`, `"warning"`).              |
   | `message`               | `string`     | Description of the notification message.                                   |
   | `code`                  | `integer`    | HTTP-like code indicating the type of error (e.g., `400` for bad request). |

--- a/design/BulkAPI.md
+++ b/design/BulkAPI.md
@@ -82,6 +82,46 @@ progress of the job.
   "job_id": "123e4567-e89b-12d3-a456-426614174000"
 }
 ```
+### Different payload parameters examples
+
+#### 1. **Request Payload with `time range` specified (JSON):**
+
+```json
+{
+  "filter": {
+    "exclude": {
+      "namespace": [],
+      "workload": [],
+      "containers": [],
+      "labels": {}
+    },
+    "include": {
+      "namespace": [],
+      "workload": [],
+      "containers": [],
+      "labels": {
+        "key1": "value1",
+        "key2": "value2"
+      }
+    }
+  },
+  "time_range": {
+    "start": "2024-11-01T00:00:00.000Z",
+    "end": "2024-11-15T23:59:59.000Z"
+  },
+  "datasource": "Cbank1Xyz",
+  "experiment_types": [
+    "container",
+    "namespace"
+  ]
+}
+```
+
+#### 2. **Request Payload with `exclude` filter specified (JSON):**
+TBA
+
+#### 3. **Request Payload with `include` filter specified (JSON):**
+TBA
 
 ### GET Request:
 
@@ -216,21 +256,21 @@ resource optimization in Kubernetes environments. Below is a breakdown of the JS
 
     - Each object in the `experiments` array has the following structure:
 
-  | Field                   | Type         | Description                                                              |
-              |-------------------------|--------------|--------------------------------------------------------------------------|
-  | `name`                  | `string`     | Name of the experiment, typically indicating a service name and deployment context. |
-  | `notification`          | `object`     | Notifications specific to this experiment (if any).                      |
-  | `recommendation`        | `object`     | Recommendation status and notifications specific to this experiment.     |
+  | Field            | Type     | Description                                                                         |
+              |------------------|----------|-------------------------------------------------------------------------------------|
+  | `name`           | `string` | Name of the experiment, typically indicating a service name and deployment context. |
+  | `notification`   | `object` | Notifications specific to this experiment (if any).                                 |
+  | `recommendation` | `object` | Recommendation status and notifications specific to this experiment.                |
 
   #### Recommendation Object
 
   The `recommendation` field within each experiment provides information about recommendation processing status and
   errors (if any).
 
-  | Field                   | Type         | Description                                                              |
-              |-------------------------|--------------|--------------------------------------------------------------------------|
-  | `status`                | `string`     | Status of the recommendation (e.g., `"unprocessed"`, `"processed"`, `"processing"`, `"failed"`). |
-  | `notification`          | `object`     | Notifications related to recommendation processing.                      |
+  | Field          | Type     | Description                                                                                      |
+              |----------------|----------|--------------------------------------------------------------------------------------------------|
+  | `status`       | `string` | Status of the recommendation (e.g., `"unprocessed"`, `"processed"`, `"processing"`, `"failed"`). |
+  | `notification` | `object` | Notifications related to recommendation processing.                                              |
 
   #### Notification Object
 

--- a/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
+++ b/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
@@ -288,8 +288,8 @@ public class BulkJobManager implements Runnable {
     private JSONObject processDateRange(BulkInput.TimeRange timeRange) {
         JSONObject dateRange = null;
         if (null != timeRange && timeRange.getStart() != null && timeRange.getEnd() != null) {
-            String intervalEndTimeStr = timeRange.getStart();
-            String intervalStartTimeStr = timeRange.getEnd();
+            String intervalStartTimeStr = timeRange.getStart();
+            String intervalEndTimeStr = timeRange.getEnd();
             long interval_end_time_epoc = 0;
             long interval_start_time_epoc = 0;
             LocalDateTime localDateTime = LocalDateTime.parse(intervalEndTimeStr, DateTimeFormatter.ofPattern(KruizeConstants.DateFormats.STANDARD_JSON_DATE_FORMAT));

--- a/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
+++ b/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
@@ -139,7 +139,7 @@ public class BulkJobManager implements Runnable {
             if (null != datasource) {
                 JSONObject daterange = processDateRange(this.bulkInput.getTime_range());
                 if (null != daterange)
-                    metadataInfo = dataSourceManager.importMetadataFromDataSource(datasource, labelString, (Long) daterange.get("start_time"), (Long) daterange.get("end_time"), (Integer) daterange.get("steps"));
+                    metadataInfo = dataSourceManager.importMetadataFromDataSource(datasource, labelString, (Long) daterange.get(START_TIME), (Long) daterange.get(END_TIME), (Integer) daterange.get(STEPS));
                 else {
                     metadataInfo = dataSourceManager.importMetadataFromDataSource(datasource, labelString, 0, 0, 0);
                 }
@@ -233,7 +233,7 @@ public class BulkJobManager implements Runnable {
             }
         } catch (IOException e) {
             LOGGER.error(e.getMessage());
-            jobData.setStatus("FAILED");
+            jobData.setStatus(FAILED);
             jobData.setEndTime(Instant.now());
             BulkJobStatus.Notification notification;
             if (e instanceof SocketTimeoutException) {
@@ -248,7 +248,7 @@ public class BulkJobManager implements Runnable {
         } catch (Exception e) {
             LOGGER.error(e.getMessage());
             e.printStackTrace();
-            jobData.setStatus("FAILED");
+            jobData.setStatus(FAILED);
             jobData.setEndTime(Instant.now());
             jobData.setNotification(String.valueOf(HttpURLConnection.HTTP_INTERNAL_ERROR), new BulkJobStatus.Notification(BulkJobStatus.NotificationType.ERROR, e.getMessage(), HttpURLConnection.HTTP_INTERNAL_ERROR));
         }
@@ -298,10 +298,10 @@ public class BulkJobManager implements Runnable {
                             includeLabelsBuilder.append(key).append("=").append("\"" + value + "\"").append(",")
                     );
                     // Remove trailing comma
-                    if (includeLabelsBuilder.length() > 0) {
+                    if (!includeLabelsBuilder.isEmpty()) {
                         includeLabelsBuilder.setLength(includeLabelsBuilder.length() - 1);
                     }
-                    LOGGER.debug("Include Labels: " + includeLabelsBuilder);
+                    LOGGER.debug("Include Labels: {}", includeLabelsBuilder);
                     uniqueKey = includeLabelsBuilder.toString();
                 }
             }
@@ -313,6 +313,7 @@ public class BulkJobManager implements Runnable {
     }
 
     private JSONObject processDateRange(BulkInput.TimeRange timeRange) {
+        //TODO: add validations for the time range
         JSONObject dateRange = null;
         if (null != timeRange && timeRange.getStart() != null && timeRange.getEnd() != null) {
             String intervalStartTimeStr = timeRange.getStart();
@@ -327,9 +328,9 @@ public class BulkJobManager implements Runnable {
             Timestamp interval_start_time = Timestamp.from(localDateTime.toInstant(ZoneOffset.UTC));
             int steps = CREATE_EXPERIMENT_CONFIG_BEAN.getMeasurementDuration() * KruizeConstants.TimeConv.NO_OF_SECONDS_PER_MINUTE; // todo fetch experiment recommendations setting measurement
             dateRange = new JSONObject();
-            dateRange.put("start_time", interval_start_time_epoc);
-            dateRange.put("end_time", interval_end_time_epoc);
-            dateRange.put("steps", steps);
+            dateRange.put(START_TIME, interval_start_time_epoc);
+            dateRange.put(END_TIME, interval_end_time_epoc);
+            dateRange.put(STEPS, steps);
         }
         return dateRange;
     }

--- a/src/main/java/com/autotune/common/datasource/DataSourceCollection.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceCollection.java
@@ -144,6 +144,10 @@ public class DataSourceCollection {
                     DataSourceInfo dataSourceInfo = new ExperimentDBService().loadDataSourceFromDBByName(name);
                     if (null != dataSourceInfo) {
                         LOGGER.error("Datasource: {} already exists!", name);
+                        // add the auth details to local object
+                        AuthenticationConfig authConfig = getAuthenticationDetails(dataSourceObject, name);
+                        dataSourceInfo.setAuthenticationConfig(authConfig);
+                        dataSourceCollection.put(name, dataSourceInfo);
                         continue;
                     }
                 } catch (Exception e) {
@@ -153,16 +157,7 @@ public class DataSourceCollection {
                 String serviceName = dataSourceObject.getString(KruizeConstants.DataSourceConstants.DATASOURCE_SERVICE_NAME);
                 String namespace = dataSourceObject.getString(KruizeConstants.DataSourceConstants.DATASOURCE_SERVICE_NAMESPACE);
                 String dataSourceURL = dataSourceObject.getString(KruizeConstants.DataSourceConstants.DATASOURCE_URL);
-                AuthenticationConfig authConfig;
-                try {
-                    JSONObject authenticationObj = dataSourceObject.optJSONObject(KruizeConstants.AuthenticationConstants.AUTHENTICATION);
-                    // create the corresponding authentication object
-                    authConfig = AuthenticationConfig.createAuthenticationConfigObject(authenticationObj);
-                } catch (Exception e) {
-                    LOGGER.warn("Auth details are missing for datasource: {}", name);
-                    authConfig = AuthenticationConfig.noAuth();
-                }
-
+                AuthenticationConfig authConfig = getAuthenticationDetails(dataSourceObject, name);
                 DataSourceInfo datasource;
                 // Validate input
                 if (!validateInput(name, provider, serviceName, dataSourceURL, namespace)) {
@@ -180,6 +175,19 @@ public class DataSourceCollection {
         } catch (IOException e) {
             LOGGER.error(e.getMessage());
         }
+    }
+
+    private AuthenticationConfig getAuthenticationDetails(JSONObject dataSourceObject, String name) {
+        AuthenticationConfig authConfig;
+        try {
+            JSONObject authenticationObj = dataSourceObject.optJSONObject(KruizeConstants.AuthenticationConstants.AUTHENTICATION);
+            // create the corresponding authentication object
+            authConfig = AuthenticationConfig.createAuthenticationConfigObject(authenticationObj);
+        } catch (Exception e) {
+            LOGGER.warn("Auth details are missing for datasource: {}", name);
+            authConfig = AuthenticationConfig.noAuth();
+        }
+        return authConfig;
     }
 
     /**

--- a/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
@@ -180,13 +180,13 @@ public class DataSourceMetadataOperator {
         String containerQuery = PromQLDataSourceQueries.CONTAINER_QUERY;
         if (null != uniqueKey && !uniqueKey.isEmpty()) {
             LOGGER.debug("uniquekey: {}", uniqueKey);
-            namespaceQuery = namespaceQuery.replace("ADDITIONAL_LABEL", "," + uniqueKey);
-            workloadQuery = workloadQuery.replace("ADDITIONAL_LABEL", "," + uniqueKey);
-            containerQuery = containerQuery.replace("ADDITIONAL_LABEL", "," + uniqueKey);
+            namespaceQuery = namespaceQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "," + uniqueKey);
+            workloadQuery = workloadQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "," + uniqueKey);
+            containerQuery = containerQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "," + uniqueKey);
         } else {
-            namespaceQuery = namespaceQuery.replace("ADDITIONAL_LABEL", "");
-            workloadQuery = workloadQuery.replace("ADDITIONAL_LABEL", "");
-            containerQuery = containerQuery.replace("ADDITIONAL_LABEL", "");
+            namespaceQuery = namespaceQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "");
+            workloadQuery = workloadQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "");
+            containerQuery = containerQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "");
         }
         LOGGER.info("namespaceQuery: {}", namespaceQuery);
         LOGGER.info("workloadQuery: {}", workloadQuery);
@@ -249,7 +249,7 @@ public class DataSourceMetadataOperator {
 
     }
 
-    private JsonArray fetchQueryResults(DataSourceInfo dataSourceInfo, String query, long startTime, long endTime, int steps) throws IOException, FetchMetricsError, NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
+    private JsonArray fetchQueryResults(DataSourceInfo dataSourceInfo, String query, long startTime, long endTime, int steps) throws IOException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
         GenericRestApiClient client = new GenericRestApiClient(dataSourceInfo);
         String metricsUrl = String.format(KruizeConstants.DataSourceConstants.DATASOURCE_ENDPOINT_WITH_QUERY,
                 dataSourceInfo.getUrl(),

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -798,6 +798,11 @@ public class KruizeConstants {
         public static final String FAILED = "FAILED";
         public static final String LIMIT_MESSAGE = "The number of experiments exceeds %s.";
         public static final String NOTHING = "Nothing to do.";
+        public static final String START_TIME = "start_time";
+        public static final String END_TIME = "end_time";
+        public static final String STEPS = "steps";
+        public static final String ADDITIONAL_LABEL = "ADDITIONAL_LABEL";
+
         // TODO : Bulk API Create Experiments defaults
         public static final CreateExperimentConfigBean CREATE_EXPERIMENT_CONFIG_BEAN;
 


### PR DESCRIPTION
## Description

This PR adds the feature to get the bulk API result within a specified duration i.e. start and end time.

**Note: This is on top of [1358](https://github.com/kruize/autotune/pull/1358) which needs to be merged first.**

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [x] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: **Minkube and Openshift**

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [x] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
