### PR TITLE
list Recommendations to support both rm and lm

### DIFF
--- a/migrations/kruize_local_ddl.sql
+++ b/migrations/kruize_local_ddl.sql
@@ -5,4 +5,4 @@ create table IF NOT EXISTS kruize_dsmetadata (id serial, version varchar(255), d
 alter table kruize_lm_experiments  add column metadata_id bigint references kruize_dsmetadata(id);
 alter table if exists kruize_lm_experiments add constraint UK_lm_experiment_name unique (experiment_name);
 create table IF NOT EXISTS kruize_metric_profiles (api_version varchar(255), kind varchar(255), metadata jsonb, name varchar(255) not null, k8s_type varchar(255), profile_version float(53) not null, slo jsonb, primary key (name));
-alter table kruize_recommendations add column experiment_type varchar(255);
+create table IF NOT EXISTS kruize_lm_recommendations (interval_end_time timestamp(6) not null, experiment_name varchar(255) not null, cluster_name varchar(255), extended_data jsonb, version varchar(255),experiment_type varchar(255), primary key (experiment_name, interval_end_time)) PARTITION BY RANGE (interval_end_time);

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -197,13 +197,13 @@ public class RecommendationEngine {
         KruizeObject kruizeObject = new KruizeObject();
         try {
 
-            if (KruizeDeploymentInfo.is_ros_enabled){
-                if(null == target_cluster ||  target_cluster.equalsIgnoreCase(AnalyzerConstants.REMOTE)){
+            if (KruizeDeploymentInfo.is_ros_enabled) {
+                if (null == target_cluster || target_cluster.equalsIgnoreCase(AnalyzerConstants.REMOTE)) {
                     new ExperimentDBService().loadExperimentFromDBByName(mainKruizeExperimentMAP, experimentName);
-                }else{
+                } else {
                     new ExperimentDBService().loadLMExperimentFromDBByName(mainKruizeExperimentMAP, experimentName);
                 }
-            }else{
+            } else {
                 new ExperimentDBService().loadLMExperimentFromDBByName(mainKruizeExperimentMAP, experimentName);
             }
 

--- a/src/main/java/com/autotune/analyzer/services/GenerateRecommendations.java
+++ b/src/main/java/com/autotune/analyzer/services/GenerateRecommendations.java
@@ -102,7 +102,7 @@ public class GenerateRecommendations extends HttpServlet {
             // validate and create KruizeObject if successful
             String validationMessage = recommendationEngine.validate_local();
             if (validationMessage.isEmpty()) {
-                KruizeObject kruizeObject = recommendationEngine.prepareRecommendations(calCount, null);
+                KruizeObject kruizeObject = recommendationEngine.prepareRecommendations(calCount, AnalyzerConstants.LOCAL);   // todo target cluster is set to LOCAL always
                 if (kruizeObject.getValidation_data().isSuccess()) {
                     LOGGER.debug("UpdateRecommendations API request count: {} success", calCount);
                     interval_end_time = Utils.DateUtils.getTimeStampFrom(KruizeConstants.DateFormats.STANDARD_JSON_DATE_FORMAT,

--- a/src/main/java/com/autotune/analyzer/services/ListRecommendations.java
+++ b/src/main/java/com/autotune/analyzer/services/ListRecommendations.java
@@ -84,18 +84,25 @@ public class ListRecommendations extends HttpServlet {
         String experimentName = request.getParameter(AnalyzerConstants.ServiceConstants.EXPERIMENT_NAME);
         String latestRecommendation = request.getParameter(AnalyzerConstants.ServiceConstants.LATEST);
         String monitoringEndTime = request.getParameter(KruizeConstants.JSONKeys.MONITORING_END_TIME);
+        String rm = request.getParameter(AnalyzerConstants.ServiceConstants.RM);
         Timestamp monitoringEndTimestamp = null;
         Map<String, KruizeObject> mKruizeExperimentMap = new ConcurrentHashMap<String, KruizeObject>();
-        ;
 
         boolean getLatest = true;
         boolean checkForTimestamp = false;
         boolean error = false;
+        boolean rmTable = false;
         if (null != latestRecommendation
                 && !latestRecommendation.isEmpty()
                 && latestRecommendation.equalsIgnoreCase(AnalyzerConstants.BooleanString.FALSE)
         ) {
             getLatest = false;
+        }
+        if (null != rm
+                && !rm.isEmpty()
+                && rm.equalsIgnoreCase(AnalyzerConstants.BooleanString.TRUE)
+        ) {
+            rmTable = true;
         }
         List<KruizeObject> kruizeObjectList = new ArrayList<>();
         try {
@@ -104,7 +111,11 @@ public class ListRecommendations extends HttpServlet {
                 // trim the experiment name to remove whitespaces
                 experimentName = experimentName.trim();
                 try {
-                    new ExperimentDBService().loadExperimentAndRecommendationsFromDBByName(mKruizeExperimentMap, experimentName);
+                    if (rmTable) {
+                        new ExperimentDBService().loadExperimentAndRecommendationsFromDBByName(mKruizeExperimentMap, experimentName);
+                    } else {
+                        new ExperimentDBService().loadLMExperimentAndRecommendationsFromDBByName(mKruizeExperimentMap, experimentName);
+                    }
                 } catch (Exception e) {
                     LOGGER.error("Loading saved experiment {} failed: {} ", experimentName, e.getMessage());
                 }
@@ -151,7 +162,11 @@ public class ListRecommendations extends HttpServlet {
                 }
             } else {
                 try {
-                    new ExperimentDBService().loadAllExperimentsAndRecommendations(mKruizeExperimentMap);
+                    if (rmTable) {
+                        new ExperimentDBService().loadAllExperimentsAndRecommendations(mKruizeExperimentMap);
+                    } else {
+                        new ExperimentDBService().loadAllLMExperimentsAndRecommendations(mKruizeExperimentMap);
+                    }
                 } catch (Exception e) {
                     LOGGER.error("Loading saved experiment {} failed: {} ", experimentName, e.getMessage());
                 }

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -438,6 +438,7 @@ public class AnalyzerConstants {
         public static final String CLUSTER_NAME = "cluster_name";
         public static final String VERBOSE = "verbose";
         public static final String FALSE = "false";
+        public static final String RM = "rm";
 
         private ServiceConstants() {
         }

--- a/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
+++ b/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
@@ -57,6 +57,7 @@ import static com.autotune.operator.KruizeDeploymentInfo.bulk_thread_pool_size;
 import static com.autotune.utils.KruizeConstants.KRUIZE_BULK_API.*;
 import static com.autotune.utils.KruizeConstants.KRUIZE_BULK_API.NotificationConstants.*;
 
+
 /**
  * The `run` method processes bulk input to create experiments and generates resource optimization recommendations.
  * It handles the creation of experiment names based on various data source components, makes HTTP POST requests
@@ -121,7 +122,7 @@ public class BulkJobManager implements Runnable {
     public void run() {
         String statusValue = "failure";
         MetricsConfig.activeJobs.incrementAndGet();
-        Timer.Sample timerRunJob = Timer.start(MetricsConfig.meterRegistry());
+        io.micrometer.core.instrument.Timer.Sample timerRunJob = Timer.start(MetricsConfig.meterRegistry());
         DataSourceMetadataInfo metadataInfo = null;
         DataSourceManager dataSourceManager = new DataSourceManager();
         DataSourceInfo datasource = null;

--- a/src/main/java/com/autotune/database/dao/ExperimentDAO.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAO.java
@@ -6,6 +6,7 @@ import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.common.data.ValidationOutputData;
 import com.autotune.database.table.*;
 import com.autotune.database.table.lm.KruizeLMExperimentEntry;
+import com.autotune.database.table.lm.KruizeLMRecommendationEntry;
 
 import java.sql.Timestamp;
 import java.util.List;
@@ -24,6 +25,10 @@ public interface ExperimentDAO {
 
     // Add recommendation  to DB
     public ValidationOutputData addRecommendationToDB(KruizeRecommendationEntry recommendationEntry);
+
+    // Add recommendation  to DB
+    public ValidationOutputData addRecommendationToDB(KruizeLMRecommendationEntry recommendationEntry);
+
 
     // Add Performance Profile  to DB
     public ValidationOutputData addPerformanceProfileToDB(KruizePerformanceProfileEntry kruizePerformanceProfileEntry);
@@ -52,6 +57,8 @@ public interface ExperimentDAO {
     // If Kruize restarts load all recommendations
     List<KruizeRecommendationEntry> loadAllRecommendations() throws Exception;
 
+    List<KruizeLMRecommendationEntry> loadAllLMRecommendations() throws Exception;
+
     // If Kruize restarts load all performance profiles
     List<KruizePerformanceProfileEntry> loadAllPerformanceProfiles() throws Exception;
 
@@ -75,6 +82,8 @@ public interface ExperimentDAO {
     // Load all recommendations of a particular experiment
     List<KruizeRecommendationEntry> loadRecommendationsByExperimentName(String experimentName) throws Exception;
 
+    // Load all recommendations of a particular experiment
+    List<KruizeLMRecommendationEntry> loadLMRecommendationsByExperimentName(String experimentName) throws Exception;
 
     // Load a single Performance Profile based on name
     List<KruizePerformanceProfileEntry> loadPerformanceProfileByName(String performanceProfileName) throws Exception;
@@ -87,6 +96,8 @@ public interface ExperimentDAO {
 
     // Load all recommendations of a particular experiment and interval end Time
     KruizeRecommendationEntry loadRecommendationsByExperimentNameAndDate(String experimentName, String cluster_name, Timestamp interval_end_time) throws Exception;
+
+    KruizeLMRecommendationEntry loadLMRecommendationsByExperimentNameAndDate(String experimentName, String cluster_name, Timestamp interval_end_time) throws Exception;
 
     // Get KruizeResult Record
     List<KruizeResultsEntry> getKruizeResultsEntry(String experiment_name, String cluster_name, Timestamp interval_start_time, Timestamp interval_end_time) throws Exception;

--- a/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
@@ -25,6 +25,7 @@ import com.autotune.database.helper.DBConstants;
 import com.autotune.database.init.KruizeHibernateUtil;
 import com.autotune.database.table.*;
 import com.autotune.database.table.lm.KruizeLMExperimentEntry;
+import com.autotune.database.table.lm.KruizeLMRecommendationEntry;
 import com.autotune.utils.KruizeConstants;
 import com.autotune.utils.MetricsConfig;
 import io.micrometer.core.instrument.Timer;
@@ -384,9 +385,48 @@ public class ExperimentDAOImpl implements ExperimentDAO {
                     tx = session.beginTransaction();
                     session.persist(recommendationEntry);
                     tx.commit();
-                    if (null == recommendationEntry.getExperimentType() || recommendationEntry.getExperimentType().isEmpty()) {
-                        updateExperimentTypeInKruizeRecommendationEntry(recommendationEntry);
-                    }
+                    validationOutputData.setSuccess(true);
+                    statusValue = "success";
+                } else {
+                    tx = session.beginTransaction();
+                    existingRecommendationEntry.setExtended_data(recommendationEntry.getExtended_data());
+                    session.merge(existingRecommendationEntry);
+                    tx.commit();
+                    validationOutputData.setSuccess(true);
+                    statusValue = "success";
+                }
+            } catch (Exception e) {
+                LOGGER.error("Not able to save recommendation due to {}", e.getMessage());
+                if (tx != null) tx.rollback();
+                e.printStackTrace();
+                validationOutputData.setSuccess(false);
+                validationOutputData.setMessage(e.getMessage());
+                //todo save error to API_ERROR_LOG
+            }
+        } catch (Exception e) {
+            LOGGER.error("Not able to save recommendation due to {}", e.getMessage());
+        } finally {
+            if (null != timerAddRecDB) {
+                MetricsConfig.timerAddRecDB = MetricsConfig.timerBAddRecDB.tag("status", statusValue).register(MetricsConfig.meterRegistry());
+                timerAddRecDB.stop(MetricsConfig.timerAddRecDB);
+            }
+        }
+        return validationOutputData;
+    }
+
+    @Override
+    public ValidationOutputData addRecommendationToDB(KruizeLMRecommendationEntry recommendationEntry) {
+        ValidationOutputData validationOutputData = new ValidationOutputData(false, null, null);
+        Transaction tx = null;
+        String statusValue = "failure";
+        Timer.Sample timerAddRecDB = Timer.start(MetricsConfig.meterRegistry());
+        try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
+            try {
+                KruizeLMRecommendationEntry existingRecommendationEntry = loadLMRecommendationsByExperimentNameAndDate(recommendationEntry.getExperiment_name(), recommendationEntry.getCluster_name(), recommendationEntry.getInterval_end_time());
+                if (null == existingRecommendationEntry) {
+                    tx = session.beginTransaction();
+                    session.persist(recommendationEntry);
+                    tx.commit();
                     validationOutputData.setSuccess(true);
                     statusValue = "success";
                 } else {
@@ -717,6 +757,27 @@ public class ExperimentDAOImpl implements ExperimentDAO {
         Timer.Sample timerLoadAllExp = Timer.start(MetricsConfig.meterRegistry());
         try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
             entries = session.createQuery(DBConstants.SQLQUERY.SELECT_FROM_EXPERIMENTS, KruizeExperimentEntry.class).list();
+            statusValue = "success";
+        } catch (Exception e) {
+            LOGGER.error("Not able to load experiment due to {}", e.getMessage());
+            throw new Exception("Error while loading exsisting experiments from database due to : " + e.getMessage());
+        } finally {
+            if (null != timerLoadAllExp) {
+                MetricsConfig.timerLoadAllExp = MetricsConfig.timerBLoadAllExp.tag("status", statusValue).register(MetricsConfig.meterRegistry());
+                timerLoadAllExp.stop(MetricsConfig.timerLoadAllExp);
+            }
+        }
+        return entries;
+    }
+
+    @Override
+    public List<KruizeLMExperimentEntry> loadAllLMExperiments() throws Exception {
+        //todo load only experimentStatus=inprogress , playback may not require completed experiments
+        List<KruizeLMExperimentEntry> entries = null;
+        String statusValue = "failure";
+        Timer.Sample timerLoadAllExp = Timer.start(MetricsConfig.meterRegistry());
+        try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
+            entries = session.createQuery(DBConstants.SQLQUERY.SELECT_FROM_LM_EXPERIMENTS, KruizeLMExperimentEntry.class).list();
             // TODO: remove native sql query and transient
             //getExperimentTypeInKruizeExperimentEntry(entries);
             statusValue = "success";
@@ -786,6 +847,28 @@ public class ExperimentDAOImpl implements ExperimentDAO {
             recommendationEntries = session.createQuery(
                     DBConstants.SQLQUERY.SELECT_FROM_RECOMMENDATIONS,
                     KruizeRecommendationEntry.class).list();
+            statusValue = "success";
+        } catch (Exception e) {
+            LOGGER.error("Not able to load recommendations due to {}", e.getMessage());
+            throw new Exception("Error while loading existing recommendations from database due to : " + e.getMessage());
+        } finally {
+            if (null != timerLoadAllRec) {
+                MetricsConfig.timerLoadAllRec = MetricsConfig.timerBLoadAllRec.tag("status", statusValue).register(MetricsConfig.meterRegistry());
+                timerLoadAllRec.stop(MetricsConfig.timerLoadAllRec);
+            }
+        }
+        return recommendationEntries;
+    }
+
+    @Override
+    public List<KruizeLMRecommendationEntry> loadAllLMRecommendations() throws Exception {
+        List<KruizeLMRecommendationEntry> recommendationEntries = null;
+        String statusValue = "failure";
+        Timer.Sample timerLoadAllRec = Timer.start(MetricsConfig.meterRegistry());
+        try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
+            recommendationEntries = session.createQuery(
+                    DBConstants.SQLQUERY.SELECT_FROM_LM_RECOMMENDATIONS,
+                    KruizeLMRecommendationEntry.class).list();
             statusValue = "success";
         } catch (Exception e) {
             LOGGER.error("Not able to load recommendations due to {}", e.getMessage());
@@ -973,7 +1056,27 @@ public class ExperimentDAOImpl implements ExperimentDAO {
         try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
             recommendationEntries = session.createQuery(DBConstants.SQLQUERY.SELECT_FROM_RECOMMENDATIONS_BY_EXP_NAME, KruizeRecommendationEntry.class)
                     .setParameter("experimentName", experimentName).list();
-            getExperimentTypeInKruizeRecommendationsEntry(recommendationEntries);
+            statusValue = "success";
+        } catch (Exception e) {
+            LOGGER.error("Not able to load recommendations due to {}", e.getMessage());
+            throw new Exception("Error while loading existing recommendations from database due to : " + e.getMessage());
+        } finally {
+            if (null != timerLoadRecExpName) {
+                MetricsConfig.timerLoadRecExpName = MetricsConfig.timerBLoadRecExpName.tag("status", statusValue).register(MetricsConfig.meterRegistry());
+                timerLoadRecExpName.stop(MetricsConfig.timerLoadRecExpName);
+            }
+        }
+        return recommendationEntries;
+    }
+
+    @Override
+    public List<KruizeLMRecommendationEntry> loadLMRecommendationsByExperimentName(String experimentName) throws Exception {
+        List<KruizeLMRecommendationEntry> recommendationEntries = null;
+        String statusValue = "failure";
+        Timer.Sample timerLoadRecExpName = Timer.start(MetricsConfig.meterRegistry());
+        try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
+            recommendationEntries = session.createQuery(DBConstants.SQLQUERY.SELECT_FROM_LM_RECOMMENDATIONS_BY_EXP_NAME, KruizeLMRecommendationEntry.class)
+                    .setParameter("experimentName", experimentName).list();
             statusValue = "success";
         } catch (Exception e) {
             LOGGER.error("Not able to load recommendations due to {}", e.getMessage());
@@ -1005,7 +1108,40 @@ public class ExperimentDAOImpl implements ExperimentDAO {
             if (cluster_name != null)
                 kruizeRecommendationEntryQuery.setParameter(CLUSTER_NAME, cluster_name);
             recommendationEntries = kruizeRecommendationEntryQuery.getSingleResult();
-            getExperimentTypeInSingleKruizeRecommendationsEntry(recommendationEntries);
+            statusValue = "success";
+        } catch (NoResultException e) {
+            LOGGER.debug("Generating new recommendation for Experiment name : %s interval_end_time: %S", experimentName, interval_end_time);
+        } catch (Exception e) {
+            LOGGER.error("Not able to load recommendations due to {}", e.getMessage());
+            recommendationEntries = null;
+            throw new Exception("Error while loading existing recommendations from database due to : " + e.getMessage());
+        } finally {
+            if (null != timerLoadRecExpNameDate) {
+                MetricsConfig.timerLoadRecExpNameDate = MetricsConfig.timerBLoadRecExpNameDate.tag("status", statusValue).register(MetricsConfig.meterRegistry());
+                timerLoadRecExpNameDate.stop(MetricsConfig.timerLoadRecExpNameDate);
+            }
+        }
+        return recommendationEntries;
+    }
+
+    @Override
+    public KruizeLMRecommendationEntry loadLMRecommendationsByExperimentNameAndDate(String experimentName, String cluster_name, Timestamp interval_end_time) throws Exception {
+        KruizeLMRecommendationEntry recommendationEntries = null;
+        String statusValue = "failure";
+        String clusterCondtionSql = "";
+        if (cluster_name != null)
+            clusterCondtionSql = String.format(" and k.%s = :%s ", KruizeConstants.JSONKeys.CLUSTER_NAME, KruizeConstants.JSONKeys.CLUSTER_NAME);
+        else
+            clusterCondtionSql = String.format(" and k.%s is null ", KruizeConstants.JSONKeys.CLUSTER_NAME);
+
+        Timer.Sample timerLoadRecExpNameDate = Timer.start(MetricsConfig.meterRegistry());
+        try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
+            Query<KruizeLMRecommendationEntry> kruizeRecommendationEntryQuery = session.createQuery(SELECT_FROM_LM_RECOMMENDATIONS_BY_EXP_NAME_AND_END_TIME + clusterCondtionSql, KruizeLMRecommendationEntry.class)
+                    .setParameter(KruizeConstants.JSONKeys.EXPERIMENT_NAME, experimentName)
+                    .setParameter(KruizeConstants.JSONKeys.INTERVAL_END_TIME, interval_end_time);
+            if (cluster_name != null)
+                kruizeRecommendationEntryQuery.setParameter(CLUSTER_NAME, cluster_name);
+            recommendationEntries = kruizeRecommendationEntryQuery.getSingleResult();
             statusValue = "success";
         } catch (NoResultException e) {
             LOGGER.debug("Generating new recommendation for Experiment name : %s interval_end_time: %S", experimentName, interval_end_time);
@@ -1266,53 +1402,12 @@ public class ExperimentDAOImpl implements ExperimentDAO {
         }
     }*/
 
-    private void getExperimentTypeInKruizeRecommendationsEntry(List<KruizeRecommendationEntry> entries) throws Exception {
-        for (KruizeRecommendationEntry recomEntry : entries) {
-            getExperimentTypeInSingleKruizeRecommendationsEntry(recomEntry);
-        }
-    }
 
     private void getExperimentTypeInSingleKruizeRecommendationsEntry(KruizeRecommendationEntry recomEntry) throws Exception {
         List<KruizeExperimentEntry> expEntries = loadExperimentByName(recomEntry.getExperiment_name());
-        if (null != expEntries && !expEntries.isEmpty()) {
-            if (isTargetCluserLocal(expEntries.get(0).getTarget_cluster())) {
-                try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
-                    String sql = DBConstants.SQLQUERY.SELECT_RECOMMENDATIONS_EXP_TYPE;
-                    Query query = session.createNativeQuery(sql);
-                    // set experiment_type parameter in sql query
-                    query.setParameter("experiment_name", recomEntry.getExperiment_name());
-                    List<String> exType = query.getResultList();
-                    if (null != exType && !exType.isEmpty()) {
-                        recomEntry.setExperimentType(exType.get(0));
-                    }
-                } catch (Exception e) {
-                    LOGGER.error("Not able to get experiment type in recommendation entry due to {}", e.getMessage());
-                    throw new Exception("Error while updating experiment type to recommendation due to : " + e.getMessage());
-                }
-            }
-        }
+
     }
 
-    private void updateExperimentTypeInKruizeRecommendationEntry(KruizeRecommendationEntry recommendationEntry) throws Exception {
-        List<KruizeExperimentEntry> entries = loadExperimentByName(recommendationEntry.getExperiment_name());
-        if (null != entries && !entries.isEmpty()) {
-            if (isTargetCluserLocal(entries.get(0).getTarget_cluster())) {
-                try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
-                    Transaction tx = session.beginTransaction();
-                    String sql = DBConstants.SQLQUERY.UPDATE_RECOMMENDATIONS_EXP_TYPE;
-                    Query query = session.createNativeQuery(sql);
-                    query.setParameter("experiment_type", recommendationEntry.getExperimentType());
-                    query.setParameter("experiment_name", recommendationEntry.getExperiment_name());
-                    query.setParameter("interval_end_time", recommendationEntry.getInterval_end_time());
-                    query.executeUpdate();
-                    tx.commit();
-                } catch (Exception e) {
-                    LOGGER.error("Not able to update experiment type in recommendation entry due to {}", e.getMessage());
-                    throw new Exception("Error while updating experiment type to recommendation due to : " + e.getMessage());
-                }
-            }
-        }
-    }
 
     private boolean isTargetCluserLocal(String targetCluster) {
         if (AnalyzerConstants.LOCAL.equalsIgnoreCase(targetCluster)) {

--- a/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
@@ -793,29 +793,7 @@ public class ExperimentDAOImpl implements ExperimentDAO {
         return entries;
     }
 
-    @Override
-    public List<KruizeLMExperimentEntry> loadAllLMExperiments() throws Exception {
-        //todo load only experimentStatus=inprogress , playback may not require completed experiments
-        List<KruizeLMExperimentEntry> entries = null;
-        String statusValue = "failure";
-        Timer.Sample timerLoadAllExp = Timer.start(MetricsConfig.meterRegistry());
-        try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
-            entries = session.createQuery(SELECT_FROM_LM_EXPERIMENTS, KruizeLMExperimentEntry.class).list();
-            // TODO: remove native sql query and transient
-            //getExperimentTypeInKruizeExperimentEntry(entries);
-            statusValue = "success";
-        } catch (Exception e) {
-            LOGGER.error("Not able to load experiment due to {}", e.getMessage());
-            throw new Exception("Error while loading exsisting experiments from database due to : " + e.getMessage());
-        } finally {
-            if (null != timerLoadAllExp) {
-                MetricsConfig.timerLoadAllExp = MetricsConfig.timerBLoadAllExp.tag("status", statusValue).register(MetricsConfig.meterRegistry());
-                timerLoadAllExp.stop(MetricsConfig.timerLoadAllExp);
-            }
-        }
-        return entries;
-    }
-
+   
     @Override
     public List<KruizeResultsEntry> loadAllResults() throws Exception {
         // TODO: load only experimentStatus=inProgress , playback may not require completed experiments

--- a/src/main/java/com/autotune/database/helper/DBConstants.java
+++ b/src/main/java/com/autotune/database/helper/DBConstants.java
@@ -51,12 +51,19 @@ public class DBConstants {
                         "k.interval_end_time = (SELECT MAX(e.interval_end_time) FROM KruizeResultsEntry e  where e.experiment_name = :%s ) ",
                 KruizeConstants.JSONKeys.EXPERIMENT_NAME, KruizeConstants.JSONKeys.EXPERIMENT_NAME);
         public static final String SELECT_FROM_RECOMMENDATIONS_BY_EXP_NAME = String.format("from KruizeRecommendationEntry k WHERE k.experiment_name = :experimentName");
+        public static final String SELECT_FROM_LM_RECOMMENDATIONS_BY_EXP_NAME = String.format("from KruizeLMRecommendationEntry k WHERE k.experiment_name = :experimentName");
         public static final String SELECT_FROM_RECOMMENDATIONS_BY_EXP_NAME_AND_END_TIME = String.format(
                 "from KruizeRecommendationEntry k WHERE " +
                         "k.experiment_name = :%s and " +
                         "k.interval_end_time= :%s ",
                 KruizeConstants.JSONKeys.EXPERIMENT_NAME, KruizeConstants.JSONKeys.INTERVAL_END_TIME);
+        public static final String SELECT_FROM_LM_RECOMMENDATIONS_BY_EXP_NAME_AND_END_TIME = String.format(
+                "from KruizeLMRecommendationEntry k WHERE " +
+                        "k.experiment_name = :%s and " +
+                        "k.interval_end_time= :%s ",
+                KruizeConstants.JSONKeys.EXPERIMENT_NAME, KruizeConstants.JSONKeys.INTERVAL_END_TIME);
         public static final String SELECT_FROM_RECOMMENDATIONS = "from KruizeRecommendationEntry";
+        public static final String SELECT_FROM_LM_RECOMMENDATIONS = "from KruizeLMRecommendationEntry";
         public static final String SELECT_FROM_PERFORMANCE_PROFILE = "from KruizePerformanceProfileEntry";
         public static final String SELECT_FROM_PERFORMANCE_PROFILE_BY_NAME = "from KruizePerformanceProfileEntry k WHERE k.name = :name";
         public static final String SELECT_FROM_METRIC_PROFILE = "from KruizeMetricProfileEntry";
@@ -78,17 +85,13 @@ public class DBConstants {
                 " WHERE container->>'container_name' = :container_name" +
                 " AND container->>'container_image_name' = :container_image_name" +
                 " ))";
-        public static final String UPDATE_EXPERIMENT_EXP_TYPE = "UPDATE kruize_experiments SET experiment_type = :experiment_type WHERE experiment_name = :experiment_name";
-        public static final String UPDATE_RECOMMENDATIONS_EXP_TYPE = "UPDATE kruize_recommendations SET experiment_type = :experiment_type WHERE experiment_name = :experiment_name and interval_end_time = :interval_end_time";
-        public static final String SELECT_EXPERIMENT_EXP_TYPE = "SELECT experiment_type from kruize_experiments WHERE experiment_id = :experiment_id";
-        public static final String SELECT_RECOMMENDATIONS_EXP_TYPE = "SELECT experiment_type from kruize_recommendations WHERE experiment_name = :experiment_name";
-
     }
 
     public static final class TABLE_NAMES {
         public static final String KRUIZE_EXPERIMENTS = "kruize_experiments";
         public static final String KRUIZE_RESULTS = "kruize_results";
         public static final String KRUIZE_RECOMMENDATIONS = "kruize_recommendations";
+        public static final String KRUIZE_LM_RECOMMENDATIONS = "kruize_lm_recommendations";
         public static final String KRUIZE_PERFORMANCE_PROFILES = "kruize_performance_profiles";
 
     }

--- a/src/main/java/com/autotune/database/init/KruizeHibernateUtil.java
+++ b/src/main/java/com/autotune/database/init/KruizeHibernateUtil.java
@@ -18,6 +18,7 @@ package com.autotune.database.init;
 
 import com.autotune.database.table.*;
 import com.autotune.database.table.lm.KruizeLMExperimentEntry;
+import com.autotune.database.table.lm.KruizeLMRecommendationEntry;
 import com.autotune.operator.KruizeDeploymentInfo;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -59,6 +60,7 @@ public class KruizeHibernateUtil {
             configuration.addAnnotatedClass(KruizePerformanceProfileEntry.class);
             if (KruizeDeploymentInfo.local) {
                 configuration.addAnnotatedClass(KruizeLMExperimentEntry.class);
+                configuration.addAnnotatedClass(KruizeLMRecommendationEntry.class);
                 configuration.addAnnotatedClass(KruizeDataSourceEntry.class);
                 configuration.addAnnotatedClass(KruizeDSMetadataEntry.class);
                 configuration.addAnnotatedClass(KruizeMetricProfileEntry.class);

--- a/src/main/java/com/autotune/database/table/lm/KruizeLMRecommendationEntry.java
+++ b/src/main/java/com/autotune/database/table/lm/KruizeLMRecommendationEntry.java
@@ -1,15 +1,17 @@
-package com.autotune.database.table;
+package com.autotune.database.table.lm;
 
-import com.autotune.database.table.lm.KruizeLMRecommendationEntry;
 import com.fasterxml.jackson.databind.JsonNode;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
 import java.sql.Timestamp;
 
 @Entity
-@Table(name = "kruize_recommendations", indexes = {
+@Table(name = "kruize_lm_recommendations", indexes = {
         @Index(
                 name = "idx_recommendation_experiment_name",
                 columnList = "experiment_name",
@@ -19,7 +21,7 @@ import java.sql.Timestamp;
                 columnList = "interval_end_time",
                 unique = false)
 })
-public class KruizeRecommendationEntry {
+public class KruizeLMRecommendationEntry {
     private String version;
     @Id
     private String experiment_name;
@@ -28,20 +30,7 @@ public class KruizeRecommendationEntry {
     private String cluster_name;
     @JdbcTypeCode(SqlTypes.JSON)
     private JsonNode extended_data;
-    @Transient
     private String experiment_type;
-
-    public KruizeRecommendationEntry(KruizeLMRecommendationEntry recommendationEntry) {
-        this.experiment_name = recommendationEntry.getExperiment_name();
-        this.interval_end_time = recommendationEntry.getInterval_end_time();
-        this.cluster_name = recommendationEntry.getCluster_name();
-        this.extended_data = recommendationEntry.getExtended_data();
-        this.version = recommendationEntry.getVersion();
-    }
-
-    public KruizeRecommendationEntry() {
-
-    }
 
     public String getExperiment_name() {
         return experiment_name;

--- a/tests/scripts/helpers/kruize.py
+++ b/tests/scripts/helpers/kruize.py
@@ -150,10 +150,12 @@ def update_recommendations(experiment_name, startTime, endTime):
 
 # Description: This function obtains the recommendations from Kruize Autotune using listRecommendations API
 # Input Parameters: experiment name, flag indicating latest result and monitoring end time
-def list_recommendations(experiment_name=None, latest=None, monitoring_end_time=None):
+def list_recommendations(experiment_name=None, latest=None, monitoring_end_time=None, rm=False):
     PARAMS = ""
     print("\nListing the recommendations...")
     url = URL + "/listRecommendations"
+    if rm:
+        url += "?rm=true"
     print("URL = ", url)
 
     if experiment_name == None:
@@ -391,6 +393,7 @@ def create_metric_profile(metric_profile_json_file):
     print(response.text)
     return response
 
+
 # Description: This function deletes the metric profile
 # Input Parameters: metric profile input json
 def delete_metric_profile(input_json_file, invalid_header=False):
@@ -447,6 +450,7 @@ def list_metric_profiles(name=None, verbose=None, logging=True):
         print("\n************************************************************")
     return response
 
+
 # Description: This function generates recommendation for the given experiment_name
 def generate_recommendations(experiment_name):
     print("\n************************************************************")
@@ -464,6 +468,7 @@ def generate_recommendations(experiment_name):
     print("\n************************************************************")
     return response
 
+
 def post_bulk_api(input_json_file):
     print("\n************************************************************")
     print("Sending POST request to URL: ", f"{URL}/bulk")
@@ -477,14 +482,15 @@ def post_bulk_api(input_json_file):
     print("Response JSON: ", response.json())
     return response
 
-def get_bulk_job_status(job_id,verbose=False):
+
+def get_bulk_job_status(job_id, verbose=False):
     print("\n************************************************************")
     url_basic = f"{URL}/bulk?job_id={job_id}"
     url_verbose = f"{URL}/bulk?job_id={job_id}&verbose={verbose}"
     getJobIDURL = url_basic
     if verbose:
         getJobIDURL = url_verbose
-    print("Sending GET request to URL ( verbose=",verbose," ): ", getJobIDURL)
+    print("Sending GET request to URL ( verbose=", verbose, " ): ", getJobIDURL)
     curl_command_verbose = f"curl -X GET '{getJobIDURL}'"
     print("Equivalent cURL command : ", curl_command_verbose)
     response = requests.get(url_verbose)

--- a/tests/scripts/remote_monitoring_tests/rest_apis/test_e2e_workflow.py
+++ b/tests/scripts/remote_monitoring_tests/rest_apis/test_e2e_workflow.py
@@ -18,6 +18,7 @@ import json
 
 import pytest
 import sys
+
 sys.path.append("../../")
 
 from helpers.fixtures import *
@@ -120,10 +121,11 @@ def test_list_recommendations_multiple_exps_from_diff_json_files(cluster_type):
             data = response.json()
             assert response.status_code == SUCCESS_STATUS_CODE
             assert data[0]['experiment_name'] == experiment_name
-            assert data[0]['kubernetes_objects'][0]['containers'][0]['recommendations']['notifications'][NOTIFICATION_CODE_FOR_RECOMMENDATIONS_AVAILABLE][
+            assert data[0]['kubernetes_objects'][0]['containers'][0]['recommendations']['notifications'][
+                       NOTIFICATION_CODE_FOR_RECOMMENDATIONS_AVAILABLE][
                        'message'] == RECOMMENDATIONS_AVAILABLE
 
-            response = list_recommendations(experiment_name)
+            response = list_recommendations(experiment_name, rm=True)
             if response.status_code == SUCCESS_200_STATUS_CODE:
                 recommendation_json = response.json()
                 recommendation_section = recommendation_json[0]["kubernetes_objects"][0]["containers"][0][
@@ -133,13 +135,14 @@ def test_list_recommendations_multiple_exps_from_diff_json_files(cluster_type):
                 assert INFO_RECOMMENDATIONS_AVAILABLE_CODE in high_level_notifications
                 data_section = recommendation_section["data"]
                 short_term_recommendation = \
-                    data_section[end_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ")[:-4] + "Z"]["recommendation_terms"]["short_term"]
+                    data_section[end_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ")[:-4] + "Z"]["recommendation_terms"][
+                        "short_term"]
                 short_term_notifications = short_term_recommendation["notifications"]
                 for notification in short_term_notifications.values():
                     assert notification["type"] != "error"
 
         # Invoke list recommendations for the specified experiment
-        response = list_recommendations(experiment_name)
+        response = list_recommendations(experiment_name, rm=True)
         assert response.status_code == SUCCESS_200_STATUS_CODE
         list_reco_json = response.json()
 
@@ -157,7 +160,7 @@ def test_list_recommendations_multiple_exps_from_diff_json_files(cluster_type):
 
     # Invoke list recommendations for a non-existing experiment
     experiment_name = "Non-existing-exp"
-    response = list_recommendations(experiment_name)
+    response = list_recommendations(experiment_name, rm=True)
     assert response.status_code == ERROR_STATUS_CODE
 
     data = response.json()


### PR DESCRIPTION
## Description

Introduced the rm=true flag for the ROS Remote Monitoring use case. When rm=true is passed in the listRecommendations API, the API refers to remote monitoring tables. By default, the flag is set to false, which points to local monitoring tables. This feature is not critical for the ROS Remote Monitoring use case, as they do not utilize the listRecommendations API. Therefore, a documentation update is not required.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [x] New Test X
- [x] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [x] Dependent changes merged
- [ ] Documentation updated
- [x] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
