### PR TITLE
2. Update Fabric8 Version to 7.0.0 and Add VerticalPodScaler Client [KRUIZE-VPA Integration]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>autotune</artifactId>
     <version>0.2</version>
     <properties>
-        <fabric8-version>6.13.4</fabric8-version>
+        <fabric8-version>7.0.0</fabric8-version>
         <org-json-version>20240303</org-json-version>
         <jetty-version>12.0.12</jetty-version>
         <slf4j-version>2.17.1</slf4j-version>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>autotune</artifactId>
     <version>0.2</version>
     <properties>
-        <fabric8-version>4.13.2</fabric8-version>
+        <fabric8-version>6.13.4</fabric8-version>
         <org-json-version>20240303</org-json-version>
         <jetty-version>12.0.12</jetty-version>
         <slf4j-version>2.17.1</slf4j-version>
@@ -69,6 +69,12 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
+            <version>${fabric8-version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>verticalpodautoscaler-client</artifactId>
             <version>${fabric8-version}</version>
         </dependency>
 

--- a/src/main/java/com/autotune/analyzer/performanceProfiles/PerformanceProfilesDeployment.java
+++ b/src/main/java/com/autotune/analyzer/performanceProfiles/PerformanceProfilesDeployment.java
@@ -11,6 +11,7 @@ import com.autotune.utils.KubeEventLogger;
 import com.google.gson.Gson;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -65,7 +66,7 @@ public class PerformanceProfilesDeployment {
             }
 
             @Override
-            public void onClose(KubernetesClientException e) { }
+            public void onClose(WatcherException e) { }
         };
 
         KubernetesServices kubernetesServices = new KubernetesServicesImpl();

--- a/src/main/java/com/autotune/operator/KruizeOperator.java
+++ b/src/main/java/com/autotune/operator/KruizeOperator.java
@@ -51,6 +51,7 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.ReplicaSet;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -119,7 +120,7 @@ public class KruizeOperator {
 
 
             @Override
-            public void onClose(KubernetesClientException e) {
+            public void onClose(WatcherException e) {
             }
         };
 
@@ -154,7 +155,7 @@ public class KruizeOperator {
             }
 
             @Override
-            public void onClose(KubernetesClientException e) {
+            public void onClose(WatcherException e) {
             }
         };
 


### PR DESCRIPTION
## Description

This pull request includes the following updates and fixes:

- Upgraded the `Fabric8 client` library to latest version `7.0.0`.
- Added the `VerticalPodScaler` client to support operations related to VPA.
- Resolved issues introduced by the `Fabric8` library upgrade.

Fixes # (issue)

1. Updated the code to use `genericKubernetesResources()` instead of the deprecated `customResource()` method. Additionally, `getAdditionalProperties()` is used to access the custom resource data dynamically.
2. `WatcherException` is now the correct exception type for handling errors related to watchers, as the method signature has been updated. 
3. `kubernetesClient.events()` is changed to `kubernetesClient.v1().events()` as access to resources like events is now scoped under API versions.
4. The change from `Watcher<String>` to `Watcher<GenericKubernetesResource>` is because now it is the preferred way in new version. 

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Tested on both the ResourceHub cluster and the Kind cluster to verify any issues. 

**Test Configuration**
* Kubernetes clusters tested on: ResourceHub (OpenShift), Kind

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

NA
