### PR TITLE
[POC] Kruize VPA Integration PoC

### DIFF
--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -3,11 +3,62 @@ kind: Namespace
 metadata:
   name: openshift-tuning
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kruize-vpa-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - customresourcedefinitions
+    verbs:
+      - '*'
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - '*'
+  - apiGroups:
+      - autoscaling.k8s.io
+    resources:
+      - verticalpodautoscalers
+      - verticalpodautoscalercheckpoints
+    verbs:
+      - '*'
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - "*"
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kruize-sa
   namespace: openshift-tuning
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kruize-vpa-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: kruize-sa
+    namespace: openshift-tuning
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kruize-vpa-role
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>autotune</artifactId>
     <version>0.2</version>
     <properties>
-        <fabric8-version>4.13.2</fabric8-version>
+        <fabric8-version>6.13.4</fabric8-version>
         <org-json-version>20240303</org-json-version>
         <jetty-version>10.0.24</jetty-version>
         <slf4j-version>2.17.1</slf4j-version>
@@ -70,6 +70,12 @@
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
             <version>${fabric8-version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>verticalpodautoscaler-client</artifactId>
+            <version>6.13.4</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.json/json -->

--- a/src/main/java/com/autotune/Autotune.java
+++ b/src/main/java/com/autotune/Autotune.java
@@ -21,6 +21,7 @@ import com.autotune.analyzer.exceptions.KruizeErrorHandler;
 import com.autotune.analyzer.exceptions.MonitoringAgentNotFoundException;
 import com.autotune.analyzer.exceptions.MonitoringAgentNotSupportedException;
 import com.autotune.analyzer.performanceProfiles.MetricProfileCollection;
+import com.autotune.analyzer.recommendations.updater.vpa.VpaUpdaterImpl;
 import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.common.datasource.DataSourceCollection;
 import com.autotune.common.datasource.DataSourceInfo;
@@ -132,6 +133,8 @@ public class Autotune {
                 checkAvailableDataSources();
                 // load available metric profiles from db
                 loadMetricProfilesFromDB();
+                // start updaters
+                startRecommendationUpdaters();
 
             }
             // close the existing session factory before recreating
@@ -285,6 +288,10 @@ public class Autotune {
         }
 
         LOGGER.info(DBConstants.DB_MESSAGES.DB_LIVELINESS_PROBE_SUCCESS);
+    }
+
+    private static void startRecommendationUpdaters() {
+        VpaUpdaterImpl.getInstance().initiateUpdater();
     }
 
 }

--- a/src/main/java/com/autotune/analyzer/exceptions/InvalidRecommendationUpdaterType.java
+++ b/src/main/java/com/autotune/analyzer/exceptions/InvalidRecommendationUpdaterType.java
@@ -1,0 +1,11 @@
+package com.autotune.analyzer.exceptions;
+
+public class InvalidRecommendationUpdaterType extends Throwable
+{
+    public InvalidRecommendationUpdaterType() {
+    }
+
+    public InvalidRecommendationUpdaterType(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/autotune/analyzer/exceptions/VpaObjectCreateError.java
+++ b/src/main/java/com/autotune/analyzer/exceptions/VpaObjectCreateError.java
@@ -1,0 +1,11 @@
+package com.autotune.analyzer.exceptions;
+
+public class VpaObjectCreateError extends Throwable
+{
+    public VpaObjectCreateError() {
+    }
+
+    public VpaObjectCreateError(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/autotune/analyzer/kruizeObject/ExperimentUseCaseType.java
+++ b/src/main/java/com/autotune/analyzer/kruizeObject/ExperimentUseCaseType.java
@@ -43,7 +43,7 @@ public class ExperimentUseCaseType {
                 setLocal_monitoring(true);
             } else if (kruizeObject.getMode().equalsIgnoreCase(AnalyzerConstants.EXPERIMENT)) {
                 setLocal_experiment(true);
-            } else if (kruizeObject.getMode().equalsIgnoreCase(AnalyzerConstants.AUTO)) {
+            } else if (kruizeObject.getMode().equalsIgnoreCase(AnalyzerConstants.RECREATE) || kruizeObject.getMode().equalsIgnoreCase(AnalyzerConstants.AUTO)) {
                 setLocal_monitoring(true);
             } else {
                 throw new Exception("Invalid Mode " + kruizeObject.getMode() + " for target cluster as Local.");

--- a/src/main/java/com/autotune/analyzer/kruizeObject/ExperimentUseCaseType.java
+++ b/src/main/java/com/autotune/analyzer/kruizeObject/ExperimentUseCaseType.java
@@ -43,6 +43,8 @@ public class ExperimentUseCaseType {
                 setLocal_monitoring(true);
             } else if (kruizeObject.getMode().equalsIgnoreCase(AnalyzerConstants.EXPERIMENT)) {
                 setLocal_experiment(true);
+            } else if (kruizeObject.getMode().equalsIgnoreCase(AnalyzerConstants.AUTO)) {
+                setLocal_monitoring(true);
             } else {
                 throw new Exception("Invalid Mode " + kruizeObject.getMode() + " for target cluster as Local.");
             }

--- a/src/main/java/com/autotune/analyzer/kruizeObject/ExperimentUseCaseType.java
+++ b/src/main/java/com/autotune/analyzer/kruizeObject/ExperimentUseCaseType.java
@@ -43,7 +43,9 @@ public class ExperimentUseCaseType {
                 setLocal_monitoring(true);
             } else if (kruizeObject.getMode().equalsIgnoreCase(AnalyzerConstants.EXPERIMENT)) {
                 setLocal_experiment(true);
-            } else if (kruizeObject.getMode().equalsIgnoreCase(AnalyzerConstants.RECREATE) || kruizeObject.getMode().equalsIgnoreCase(AnalyzerConstants.AUTO)) {
+            } else if (kruizeObject.getMode().equalsIgnoreCase(AnalyzerConstants.RECREATE)) {
+                setLocal_monitoring(true);
+            } else if (kruizeObject.getMode().equalsIgnoreCase(AnalyzerConstants.AUTO)) {
                 setLocal_monitoring(true);
             } else {
                 throw new Exception("Invalid Mode " + kruizeObject.getMode() + " for target cluster as Local.");

--- a/src/main/java/com/autotune/analyzer/performanceProfiles/PerformanceProfilesDeployment.java
+++ b/src/main/java/com/autotune/analyzer/performanceProfiles/PerformanceProfilesDeployment.java
@@ -11,6 +11,7 @@ import com.autotune.utils.KubeEventLogger;
 import com.google.gson.Gson;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -65,7 +66,12 @@ public class PerformanceProfilesDeployment {
             }
 
             @Override
-            public void onClose(KubernetesClientException e) { }
+            public void onClose(WatcherException e) {
+
+            }
+
+//            @Override
+//            public void onClose(KubernetesClientException e) { }
         };
 
         KubernetesServices kubernetesServices = new KubernetesServicesImpl();

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -273,6 +273,7 @@ public class RecommendationEngine {
         if (!kruizeObject.getValidation_data().isSuccess())
             return kruizeObject;
         setKruizeObject(kruizeObject);
+        LOGGER.info("Setting Kruize Object.");
         mainKruizeExperimentMAP.put(kruizeObject.getExperimentName(), kruizeObject);
         // continue to generate recommendation when kruizeObject is successfully created
         try {
@@ -1771,10 +1772,11 @@ public class RecommendationEngine {
     private String getResults(Map<String, KruizeObject> mainKruizeExperimentMAP, KruizeObject kruizeObject,
                               String experimentName, Timestamp intervalStartTime, String dataSource) throws Exception, FetchMetricsError {
         String errorMsg = "";
-
+        LOGGER.info("Inside Get Results");
         mainKruizeExperimentMAP.put(experimentName, kruizeObject);
         // get data from the DB in case of remote monitoring
         if (kruizeObject.getExperiment_usecase_type().isRemote_monitoring()) {
+            LOGGER.info("Remote Monitoring.");
             try {
                 boolean resultsAvailable = new ExperimentDBService().loadResultsFromDBByName(mainKruizeExperimentMAP, experimentName, intervalStartTime, interval_end_time);
                 if (!resultsAvailable) {
@@ -1788,6 +1790,7 @@ public class RecommendationEngine {
                 LOGGER.error(String.format(AnalyzerErrorConstants.APIErrors.UpdateRecommendationsAPI.FETCHING_RESULTS_FAILED, e.getMessage()));
             }
         } else if (kruizeObject.getExperiment_usecase_type().isLocal_monitoring()) {
+            LOGGER.info("Local Monitoring.");
             // get data from the provided datasource in case of local monitoring
             DataSourceInfo dataSourceInfo;
             try {

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -2156,10 +2156,17 @@ public class RecommendationEngine {
                             }
 
                             // If promQL is determined, fetch metrics from the datasource
+//                            promQL = promQL
+//                                    .replace(AnalyzerConstants.NAMESPACE_VARIABLE, namespace)
+//                                    .replace(AnalyzerConstants.CONTAINER_VARIABLE, containerName)
+//                                    .replace(AnalyzerConstants.MEASUREMENT_DURATION_IN_MIN_VARAIBLE, Integer.toString(measurementDurationMinutesInDouble.intValue()))
+//                                    .replace(AnalyzerConstants.WORKLOAD_VARIABLE, workload)
+//                                    .replace(AnalyzerConstants.WORKLOAD_TYPE_VARIABLE, workload_type);
+
                             promQL = promQL
                                     .replace(AnalyzerConstants.NAMESPACE_VARIABLE, namespace)
                                     .replace(AnalyzerConstants.CONTAINER_VARIABLE, containerName)
-                                    .replace(AnalyzerConstants.MEASUREMENT_DURATION_IN_MIN_VARAIBLE, Integer.toString(measurementDurationMinutesInDouble.intValue()))
+                                    .replace(AnalyzerConstants.MEASUREMENT_DURATION_IN_MIN_VARAIBLE, Integer.toString(1))
                                     .replace(AnalyzerConstants.WORKLOAD_VARIABLE, workload)
                                     .replace(AnalyzerConstants.WORKLOAD_TYPE_VARIABLE, workload_type);
 

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -1772,11 +1772,9 @@ public class RecommendationEngine {
     private String getResults(Map<String, KruizeObject> mainKruizeExperimentMAP, KruizeObject kruizeObject,
                               String experimentName, Timestamp intervalStartTime, String dataSource) throws Exception, FetchMetricsError {
         String errorMsg = "";
-        LOGGER.info("Inside Get Results");
         mainKruizeExperimentMAP.put(experimentName, kruizeObject);
         // get data from the DB in case of remote monitoring
         if (kruizeObject.getExperiment_usecase_type().isRemote_monitoring()) {
-            LOGGER.info("Remote Monitoring.");
             try {
                 boolean resultsAvailable = new ExperimentDBService().loadResultsFromDBByName(mainKruizeExperimentMAP, experimentName, intervalStartTime, interval_end_time);
                 if (!resultsAvailable) {
@@ -1790,7 +1788,6 @@ public class RecommendationEngine {
                 LOGGER.error(String.format(AnalyzerErrorConstants.APIErrors.UpdateRecommendationsAPI.FETCHING_RESULTS_FAILED, e.getMessage()));
             }
         } else if (kruizeObject.getExperiment_usecase_type().isLocal_monitoring()) {
-            LOGGER.info("Local Monitoring.");
             // get data from the provided datasource in case of local monitoring
             DataSourceInfo dataSourceInfo;
             try {

--- a/src/main/java/com/autotune/analyzer/recommendations/updater/RecommendationUpdater.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/updater/RecommendationUpdater.java
@@ -1,0 +1,8 @@
+package com.autotune.analyzer.recommendations.updater;
+
+import com.autotune.analyzer.exceptions.InvalidRecommendationUpdaterType;
+
+public interface RecommendationUpdater {
+    RecommendationUpdaterImpl getUpdater(String updaterType) throws InvalidRecommendationUpdaterType;
+    boolean isUpdaterInstalled();
+}

--- a/src/main/java/com/autotune/analyzer/recommendations/updater/RecommendationUpdaterImpl.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/updater/RecommendationUpdaterImpl.java
@@ -1,0 +1,25 @@
+package com.autotune.analyzer.recommendations.updater;
+
+import com.autotune.analyzer.exceptions.InvalidRecommendationUpdaterType;
+import com.autotune.analyzer.recommendations.updater.vpa.VpaUpdaterImpl;
+import com.autotune.analyzer.utils.AnalyzerConstants;
+import com.autotune.analyzer.utils.AnalyzerErrorConstants;
+
+import java.util.Objects;
+
+public class RecommendationUpdaterImpl implements RecommendationUpdater{
+
+    @Override
+    public RecommendationUpdaterImpl getUpdater(String updaterType) throws InvalidRecommendationUpdaterType {
+        if (AnalyzerConstants.RecommendationUpdaterConstants.VPA_UPDATER.equalsIgnoreCase(updaterType)) {
+            return VpaUpdaterImpl.getInstance();
+        } else {
+            throw new InvalidRecommendationUpdaterType(String.format(AnalyzerErrorConstants.RecommendationUpdaterErrorConstant.INVALID_UPDATER_TYPE, updaterType));
+        }
+    }
+
+    @Override
+    public boolean isUpdaterInstalled() {
+        return false;
+    }
+}

--- a/src/main/java/com/autotune/analyzer/recommendations/updater/vpa/VpaUpdaterImpl.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/updater/vpa/VpaUpdaterImpl.java
@@ -94,20 +94,20 @@ public class VpaUpdaterImpl extends RecommendationUpdaterImpl {
 
     private void getRecommendationsAndUpdateVpas() {
         try {
-            LOGGER.info("\\u001B[32m Checking Available VPA Objects - \\u001B[0m");
+            LOGGER.info("Checking Available VPA Objects...");
             NamespacedVerticalPodAutoscalerClient client = new DefaultVerticalPodAutoscalerClient();
             VerticalPodAutoscalerList vpas = client.v1().verticalpodautoscalers().inAnyNamespace().list();
-            LOGGER.info("\\u001B[33m Found " + vpas.getItems().size() + " vpa objects. \\u001B[0m");
+            LOGGER.info("Found " + vpas.getItems().size() + " vpa objects.");
 
 //            List<VerticalPodAutoscaler> vpasList = selectVpasForKruizeRecommender(vpas.getItems());
             for (VerticalPodAutoscaler vpa: vpas.getItems()) {
                 String name = vpa.getMetadata().getName();
-                LOGGER.info("\\u001B[33m Generating Recommendations For VPA - " +  name + " \\u001B[0m");
+                LOGGER.info("Generating Recommendations For VPA - " +  name );
                 VerticalPodAutoscalerStatus vpaStatus = generateRecommendations(name);
                 if (vpaStatus != null) {
                     vpa.setStatus(vpaStatus);
                     client.v1().verticalpodautoscalers().inNamespace(vpa.getMetadata().getNamespace()).withName(vpa.getMetadata().getName()).patchStatus(vpa);
-                    LOGGER.info("\\u001B[33m VPA Object is patched with recommendations successfully. \\u001B[0m");
+                    LOGGER.info("VPA Object is patched with recommendations successfully.");
                 }
             }
         } catch (Exception e) {
@@ -123,12 +123,12 @@ public class VpaUpdaterImpl extends RecommendationUpdaterImpl {
             if (validationMessage.isEmpty()) {
                 KruizeObject kruizeObject = recommendationEngine.prepareRecommendations(calCount);
                 if (kruizeObject.getValidation_data().isSuccess()) {
-                    LOGGER.info("\\u001B[33m Recommendations generated. \\u001B[0m");
+                    LOGGER.info("Recommendations generated.");
                     for (K8sObject k8sObject: kruizeObject.getKubernetes_objects()) {
 //                        LOGGER.info(k8sObject.getContainerDataMap().toString());
                         List<RecommendedContainerResources> recoms = convertRecommendationsToContainerPolicy(k8sObject.getContainerDataMap());
                         if (recoms.isEmpty()){
-                            LOGGER.error("\\u001B[33m No Recommendations could be generated. \\u001B[0m");
+                            LOGGER.error("No Recommendations could be generated.");
                         } else {
                             RecommendedPodResources recommendedPodResources = new RecommendedPodResources();
                             recommendedPodResources.setContainerRecommendations(recoms);
@@ -139,7 +139,7 @@ public class VpaUpdaterImpl extends RecommendationUpdaterImpl {
                         }
                     }
                 } else {
-                    LOGGER.error("\\u001B[31m Failed to generate recommendations. \\u001B[0m");
+                    LOGGER.error("Failed to generate recommendations.");
                 }
             } else {
                 LOGGER.error(validationMessage);
@@ -163,8 +163,8 @@ public class VpaUpdaterImpl extends RecommendationUpdaterImpl {
                     HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> config = termRecommendations.getCostRecommendations().getConfig();
                     Double shortTermCpu = config.get(AnalyzerConstants.ResourceSetting.requests).get(AnalyzerConstants.RecommendationItem.CPU).getAmount();
                     Double shortTermMemory = config.get(AnalyzerConstants.ResourceSetting.requests).get(AnalyzerConstants.RecommendationItem.MEMORY).getAmount();
-                    LOGGER.info("\\u001B[33m Recommended cpu value for container " + containerName + " - " + shortTermCpu + "\\u001B[0m");
-                    LOGGER.info("\\u001B[33m Recommended memory value for container " + containerName + " - " + shortTermMemory + "\\u001B[0m");
+                    LOGGER.info("Recommended cpu value for container " + containerName + " - " + shortTermCpu);
+                    LOGGER.info("Recommended memory value for container " + containerName + " - " + shortTermMemory);
                     String finalCpu = resource2str("cpu", shortTermCpu);
                     String finalMemory = resource2str("memory", shortTermMemory);
 
@@ -192,7 +192,7 @@ public class VpaUpdaterImpl extends RecommendationUpdaterImpl {
                     containerRecommendations.add(recommendedContainerResources);
                 }
             } else {
-                LOGGER.error("\\u001B[33m No Recommendation Data. \\u001B[0m");
+                LOGGER.error("No Recommendation Data.");
             }
         }
         return containerRecommendations;

--- a/src/main/java/com/autotune/analyzer/recommendations/updater/vpa/VpaUpdaterImpl.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/updater/vpa/VpaUpdaterImpl.java
@@ -1,0 +1,303 @@
+package com.autotune.analyzer.recommendations.updater.vpa;
+
+import com.autotune.analyzer.exceptions.FetchMetricsError;
+import com.autotune.analyzer.exceptions.VpaObjectCreateError;
+import com.autotune.analyzer.kruizeObject.KruizeObject;
+import com.autotune.analyzer.recommendations.ContainerRecommendations;
+import com.autotune.analyzer.recommendations.RecommendationConfigItem;
+import com.autotune.analyzer.recommendations.engine.RecommendationEngine;
+import com.autotune.analyzer.recommendations.objects.MappedRecommendationForTimestamp;
+import com.autotune.analyzer.recommendations.objects.TermRecommendations;
+import com.autotune.analyzer.recommendations.updater.RecommendationUpdaterImpl;
+import com.autotune.analyzer.serviceObjects.ContainerAPIObject;
+import com.autotune.analyzer.serviceObjects.KubernetesAPIObject;
+import com.autotune.analyzer.utils.AnalyzerConstants;
+import com.autotune.analyzer.utils.AnalyzerErrorConstants;
+import com.autotune.common.data.result.ContainerData;
+import com.autotune.common.k8sObjects.K8sObject;
+import com.autotune.utils.KruizeConstants;
+import com.autotune.utils.Utils;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionList;
+import io.fabric8.kubernetes.api.model.autoscaling.v1.CrossVersionObjectReferenceBuilder;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.ApiextensionsAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
+import io.fabric8.verticalpodautoscaler.client.DefaultVerticalPodAutoscalerClient;
+import io.fabric8.verticalpodautoscaler.client.NamespacedVerticalPodAutoscalerClient;
+import io.fabric8.verticalpodautoscaler.client.dsl.V1APIGroupDSL;
+import io.fabric8.verticalpodautoscaler.api.model.v1.*;
+import io.fabric8.verticalpodautoscaler.client.VerticalPodAutoscalerClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class VpaUpdaterImpl extends RecommendationUpdaterImpl {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(VpaUpdaterImpl.class);
+    private static VpaUpdaterImpl vpaUpdater = new VpaUpdaterImpl();
+
+    private KubernetesClient kubernetesClient;
+    private ApiextensionsAPIGroupDSL apiextensionsClient;
+    boolean isVpaInstalled = false;
+    private String recommendationTerm;
+    private String recommendationEngine;
+    private int sleepWindow;
+
+
+    private VpaUpdaterImpl() {
+        this.kubernetesClient = new DefaultKubernetesClient();
+        this.apiextensionsClient = kubernetesClient.apiextensions();
+        this.isVpaInstalled = isUpdaterInstalled();
+    }
+
+    public static VpaUpdaterImpl getInstance() {
+        return vpaUpdater;
+    }
+
+    @Override
+    public boolean isUpdaterInstalled() {
+        CustomResourceDefinitionList crdList = apiextensionsClient.v1().customResourceDefinitions().list();
+        this.isVpaInstalled = crdList.getItems().stream().anyMatch(crd -> AnalyzerConstants.RecommendationUpdaterConstants.VERTICAL_POD_AUTOSCALER.equalsIgnoreCase(crd.getSpec().getNames().getKind()));
+        return isVpaInstalled;
+    }
+
+    public void initiateUpdater() {
+        LOGGER.info("Trying to start the VPA updater.");
+        ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+
+        if (!isVpaInstalled) {
+            LOGGER.error(AnalyzerErrorConstants.RecommendationUpdaterErrorConstant.VPA_NOT_INSTALLED);
+        } else {
+            setVpaUpdaterConfigs();
+            LOGGER.info(AnalyzerConstants.RecommendationUpdaterConstants.STARTING_VPA_INFO_MSG);
+            executorService.scheduleAtFixedRate(() -> {
+                try {
+                    getRecommendationsAndUpdateVpas();
+                } catch (Exception e) {
+                    LOGGER.error(String.format(AnalyzerErrorConstants.RecommendationUpdaterErrorConstant.ERROR_PROCESSING_THREADS, e.getMessage()));
+                }
+            }, 0, sleepWindow, TimeUnit.SECONDS);
+        }
+    }
+
+    private void getRecommendationsAndUpdateVpas() {
+        try {
+            LOGGER.info("Checking Available VPA Objects - ");
+            NamespacedVerticalPodAutoscalerClient client = new DefaultVerticalPodAutoscalerClient();
+            VerticalPodAutoscalerList vpas = client.v1().verticalpodautoscalers().inAnyNamespace().list();
+            LOGGER.info("Found vpa objects." + " " + vpas.getItems().size());
+
+//            List<VerticalPodAutoscaler> vpasList = selectVpasForKruizeRecommender(vpas.getItems());
+            for (VerticalPodAutoscaler vpa: vpas.getItems()) {
+                String name = vpa.getMetadata().getName();
+                LOGGER.info("Generating Recommendations For VPA {}", name);
+                VerticalPodAutoscalerStatus vpaStatus = generateRecommendations(name);
+                if (vpaStatus != null) {
+                    vpa.setStatus(vpaStatus);
+                    client.v1().verticalpodautoscalers().inNamespace(vpa.getMetadata().getNamespace()).withName(vpa.getMetadata().getName()).patchStatus(vpa);
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.error(e.getMessage());
+        }
+    }
+
+    private VerticalPodAutoscalerStatus generateRecommendations(String name) {
+        try {
+            RecommendationEngine recommendationEngine = new RecommendationEngine(name, null, null);
+            int calCount = 0;
+            LOGGER.info("Inside GR.");
+            String validationMessage = recommendationEngine.validate_local();
+            LOGGER.info("Validation msg - " + validationMessage);
+            if (validationMessage.isEmpty()) {
+                KruizeObject kruizeObject = recommendationEngine.prepareRecommendations(calCount);
+                if (kruizeObject.getValidation_data().isSuccess()) {
+                    LOGGER.info("Recommendations generated.");
+                    for (K8sObject k8sObject: kruizeObject.getKubernetes_objects()) {
+//                        LOGGER.info(k8sObject.getContainerDataMap().toString());
+                        List<RecommendedContainerResources> recoms = convertRecommendationsToContainerPolicy(k8sObject.getContainerDataMap());
+                        if (recoms.isEmpty()){
+                            LOGGER.error("NO RECOMS");
+                        } else {
+                            RecommendedPodResources recommendedPodResources = new RecommendedPodResources();
+                            recommendedPodResources.setContainerRecommendations(recoms);
+                            VerticalPodAutoscalerStatus vpaStatus = new VerticalPodAutoscalerStatusBuilder()
+                                    .withRecommendation(recommendedPodResources)
+                                    .build();
+                            return vpaStatus;
+                        }
+                    }
+                } else {
+                    LOGGER.error("Failed to generate recommendations.");
+                }
+            } else {
+                LOGGER.error(validationMessage);
+            }
+        }  catch (Exception | FetchMetricsError e) {
+            LOGGER.error(e.getMessage());
+        }
+        return null;
+    }
+
+    private List<RecommendedContainerResources>  convertRecommendationsToContainerPolicy(HashMap<String, ContainerData> containerDataMap) {
+        List<RecommendedContainerResources> containerRecommendations = new ArrayList<>();
+        for (Map.Entry<String, ContainerData> entry : containerDataMap.entrySet()) {
+            String name = entry.getKey();
+            ContainerData data = entry.getValue();
+            String containerName = data.getContainer_name();
+            HashMap<Timestamp, MappedRecommendationForTimestamp> recommendationData = data.getContainerRecommendations().getData();
+            if (recommendationData != null) {
+                for (MappedRecommendationForTimestamp value : recommendationData.values()) {
+                    TermRecommendations termRecommendations = value.getShortTermRecommendations();
+                    HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> config = termRecommendations.getCostRecommendations().getConfig();
+                    Double shortTermCpu = config.get(AnalyzerConstants.ResourceSetting.requests).get(AnalyzerConstants.RecommendationItem.CPU).getAmount();
+                    Double shortTermMemory = config.get(AnalyzerConstants.ResourceSetting.requests).get(AnalyzerConstants.RecommendationItem.MEMORY).getAmount();
+                    LOGGER.info("CPU - " + shortTermCpu + " " + containerName);
+                    LOGGER.info("Memory - " + shortTermMemory + " " + containerName);
+                    String finalCpu = resource2str("cpu", shortTermCpu);
+                    String finalMemory = resource2str("memory", shortTermMemory);
+
+                    RecommendedContainerResources recommendedContainerResources = new RecommendedContainerResources();
+////                    Map<String, Quantity>
+                    recommendedContainerResources.setContainerName(containerName);
+//                    recommendedContainerResources.setLowerBound();
+
+                    Map<String, Quantity> target = new HashMap<>();
+                    target.put("cpu", new Quantity(finalCpu)); // Target 1 CPU
+                    target.put("memory", new Quantity(finalMemory)); // Target 1 Gi memory
+
+                    Map<String, Quantity> lowerBound = new HashMap<>();
+                    lowerBound.put("cpu", new Quantity(finalCpu)); // Lower bound 0.5 CPU
+                    lowerBound.put("memory", new Quantity(finalMemory)); // Lower bound 512 Mi memory
+
+                    Map<String, Quantity> upperBound = new HashMap<>();
+                    upperBound.put("cpu", new Quantity(finalCpu)); // Upper bound 2 CPUs
+                    upperBound.put("memory", new Quantity(finalMemory)); // Upper bound 2 Gi memory
+
+                    recommendedContainerResources.setLowerBound(lowerBound);
+                    recommendedContainerResources.setTarget(target);
+                    recommendedContainerResources.setUpperBound(upperBound);
+
+                    containerRecommendations.add(recommendedContainerResources);
+                }
+            } else {
+                LOGGER.error("No Recommendation Data.");
+            }
+        }
+        return containerRecommendations;
+    }
+
+    public static String resource2str(String resource, double value) {
+        if (resource.equalsIgnoreCase("cpu")) {
+            if (value < 1) {
+                return (int) (value * 1000) + "m";
+            } else {
+                return String.valueOf(value);
+            }
+        } else {
+            if (value < 1024) {
+                return (int) value + "B";
+            } else if (value < 1024 * 1024) {
+                return (int) (value / 1024) + "k";
+            } else if (value < 1024 * 1024 * 1024) {
+                return (int) (value / 1024 / 1024) + "Mi";
+            } else {
+                return (int) (value / 1024 / 1024 / 1024) + "Gi";
+            }
+        }
+    }
+
+//    private List<VerticalPodAutoscaler> selectVpasForKruizeRecommender(List<VerticalPodAutoscaler> vpasList) {
+//        List<VerticalPodAutoscaler> selectedVpas = new ArrayList<>();
+//        for (VerticalPodAutoscaler vpa : vpasList) {
+////            LOGGER.info(vpa.getAdditionalProperties().get(AnalyzerConstants.RecommendationUpdaterConstants.RECOMMENDERS).toString());
+////            if (vpa.getAdditionalProperties().containsKey(AnalyzerConstants.RecommendationUpdaterConstants.RECOMMENDERS)) {
+//                List<Map<String, Object>> recommenders = (List<Map<String, Object>>) vpa.getAdditionalProperties().get(AnalyzerConstants.RecommendationUpdaterConstants.RECOMMENDERS);
+//                for (Map<String, Object> recommender : recommenders) {
+////                    if (recommender.get("name").toString().equalsIgnoreCase("kruize")) {
+//                        selectedVpas.add(vpa);
+////                    }
+////                }
+////            }
+//        }
+//        return selectedVpas;
+//    }
+
+    public void createVpaObject(String vpaName, String deploymentName, String namespace, List<ContainerAPIObject> containersList) throws VpaObjectCreateError {
+        try {
+            if (isVpaInstalled) {
+                LOGGER.info(AnalyzerConstants.RecommendationUpdaterConstants.CREATING_VPA_OBJECT_INFO_MSG + " " + vpaName);
+                Map<String, Object> additionalVpaObjectProps = new HashMap<>();
+                List<Map<String, Object>> recommenders = new ArrayList<>();
+                Map<String, Object> recommender = new HashMap<>();
+                recommender.put("name", "kruize");
+                recommenders.add(recommender);
+
+                additionalVpaObjectProps.put(AnalyzerConstants.RecommendationUpdaterConstants.RECOMMENDERS, recommenders);
+
+                List<String> controlledResources = new ArrayList<>();
+                controlledResources.add("cpu");
+                controlledResources.add("memory");
+
+                List<ContainerResourcePolicy> containerPolicies = new ArrayList<>();
+                for (ContainerAPIObject container : containersList) {
+                    ContainerResourcePolicy policy = new ContainerResourcePolicyBuilder()
+                            .withContainerName(container.getContainer_name())
+                            .withControlledResources(controlledResources)
+                            .build();
+                    containerPolicies.add(policy);
+                }
+
+                PodResourcePolicy podPolicy = new PodResourcePolicyBuilder()
+                        .withContainerPolicies(containerPolicies)
+                        .build();
+
+                VerticalPodAutoscaler vpa = new VerticalPodAutoscalerBuilder()
+                        .withApiVersion(AnalyzerConstants.RecommendationUpdaterConstants.VPA_API_VERSION)
+                        .withKind(AnalyzerConstants.RecommendationUpdaterConstants.VERTICAL_POD_AUTOSCALER)
+                        .withMetadata(new ObjectMeta() {{
+                            setName(vpaName);
+                        }})
+                        .withSpec(new VerticalPodAutoscalerSpecBuilder()
+                                .withTargetRef(new CrossVersionObjectReferenceBuilder()
+                                        .withApiVersion(AnalyzerConstants.RecommendationUpdaterConstants.VPA_TARGET_REF_API_VERSION)
+                                        .withKind(AnalyzerConstants.RecommendationUpdaterConstants.VPA_TARGET_REF_KIND)
+                                        .withName(deploymentName)
+                                        .build())
+                                .withResourcePolicy(podPolicy)
+                                .withAdditionalProperties(additionalVpaObjectProps)
+                                .build())
+                        .build();
+
+//                NamespacedVerticalPodAutoscalerClient vpaClient = new DefaultVerticalPodAutoscalerClient();
+//                vpaClient.v1().verticalpodautoscalers().inNamespace(namespace).resource(vpa).create();
+
+                kubernetesClient.resource(vpa).inNamespace(namespace).createOrReplace();
+
+                LOGGER.info(AnalyzerConstants.RecommendationUpdaterConstants.CREATED_VPA_OBJECT_INFO_MSG + " " + vpaName);
+            } else {
+                throw new VpaObjectCreateError(AnalyzerErrorConstants.RecommendationUpdaterErrorConstant.VPA_NOT_INSTALLED);
+            }
+        } catch (Exception e) {
+            throw new VpaObjectCreateError(e.getMessage());
+        }
+    }
+
+    private void setVpaUpdaterConfigs() {
+        this.recommendationTerm = AnalyzerConstants.RecommendationUpdaterConstants.DEFAULT_RECOMMENDATION_TERM;
+        this.recommendationEngine = AnalyzerConstants.RecommendationUpdaterConstants.DEFAULT_RECOMMENDATION_ENGINE;
+        this.sleepWindow = AnalyzerConstants.RecommendationUpdaterConstants.SLEEP_WINDOW;
+    }
+}

--- a/src/main/java/com/autotune/analyzer/serviceObjects/CreateExperimentAPIObject.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/CreateExperimentAPIObject.java
@@ -26,6 +26,7 @@ import com.autotune.utils.KruizeConstants;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Simulating the KruizeObject class for the CreateExperiment API
@@ -168,6 +169,10 @@ public class CreateExperimentAPIObject extends BaseSO implements ExperimentTypeA
     @Override
     public boolean isContainerExperiment() {
         return ExperimentTypeUtil.isContainerExperiment(experimentType);
+    }
+
+    public boolean isAutoMode() {
+        return AnalyzerConstants.AUTO.equalsIgnoreCase(this.mode);
     }
 
     @Override

--- a/src/main/java/com/autotune/analyzer/serviceObjects/CreateExperimentAPIObject.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/CreateExperimentAPIObject.java
@@ -172,7 +172,7 @@ public class CreateExperimentAPIObject extends BaseSO implements ExperimentTypeA
     }
 
     public boolean isAutoMode() {
-        return AnalyzerConstants.AUTO.equalsIgnoreCase(this.mode);
+        return (AnalyzerConstants.AUTO.equalsIgnoreCase(this.mode) || AnalyzerConstants.RECREATE.equalsIgnoreCase(this.mode));
     }
 
     @Override

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -30,6 +30,7 @@ public class AnalyzerConstants {
     public static final String EXPERIMENT = "experiment";
     public static final String LOCAL = "local";
     public static final String REMOTE = "remote";
+    public static final String AUTO = "auto";
 
 
     // Used to parse autotune configmaps
@@ -665,5 +666,24 @@ public class AnalyzerConstants {
 
             }
         }
+    }
+
+    public static final class RecommendationUpdaterConstants {
+        public static final String VPA_UPDATER = "vpa";
+        public static final String VERTICAL_POD_AUTOSCALER = "VerticalPodAutoscaler";
+        public static final String VPA_API_VERSION = "autoscaling.k8s.io/v1";
+        public static final String VPA_TARGET_REF_API_VERSION = "apps/v1";
+        public static final String VPA_TARGET_REF_KIND = "Deployment";
+        public static final String RECOMMENDERS = "recommenders";
+        public static final String KRUIZE_RECOMMENDER = "[{\"recommenderName\":\"kruize\"}]";
+        public static final String AUTO_MODE = "auto";
+
+        public static final String DEFAULT_RECOMMENDATION_TERM = "short_term";
+        public static final String DEFAULT_RECOMMENDATION_ENGINE = "cost";
+        public static final int SLEEP_WINDOW = 60;
+
+        public static final String CREATING_VPA_OBJECT_INFO_MSG = "Creating VPA Object - {}.";
+        public static final String CREATED_VPA_OBJECT_INFO_MSG = "Created VPA Object - {}.";
+        public static final String STARTING_VPA_INFO_MSG = "Starting VPA updater. VPA CRD found.";
     }
 }

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -686,6 +686,6 @@ public class AnalyzerConstants {
 
         public static final String CREATING_VPA_OBJECT_INFO_MSG = "Creating VPA Object - {}.";
         public static final String CREATED_VPA_OBJECT_INFO_MSG = "Created VPA Object - {}.";
-        public static final String STARTING_VPA_INFO_MSG = "\\u001B[32mStarting VPA updater... VPA CRD found.\\u001B[0m";
+        public static final String STARTING_VPA_INFO_MSG = "Starting VPA updater... VPA CRD found.";
     }
 }

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -31,6 +31,7 @@ public class AnalyzerConstants {
     public static final String LOCAL = "local";
     public static final String REMOTE = "remote";
     public static final String AUTO = "auto";
+    public static final String RECREATE = "recreate";
 
 
     // Used to parse autotune configmaps
@@ -677,6 +678,7 @@ public class AnalyzerConstants {
         public static final String RECOMMENDERS = "recommenders";
         public static final String KRUIZE_RECOMMENDER = "[{\"recommenderName\":\"kruize\"}]";
         public static final String AUTO_MODE = "auto";
+        public static final String RECREATE_MODE = "recreate";
 
         public static final String DEFAULT_RECOMMENDATION_TERM = "short_term";
         public static final String DEFAULT_RECOMMENDATION_ENGINE = "cost";
@@ -684,6 +686,6 @@ public class AnalyzerConstants {
 
         public static final String CREATING_VPA_OBJECT_INFO_MSG = "Creating VPA Object - {}.";
         public static final String CREATED_VPA_OBJECT_INFO_MSG = "Created VPA Object - {}.";
-        public static final String STARTING_VPA_INFO_MSG = "Starting VPA updater. VPA CRD found.";
+        public static final String STARTING_VPA_INFO_MSG = "\\u001B[32mStarting VPA updater... VPA CRD found.\\u001B[0m";
     }
 }

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
@@ -286,4 +286,11 @@ public class AnalyzerErrorConstants {
             }
         }
     }
+
+    public static final class RecommendationUpdaterErrorConstant {
+        public static final String INVALID_UPDATER_TYPE = "Recommendation updater {} type is not supported.";
+        public static final String VPA_OBJECT_CREATION_FAILED = "Unable to create VPA object for experiment - {}.";
+        public static final String VPA_NOT_INSTALLED = "VPA is not installed.";
+        public static final String ERROR_PROCESSING_THREADS = "Error processing VPAs in background thread - {}";
+    }
 }

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
@@ -288,9 +288,9 @@ public class AnalyzerErrorConstants {
     }
 
     public static final class RecommendationUpdaterErrorConstant {
-        public static final String INVALID_UPDATER_TYPE = "Recommendation updater {} type is not supported.";
-        public static final String VPA_OBJECT_CREATION_FAILED = "Unable to create VPA object for experiment - {}.";
-        public static final String VPA_NOT_INSTALLED = "VPA is not installed.";
-        public static final String ERROR_PROCESSING_THREADS = "Error processing VPAs in background thread - {}";
+        public static final String INVALID_UPDATER_TYPE = "\\u001B[31m Recommendation updater %s type is not supported. \\u001B[0m";
+        public static final String VPA_OBJECT_CREATION_FAILED = "\\u001B[31m Unable to create VPA object for experiment - %s \\u001B[0m";
+        public static final String VPA_NOT_INSTALLED = "\\u001B[31m VPA is not installed. \\u001B[0m";
+        public static final String ERROR_PROCESSING_THREADS = "\\u001B[31m Error processing VPAs in background thread - %s \\u001B[0m";
     }
 }

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
@@ -288,9 +288,9 @@ public class AnalyzerErrorConstants {
     }
 
     public static final class RecommendationUpdaterErrorConstant {
-        public static final String INVALID_UPDATER_TYPE = "\\u001B[31m Recommendation updater %s type is not supported. \\u001B[0m";
-        public static final String VPA_OBJECT_CREATION_FAILED = "\\u001B[31m Unable to create VPA object for experiment - %s \\u001B[0m";
-        public static final String VPA_NOT_INSTALLED = "\\u001B[31m VPA is not installed. \\u001B[0m";
-        public static final String ERROR_PROCESSING_THREADS = "\\u001B[31m Error processing VPAs in background thread - %s \\u001B[0m";
+        public static final String INVALID_UPDATER_TYPE = "Recommendation updater %s type is not supported.";
+        public static final String VPA_OBJECT_CREATION_FAILED = "Unable to create VPA object for experiment - %s";
+        public static final String VPA_NOT_INSTALLED = "VPA is not installed.";
+        public static final String ERROR_PROCESSING_THREADS = "Error processing VPAs in background thread - %s";
     }
 }

--- a/src/main/java/com/autotune/common/target/kubernetes/service/impl/KubernetesServicesImpl.java
+++ b/src/main/java/com/autotune/common/target/kubernetes/service/impl/KubernetesServicesImpl.java
@@ -26,12 +26,9 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentSpec;
 import io.fabric8.kubernetes.api.model.apps.DeploymentStatus;
 import io.fabric8.kubernetes.api.model.apps.ReplicaSet;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.*;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
-import io.fabric8.kubernetes.client.dsl.internal.RawCustomResourceOperationsImpl;
+//import io.fabric8.kubernetes.client.dsl.internal.RawCustomResourceOperationsImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -226,7 +223,11 @@ public class KubernetesServicesImpl implements KubernetesServices {
     public Map<String, Object> getCRDEnvMap(CustomResourceDefinitionContext crd, String namespace, String kubernetesType) {
         Map<String, Object> envMap = null;
         try {
-            envMap = kubernetesClient.customResource(crd).get(namespace, kubernetesType);
+//            envMap = kubernetesClient.customResource(crd).get(namespace, kubernetesType);
+            envMap = (Map<String, Object>) kubernetesClient.genericKubernetesResources(crd)
+                    .inNamespace(namespace)
+                    .withName(kubernetesType)
+                    .get();
         } catch (Exception e) {
             new TargetHandlerException(e, "getCRDEnvMap failed!");
         }
@@ -418,9 +419,10 @@ public class KubernetesServicesImpl implements KubernetesServices {
     @Override
     public void addWatcher(CustomResourceDefinitionContext crd, Watcher watcher) {
         try {
-            RawCustomResourceOperationsImpl rawCustomResourceOperations = kubernetesClient.customResource(crd);
-            if (null != rawCustomResourceOperations.list())
-                rawCustomResourceOperations.watch(watcher);
+            kubernetesClient.genericKubernetesResources(crd).watch(watcher);
+//            RawCustomResourceOperationsImpl rawCustomResourceOperations = kubernetesClient.customResource(crd);
+//            if (null != rawCustomResourceOperations.list())
+//                rawCustomResourceOperations.watch(watcher);
         } catch (Exception e) {
             LOGGER.warn("Watcher not added! Only REST API access is enabled.");
         }
@@ -437,7 +439,8 @@ public class KubernetesServicesImpl implements KubernetesServices {
     public Event getEvent(String namespace, String eventName) {
         Event event = null;
         try {
-            event = kubernetesClient.events().inNamespace(namespace).withName(eventName).get();
+            event = kubernetesClient.v1().events().inNamespace(namespace).withName(eventName).get();
+//            event = kubernetesClient.events().inNamespace(namespace).withName(eventName).get();
         } catch (Exception e) {
             new TargetHandlerException(e, "getEvent failed! Event : " + event + " not found!");
         }
@@ -456,7 +459,8 @@ public class KubernetesServicesImpl implements KubernetesServices {
     public boolean replaceEvent(String namespace, String eventName, Event newEvent) {
         boolean replaced = false;
         try {
-            kubernetesClient.events().inNamespace(namespace).withName(eventName).replace(newEvent);
+            kubernetesClient.v1().events().inNamespace(namespace).withName(eventName).replace(newEvent);
+//            kubernetesClient.events().inNamespace(namespace).withName(eventName).replace(newEvent);
             replaced = true;
         } catch (Exception e) {
             new TargetHandlerException(e, "replaceEvent for the eventName " + eventName + " failed!");
@@ -476,7 +480,8 @@ public class KubernetesServicesImpl implements KubernetesServices {
     public boolean createEvent(String namespace, String eventName, Event newEvent) {
         boolean created = false;
         try {
-            kubernetesClient.events().inNamespace(namespace).withName(eventName).create(newEvent);
+            kubernetesClient.v1().events().inNamespace(namespace).withName(eventName).create(newEvent);
+//            kubernetesClient.events().inNamespace(namespace).withName(eventName).create(newEvent);
             created = true;
         } catch (Exception e) {
             new TargetHandlerException(e, "createEvent for the eventName " + eventName + " failed!");
@@ -491,21 +496,34 @@ public class KubernetesServicesImpl implements KubernetesServices {
      */
     @Override
     public void watchEndpoints(CustomResourceDefinitionContext crd) {
-        Watcher<String> autotuneObjectWatcher = new Watcher<>() {
+//        Watcher<String> autotuneObjectWatcher = new Watcher<>() {
+        Watcher<GenericKubernetesResource> autotuneObjectWatcher = new Watcher<>() {
+
+//            @Override
+//            public void eventReceived(Action action, String resource) {
+//            }
 
             @Override
-            public void eventReceived(Action action, String resource) {
+            public void eventReceived(Action action, GenericKubernetesResource genericKubernetesResource) {
+
             }
 
             @Override
-            public void onClose(KubernetesClientException cause) {
+            public void onClose(WatcherException e) {
+
             }
+
+//            @Override
+//            public void onClose(KubernetesClientException cause) {
+//            }
         };
-        try {
-            kubernetesClient.customResource(crd).watch(autotuneObjectWatcher);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+        kubernetesClient.genericKubernetesResources(crd).watch(autotuneObjectWatcher);
+//        try {
+//            kubernetesClient.genericKubernetesResources(crd).watch(autotuneObjectWatcher);
+//           kubernetesClient.customResource(crd).watch(autotuneObjectWatcher);
+//        } catch (IOException e) {
+//            e.printStackTrace();
+//        }
     }
 
     @Override

--- a/src/main/java/com/autotune/experimentManager/transitions/TransitionToCreateConfig.java
+++ b/src/main/java/com/autotune/experimentManager/transitions/TransitionToCreateConfig.java
@@ -32,7 +32,7 @@ public class TransitionToCreateConfig extends AbstractBaseTransition {
         IntOrString maxUnavailable = new IntOrString(0);
         rud.setMaxSurge(maxSurge);
         rud.setMaxUnavailable(maxUnavailable);
-        client.apps().deployments().inNamespace(trialData.getConfig().getDeploymentNamespace()).withName(trialData.getConfig().getDeploymentName()).edit().editSpec().editOrNewStrategy().withRollingUpdate(rud).endStrategy().endSpec().done();
+//        client.apps().deployments().inNamespace(trialData.getConfig().getDeploymentNamespace()).withName(trialData.getConfig().getDeploymentName()).edit().editSpec().editOrNewStrategy().withRollingUpdate(rud).endStrategy().endSpec().done();
         Deployment defaultDeployment = client.apps().deployments().inNamespace(trialData.getConfig().getDeploymentNamespace()).withName(trialData.getConfig().getDeploymentName()).get();
         try {
             ByteArrayOutputStream bos = new ByteArrayOutputStream();

--- a/src/main/java/com/autotune/operator/KruizeOperator.java
+++ b/src/main/java/com/autotune/operator/KruizeOperator.java
@@ -51,6 +51,7 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.ReplicaSet;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -117,10 +118,13 @@ public class KruizeOperator {
                 }
             }
 
-
             @Override
-            public void onClose(KubernetesClientException e) {
+            public void onClose(WatcherException e) {
+
             }
+//            @Override
+//            public void onClose(KubernetesClientException e) {
+//            }
         };
 
         Watcher<String> autotuneConfigWatcher = new Watcher<>() {
@@ -153,8 +157,12 @@ public class KruizeOperator {
                 }
             }
 
+//            @Override
+//            public void onClose(KubernetesClientException e) {
+//            }
             @Override
-            public void onClose(KubernetesClientException e) {
+            public void onClose(WatcherException e) {
+
             }
         };
 


### PR DESCRIPTION
## Description

This PR includes POC changes necessary to introduce the "recreate" mode in Kruize, enabling the automatic application of recommendations through integration with VPA.


### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

**Test Configuration**
* Kubernetes clusters tested on: Openshift

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Image - quay.io/rh-ee-shesaxen/autotune:vpa-0.3
Try Out - https://github.com/kruize/kruize-demos/pull/107
