### PR TITLE
[Kruize VPA Integration] Updating Default Model to Short Term Performance 

### DIFF
--- a/src/main/java/com/autotune/analyzer/recommendations/updater/vpa/VpaUpdaterImpl.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/updater/vpa/VpaUpdaterImpl.java
@@ -246,7 +246,7 @@ public class VpaUpdaterImpl extends RecommendationUpdaterImpl {
             } else {
                 for (MappedRecommendationForTimestamp value : recommendationData.values()) {
                     /*
-                     * Fetching Short Term Cost Recommendations By Default
+                     * The short-term performance recommendations is currently the default for VPA and is hardcoded.
                      * TODO:// Implement functionality to choose the desired term and model
                      **/
                     TermRecommendations termRecommendations = value.getShortTermRecommendations();

--- a/src/main/java/com/autotune/analyzer/recommendations/updater/vpa/VpaUpdaterImpl.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/updater/vpa/VpaUpdaterImpl.java
@@ -252,7 +252,7 @@ public class VpaUpdaterImpl extends RecommendationUpdaterImpl {
                     TermRecommendations termRecommendations = value.getShortTermRecommendations();
                     HashMap<AnalyzerConstants.ResourceSetting,
                             HashMap<AnalyzerConstants.RecommendationItem,
-                                    RecommendationConfigItem>> recommendationsConfig = termRecommendations.getCostRecommendations().getConfig();
+                                    RecommendationConfigItem>> recommendationsConfig = termRecommendations.getPerformanceRecommendations().getConfig();
 
                     Double cpuRecommendationValue = recommendationsConfig.get(AnalyzerConstants.ResourceSetting.requests).get(AnalyzerConstants.RecommendationItem.CPU).getAmount();
                     Double memoryRecommendationValue = recommendationsConfig.get(AnalyzerConstants.ResourceSetting.requests).get(AnalyzerConstants.RecommendationItem.MEMORY).getAmount();


### PR DESCRIPTION
## Description

Earlier, we were using `cost` short term recommendations as default for VPA. This PR updates the default to use `performance` short term recommendations.

## How has this been tested?

**Test Configuration**
* Kubernetes clusters tested on: Openshift

## Checklist :dart:

- [x] Followed coding guidelines
- [ ] Comments added
- [x] Dependent changes merged
- [x] Documentation updated
- [x] Tests added or updated

