### PR TITLE
Bulk demo fix

### DIFF
--- a/src/main/java/com/autotune/analyzer/serviceObjects/BulkJobStatus.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/BulkJobStatus.java
@@ -147,7 +147,7 @@ public class BulkJobStatus {
     }
 
 
-    public synchronized void incrementProcessed_experiments() {
+    public void incrementProcessed_experiments() {
         this.processed_experiments.incrementAndGet();
     }
 

--- a/src/main/java/com/autotune/analyzer/serviceObjects/BulkJobStatus.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/BulkJobStatus.java
@@ -27,6 +27,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.autotune.utils.KruizeConstants.KRUIZE_BULK_API.JOB_ID;
 import static com.autotune.utils.KruizeConstants.KRUIZE_BULK_API.NotificationConstants.Status.UNPROCESSED;
@@ -41,7 +42,7 @@ public class BulkJobStatus {
     private String jobID;
     private String status;
     private int total_experiments;
-    private int processed_experiments;  //todo : If the primary operations are increments or simple atomic updates, use AtomicInteger. It is designed for lock-free thread-safe access
+    private AtomicInteger processed_experiments;  //todo : If the primary operations are increments or simple atomic updates, use AtomicInteger. It is designed for lock-free thread-safe access
     @JsonProperty("job_start_time")
     private String startTime; // Change to String to store formatted time
     @JsonProperty("job_end_time")
@@ -54,6 +55,7 @@ public class BulkJobStatus {
         this.jobID = jobID;
         this.status = status;
         setStartTime(startTime);
+        this.processed_experiments = new AtomicInteger(0);
     }
 
 
@@ -144,12 +146,17 @@ public class BulkJobStatus {
         this.total_experiments = total_experiments;
     }
 
-    public synchronized int getProcessed_experiments() {
+
+    public synchronized void incrementProcessed_experiments() {
+        this.processed_experiments.incrementAndGet();
+    }
+
+    public AtomicInteger getProcessed_experiments() {
         return processed_experiments;
     }
 
-    public synchronized void setProcessed_experiments(int processed_experiments) {
-        this.processed_experiments = processed_experiments;
+    public void setProcessed_experiments(int count) {
+        this.processed_experiments.set(count);
     }
 
     // Utility function to format Instant into the required UTC format
@@ -194,16 +201,16 @@ public class BulkJobStatus {
             return recommendations;
         }
 
-        public void setNotification(Notification notification) {
-            this.notification = notification;
+        public void setRecommendations(Recommendation recommendations) {
+            this.recommendations = recommendations;
         }
 
         public Notification getNotification() {
             return notification;
         }
 
-        public void setRecommendations(Recommendation recommendations) {
-            this.recommendations = recommendations;
+        public void setNotification(Notification notification) {
+            this.notification = notification;
         }
     }
 
@@ -297,4 +304,4 @@ public class BulkJobStatus {
         }
     }
 
-    }
+}

--- a/src/main/java/com/autotune/analyzer/services/BulkService.java
+++ b/src/main/java/com/autotune/analyzer/services/BulkService.java
@@ -109,7 +109,10 @@ public class BulkService extends HttpServlet {
                         filters.addFilter("jobFilter", SimpleBeanPropertyFilter.serializeAll());
                     }
                     objectMapper.setFilterProvider(filters);
-                    String jsonResponse = objectMapper.writeValueAsString(jobDetails);
+                    String jsonResponse = "";
+                    synchronized (jobDetails) {
+                        jsonResponse = objectMapper.writeValueAsString(jobDetails);
+                    }
                     resp.getWriter().write(jsonResponse);
                     statusValue = "success";
                 } catch (Exception e) {

--- a/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
+++ b/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
@@ -179,14 +179,14 @@ public class BulkJobManager implements Runnable {
                                         GenericRestApiClient apiClient = new GenericRestApiClient(finalDatasource);
                                         apiClient.setBaseURL(KruizeDeploymentInfo.experiments_url);
                                         GenericRestApiClient.HttpResponseWrapper responseCode;
-                                        boolean expriment_exists = false;
+                                        boolean experiment_exists = false;
                                         try {
                                             responseCode = apiClient.callKruizeAPI("[" + new Gson().toJson(apiObject) + "]");
                                             LOGGER.debug("API Response code: {}", responseCode);
                                             if (responseCode.getStatusCode() == HttpURLConnection.HTTP_CREATED) {
-                                                expriment_exists = true;
+                                                experiment_exists = true;
                                             } else if (responseCode.getStatusCode() == HttpURLConnection.HTTP_CONFLICT) {
-                                                expriment_exists = true;
+                                                experiment_exists = true;
                                             } else {
                                                 experiment.setNotification(new BulkJobStatus.Notification(BulkJobStatus.NotificationType.ERROR, responseCode.getResponseBody().toString(), responseCode.getStatusCode()));
                                             }
@@ -194,7 +194,7 @@ public class BulkJobManager implements Runnable {
                                             e.printStackTrace();
                                             experiment.setNotification(new BulkJobStatus.Notification(BulkJobStatus.NotificationType.ERROR, e.getMessage(), HttpURLConnection.HTTP_BAD_REQUEST));
                                         } finally {
-                                            if (!expriment_exists) {
+                                            if (!experiment_exists) {
                                                 LOGGER.info("Processing experiment {}", jobData.getProcessed_experiments());
                                                 jobData.incrementProcessed_experiments();
                                             }
@@ -205,7 +205,7 @@ public class BulkJobManager implements Runnable {
                                             }
                                         }
 
-                                        if (expriment_exists) {
+                                        if (experiment_exists) {
                                             generateExecutor.submit(() -> {
                                                 // send request to generateRecommendations API
                                                 GenericRestApiClient recommendationApiClient = new GenericRestApiClient(finalDatasource);

--- a/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
+++ b/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
@@ -153,8 +153,7 @@ public class BulkJobManager implements Runnable {
                 if (null != daterange) {
                     metadataInfo = dataSourceManager.importMetadataFromDataSource(datasource, labelString, (Long) daterange.get(START_TIME),
                             (Long) daterange.get(END_TIME), (Integer) daterange.get(STEPS), includeResourcesMap, excludeResourcesMap);
-                }
-                else {
+                } else {
                     metadataInfo = dataSourceManager.importMetadataFromDataSource(datasource, labelString, 0, 0,
                             0, includeResourcesMap, excludeResourcesMap);
                 }
@@ -197,10 +196,10 @@ public class BulkJobManager implements Runnable {
                                         } finally {
                                             if (!expriment_exists) {
                                                 LOGGER.info("Processing experiment {}", jobData.getProcessed_experiments());
-                                                jobData.setProcessed_experiments(jobData.getProcessed_experiments() + 1);
+                                                jobData.incrementProcessed_experiments();
                                             }
                                             synchronized (new Object()) {
-                                                if (jobData.getTotal_experiments() == jobData.getProcessed_experiments()) {
+                                                if (jobData.getTotal_experiments() == jobData.getProcessed_experiments().get()) {
                                                     setFinalJobStatus(COMPLETED, null, null, finalDatasource);
                                                 }
                                             }
@@ -228,9 +227,9 @@ public class BulkJobManager implements Runnable {
                                                     experiment.getRecommendations().setStatus(NotificationConstants.Status.FAILED);
                                                     experiment.getRecommendations().setNotifications(new BulkJobStatus.Notification(BulkJobStatus.NotificationType.ERROR, e.getMessage(), HttpURLConnection.HTTP_INTERNAL_ERROR));
                                                 } finally {
-                                                    jobData.setProcessed_experiments(jobData.getProcessed_experiments() + 1);
+                                                    jobData.incrementProcessed_experiments();
                                                     synchronized (new Object()) {
-                                                        if (jobData.getTotal_experiments() == jobData.getProcessed_experiments()) {
+                                                        if (jobData.getTotal_experiments() == jobData.getProcessed_experiments().get()) {
                                                             setFinalJobStatus(COMPLETED, null, null, finalDatasource);
                                                         }
                                                     }
@@ -240,8 +239,8 @@ public class BulkJobManager implements Runnable {
                                     } catch (Exception e) {
                                         e.printStackTrace();
                                         experiment.setNotification(new BulkJobStatus.Notification(BulkJobStatus.NotificationType.ERROR, e.getMessage(), HttpURLConnection.HTTP_INTERNAL_ERROR));
-                                        jobData.setProcessed_experiments(jobData.getProcessed_experiments() + 1);
-                                        if (jobData.getTotal_experiments() == jobData.getProcessed_experiments()) {
+                                        jobData.incrementProcessed_experiments();
+                                        if (jobData.getTotal_experiments() == jobData.getProcessed_experiments().get()) {
                                             setFinalJobStatus(COMPLETED, null, null, finalDatasource);
                                         }
                                     }
@@ -270,7 +269,7 @@ public class BulkJobManager implements Runnable {
                                 }
                             }
 
-                            if (jobData.getTotal_experiments() == jobData.getProcessed_experiments()) {
+                            if (jobData.getTotal_experiments() == jobData.getProcessed_experiments().get()) {
                                 statusValue = "success";
                             }
                         }

--- a/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
+++ b/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
@@ -198,7 +198,7 @@ public class BulkJobManager implements Runnable {
                                                 LOGGER.info("Processing experiment {}", jobData.getProcessed_experiments());
                                                 jobData.incrementProcessed_experiments();
                                             }
-                                            synchronized (new Object()) {
+                                            synchronized (jobData) {
                                                 if (jobData.getTotal_experiments() == jobData.getProcessed_experiments().get()) {
                                                     setFinalJobStatus(COMPLETED, null, null, finalDatasource);
                                                 }
@@ -228,7 +228,7 @@ public class BulkJobManager implements Runnable {
                                                     experiment.getRecommendations().setNotifications(new BulkJobStatus.Notification(BulkJobStatus.NotificationType.ERROR, e.getMessage(), HttpURLConnection.HTTP_INTERNAL_ERROR));
                                                 } finally {
                                                     jobData.incrementProcessed_experiments();
-                                                    synchronized (new Object()) {
+                                                    synchronized (jobData) {
                                                         if (jobData.getTotal_experiments() == jobData.getProcessed_experiments().get()) {
                                                             setFinalJobStatus(COMPLETED, null, null, finalDatasource);
                                                         }


### PR DESCRIPTION
## Description


The incorrect count occurred because the get and increment operations were performed in separate functions. As a result, the first two threads retrieved the same initial value, which was zero, and incrementing did not occur as expected. This issue has been resolved by using AtomicInteger, which ensures thread-safe operations. Additionally, I noticed a reduction in execution time after introducing the AtomicInteger utility. I added todo in my previous PR thinking this issue could appear.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [x] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [x] Dependent changes merged
- [ ] Documentation updated
- [x] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
