### PR TITLE
Fixing Namespace Experiments Not Getting Created 

### DIFF
--- a/src/main/java/com/autotune/analyzer/kruizeObject/KruizeObject.java
+++ b/src/main/java/com/autotune/analyzer/kruizeObject/KruizeObject.java
@@ -26,6 +26,7 @@ import com.autotune.common.k8sObjects.TrialSettings;
 import com.autotune.utils.KruizeConstants;
 import com.autotune.utils.KruizeSupportedTypes;
 import com.autotune.utils.Utils;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
 import io.fabric8.kubernetes.api.model.ObjectReference;
 
@@ -50,6 +51,7 @@ public final class KruizeObject implements ExperimentTypeAware {
     @SerializedName("datasource")
     private String datasource;
     @SerializedName(KruizeConstants.JSONKeys.EXPERIMENT_TYPE) //TODO: to be used in future
+    @JsonAdapter(ExperimentTypeUtil.ExperimentTypeSerializer.class)
     private AnalyzerConstants.ExperimentType experimentType;
     @SerializedName("default_updater")
     private String defaultUpdater;

--- a/src/main/java/com/autotune/analyzer/serviceObjects/CreateExperimentAPIObject.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/CreateExperimentAPIObject.java
@@ -23,6 +23,7 @@ import com.autotune.analyzer.utils.ExperimentTypeUtil;
 import com.autotune.common.data.ValidationOutputData;
 import com.autotune.common.k8sObjects.TrialSettings;
 import com.autotune.utils.KruizeConstants;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.List;
@@ -50,6 +51,7 @@ public class CreateExperimentAPIObject extends BaseSO implements ExperimentTypeA
     @SerializedName(KruizeConstants.JSONKeys.DATASOURCE) //TODO: to be used in future
     private String datasource;
     @SerializedName(KruizeConstants.JSONKeys.EXPERIMENT_TYPE) //TODO: to be used in future
+    @JsonAdapter(ExperimentTypeUtil.ExperimentTypeDeserializer.class)
     private AnalyzerConstants.ExperimentType experimentType;
     private AnalyzerConstants.ExperimentStatus status;
     private String experiment_id;   // this id is UUID and getting set at createExperiment API

--- a/src/main/java/com/autotune/analyzer/serviceObjects/CreateExperimentAPIObject.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/CreateExperimentAPIObject.java
@@ -51,7 +51,7 @@ public class CreateExperimentAPIObject extends BaseSO implements ExperimentTypeA
     @SerializedName(KruizeConstants.JSONKeys.DATASOURCE) //TODO: to be used in future
     private String datasource;
     @SerializedName(KruizeConstants.JSONKeys.EXPERIMENT_TYPE) //TODO: to be used in future
-    @JsonAdapter(ExperimentTypeUtil.ExperimentTypeDeserializer.class)
+    @JsonAdapter(ExperimentTypeUtil.ExperimentTypeSerializer.class)
     private AnalyzerConstants.ExperimentType experimentType;
     private AnalyzerConstants.ExperimentStatus status;
     private String experiment_id;   // this id is UUID and getting set at createExperiment API

--- a/src/main/java/com/autotune/analyzer/serviceObjects/ListRecommendationsAPIObject.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/ListRecommendationsAPIObject.java
@@ -19,6 +19,7 @@ import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.analyzer.utils.ExperimentTypeAware;
 import com.autotune.analyzer.utils.ExperimentTypeUtil;
 import com.autotune.utils.KruizeConstants;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.List;
@@ -27,6 +28,7 @@ public class ListRecommendationsAPIObject extends BaseSO implements ExperimentTy
     @SerializedName(KruizeConstants.JSONKeys.CLUSTER_NAME)
     private String clusterName;
     @SerializedName(KruizeConstants.JSONKeys.EXPERIMENT_TYPE)
+    @JsonAdapter(ExperimentTypeUtil.ExperimentTypeSerializer.class)
     private AnalyzerConstants.ExperimentType experimentType;
 
     @SerializedName(KruizeConstants.JSONKeys.KUBERNETES_OBJECTS)

--- a/src/main/java/com/autotune/analyzer/utils/ExperimentTypeUtil.java
+++ b/src/main/java/com/autotune/analyzer/utils/ExperimentTypeUtil.java
@@ -16,6 +16,13 @@
 
 package com.autotune.analyzer.utils;
 
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+
+import java.lang.reflect.Type;
+
 /**
  * This class contains utility functions to determine experiment type
  */
@@ -26,5 +33,16 @@ public class ExperimentTypeUtil {
 
     public static boolean isNamespaceExperiment(AnalyzerConstants.ExperimentType experimentType) {
         return experimentType != null && AnalyzerConstants.ExperimentType.NAMESPACE.equals(experimentType);
+    }
+
+    public class ExperimentTypeDeserializer implements JsonDeserializer<AnalyzerConstants.ExperimentType> {
+        @Override
+        public AnalyzerConstants.ExperimentType deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+            String experimentType = json.getAsString();
+            if (experimentType != null) {
+                return AnalyzerConstants.ExperimentType.valueOf(experimentType.toUpperCase());
+            }
+            return null;
+        }
     }
 }

--- a/src/main/java/com/autotune/analyzer/utils/ExperimentTypeUtil.java
+++ b/src/main/java/com/autotune/analyzer/utils/ExperimentTypeUtil.java
@@ -16,10 +16,7 @@
 
 package com.autotune.analyzer.utils;
 
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParseException;
+import com.google.gson.*;
 
 import java.lang.reflect.Type;
 
@@ -35,7 +32,15 @@ public class ExperimentTypeUtil {
         return experimentType != null && AnalyzerConstants.ExperimentType.NAMESPACE.equals(experimentType);
     }
 
-    public class ExperimentTypeDeserializer implements JsonDeserializer<AnalyzerConstants.ExperimentType> {
+    public class ExperimentTypeSerializer implements JsonSerializer<AnalyzerConstants.ExperimentType>, JsonDeserializer<AnalyzerConstants.ExperimentType> {
+        @Override
+        public JsonElement serialize(AnalyzerConstants.ExperimentType experimentType, Type typeOfT, JsonSerializationContext context) {
+            if (experimentType != null) {
+                return new JsonPrimitive(experimentType.name().toLowerCase());
+            }
+            return null;
+        }
+
         @Override
         public AnalyzerConstants.ExperimentType deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
             String experimentType = json.getAsString();


### PR DESCRIPTION
## Description

This PR fixes a bug in the `experiment_type` field `deserialization` for the `CreateExperimentAPIObject`. The issue is caused because the `experiment_type` in the JSON input "`namespace`" is in lowercase, but our code expects an `enum` (`AnalyzerConstants.ExperimentType`) in uppercase ( `NAMESPACE`). This mismatch is converting `experiment_type` to be `null` during `deserialization`.

Fixes # (issue)
- Can not specify namespace data in container experiment.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

**Test Configuration**
* Kubernetes clusters tested on: Openshift Cluster

## Checklist :dart:

- [x] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Added the custom deserialization adapter for converting the lower case string values to proper enum values. 
