### PR TITLE
Fixing ListExperiments API Not Listing Recommendations

### DIFF
--- a/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
@@ -142,86 +142,9 @@ public class Converters {
                     kubernetesAPIObject = new KubernetesAPIObject(k8sObject.getName(), k8sObject.getType(), k8sObject.getNamespace());
                     // namespace recommendations experiment type
                     if (kruizeObject.isNamespaceExperiment()) {
-                        NamespaceAPIObject namespaceAPIObject;
-                        NamespaceData clonedNamespaceData = Utils.getClone(k8sObject.getNamespaceData(), NamespaceData.class);
-
-                        if (null != clonedNamespaceData) {
-                            HashMap<Timestamp, MappedRecommendationForTimestamp> namespaceRecommendations = clonedNamespaceData.getNamespaceRecommendations().getData();
-                            LOGGER.info("Namespace Recommendations: " + namespaceRecommendations.toString());
-                            clonedNamespaceData.getNamespaceRecommendations().setData(namespaceRecommendations);
-                            namespaceAPIObject = new NamespaceAPIObject(clonedNamespaceData.getNamespace_name(), clonedNamespaceData.getNamespaceRecommendations(), null);
-                            kubernetesAPIObject.setNamespaceAPIObject(namespaceAPIObject);
-                        }
+                        processNamespaceRecommendations(k8sObject, kubernetesAPIObject, checkForTimestamp, getLatest, monitoringEndTime);
                     }
-
-                    HashMap<String, ContainerData> containerDataMap = new HashMap<>();
-                    List<ContainerAPIObject> containerAPIObjects = new ArrayList<>();
-                    for (ContainerData containerData : k8sObject.getContainerDataMap().values()) {
-                        ContainerAPIObject containerAPIObject;
-                        // if a Time stamp is passed it holds the priority than latest
-                        if (checkForTimestamp) {
-                            // This step causes a performance degradation, need to be replaced with a better flow of creating SO's
-                            ContainerData clonedContainerData = Utils.getClone(containerData, ContainerData.class);
-                            if (null != clonedContainerData) {
-                                HashMap<Timestamp, MappedRecommendationForTimestamp> recommendations
-                                        = clonedContainerData.getContainerRecommendations().getData();
-                                if (null != monitoringEndTime && recommendations.containsKey(monitoringEndTime)) {
-                                    List<Timestamp> tempList = new ArrayList<>();
-                                    for (Timestamp timestamp : recommendations.keySet()) {
-                                        if (!timestamp.equals(monitoringEndTime))
-                                            tempList.add(timestamp);
-                                    }
-                                    for (Timestamp timestamp : tempList) {
-                                        recommendations.remove(timestamp);
-                                    }
-                                    clonedContainerData.getContainerRecommendations().setData(recommendations);
-                                    containerAPIObject = new ContainerAPIObject(clonedContainerData.getContainer_name(),
-                                            clonedContainerData.getContainer_image_name(),
-                                            clonedContainerData.getContainerRecommendations(),
-                                            null);
-                                    containerAPIObjects.add(containerAPIObject);
-                                }
-                            }
-                        } else if (getLatest) {
-                            // This step causes a performance degradation, need to be replaced with a better flow of creating SO's
-                            ContainerData clonedContainerData = Utils.getClone(containerData, ContainerData.class);
-                            if (null != clonedContainerData) {
-                                HashMap<Timestamp, MappedRecommendationForTimestamp> recommendations
-                                        = clonedContainerData.getContainerRecommendations().getData();
-                                Timestamp latestTimestamp = null;
-                                List<Timestamp> tempList = new ArrayList<>();
-                                for (Timestamp timestamp : recommendations.keySet()) {
-                                    if (null == latestTimestamp) {
-                                        latestTimestamp = timestamp;
-                                    } else {
-                                        if (timestamp.after(latestTimestamp)) {
-                                            tempList.add(latestTimestamp);
-                                            latestTimestamp = timestamp;
-                                        } else {
-                                            tempList.add(timestamp);
-                                        }
-                                    }
-                                }
-                                for (Timestamp timestamp : tempList) {
-                                    recommendations.remove(timestamp);
-                                }
-                                clonedContainerData.getContainerRecommendations().setData(recommendations);
-                                containerAPIObject = new ContainerAPIObject(clonedContainerData.getContainer_name(),
-                                        clonedContainerData.getContainer_image_name(),
-                                        clonedContainerData.getContainerRecommendations(),
-                                        null);
-                                containerAPIObjects.add(containerAPIObject);
-                            }
-                        } else {
-                            containerAPIObject = new ContainerAPIObject(containerData.getContainer_name(),
-                                    containerData.getContainer_image_name(),
-                                    containerData.getContainerRecommendations(),
-                                    null);
-                            containerAPIObjects.add(containerAPIObject);
-                            containerDataMap.put(containerData.getContainer_name(), containerData);
-                        }
-                    }
-                    kubernetesAPIObject.setContainerAPIObjects(containerAPIObjects);
+                    processContainerRecommendations(k8sObject, kubernetesAPIObject, checkForTimestamp, getLatest, monitoringEndTime);
                     kubernetesAPIObjects.add(kubernetesAPIObject);
                 }
                 listRecommendationsAPIObject.setKubernetesObjects(kubernetesAPIObjects);
@@ -229,6 +152,87 @@ public class Converters {
                 e.printStackTrace();
             }
             return listRecommendationsAPIObject;
+        }
+
+        private static void processNamespaceRecommendations(K8sObject k8sObject, KubernetesAPIObject kubernetesAPIObject,
+                                                            boolean checkForTimestamp, boolean getLatest, Timestamp monitoringEndTime) {
+            NamespaceData clonedNamespaceData = Utils.getClone(k8sObject.getNamespaceData(), NamespaceData.class);
+            if (clonedNamespaceData != null) {
+                HashMap<Timestamp, MappedRecommendationForTimestamp> namespaceRecommendations = clonedNamespaceData.getNamespaceRecommendations().getData();
+
+                if (checkForTimestamp) {
+                    filterRecommendationsByTimestamp(namespaceRecommendations, monitoringEndTime);
+                } else if (getLatest) {
+                    filterRecommendationsByLatest(namespaceRecommendations);
+                }
+
+                NamespaceAPIObject namespaceAPIObject = new NamespaceAPIObject(
+                        clonedNamespaceData.getNamespace_name(),
+                        clonedNamespaceData.getNamespaceRecommendations(),
+                        null);
+                kubernetesAPIObject.setNamespaceAPIObject(namespaceAPIObject);
+            }
+        }
+
+        private static void processContainerRecommendations(K8sObject k8sObject, KubernetesAPIObject kubernetesAPIObject,
+                                                            boolean checkForTimestamp, boolean getLatest, Timestamp monitoringEndTime) {
+            List<ContainerAPIObject> containerAPIObjects = new ArrayList<>();
+
+            for (ContainerData containerData : k8sObject.getContainerDataMap().values()) {
+                ContainerData clonedContainerData = Utils.getClone(containerData, ContainerData.class);
+
+                if (clonedContainerData != null) {
+                    HashMap<Timestamp, MappedRecommendationForTimestamp> recommendations = clonedContainerData.getContainerRecommendations().getData();
+
+                    if (checkForTimestamp) {
+                        filterRecommendationsByTimestamp(recommendations, monitoringEndTime);
+                    } else if (getLatest) {
+                        filterRecommendationsByLatest(recommendations);
+                    }
+
+                    ContainerAPIObject containerAPIObject = new ContainerAPIObject(
+                            clonedContainerData.getContainer_name(),
+                            clonedContainerData.getContainer_image_name(),
+                            clonedContainerData.getContainerRecommendations(),
+                            null);
+                    containerAPIObjects.add(containerAPIObject);
+                } else {
+                    containerAPIObjects.add(new ContainerAPIObject(
+                            containerData.getContainer_name(),
+                            containerData.getContainer_image_name(),
+                            containerData.getContainerRecommendations(),
+                            null));
+                }
+            }
+
+            kubernetesAPIObject.setContainerAPIObjects(containerAPIObjects);
+        }
+
+        private static void filterRecommendationsByTimestamp(HashMap<Timestamp, MappedRecommendationForTimestamp> recommendations,
+                                                             Timestamp monitoringEndTime) {
+            if (monitoringEndTime != null && recommendations.containsKey(monitoringEndTime)) {
+                recommendations.keySet().removeIf(timestamp -> !timestamp.equals(monitoringEndTime));
+            }
+        }
+
+        private static void filterRecommendationsByLatest(HashMap<Timestamp, MappedRecommendationForTimestamp> recommendations) {
+            Timestamp latestTimestamp = null;
+            List<Timestamp> timestampsToRemove = new ArrayList<>();
+
+            for (Timestamp timestamp : recommendations.keySet()) {
+                if (latestTimestamp == null || timestamp.after(latestTimestamp)) {
+                    if (latestTimestamp != null) {
+                        timestampsToRemove.add(latestTimestamp);
+                    }
+                    latestTimestamp = timestamp;
+                } else {
+                    timestampsToRemove.add(timestamp);
+                }
+            }
+
+            for (Timestamp timestamp : timestampsToRemove) {
+                recommendations.remove(timestamp);
+            }
         }
 
         /**


### PR DESCRIPTION
## Description

This PR fixes a issue with `listExperiment` api not showing the recommendations with `recommendations=true` parameter. Additionally, adds support for listing recommendations using `listExperiment` api for `namespace` experiments. 

Fixes # (issue)
- `listExperiment` api not showing the recommendations with `recommendations=true`

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

**Test Configuration**
* Kubernetes clusters tested on: Openshift Cluster

## Checklist :dart:

- [x] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

THIS PR IS BASED ON: https://github.com/kruize/autotune/pull/1428 
PR https://github.com/kruize/autotune/pull/1428 should be merged before this one. 

Image for Testing: `quay.io/rh-ee-shesaxen/autotune:v74`