### PR TITLE
Adding Functionality to Dynamically Calculate Threshold Value For Minimum Time Required For Term

### DIFF
--- a/src/main/java/com/autotune/analyzer/kruizeObject/KruizeObject.java
+++ b/src/main/java/com/autotune/analyzer/kruizeObject/KruizeObject.java
@@ -136,15 +136,33 @@ public final class KruizeObject implements ExperimentTypeAware {
     public static void setDefaultTerms(Map<String, Terms> terms, KruizeObject kruizeObject) {
         // TODO: define term names like daily, weekly, fortnightly etc
         // TODO: add CRD for terms
-        terms.put(KruizeConstants.JSONKeys.SHORT_TERM, new Terms(KruizeConstants.JSONKeys.SHORT_TERM, KruizeConstants.RecommendationEngineConstants
-                .DurationBasedEngine.DurationAmount.SHORT_TERM_DURATION_DAYS, KruizeConstants.RecommendationEngineConstants
-                .DurationBasedEngine.DurationAmount.SHORT_TERM_DURATION_DAYS_THRESHOLD, 4, 0.25));
-        terms.put(KruizeConstants.JSONKeys.MEDIUM_TERM, new Terms(KruizeConstants.JSONKeys.MEDIUM_TERM, KruizeConstants
-                .RecommendationEngineConstants.DurationBasedEngine.DurationAmount.MEDIUM_TERM_DURATION_DAYS, KruizeConstants
-                .RecommendationEngineConstants.DurationBasedEngine.DurationAmount.MEDIUM_TERM_DURATION_DAYS_THRESHOLD, 7, 1));
-        terms.put(KruizeConstants.JSONKeys.LONG_TERM, new Terms(KruizeConstants.JSONKeys.LONG_TERM, KruizeConstants
-                .RecommendationEngineConstants.DurationBasedEngine.DurationAmount.LONG_TERM_DURATION_DAYS, KruizeConstants
-                .RecommendationEngineConstants.DurationBasedEngine.DurationAmount.LONG_TERM_DURATION_DAYS_THRESHOLD, 15, 1));
+        HashMap<String, Double> minDuration = new HashMap<>();
+
+        if (null != kruizeObject.getRecommendation_settings().getMinDurationInMins()) {
+            minDuration = kruizeObject.getRecommendation_settings().getMinDurationInMins();
+        }
+
+        double shortTermThreshold = minDuration.containsKey(KruizeConstants.JSONKeys.SHORT_TERM)
+                ? kruizeObject.getRecommendation_settings().getThresholdForTerm(KruizeConstants.JSONKeys.SHORT_TERM)
+                : KruizeConstants.RecommendationEngineConstants.DurationBasedEngine.DurationAmount.SHORT_TERM_DURATION_DAYS_THRESHOLD;
+
+        double mediumTermThreshold = minDuration.containsKey(KruizeConstants.JSONKeys.MEDIUM_TERM)
+                ? kruizeObject.getRecommendation_settings().getThresholdForTerm(KruizeConstants.JSONKeys.MEDIUM_TERM)
+                : KruizeConstants.RecommendationEngineConstants.DurationBasedEngine.DurationAmount.MEDIUM_TERM_DURATION_DAYS_THRESHOLD;
+
+        double longTermThreshold = minDuration.containsKey(KruizeConstants.JSONKeys.LONG_TERM)
+                ? kruizeObject.getRecommendation_settings().getThresholdForTerm(KruizeConstants.JSONKeys.LONG_TERM)
+                : KruizeConstants.RecommendationEngineConstants.DurationBasedEngine.DurationAmount.LONG_TERM_DURATION_DAYS_THRESHOLD;
+
+        terms.put(KruizeConstants.JSONKeys.SHORT_TERM, new Terms(KruizeConstants.JSONKeys.SHORT_TERM,
+                KruizeConstants.RecommendationEngineConstants.DurationBasedEngine.DurationAmount.SHORT_TERM_DURATION_DAYS,
+                shortTermThreshold, 4, 0.25));
+        terms.put(KruizeConstants.JSONKeys.MEDIUM_TERM, new Terms(KruizeConstants.JSONKeys.MEDIUM_TERM,
+                KruizeConstants.RecommendationEngineConstants.DurationBasedEngine.DurationAmount.MEDIUM_TERM_DURATION_DAYS,
+                mediumTermThreshold, 7, 1));
+        terms.put(KruizeConstants.JSONKeys.LONG_TERM, new Terms(KruizeConstants.JSONKeys.LONG_TERM,
+                KruizeConstants.RecommendationEngineConstants.DurationBasedEngine.DurationAmount.LONG_TERM_DURATION_DAYS,
+                longTermThreshold, 15, 1));
 
         kruizeObject.setTerms(terms);
     }

--- a/src/main/java/com/autotune/analyzer/kruizeObject/KruizeObject.java
+++ b/src/main/java/com/autotune/analyzer/kruizeObject/KruizeObject.java
@@ -29,7 +29,6 @@ import com.autotune.utils.Utils;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
 import io.fabric8.kubernetes.api.model.ObjectReference;
-import org.apache.logging.log4j.spi.LoggerRegistry;
 
 import java.util.HashMap;
 import java.util.List;

--- a/src/main/java/com/autotune/analyzer/kruizeObject/RecommendationSettings.java
+++ b/src/main/java/com/autotune/analyzer/kruizeObject/RecommendationSettings.java
@@ -15,11 +15,34 @@
  *******************************************************************************/
 package com.autotune.analyzer.kruizeObject;
 
+import com.autotune.utils.KruizeConstants;
+
+import java.util.HashMap;
+
 public class RecommendationSettings {
     private Double threshold;
 
+    /**
+     * A map to store the custom minimum duration (in minutes) provided by user for recommendation terms
+     * The keys represent the recommendation terms (e.g., "short_term"), and the values are the corresponding minimum durations in minutes.
+     */
+    private HashMap<String, Double> minDurationInMins;
+
     public Double getThreshold() {
         return threshold;
+    }
+
+    public HashMap<String, Double> getMinDurationInMins() {
+        return minDurationInMins;
+    }
+
+    public void setMinDurationInMins(HashMap<String, Double> minDurationInMins) {
+        this.minDurationInMins = minDurationInMins;
+    }
+
+    // converts minimum duration required for terms in minutes to days
+    public double getThresholdForTerm(String term) {
+        return minDurationInMins.get(term) / (KruizeConstants.TimeConv.NO_OF_HOURS_PER_DAY * KruizeConstants.TimeConv.NO_OF_MINUTES_PER_HOUR);
     }
 
     public void setThreshold(Double threshold) {

--- a/src/main/java/com/autotune/analyzer/kruizeObject/RecommendationSettings.java
+++ b/src/main/java/com/autotune/analyzer/kruizeObject/RecommendationSettings.java
@@ -15,34 +15,11 @@
  *******************************************************************************/
 package com.autotune.analyzer.kruizeObject;
 
-import com.autotune.utils.KruizeConstants;
-
-import java.util.HashMap;
-
 public class RecommendationSettings {
     private Double threshold;
 
-    /**
-     * A map to store the custom minimum duration (in minutes) provided by user for recommendation terms
-     * The keys represent the recommendation terms (e.g., "short_term"), and the values are the corresponding minimum durations in minutes.
-     */
-    private HashMap<String, Double> minDurationInMins;
-
     public Double getThreshold() {
         return threshold;
-    }
-
-    public HashMap<String, Double> getMinDurationInMins() {
-        return minDurationInMins;
-    }
-
-    public void setMinDurationInMins(HashMap<String, Double> minDurationInMins) {
-        this.minDurationInMins = minDurationInMins;
-    }
-
-    // converts minimum duration required for terms in minutes to days
-    public double getThresholdForTerm(String term) {
-        return minDurationInMins.get(term) / (KruizeConstants.TimeConv.NO_OF_HOURS_PER_DAY * KruizeConstants.TimeConv.NO_OF_MINUTES_PER_HOUR);
     }
 
     public void setThreshold(Double threshold) {

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -730,6 +730,14 @@ public class KruizeConstants {
                 public static final int MEDIUM_TERM_DURATION_DAYS_THRESHOLD = 2;
                 public static final int LONG_TERM_DURATION_DAYS = 15;
                 public static final int LONG_TERM_DURATION_DAYS_THRESHOLD = 8;
+                // Represents the minimum number of data points required for different term thresholds.
+                // Minimum data points are calculated based on the above threshold in days and a 15-minute measurement duration.
+                // If the short-term threshold is 30 minutes and the measurement duration is 15 minutes
+                // then the minimum data points = 30 / 15 = 2
+                public static final int SHORT_TERM_MIN_DATAPOINTS = 2;
+                public static final int MEDIUM_TERM_MIN_DATAPOINTS = 192;
+                public static final int LONG_TERM_MIN_DATAPOINTS = 768;
+
 
                 private DurationAmount() {
 


### PR DESCRIPTION
## Description

Updated the threshold calculation logic to dynamically calculate based on user-provided minimum default values for `measurement_duration`.

Fixes # (issue)
Delay in generating the recommendations during demos

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Manually with OpenShift Cluster


**Test Configuration**
* Kubernetes clusters tested on: Openshift

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Image for Testing: quay.io/rh-ee-shesaxen/autotune:hello2
