### PR TITLE
Concurrent RM and LM fault tolerance fix

### DIFF
--- a/tests/scripts/helpers/kruize.py
+++ b/tests/scripts/helpers/kruize.py
@@ -229,7 +229,7 @@ def create_performance_profile(perf_profile_json_file):
 
 # Description: This function obtains the experiments from Kruize Autotune using listExperiments API
 # Input Parameters: None
-def list_experiments(results=None, recommendations=None, latest=None, experiment_name=None):
+def list_experiments(results=None, recommendations=None, latest=None, experiment_name=None, rm=False):
     print("\nListing the experiments...")
     query_params = {}
 
@@ -245,7 +245,11 @@ def list_experiments(results=None, recommendations=None, latest=None, experiment
     query_string = "&".join(f"{key}={value}" for key, value in query_params.items())
 
     url = URL + "/listExperiments"
-    if query_string:
+    if rm:
+        url += "?rm=true"
+        if query_string:
+            url += "&" + query_string
+    else:
         url += "?" + query_string
     print("URL = ", url)
     response = requests.get(url)

--- a/tests/scripts/remote_monitoring_tests/fault_tolerant_tests/kruize_pod_restart_test.py
+++ b/tests/scripts/remote_monitoring_tests/fault_tolerant_tests/kruize_pod_restart_test.py
@@ -14,14 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import sys, getopt
+import getopt
 import json
 import os
+import sys
 import time
+
 sys.path.append("../../")
 from helpers.kruize import *
 from helpers.utils import *
 from helpers.generate_rm_jsons import *
+
 
 def main(argv):
     cluster_type = "minikube"
@@ -30,14 +33,16 @@ def main(argv):
     num_exps = 1
     failed = 0
     try:
-        opts, args = getopt.getopt(argv,"h:c:a:u:r:d:")
+        opts, args = getopt.getopt(argv, "h:c:a:u:r:d:")
     except getopt.GetoptError:
-        print("kruize_pod_restart_test.py -c <cluster type> -a <openshift kruize route> -u <no. of experiments> -d <no. of iterations to test restart (default - 2> -r <results dir>")
+        print(
+            "kruize_pod_restart_test.py -c <cluster type> -a <openshift kruize route> -u <no. of experiments> -d <no. of iterations to test restart (default - 2> -r <results dir>")
         print("Note: -a option is required only on openshift when kruize service is exposed")
         sys.exit(2)
     for opt, arg in opts:
         if opt == '-h':
-            print("kruize_pod_restart_test.py -c <cluster type> -a <openshift kruize route> -u <no. of experiments> -d <no. of iterations to test restart(default - 2> -r <results dir>")
+            print(
+                "kruize_pod_restart_test.py -c <cluster type> -a <openshift kruize route> -u <no. of experiments> -d <no. of iterations to test restart(default - 2> -r <results dir>")
             sys.exit(0)
         elif opt == '-c':
             cluster_type = arg
@@ -49,7 +54,6 @@ def main(argv):
             results_dir = arg
         elif opt == '-d':
             iterations = int(arg)
-        
 
     print(f"Cluster type = {cluster_type}")
     print(f"No. of experiments = {num_exps}")
@@ -72,11 +76,10 @@ def main(argv):
     split = False
     split_count = 1
 
-
     # Post 100 results
     num_res = 100
 
-    for i in range(1, iterations+1):
+    for i in range(1, iterations + 1):
         print("\n*************************")
         print(f"Iteration {i}...")
         print("*************************\n")
@@ -92,13 +95,15 @@ def main(argv):
 
         if i == 1:
             new_timestamp = None
-            create_update_results_jsons(csv_filename, split, split_count, result_json_dir, num_exps, num_res, new_timestamp)
+            create_update_results_jsons(csv_filename, split, split_count, result_json_dir, num_exps, num_res,
+                                        new_timestamp)
             start_ts = get_datetime()
         else:
             # Increment the time by 1505 mins for the next set of data timestamps
             new_timestamp = increment_timestamp_by_given_mins(start_ts, 1505)
             start_ts = new_timestamp
-            create_update_results_jsons(csv_filename, split, split_count, result_json_dir, num_exps, num_res, new_timestamp)
+            create_update_results_jsons(csv_filename, split, split_count, result_json_dir, num_exps, num_res,
+                                        new_timestamp)
 
         reco_json_dir = results_dir + "/reco_jsons" + "_iter" + str(i)
         os.mkdir(reco_json_dir)
@@ -107,7 +112,7 @@ def main(argv):
                 # create the experiment and post it
                 create_exp_json_file = exp_json_dir + "/create_exp_" + str(exp_num) + ".json"
                 create_experiment(create_exp_json_file)
-                
+
                 # Obtain the experiment name
                 json_data = json.load(open(create_exp_json_file))
 
@@ -123,12 +128,12 @@ def main(argv):
                 interval_end_time = json_data[0]['interval_end_time']
 
                 # sleep for a while before fetching recommendations for the experiments
-                #time.sleep(1)
+                # time.sleep(1)
 
                 # Fetch the recommendations for all the experiments
                 latest = None
                 reco = update_recommendations(experiment_name, latest, interval_end_time)
-                filename = reco_json_dir + '/update_reco_' + str(res_num) + '_' +  str(exp_num) + '.json'
+                filename = reco_json_dir + '/update_reco_' + str(res_num) + '_' + str(exp_num) + '.json'
                 write_json_data_to_file(filename, reco.json())
 
         # Fetch listExperiments
@@ -138,9 +143,9 @@ def main(argv):
         recommendations = "true"
         latest = "false"
         experiment_name = None
-        response = list_experiments(results, recommendations, latest, experiment_name)
+        response = list_experiments(results, recommendations, latest, experiment_name, rm=True)
         if response.status_code == SUCCESS_200_STATUS_CODE:
-           list_exp_json = response.json()
+            list_exp_json = response.json()
         else:
             print(f"listExperiments failed!")
             failed = 1
@@ -152,7 +157,7 @@ def main(argv):
         experiment_name = None
         latest = "false"
         interval_end_time = None
-        response = list_recommendations(experiment_name, latest, interval_end_time)
+        response = list_recommendations(experiment_name, latest, interval_end_time, rm=True)
         if response.status_code == SUCCESS_200_STATUS_CODE:
             list_reco_json_file_before = list_reco_json_dir + '/list_reco_json_before_' + str(i) + '.json'
             write_json_data_to_file(list_reco_json_file_before, response.json())
@@ -182,7 +187,7 @@ def main(argv):
         recommendations = "true"
         latest = "false"
         experiment_name = None
-        response = list_experiments(results, recommendations, latest, experiment_name)
+        response = list_experiments(results, recommendations, latest, experiment_name, rm=True)
         if response.status_code == SUCCESS_200_STATUS_CODE:
             list_exp_json = response.json()
         else:
@@ -195,7 +200,7 @@ def main(argv):
         # Fetch the recommendations for all the experiments
         latest = "false"
         interval_end_time = None
-        response = list_recommendations(experiment_name, latest, interval_end_time)
+        response = list_recommendations(experiment_name, latest, interval_end_time, rm=True)
         if response.status_code == SUCCESS_200_STATUS_CODE:
             list_reco_json_file_after = list_reco_json_dir + '/list_reco_json_after_' + str(i) + '.json'
             write_json_data_to_file(list_reco_json_file_after, response.json())
@@ -203,7 +208,6 @@ def main(argv):
             print(f"listRecommendations for experiment name - ${experiment_name} failed")
             failed = 1
             sys.exit(1)
-
 
         # Compare the listExperiments before and after kruize pod restart
         result = compare_json_files(list_exp_json_file_before, list_exp_json_file_after)
@@ -235,6 +239,7 @@ def main(argv):
     else:
         print("Test Passed! Check the logs for details")
         sys.exit(0)
+
 
 if __name__ == '__main__':
     main(sys.argv[1:])


### PR DESCRIPTION
## Description

Please describe the issue or feature and the summary of changes made to fix this. 

Introduced the rm=true flag for the ROS Remote Monitoring use case. When rm=true is passed in the listExperiments API, the API refers to remote monitoring tables. By default, the flag is set to false, which points to local monitoring tables. This feature is not critical for the ROS Remote Monitoring use case, as they do not utilize the listExperiments API. Therefore, a documentation update is not required.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [x] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [x] Dependent changes merged
- [x] Documentation updated
- [x] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
