### PR TITLE
Environment variable error found in the log

### DIFF
--- a/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
+++ b/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
@@ -148,8 +148,8 @@ public class BulkJobManager implements Runnable {
                     Map<String, CreateExperimentAPIObject> createExperimentAPIObjectMap = getExperimentMap(labelString, jobData, metadataInfo, datasource); //Todo Store this map in buffer and use it if BulkAPI pods restarts and support experiment_type
                     jobData.setTotal_experiments(createExperimentAPIObjectMap.size());
                     jobData.setProcessed_experiments(0);
-                    if (jobData.getTotal_experiments() > KruizeDeploymentInfo.BULK_API_LIMIT) {
-                        setFinalJobStatus(FAILED,String.valueOf(HttpURLConnection.HTTP_BAD_REQUEST),LIMIT_INFO,datasource);
+                    if (jobData.getTotal_experiments() > KruizeDeploymentInfo.bulk_api_limit) {
+                      setFinalJobStatus(FAILED,String.valueOf(HttpURLConnection.HTTP_BAD_REQUEST),LIMIT_INFO,datasource);
                     } else {
                         ExecutorService createExecutor = Executors.newFixedThreadPool(bulk_thread_pool_size);
                         ExecutorService generateExecutor = Executors.newFixedThreadPool(bulk_thread_pool_size);

--- a/src/main/java/com/autotune/operator/KruizeDeploymentInfo.java
+++ b/src/main/java/com/autotune/operator/KruizeDeploymentInfo.java
@@ -81,8 +81,7 @@ public class KruizeDeploymentInfo {
     public static Boolean log_http_req_resp = false;
     public static String recommendations_url;
     public static String experiments_url;
-    public static int BULK_API_LIMIT = 1000;
-    public static int BULK_API_MAX_BATCH_SIZE = 100;
+    public static Integer bulk_api_limit = 1000;
     public static Integer bulk_thread_pool_size = 3;
     public static int generate_recommendations_date_range_limit_in_days = 15;
     public static Integer delete_partition_threshold_in_days = DELETE_PARTITION_THRESHOLD_IN_DAYS;

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -805,7 +805,7 @@ public class KruizeConstants {
         public static final String IN_PROGRESS = "IN_PROGRESS";
         public static final String COMPLETED = "COMPLETED";
         public static final String FAILED = "FAILED";
-        public static final String LIMIT_MESSAGE = "The number of experiments exceeds %s.";
+        public static final String LIMIT_MESSAGE = "The number of experiments exceeds the defined limit.";
         public static final String NOTHING = "Nothing to do.";
         public static final String START_TIME = "start_time";
         public static final String END_TIME = "end_time";

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -708,7 +708,6 @@ public class KruizeConstants {
         public static final String RECOMMENDATIONS_URL = "recommendationsURL";
         public static final String EXPERIMENTS_URL = "experimentsURL";
         public static final String BULK_API_LIMIT = "bulkapilimit";
-        public static final String BULK_API_CHUNK_SIZE = "bulkapichunksize";
         public static final String BULK_THREAD_POOL_SIZE = "bulkThreadPoolSize";
         public static final String EXPERIMENT_NAME_FORMAT = "experimentNameFormat";
     }


### PR DESCRIPTION
## Description

Following error found in Log and this PR should fix this issue

```
2024-11-2112:17:00.721 WARN [main][InitializeDeployment.java(112)]-Error while setting config variables : class java.lang.NoSuchFieldException : bulk_api_limit
2024-11-2112:17:00.721 WARN [main][InitializeDeployment.java(112)]-Error while setting config variables : class java.lang.NoSuchFieldException : bulk_api_chunk_size
```


Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [x] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [x] Dependent changes merged
- [x] Documentation updated
- [x] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
