### PR TITLE
4. Adding Support For VPA and Auto Mode in CreateExperiment [KRUIZE-VPA Integration]

### DIFF
--- a/src/main/java/com/autotune/analyzer/kruizeObject/ExperimentUseCaseType.java
+++ b/src/main/java/com/autotune/analyzer/kruizeObject/ExperimentUseCaseType.java
@@ -39,16 +39,22 @@ public class ExperimentUseCaseType {
                 throw new Exception("Invalid Mode " + kruizeObject.getMode() + " for target cluster as Remote.");
             }
         } else if (kruizeObject.getTarget_cluster().equalsIgnoreCase(AnalyzerConstants.LOCAL)) {
-            if (kruizeObject.getMode().equalsIgnoreCase(AnalyzerConstants.MONITOR)) {
-                setLocal_monitoring(true);
-            } else if (kruizeObject.getMode().equalsIgnoreCase(AnalyzerConstants.EXPERIMENT)) {
-                setLocal_experiment(true);
-            } else if (kruizeObject.getMode().equalsIgnoreCase(AnalyzerConstants.RECREATE)) {
-                setLocal_monitoring(true);
-            } else if (kruizeObject.getMode().equalsIgnoreCase(AnalyzerConstants.AUTO)) {
-                setLocal_monitoring(true);
-            } else {
-                throw new Exception("Invalid Mode " + kruizeObject.getMode() + " for target cluster as Local.");
+            switch (kruizeObject.getMode().toLowerCase()) {
+                case AnalyzerConstants.MONITOR:
+                    setLocal_monitoring(true);
+                    break;
+
+                case AnalyzerConstants.EXPERIMENT:
+                    setLocal_experiment(true);
+                    break;
+
+                case AnalyzerConstants.RECREATE:
+                case AnalyzerConstants.AUTO:
+                    setLocal_monitoring(true);
+                    break;
+
+                default:
+                    throw new Exception("Invalid Mode " + kruizeObject.getMode() + " for target cluster as Local.");
             }
         } else {
             throw new Exception("Invalid Target cluster type");

--- a/src/main/java/com/autotune/analyzer/kruizeObject/ExperimentUseCaseType.java
+++ b/src/main/java/com/autotune/analyzer/kruizeObject/ExperimentUseCaseType.java
@@ -41,16 +41,13 @@ public class ExperimentUseCaseType {
         } else if (kruizeObject.getTarget_cluster().equalsIgnoreCase(AnalyzerConstants.LOCAL)) {
             switch (kruizeObject.getMode().toLowerCase()) {
                 case AnalyzerConstants.MONITOR:
+                case AnalyzerConstants.RECREATE:
+                case AnalyzerConstants.AUTO:
                     setLocal_monitoring(true);
                     break;
 
                 case AnalyzerConstants.EXPERIMENT:
                     setLocal_experiment(true);
-                    break;
-
-                case AnalyzerConstants.RECREATE:
-                case AnalyzerConstants.AUTO:
-                    setLocal_monitoring(true);
                     break;
 
                 default:

--- a/src/main/java/com/autotune/analyzer/kruizeObject/ExperimentUseCaseType.java
+++ b/src/main/java/com/autotune/analyzer/kruizeObject/ExperimentUseCaseType.java
@@ -43,6 +43,10 @@ public class ExperimentUseCaseType {
                 setLocal_monitoring(true);
             } else if (kruizeObject.getMode().equalsIgnoreCase(AnalyzerConstants.EXPERIMENT)) {
                 setLocal_experiment(true);
+            } else if (kruizeObject.getMode().equalsIgnoreCase(AnalyzerConstants.RECREATE)) {
+                setLocal_monitoring(true);
+            } else if (kruizeObject.getMode().equalsIgnoreCase(AnalyzerConstants.AUTO)) {
+                setLocal_monitoring(true);
             } else {
                 throw new Exception("Invalid Mode " + kruizeObject.getMode() + " for target cluster as Local.");
             }

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -30,6 +30,9 @@ public class AnalyzerConstants {
     public static final String EXPERIMENT = "experiment";
     public static final String LOCAL = "local";
     public static final String REMOTE = "remote";
+    public static final String AUTO = "auto";
+    public static final String RECREATE = "recreate";
+
 
 
     // Used to parse autotune configmaps


### PR DESCRIPTION
## Description

This PR adds `auto` and `recreate` modes required for VPA in createExperiment for Local Monitoring. 

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?
Tested on both the ResourceHub cluster.

Test Configuration

Kubernetes clusters tested on: ResourceHub (OpenShift)

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated
