### PR TITLE
[wip- Bug Fix] Fixing Delete Experiment API 

### DIFF
--- a/src/main/java/com/autotune/analyzer/services/CreateExperiment.java
+++ b/src/main/java/com/autotune/analyzer/services/CreateExperiment.java
@@ -181,7 +181,6 @@ public class CreateExperiment extends HttpServlet {
             } else {
                 for (CreateExperimentAPIObject ko : createExperimentAPIObjects) {
                     try {
-                        LOGGER.info("Hello: " + ko.getTargetCluster());
                         if (is_ros_enabled && AnalyzerConstants.REMOTE.equalsIgnoreCase(ko.getTargetCluster())) {
                             new ExperimentDBService().loadExperimentFromDBByName(mKruizeExperimentMap, ko.getExperimentName());
                         } else {

--- a/src/main/java/com/autotune/database/dao/ExperimentDAO.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAO.java
@@ -45,6 +45,9 @@ public interface ExperimentDAO {
     // Delete experiment
     public ValidationOutputData deleteKruizeExperimentEntryByName(String experimentName);
 
+    // Delete LM experiment
+    public ValidationOutputData deleteKruizeLMExperimentEntryByName(String experimentName);
+
     // If Kruize object restarts load all experiment which are in inprogress
     public List<KruizeExperimentEntry> loadAllExperiments() throws Exception;
 

--- a/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
@@ -623,10 +623,10 @@ public class ExperimentDAOImpl implements ExperimentDAO {
     }
 
     /**
-     * Delete an experiment with the name experimentName
+     * Delete an experiment with the name experimentName for local monitoring use case
      * This deletes the experiment from all three tables
-     * kruize_experiments, kruize_results and kruize_recommendations
-     * Delete from kruize_results and kruize_recommendations only if the delete from kruize_experiments succeeds.
+     * kruize_lm_experiments, kruize_results and kruize_lm_recommendations
+     * Delete from kruize_results and kruize_lm_recommendations only if the delete from kruize_lm_experiments succeeds.
      *
      * @param experimentName
      * @return

--- a/src/main/java/com/autotune/database/helper/DBConstants.java
+++ b/src/main/java/com/autotune/database/helper/DBConstants.java
@@ -69,8 +69,10 @@ public class DBConstants {
         public static final String SELECT_FROM_METRIC_PROFILE = "from KruizeMetricProfileEntry";
         public static final String SELECT_FROM_METRIC_PROFILE_BY_NAME = "from KruizeMetricProfileEntry k WHERE k.name = :name";
         public static final String DELETE_FROM_EXPERIMENTS_BY_EXP_NAME = "DELETE FROM KruizeExperimentEntry k WHERE k.experiment_name = :experimentName";
+        public static final String DELETE_FROM_LM_EXPERIMENTS_BY_EXP_NAME = "DELETE FROM KruizeLMExperimentEntry k WHERE k.experiment_name = :experimentName";
         public static final String DELETE_FROM_RESULTS_BY_EXP_NAME = "DELETE FROM KruizeResultsEntry k WHERE k.experiment_name = :experimentName";
         public static final String DELETE_FROM_RECOMMENDATIONS_BY_EXP_NAME = "DELETE FROM KruizeRecommendationEntry k WHERE k.experiment_name = :experimentName";
+        public static final String DELETE_FROM_LM_RECOMMENDATIONS_BY_EXP_NAME = "DELETE FROM KruizeLMRecommendationEntry k WHERE k.experiment_name = :experimentName";
         public static final String DELETE_FROM_METADATA_BY_DATASOURCE_NAME = "DELETE FROM KruizeDSMetadataEntry km WHERE km.datasource_name = :dataSourceName";
         public static final String DELETE_FROM_METRIC_PROFILE_BY_PROFILE_NAME = "DELETE FROM KruizeMetricProfileEntry km WHERE km.name = :metricProfileName";
         public static final String DB_PARTITION_DATERANGE = "CREATE TABLE IF NOT EXISTS %s_%s%s%s PARTITION OF %s FOR VALUES FROM ('%s-%s-%s 00:00:00.000') TO ('%s-%s-%s 23:59:59');";


### PR DESCRIPTION
## Description

This PR addresses the issue with the delete experiment functionality for the local monitoring use case. Previously, the delete operation was incorrectly attempting to find the experiment in the `KruizeExperimentEntry` table, which is not applicable for local monitoring. The logic has now been updated to use the `KruizeLMExperimentEntry` table for local monitoring use case. For cases where ROS is enabled and local monitoring use case, the `KruizeExperimentEntry` table will continue to be used.

Fixes # (issue)
https://github.com/kruize/autotune/issues/1456

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Manually tested on OpenShift cluster (Resource Hub)


**Test Configuration**
* Kubernetes clusters tested on: OpenShift

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Image for testing: `quay.io/rh-ee-shesaxen/autotune:fixDelExp`