### PR TITLE
Fixing "No Data Available" in GenerateRecommendations API

### DIFF
--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -2408,8 +2408,8 @@ public class RecommendationEngine {
 
                     // Include metrics based on experiment_type, kubernetes_object and exclude maxDate metric
                     return !name.equals(maxDateQuery) && (
-                            (experimentType.equals(AnalyzerConstants.ExperimentTypes.NAMESPACE_EXPERIMENT) && kubernetes_object.equals(namespace)) ||
-                                    (experimentType.equals(AnalyzerConstants.ExperimentTypes.CONTAINER_EXPERIMENT) && kubernetes_object.equals(container))
+                            (experimentType.name().equalsIgnoreCase(AnalyzerConstants.ExperimentTypes.NAMESPACE_EXPERIMENT) && kubernetes_object.equals(namespace)) ||
+                                    (experimentType.name().equalsIgnoreCase(AnalyzerConstants.ExperimentTypes.CONTAINER_EXPERIMENT) && kubernetes_object.equals(container))
                     );
                 })
                 .toList();


### PR DESCRIPTION
## Description

This PR fixes issue with `generatedRecommendations` API. After the recent changes we were facing issue with error `There is not enough data available to generate a recommendation` every time. 

Fixes # (issue)
- There is not enough data available to generate a recommendation error in `generatedRecommendations` API

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

**Test Configuration**
* Kubernetes clusters tested on: Openshift Cluster

## Checklist :dart:

- [x] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

The debug log showed that the `containerData` was `null`. Upon further debugging, found that metrics were not being fetched because the `metricList` was empty. Digging deeper, discovered that directly comparing the `experimentType` using the `equals` function was returning false, even for seemingly equivalent values. This issue was resolved by converting the `experimentType` to a `String` using `.name()` and performing the comparison, which avoids potential pitfalls associated with `enum` equality checks.

By relying on .name() for comparison, we mitigate issues such as case sensitivity or mismatches caused by runtime discrepancies (e.g., different instances of the same enum under different class loaders). This approach ensures robust and predictable behavior when comparing enum values.
