### PR TITLE
Update kruize default cpu/memory resources for openshift

### DIFF
--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -54,7 +54,7 @@ metadata:
 spec:
   storageClassName: manual
   capacity:
-    storage: 1Gi # Sets PV Volume
+    storage: 500Mi # Sets PV Volume
   accessModes:
     - ReadWriteMany
   hostPath:
@@ -73,7 +73,7 @@ spec:
     - ReadWriteMany  # Sets read and write access
   resources:
     requests:
-      storage: 1Gi  # Sets volume size
+      storage: 500Mi  # Sets volume size
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -182,11 +182,11 @@ spec:
               value: /var/lib/pg_data
           resources:
             requests:
-              memory: "2Gi"
-              cpu: "2"
+              memory: "100Mi"
+              cpu: "0.5"
             limits:
-              memory: "2Gi"
-              cpu: "2"
+              memory: "100Mi"
+              cpu: "0.5"
           ports:
             - containerPort: 5432
           volumeMounts:
@@ -264,11 +264,11 @@ spec:
               value: "-XX:MaxRAMPercentage=80"
           resources:
             requests:
-              memory: "2Gi"
-              cpu: "2"
+              memory: "350Mi"
+              cpu: "0.7"
             limits:
-              memory: "2Gi"
-              cpu: "2"
+              memory: "350Mi"
+              cpu: "0.7"
           ports:
             - name: kruize-port
               containerPort: 8080


### PR DESCRIPTION
## Description

By default kruize uses 2 cores of cpu and 2Gi of memory while deploying kruize. Reducing it to 0.7 cores - 350Mi for kruize and 0.5 cores - 100Mi for kruize-db
Also, pvc storage is reduced from 1Gi to 500Mi.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Tested with the new resources with kruize-demo and it works fine.

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on:  openshift

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

None
