### PR TITLE
KAMS - 3 : Adds support for MIG partition data in Device Details 

### DIFF
--- a/src/main/java/com/autotune/analyzer/adapters/DeviceDetailsAdapter.java
+++ b/src/main/java/com/autotune/analyzer/adapters/DeviceDetailsAdapter.java
@@ -26,7 +26,8 @@ public class DeviceDetailsAdapter extends TypeAdapter<DeviceDetails> {
             out.name("hostName").value(accelerator.getHostName());
             out.name("UUID").value(accelerator.getUUID());
             out.name("deviceName").value(accelerator.getDeviceName());
-            out.name("isMIG").value(accelerator.isMIG());
+            out.name("isMIGSupported").value(accelerator.isMIGSupported());
+            out.name("isMIGPartition").value(accelerator.isMIGPartition());
         }
         // Add for other devices when added
 
@@ -41,7 +42,9 @@ public class DeviceDetailsAdapter extends TypeAdapter<DeviceDetails> {
         String hostName = null;
         String UUID = null;
         String deviceName = null;
+        String profile = null;
         boolean isMIG = false;
+        boolean isMIGPartition = false;
 
         in.beginObject();
         while (in.hasNext()) {
@@ -64,8 +67,14 @@ public class DeviceDetailsAdapter extends TypeAdapter<DeviceDetails> {
                 case "deviceName":
                     deviceName = in.nextString();
                     break;
-                case "isMIG":
+                case "isMIGSupported":
                     isMIG = in.nextBoolean();
+                    break;
+                case "isMIGPartition":
+                    isMIGPartition = in.nextBoolean();
+                    break;
+                case "profile":
+                    profile = in.nextString();
                     break;
                 default:
                     in.skipValue();
@@ -74,7 +83,7 @@ public class DeviceDetailsAdapter extends TypeAdapter<DeviceDetails> {
         in.endObject();
 
         if (type != null && type.equals(AnalyzerConstants.DeviceType.ACCELERATOR.name())) {
-            return (DeviceDetails) new AcceleratorDeviceData(modelName, hostName, UUID, deviceName, isMIG);
+            return (DeviceDetails) new AcceleratorDeviceData(modelName, hostName, UUID, deviceName, profile, isMIG, isMIGPartition);
         }
         // Add for other device types if implemented in future
 

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -2227,7 +2227,7 @@ public class RecommendationEngine {
                                                 metricObject.get(KruizeConstants.JSONKeys.HOSTNAME).getAsString(),
                                                 metricObject.get(KruizeConstants.JSONKeys.UUID).getAsString(),
                                                 metricObject.get(KruizeConstants.JSONKeys.DEVICE).getAsString(),
-                                                true);
+                                                null, true, false);
 
                                         JsonArray valuesArray = resultObject.getAsJsonArray(KruizeConstants.DataSourceConstants
                                                 .DataSourceQueryJSONKeys.VALUES);

--- a/src/main/java/com/autotune/analyzer/recommendations/utils/RecommendationUtils.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/utils/RecommendationUtils.java
@@ -256,7 +256,7 @@ public class RecommendationUtils {
                                 metricObject.get(KruizeConstants.JSONKeys.HOSTNAME).getAsString(),
                                 metricObject.get(KruizeConstants.JSONKeys.UUID).getAsString(),
                                 metricObject.get(KruizeConstants.JSONKeys.DEVICE).getAsString(),
-                                isSupportedMig);
+                                null, isSupportedMig, false);
 
 
                         if (null == containerData.getContainerDeviceList()) {

--- a/src/main/java/com/autotune/common/data/system/info/device/accelerator/AcceleratorDeviceData.java
+++ b/src/main/java/com/autotune/common/data/system/info/device/accelerator/AcceleratorDeviceData.java
@@ -8,15 +8,25 @@ public class AcceleratorDeviceData implements AcceleratorDeviceDetails {
     private final String hostName;
     private final String UUID;
     private final String deviceName;
-    private boolean isMIG;
+    private final String profile;
+    private boolean isMIGSupported;
+    private boolean isMIGPartition;
 
-    public AcceleratorDeviceData (String modelName, String hostName, String UUID, String deviceName, boolean isMIG) {
+    public AcceleratorDeviceData (String modelName,
+                                  String hostName,
+                                  String UUID,
+                                  String deviceName,
+                                  String profile,
+                                  boolean isMIGSupported,
+                                  boolean isMIGPartition) {
+        this.profile = profile;
+        this.isMIGPartition = isMIGPartition;
         this.manufacturer = "NVIDIA";
         this.modelName = modelName;
         this.hostName = hostName;
         this.UUID = UUID;
         this.deviceName = deviceName;
-        this.isMIG = isMIG;
+        this.isMIGSupported = isMIGSupported;
     }
 
     @Override
@@ -44,12 +54,16 @@ public class AcceleratorDeviceData implements AcceleratorDeviceDetails {
         return deviceName;
     }
 
-    public boolean isMIG() {
-        return isMIG;
+    public String getProfile() {
+        return profile;
     }
 
-    public void setMIG(boolean isMIG) {
-        this.isMIG = isMIG;
+    public boolean isMIGPartition() {
+        return isMIGPartition;
+    }
+
+    public boolean isMIGSupported() {
+        return isMIGSupported;
     }
 
     @Override


### PR DESCRIPTION
## Description

KAMS - Kruize Accelerator MIG-tuning Service

As we need to add support for the MIG partitions in kruize the Device details implementation for the accelerator should have variables to store the MIG profile. This PR adds that support.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Tests are pending due to resource unavailability 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated
