### PR TITLE
Updated aws sdk version to fix netty CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <hibernatecp30-version>6.1.7.Final</hibernatecp30-version>
         <hibernate-Validator>8.0.1.Final</hibernate-Validator>
         <micrometer-version>1.9.9</micrometer-version>
-        <awssdk-version>2.25.35</awssdk-version>
+        <awssdk-version>2.29.15</awssdk-version>
     </properties>
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <hibernatecp30-version>6.1.7.Final</hibernatecp30-version>
         <hibernate-Validator>8.0.1.Final</hibernate-Validator>
         <micrometer-version>1.9.9</micrometer-version>
-        <awssdk-version>2.29.15</awssdk-version>
+        <awssdk-version>2.29.16</awssdk-version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
## Description

Updated aws sdk version to fix the new CVE with netty as seen [here](https://quay.io/repository/kruize/autotune/manifest/sha256:0f2d0a107bb835b51af0d337f5fe94f87b7b05cb752486364bc743de627a4b95?tab=vulnerabilities) 

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Tested by creating a build and ensuring the quay scanner [report](https://quay.io/repository/kruize/autotune/manifest/sha256:d49e95a710340c83e0151fb7b1966e44c7d04a3bbf8c861c7d422eb897c14873?tab=vulnerabilities) doesn't report this issue

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: NA

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
