### PR TITLE
Fix Remote Monitoring Negative Test Failure

### DIFF
--- a/tests/scripts/remote_monitoring_tests/rest_apis/test_update_results.py
+++ b/tests/scripts/remote_monitoring_tests/rest_apis/test_update_results.py
@@ -785,7 +785,7 @@ def test_update_results__duplicate_records_with_single_exp_multiple_results(clus
     results = "true"
     recommendations = "false"
     latest = "false"
-    response = list_experiments(results, recommendations, latest, experiment_name)
+    response = list_experiments(results, recommendations, latest, experiment_name, True)
 
     list_exp_json = response.json()
     assert response.status_code == SUCCESS_200_STATUS_CODE


### PR DESCRIPTION
## Description

This PR adds a missing flag in the listExperiments API call from one of the Remote Monitoring negative test :  `test_update_results__duplicate_records_with_single_exp_multiple_results` .

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [x] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: Minikube, Openshift

## Checklist :dart:

- [x] Followed coding guidelines
- [ ] Comments added
- [x] Dependent changes merged
- [ ] Documentation updated
- [x] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
