### PR TITLE
Update resource configuration in remote monitoring tests for openshift

### DIFF
--- a/tests/scripts/common/common_functions.sh
+++ b/tests/scripts/common/common_functions.sh
@@ -1905,6 +1905,7 @@ function kruize_local_patch() {
 
 #
 # "local" flag is turned off for RM.
+# Restores kruize default cpu/memory resources, PV storage for openshift
 #
 function kruize_remote_patch() {
 	CRC_DIR="./manifests/crc/default-db-included-installation"
@@ -1916,6 +1917,8 @@ function kruize_remote_patch() {
     sed -i 's/"local": "true"/"local": "false"/' ${KRUIZE_CRC_DEPLOY_MANIFEST_MINIKUBE}
   elif [ ${cluster_type} == "openshift" ]; then
     sed -i 's/"local": "true"/"local": "false"/' ${KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT}
+    sed -i 's/\([[:space:]]*\)\(storage:\)[[:space:]]*[0-9]\+Mi/\1\2 1Gi/' ${KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT}
+    sed -i 's/\([[:space:]]*\)\(memory:\)[[:space:]]*".*"/\1\2 "2Gi"/; s/\([[:space:]]*\)\(cpu:\)[[:space:]]*".*"/\1\2 "2"/' ${KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT}
   fi
 }
 


### PR DESCRIPTION
## Description

With the latest updates by default Kruize uses 500Mi PVC storage, 0.7 cores - 350Mi for kruize and 0.5 cores - 100Mi for kruize-db. 

This PR restores the previous default values i.e 1Gi of PVC storage, 2 cores of CPU and 2Gi of memory while deploying Kruize in remote monitoring tests for Openshift. To fix the `database system is shut down` issue faced during testing.

Fixes #1393

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [x] Functional testsuite - Remote monitoring sanity tests [In progress]

**Test Configuration**
* Kubernetes clusters tested on: Openshift, ResourceHub

## Checklist :dart:

- [ ] Followed coding guidelines
- [x] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [] Tests added or updated

## Additional information

.
