### PR TITLE
[Kruize VPA Integration] Validation to Restrictions For Auto and Recreate Modes

### DIFF
--- a/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
+++ b/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
@@ -141,6 +141,22 @@ public class ExperimentValidation {
                         }
                     }
                     // validate mode and experiment type
+                    if (AnalyzerConstants.AUTO.equalsIgnoreCase(mode) || AnalyzerConstants.RECREATE.equalsIgnoreCase(mode)) {
+                        if (kruizeObject.isNamespaceExperiment()) {
+                            errorMsg = AnalyzerErrorConstants.APIErrors.CreateExperimentAPI.INVALID_MODE_FOR_NAMESPACE_EXP;
+                            validationOutputData.setErrorCode(HttpServletResponse.SC_BAD_REQUEST);
+                            proceed = false;
+                        }
+                        // verifying kubernetes object type
+                        List<K8sObject> k8sObjects = kruizeObject.getKubernetes_objects();
+                        for (K8sObject k8sObject : k8sObjects) {
+                            if (!AnalyzerConstants.K8sObjectConstants.Types.DEPLOYMENT.equalsIgnoreCase(k8sObject.getType())) {
+                                errorMsg = AnalyzerErrorConstants.APIErrors.CreateExperimentAPI.INVALID_OBJECT_TYPE_FOR_AUTO_EXP;
+                                validationOutputData.setErrorCode(HttpServletResponse.SC_BAD_REQUEST);
+                                proceed = false;
+                            }
+                        }
+                    }
                     if (kruizeObject.isNamespaceExperiment()) {
                         if (AnalyzerConstants.AUTO.equalsIgnoreCase(mode) || AnalyzerConstants.RECREATE.equalsIgnoreCase(mode)) {
                             errorMsg = AnalyzerErrorConstants.APIErrors.CreateExperimentAPI.INVALID_MODE_FOR_NAMESPACE_EXP;

--- a/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
+++ b/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
@@ -140,6 +140,14 @@ public class ExperimentValidation {
                             proceed = true;
                         }
                     }
+                    // validate mode and experiment type
+                    if (kruizeObject.isNamespaceExperiment()) {
+                        if (AnalyzerConstants.AUTO.equalsIgnoreCase(mode) || AnalyzerConstants.RECREATE.equalsIgnoreCase(mode)) {
+                            errorMsg = AnalyzerErrorConstants.APIErrors.CreateExperimentAPI.INVALID_MODE_FOR_NAMESPACE_EXP;
+                            validationOutputData.setErrorCode(HttpServletResponse.SC_BAD_REQUEST);
+                            proceed = false;
+                        }
+                    }
                 } else {
                     errorMsg = errorMsg.concat(String.format(AnalyzerErrorConstants.AutotuneObjectErrors.DUPLICATE_EXPERIMENT)).concat(expName);
                     validationOutputData.setErrorCode(HttpServletResponse.SC_CONFLICT);

--- a/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
+++ b/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
@@ -146,14 +146,15 @@ public class ExperimentValidation {
                             errorMsg = AnalyzerErrorConstants.APIErrors.CreateExperimentAPI.INVALID_MODE_FOR_NAMESPACE_EXP;
                             validationOutputData.setErrorCode(HttpServletResponse.SC_BAD_REQUEST);
                             proceed = false;
-                        }
-                        // verifying kubernetes object type
-                        List<K8sObject> k8sObjects = kruizeObject.getKubernetes_objects();
-                        for (K8sObject k8sObject : k8sObjects) {
-                            if (!AnalyzerConstants.K8sObjectConstants.Types.DEPLOYMENT.equalsIgnoreCase(k8sObject.getType())) {
-                                errorMsg = AnalyzerErrorConstants.APIErrors.CreateExperimentAPI.INVALID_OBJECT_TYPE_FOR_AUTO_EXP;
-                                validationOutputData.setErrorCode(HttpServletResponse.SC_BAD_REQUEST);
-                                proceed = false;
+                        } else {
+                            // verifying kubernetes object type for container experiment
+                            List<K8sObject> k8sObjects = kruizeObject.getKubernetes_objects();
+                            for (K8sObject k8sObject : k8sObjects) {
+                                if (!AnalyzerConstants.K8sObjectConstants.Types.DEPLOYMENT.equalsIgnoreCase(k8sObject.getType())) {
+                                    errorMsg = AnalyzerErrorConstants.APIErrors.CreateExperimentAPI.INVALID_OBJECT_TYPE_FOR_AUTO_EXP;
+                                    validationOutputData.setErrorCode(HttpServletResponse.SC_BAD_REQUEST);
+                                    proceed = false;
+                                }
                             }
                         }
                     }

--- a/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
+++ b/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
@@ -157,13 +157,6 @@ public class ExperimentValidation {
                             }
                         }
                     }
-                    if (kruizeObject.isNamespaceExperiment()) {
-                        if (AnalyzerConstants.AUTO.equalsIgnoreCase(mode) || AnalyzerConstants.RECREATE.equalsIgnoreCase(mode)) {
-                            errorMsg = AnalyzerErrorConstants.APIErrors.CreateExperimentAPI.INVALID_MODE_FOR_NAMESPACE_EXP;
-                            validationOutputData.setErrorCode(HttpServletResponse.SC_BAD_REQUEST);
-                            proceed = false;
-                        }
-                    }
                 } else {
                     errorMsg = errorMsg.concat(String.format(AnalyzerErrorConstants.AutotuneObjectErrors.DUPLICATE_EXPERIMENT)).concat(expName);
                     validationOutputData.setErrorCode(HttpServletResponse.SC_CONFLICT);

--- a/src/main/java/com/autotune/analyzer/services/CreateExperiment.java
+++ b/src/main/java/com/autotune/analyzer/services/CreateExperiment.java
@@ -108,6 +108,11 @@ public class CreateExperiment extends HttpServlet {
                             if (null != kubernetesAPIObject.getNamespaceAPIObjects()) {
                                 throw new InvalidExperimentType(AnalyzerErrorConstants.APIErrors.CreateExperimentAPI.NAMESPACE_DATA_NOT_NULL_FOR_CONTAINER_EXP);
                             }
+                            if ((AnalyzerConstants.AUTO.equalsIgnoreCase(createExperimentAPIObject.getMode())
+                                    || AnalyzerConstants.RECREATE.equalsIgnoreCase(createExperimentAPIObject.getMode())) &&
+                                            AnalyzerConstants.REMOTE.equalsIgnoreCase(createExperimentAPIObject.getTargetCluster())) {
+                                throw new InvalidExperimentType(AnalyzerErrorConstants.APIErrors.CreateExperimentAPI.AUTO_EXP_NOT_SUPPORTED_FOR_REMOTE);
+                            }
                         } else if (createExperimentAPIObject.isNamespaceExperiment()) {
                             if (null != kubernetesAPIObject.getContainerAPIObjects()) {
                                 throw new InvalidExperimentType(AnalyzerErrorConstants.APIErrors.CreateExperimentAPI.CONTAINER_DATA_NOT_NULL_FOR_NAMESPACE_EXP);

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
@@ -176,7 +176,7 @@ public class AnalyzerErrorConstants {
             public static final String NAMESPACE_EXP_NOT_SUPPORTED_FOR_REMOTE = "Namespace experiment type is not supported for remote monitoring use case.";
             public static final String INVALID_MODE_FOR_NAMESPACE_EXP = "Auto or recreate mode is not supported for namespace experiment.";
             public static final String INVALID_OBJECT_TYPE_FOR_AUTO_EXP = "Kubernetes object type is not supported for auto or recreate mode.";
-
+            public static final String AUTO_EXP_NOT_SUPPORTED_FOR_REMOTE = "Auto or recreate mode is not supported for remote monitoring use case.";
             private CreateExperimentAPI() {
 
             }

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
@@ -174,7 +174,8 @@ public class AnalyzerErrorConstants {
             public static final String CONTAINER_DATA_NOT_NULL_FOR_NAMESPACE_EXP = "Can not specify container data for namespace experiment";
             public static final String NAMESPACE_DATA_NOT_NULL_FOR_CONTAINER_EXP = "Can not specify namespace data for container experiment";
             public static final String NAMESPACE_EXP_NOT_SUPPORTED_FOR_REMOTE = "Namespace experiment type is not supported for remote monitoring use case.";
-            public static final String INVALID_MODE_FOR_NAMESPACE_EXP = "auto or recreate mode is not supported for namespace experiment.";
+            public static final String INVALID_MODE_FOR_NAMESPACE_EXP = "Auto or recreate mode is not supported for namespace experiment.";
+            public static final String INVALID_OBJECT_TYPE_FOR_AUTO_EXP = "Kubernetes object type is not supported for auto or recreate mode.";
 
             private CreateExperimentAPI() {
 

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
@@ -174,6 +174,7 @@ public class AnalyzerErrorConstants {
             public static final String CONTAINER_DATA_NOT_NULL_FOR_NAMESPACE_EXP = "Can not specify container data for namespace experiment";
             public static final String NAMESPACE_DATA_NOT_NULL_FOR_CONTAINER_EXP = "Can not specify namespace data for container experiment";
             public static final String NAMESPACE_EXP_NOT_SUPPORTED_FOR_REMOTE = "Namespace experiment type is not supported for remote monitoring use case.";
+            public static final String INVALID_MODE_FOR_NAMESPACE_EXP = "auto or recreate mode is not supported for namespace experiment.";
 
             private CreateExperimentAPI() {
 


### PR DESCRIPTION
## Description

This PR adds following validations - 
- Restrict `namespace` experiments with `auto` or `recreate` mode
- Allow only `deployment` kubernetes object type with `auto` and `recreate` mode
- Restrict `remote` target cluster with `auto` and `recreate` mode

Fixes # (issue)
https://github.com/kruize/autotune/issues/1462

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Manually tested on OpenShift cluster (Resource Hub)

**Test Configuration**
* Kubernetes clusters tested on: OpenShift

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Image for testing: `quay.io/rh-ee-shesaxen/autotune:hello3`
