### PR TITLE
3- New BulkAPI format - bulk api recommendation api responses are recorded

### DIFF
--- a/src/main/java/com/autotune/analyzer/serviceObjects/BulkJobStatus.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/BulkJobStatus.java
@@ -15,6 +15,7 @@
  *******************************************************************************/
 package com.autotune.analyzer.serviceObjects;
 
+import com.autotune.common.data.dataSourceMetadata.DataSourceMetadataInfo;
 import com.autotune.utils.KruizeConstants;
 import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -42,6 +43,7 @@ public class BulkJobStatus {
     // Change to String to store formatted time
     private Map<String, Experiment> experiments = Collections.synchronizedMap(new HashMap<>());
     private Webhook webhook;
+    private DataSourceMetadataInfo metadata;
 
     public BulkJobStatus(String jobID, String status, Instant startTime) {
         this.summary = new Summary(jobID, status, startTime);
@@ -85,6 +87,14 @@ public class BulkJobStatus {
         Experiment experiment = new Experiment(experimentName);
         experiments.put(experimentName, experiment);
         return experiment;
+    }
+
+    public DataSourceMetadataInfo getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(DataSourceMetadataInfo metadata) {
+        this.metadata = metadata;
     }
 
     public static enum NotificationType {
@@ -327,5 +337,4 @@ public class BulkJobStatus {
             this.notifications = notifications;
         }
     }
-
 }

--- a/src/main/java/com/autotune/analyzer/services/BulkService.java
+++ b/src/main/java/com/autotune/analyzer/services/BulkService.java
@@ -86,7 +86,7 @@ public class BulkService extends HttpServlet {
                 return;
             }
             jobDetails = jobStatusMap.get(jobID);
-            LOGGER.info("Job Status: " + jobDetails.getStatus());
+            LOGGER.info("Job Status: " + jobDetails.getSummary().getStatus());
             resp.setContentType(JSON_CONTENT_TYPE);
             resp.setCharacterEncoding(CHARACTER_ENCODING);
             SimpleFilterProvider filters = new SimpleFilterProvider();

--- a/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
+++ b/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
@@ -15,10 +15,16 @@
  *******************************************************************************/
 package com.autotune.analyzer.workerimpl;
 
+import com.autotune.analyzer.adapters.DeviceDetailsAdapter;
+import com.autotune.analyzer.adapters.RecommendationItemAdapter;
+import com.autotune.analyzer.exceptions.KruizeResponse;
 import com.autotune.analyzer.kruizeObject.RecommendationSettings;
 import com.autotune.analyzer.serviceObjects.*;
 import com.autotune.analyzer.utils.AnalyzerConstants;
+import com.autotune.analyzer.utils.GsonUTCDateAdapter;
 import com.autotune.common.data.dataSourceMetadata.*;
+import com.autotune.common.data.result.ContainerData;
+import com.autotune.common.data.system.info.device.DeviceDetails;
 import com.autotune.common.datasource.DataSourceInfo;
 import com.autotune.common.datasource.DataSourceManager;
 import com.autotune.common.k8sObjects.TrialSettings;
@@ -29,7 +35,10 @@ import com.autotune.utils.KruizeConstants;
 import com.autotune.utils.MetricsConfig;
 import com.autotune.utils.Utils;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import io.micrometer.core.instrument.Timer;
 import org.apache.http.conn.ConnectTimeoutException;
 import org.json.JSONObject;
@@ -95,6 +104,7 @@ public class BulkJobManager implements Runnable {
         this.jobID = jobID;
         this.jobData = jobData;
         this.bulkInput = payload;
+
     }
 
     public static List<String> appendExperiments(List<String> allExperiments, String experimentName) {
@@ -163,6 +173,7 @@ public class BulkJobManager implements Runnable {
 
                     jobData.setMetadata(metadataInfo);
                     Map<String, CreateExperimentAPIObject> createExperimentAPIObjectMap = getExperimentMap(labelString, jobData, metadataInfo, datasource); //Todo Store this map in buffer and use it if BulkAPI pods restarts and support experiment_type
+                    //  TODO: Remove getExperimentMap and instead collect all metadata, process it, and create experiments dynamically during metadata iteration.
                     jobData.getSummary().setTotal_experiments(createExperimentAPIObjectMap.size());
                     jobData.getSummary().setProcessed_experiments(0);
                     if (jobData.getSummary().getTotal_experiments() > KruizeDeploymentInfo.bulk_api_limit) {
@@ -184,17 +195,14 @@ public class BulkJobManager implements Runnable {
                                         boolean experiment_exists = false;
                                         try {
                                             responseCode = apiClient.callKruizeAPI("[" + new Gson().toJson(apiObject) + "]");
+                                            experiment.getApis().getCreate().setResponse(new Gson().fromJson(responseCode.getResponseBody().toString(), KruizeResponse.class));
                                             LOGGER.debug("API Response code: {}", responseCode);
-                                            if (responseCode.getStatusCode() == HttpURLConnection.HTTP_CREATED) {
+                                            if (responseCode.getStatusCode() == HttpURLConnection.HTTP_CREATED || responseCode.getStatusCode() == HttpURLConnection.HTTP_CONFLICT) {
                                                 experiment_exists = true;
-                                            } else if (responseCode.getStatusCode() == HttpURLConnection.HTTP_CONFLICT) {
-                                                experiment_exists = true;
-                                            } else {
-                                                experiment.setNotification(new BulkJobStatus.Notification(BulkJobStatus.NotificationType.ERROR, responseCode.getResponseBody().toString(), responseCode.getStatusCode()));
                                             }
                                         } catch (Exception e) {
                                             e.printStackTrace();
-                                            experiment.setNotification(new BulkJobStatus.Notification(BulkJobStatus.NotificationType.ERROR, e.getMessage(), HttpURLConnection.HTTP_BAD_REQUEST));
+                                            experiment.getApis().getCreate().setResponse(new KruizeResponse(e.getMessage(), HttpURLConnection.HTTP_INTERNAL_ERROR, null, FAILED));
                                         } finally {
                                             if (!experiment_exists) {
                                                 LOGGER.info("Processing experiment {}", jobData.getSummary().getProcessed_experiments());
@@ -206,7 +214,6 @@ public class BulkJobManager implements Runnable {
                                                 }
                                             }
                                         }
-
                                         if (experiment_exists) {
                                             generateExecutor.submit(() -> {
                                                 // send request to generateRecommendations API
@@ -218,16 +225,40 @@ public class BulkJobManager implements Runnable {
                                                 try {
                                                     recommendationResponseCode = recommendationApiClient.callKruizeAPI(null);
                                                     LOGGER.debug("API Response code: {}", recommendationResponseCode);
+                                                    ExclusionStrategy strategy = new ExclusionStrategy() {
+                                                        @Override
+                                                        public boolean shouldSkipField(FieldAttributes field) {
+                                                            return field.getDeclaringClass() == ContainerData.class && (field.getName().equals("results"))
+                                                                    || (field.getDeclaringClass() == ContainerAPIObject.class && (field.getName().equals("metrics")));
+                                                        }
+
+                                                        @Override
+                                                        public boolean shouldSkipClass(Class<?> clazz) {
+                                                            return false;
+                                                        }
+                                                    };
+                                                    Gson gsonObj = new GsonBuilder()                        //Todo move this to common code
+                                                            .disableHtmlEscaping()
+                                                            .setPrettyPrinting()
+                                                            .enableComplexMapKeySerialization()
+                                                            .registerTypeAdapter(Date.class, new GsonUTCDateAdapter())
+                                                            .registerTypeAdapter(AnalyzerConstants.RecommendationItem.class, new RecommendationItemAdapter())
+                                                            .registerTypeAdapter(DeviceDetails.class, new DeviceDetailsAdapter())
+                                                            .setExclusionStrategies(strategy)
+                                                            .create();
+                                                    experiment.getApis().getRecommendations().setResponse(gsonObj.fromJson(recommendationResponseCode.getResponseBody().toString(), List.class));
                                                     if (recommendationResponseCode.getStatusCode() == HttpURLConnection.HTTP_CREATED) {
-                                                        experiment.getRecommendations().setStatus(NotificationConstants.Status.PROCESSED);
+                                                        experiment.setStatus(NotificationConstants.Status.PROCESSED);
                                                     } else {
-                                                        experiment.getRecommendations().setStatus(NotificationConstants.Status.FAILED);
-                                                        experiment.setNotification(new BulkJobStatus.Notification(BulkJobStatus.NotificationType.ERROR, recommendationResponseCode.getResponseBody().toString(), recommendationResponseCode.getStatusCode()));
+                                                        experiment.setStatus(NotificationConstants.Status.FAILED);
+                                                        experiment.getApis().getRecommendations().setResponse(new KruizeResponse(recommendationResponseCode.getResponseBody().toString(),
+                                                                recommendationResponseCode.getStatusCode(), null, FAILED));
                                                     }
                                                 } catch (Exception e) {
                                                     e.printStackTrace();
-                                                    experiment.getRecommendations().setStatus(NotificationConstants.Status.FAILED);
-                                                    experiment.getRecommendations().setNotifications(new BulkJobStatus.Notification(BulkJobStatus.NotificationType.ERROR, e.getMessage(), HttpURLConnection.HTTP_INTERNAL_ERROR));
+                                                    experiment.setStatus(NotificationConstants.Status.FAILED);
+                                                    experiment.getApis().getRecommendations().setResponse(new KruizeResponse(e.getMessage(),
+                                                            HttpURLConnection.HTTP_INTERNAL_ERROR, null, FAILED));
                                                 } finally {
                                                     jobData.getSummary().incrementProcessed_experiments();
                                                     synchronized (jobData) {
@@ -240,7 +271,7 @@ public class BulkJobManager implements Runnable {
                                         }
                                     } catch (Exception e) {
                                         e.printStackTrace();
-                                        experiment.setNotification(new BulkJobStatus.Notification(BulkJobStatus.NotificationType.ERROR, e.getMessage(), HttpURLConnection.HTTP_INTERNAL_ERROR));
+                                        experiment.getApis().getCreate().setResponse(new KruizeResponse(e.getMessage(), HttpURLConnection.HTTP_INTERNAL_ERROR, null, FAILED));
                                         jobData.getSummary().incrementProcessed_experiments();
                                         if (jobData.getSummary().getTotal_experiments() == jobData.getSummary().getProcessed_experiments().get()) {
                                             setFinalJobStatus(COMPLETED, null, null, finalDatasource);

--- a/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSource.java
+++ b/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSource.java
@@ -1,6 +1,7 @@
 package com.autotune.common.data.dataSourceMetadata;
 
 import com.autotune.utils.KruizeConstants;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.SerializedName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,38 +15,38 @@ import java.util.HashMap;
 public class DataSource {
     private static final Logger LOGGER = LoggerFactory.getLogger(DataSource.class);
     @SerializedName(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.DATASOURCE_NAME)
+    @JsonProperty(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.DATASOURCE_NAME)
     private String dataSourceName;
 
     /**
      * Key: Cluster name
      * Value: Associated DataSourceCluster object
      */
-    @SerializedName(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.CLUSTERS)
-    private HashMap<String, DataSourceCluster> clusterHashMap;
+    private HashMap<String, DataSourceCluster> clusters;
 
-    public DataSource(String dataSourceName, HashMap<String,DataSourceCluster> clusterHashMap) {
+    public DataSource(String dataSourceName, HashMap<String, DataSourceCluster> clusters) {
         this.dataSourceName = dataSourceName;
-        this.clusterHashMap = clusterHashMap;
+        this.clusters = clusters;
     }
 
     public String getDataSourceName() {
         return dataSourceName;
     }
 
-    public HashMap<String, DataSourceCluster> getDataSourceClusterHashMap() {
-        return clusterHashMap;
+    public HashMap<String, DataSourceCluster> getClusters() {
+        return clusters;
     }
 
-    public void setDataSourceClusterHashMap(HashMap<String, DataSourceCluster> clusterHashMap) {
+    public void setClusters(HashMap<String, DataSourceCluster> clusterHashMap) {
         if (null == clusterHashMap) {
             LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.SET_CLUSTER_MAP_ERROR + "{}", dataSourceName);
         }
-        this.clusterHashMap = clusterHashMap;
+        this.clusters = clusterHashMap;
     }
 
     public DataSourceCluster getDataSourceClusterObject(String clusterName) {
-        if (null != clusterHashMap && clusterHashMap.containsKey(clusterName)) {
-            return clusterHashMap.get(clusterName);
+        if (null != clusters && clusters.containsKey(clusterName)) {
+            return clusters.get(clusterName);
         }
         return null;
     }
@@ -54,7 +55,7 @@ public class DataSource {
     public String toString() {
         return "DataSource{" +
                 "datasource_name='" + dataSourceName + '\'' +
-                ", clusters=" + clusterHashMap +
+                ", clusters=" + clusters +
                 '}';
     }
 }

--- a/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceCluster.java
+++ b/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceCluster.java
@@ -1,6 +1,7 @@
 package com.autotune.common.data.dataSourceMetadata;
 
 import com.autotune.utils.KruizeConstants;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.SerializedName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,38 +15,38 @@ import java.util.HashMap;
 public class DataSourceCluster {
     private static final Logger LOGGER = LoggerFactory.getLogger(DataSourceCluster.class);
     @SerializedName(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.CLUSTER_NAME)
+    @JsonProperty(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.CLUSTER_NAME)
     private String clusterName;
 
     /**
      * Key: Namespace
      * Value: Associated DataSourceNamespace object
      */
-    @SerializedName(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.NAMESPACES)
-    private HashMap<String, DataSourceNamespace> namespaceHashMap;
+    private HashMap<String, DataSourceNamespace> namespaces;
 
-    public DataSourceCluster(String clusterName, HashMap<String, DataSourceNamespace> namespaceHashMap) {
+    public DataSourceCluster(String clusterName, HashMap<String, DataSourceNamespace> namespaces) {
         this.clusterName = clusterName;
-        this.namespaceHashMap = namespaceHashMap;
+        this.namespaces = namespaces;
     }
 
     public String getDataSourceClusterName() {
         return clusterName;
     }
 
-    public HashMap<String, DataSourceNamespace> getDataSourceNamespaceHashMap() {
-        return namespaceHashMap;
+    public HashMap<String, DataSourceNamespace> getNamespaces() {
+        return namespaces;
     }
 
-    public void setDataSourceNamespaceHashMap(HashMap<String, DataSourceNamespace> namespaceHashMap) {
+    public void setNamespaces(HashMap<String, DataSourceNamespace> namespaceHashMap) {
         if (null == namespaceHashMap) {
             LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.SET_NAMESPACE_MAP_ERROR + "{}", clusterName);
         }
-        this.namespaceHashMap = namespaceHashMap;
+        this.namespaces = namespaceHashMap;
     }
 
     public DataSourceNamespace getDataSourceNamespaceObject(String namespace) {
-        if  (null != namespaceHashMap && namespaceHashMap.containsKey(namespace)) {
-            return namespaceHashMap.get(namespace);
+        if (null != namespaces && namespaces.containsKey(namespace)) {
+            return namespaces.get(namespace);
         }
         return null;
     }
@@ -54,7 +55,7 @@ public class DataSourceCluster {
     public String toString() {
         return "DataSourceCluster{" +
                 "cluster_name='" + clusterName + '\'' +
-                ", namespaces=" + namespaceHashMap +
+                ", namespaces=" + namespaces +
                 '}';
     }
 }

--- a/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceContainer.java
+++ b/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceContainer.java
@@ -1,6 +1,7 @@
 package com.autotune.common.data.dataSourceMetadata;
 
 import com.autotune.utils.KruizeConstants;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.SerializedName;
 
 /**
@@ -8,8 +9,10 @@ import com.google.gson.annotations.SerializedName;
  */
 public class DataSourceContainer {
     @SerializedName(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.CONTAINER_NAME)
+    @JsonProperty(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.CONTAINER_NAME)
     private String containerName;
     @SerializedName(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.CONTAINER_IMAGE_NAME)
+    @JsonProperty(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.CONTAINER_IMAGE_NAME)
     private String containerImageName;
 
     public DataSourceContainer(String containerName, String containerImageName) {
@@ -17,8 +20,13 @@ public class DataSourceContainer {
         this.containerImageName = containerImageName;
     }
 
-    public String getDataSourceContainerName() { return containerName;}
-    public String getDataSourceContainerImageName() { return containerImageName;}
+    public String getContainerName() {
+        return containerName;
+    }
+
+    public String getContainerImageName() {
+        return containerImageName;
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceMetadataHelper.java
+++ b/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceMetadataHelper.java
@@ -27,26 +27,26 @@ public class DataSourceMetadataHelper {
      *
      * @param resultArray The JsonArray containing the namespace information.
      * @return A HashMap<String, DataSourceNamespace> representing namespaces
-     *
+     * <p>
      * Example:
      * input resultArray structure:
      * {
-     *   "result": [
-     *     {
-     *       "metric": {
-     *         "namespace": "exampleNamespace"
-     *       }
-     *     },
-     *     // ... additional result objects ...
-     *   ]
+     * "result": [
+     * {
+     * "metric": {
+     * "namespace": "exampleNamespace"
      * }
-     *
+     * },
+     * // ... additional result objects ...
+     * ]
+     * }
+     * <p>
      * The function would parse the JsonObject and return a HashMap like:
      * {
-     *   "exampleNamespace": {
-     *     "namespaceName": "exampleNamespace"
-     *   },
-     *   // ... additional namespace entries ...
+     * "exampleNamespace": {
+     * "namespaceName": "exampleNamespace"
+     * },
+     * // ... additional namespace entries ...
      * }
      */
     public HashMap<String, DataSourceNamespace> getActiveNamespaces(JsonArray resultArray) {
@@ -71,7 +71,7 @@ public class DataSourceMetadataHelper {
                 }
                 String namespace = metricObject.get(KruizeConstants.DataSourceConstants.DataSourceQueryMetricKeys.NAMESPACE).getAsString();
 
-                DataSourceNamespace dataSourceNamespace = new DataSourceNamespace(namespace,null);
+                DataSourceNamespace dataSourceNamespace = new DataSourceNamespace(namespace, null);
                 namespaceMap.put(namespace, dataSourceNamespace);
             }
         } catch (JsonParseException e) {
@@ -96,32 +96,32 @@ public class DataSourceMetadataHelper {
      *
      * @param resultArray The JsonArray containing the workload information.
      * @return A HashMap<String, HashMap<String, DataSourceWorkload>> representing namespaces
-     *         and their associated workload details.
-     *
+     * and their associated workload details.
+     * <p>
      * Example:
      * input resultArray structure:
      * {
-     *   "result": [
-     *     {
-     *       "metric": {
-     *         "namespace": "exampleNamespace",
-     *         "workload": "exampleWorkload",
-     *         "workloadType": "exampleWorkloadType"
-     *       }
-     *     },
-     *     // ... additional result objects ...
-     *   ]
+     * "result": [
+     * {
+     * "metric": {
+     * "namespace": "exampleNamespace",
+     * "workload": "exampleWorkload",
+     * "workloadType": "exampleWorkloadType"
      * }
-     *
+     * },
+     * // ... additional result objects ...
+     * ]
+     * }
+     * <p>
      * The function would parse the JsonObject and return a nested HashMap like:
      * {
-     *   "exampleNamespace": {
-     *     "exampleWorkload": {
-     *       "workload": "exampleWorkload",
-     *       "workloadType": "exampleWorkloadType"
-     *     }
-     *   },
-     *   // ... additional namespace entries ...
+     * "exampleNamespace": {
+     * "exampleWorkload": {
+     * "workload": "exampleWorkload",
+     * "workloadType": "exampleWorkloadType"
+     * }
+     * },
+     * // ... additional namespace entries ...
      * }
      */
     public HashMap<String, HashMap<String, DataSourceWorkload>> getWorkloadInfo(JsonArray resultArray) {
@@ -152,7 +152,7 @@ public class DataSourceMetadataHelper {
 
                 String workloadName = metricObject.get(KruizeConstants.DataSourceConstants.DataSourceQueryMetricKeys.WORKLOAD).getAsString();
                 String workloadType = metricObject.get(KruizeConstants.DataSourceConstants.DataSourceQueryMetricKeys.WORKLOAD_TYPE).getAsString();
-                DataSourceWorkload dataSourceWorkload = new DataSourceWorkload(workloadName, workloadType,null);
+                DataSourceWorkload dataSourceWorkload = new DataSourceWorkload(workloadName, workloadType, null);
 
                 // Put the DataSourceWorkload into the inner hashmap directly
                 namespaceWorkloadMap.get(namespace).put(workloadName, dataSourceWorkload);
@@ -178,32 +178,32 @@ public class DataSourceMetadataHelper {
      *
      * @param resultArray The JsonArray containing the container information.
      * @return A HashMap<String, HashMap<String, DataSourceContainer>> representing workloads
-     *         and their associated container details.
-     *
+     * and their associated container details.
+     * <p>
      * Example:
      * input resultArray structure:
      * {
-     *   "result": [
-     *     {
-     *       "metric": {
-     *         "workload_name": "exampleWorkloadName",
-     *         "container": "exampleContainer",
-     *         "image_name": "exampleImageName"
-     *       }
-     *     },
-     *     // ... additional result objects ...
-     *   ]
+     * "result": [
+     * {
+     * "metric": {
+     * "workload_name": "exampleWorkloadName",
+     * "container": "exampleContainer",
+     * "image_name": "exampleImageName"
      * }
-     *
+     * },
+     * // ... additional result objects ...
+     * ]
+     * }
+     * <p>
      * The function would parse the JsonObject and return a nested HashMap like:
      * {
-     *   "exampleWorkloadName": {
-     *     "exampleContainer": {
-     *       "containerName": "exampleContainer",
-     *       "containerImageName": "exampleImageName"
-     *     }
-     *   },
-     *   // ... additional workload entries ...
+     * "exampleWorkloadName": {
+     * "exampleContainer": {
+     * "containerName": "exampleContainer",
+     * "containerImageName": "exampleImageName"
+     * }
+     * },
+     * // ... additional workload entries ...
      * }
      */
     public HashMap<String, HashMap<String, DataSourceContainer>> getContainerInfo(JsonArray resultArray) {
@@ -254,16 +254,16 @@ public class DataSourceMetadataHelper {
      * Creates and returns a DataSourceMetadataInfo object based on the provided parameters.
      * This function populates the DataSourceMetadataInfo object with information about active namespaces
      *
-     * @param dataSourceName         Name of the data source.
-     * @param namespaceMap           Map of namespace objects
-     * @return                       A DataSourceMetadataInfo object with populated information.
+     * @param dataSourceName Name of the data source.
+     * @param namespaceMap   Map of namespace objects
+     * @return A DataSourceMetadataInfo object with populated information.
      */
     public DataSourceMetadataInfo createDataSourceMetadataInfoObject(String dataSourceName, HashMap<String, DataSourceNamespace> namespaceMap) {
 
         try {
             DataSourceMetadataInfo dataSourceMetadataInfo = new DataSourceMetadataInfo(null);
 
-            DataSource dataSource = new DataSource(dataSourceName,null);
+            DataSource dataSource = new DataSource(dataSourceName, null);
 
             DataSourceCluster dataSourceCluster = new DataSourceCluster(KruizeConstants.DataSourceConstants.
                     DataSourceMetadataInfoConstants.CLUSTER_NAME, namespaceMap);
@@ -272,12 +272,12 @@ public class DataSourceMetadataHelper {
             HashMap<String, DataSourceCluster> clusters = new HashMap<>();
             clusters.put(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoConstants.CLUSTER_NAME,
                     dataSourceCluster);
-            dataSource.setDataSourceClusterHashMap(clusters);
+            dataSource.setClusters(clusters);
 
             // Set data source in DataSourceMetadataInfo
             HashMap<String, DataSource> dataSources = new HashMap<>();
             dataSources.put(dataSourceName, dataSource);
-            dataSourceMetadataInfo.setDataSourceHashMap(dataSources);
+            dataSourceMetadataInfo.setDatasources(dataSources);
 
             return dataSourceMetadataInfo;
         } catch (Exception e) {
@@ -289,9 +289,9 @@ public class DataSourceMetadataHelper {
     /**
      * Updates the namespace metadata in the provided DataSourceMetadataInfo object for a specific data source.
      *
-     * @param dataSourceName        The name of the data source to update.
+     * @param dataSourceName         The name of the data source to update.
      * @param dataSourceMetadataInfo The DataSourceMetadataInfo object to update.
-     * @param namespaceMap          A map containing namespace name as keys and namespace object as values.
+     * @param namespaceMap           A map containing namespace name as keys and namespace object as values.
      */
     public void updateNamespaceDataSourceMetadataInfoObject(String dataSourceName, DataSourceMetadataInfo dataSourceMetadataInfo,
                                                             HashMap<String, DataSourceNamespace> namespaceMap) {
@@ -299,14 +299,14 @@ public class DataSourceMetadataHelper {
             DataSourceCluster dataSourceCluster = dataSourceMetadataInfo.getDataSourceObject(dataSourceName)
                     .getDataSourceClusterObject("default");
 
-            dataSourceCluster.getDataSourceNamespaceHashMap().entrySet().removeIf(entry -> !namespaceMap.containsKey(entry.getKey()));
+            dataSourceCluster.getNamespaces().entrySet().removeIf(entry -> !namespaceMap.containsKey(entry.getKey()));
 
             //Add new namespaces, if not present
             for (HashMap.Entry<String, DataSourceNamespace> entry : namespaceMap.entrySet()) {
                 String namespaceName = entry.getKey();
                 DataSourceNamespace namespace = entry.getValue();
-                if (!dataSourceCluster.getDataSourceNamespaceHashMap().containsKey(namespaceName)) {
-                    dataSourceCluster.getDataSourceNamespaceHashMap().put(namespaceName, namespace);
+                if (!dataSourceCluster.getNamespaces().containsKey(namespaceName)) {
+                    dataSourceCluster.getNamespaces().put(namespaceName, namespace);
                 }
             }
 
@@ -318,9 +318,9 @@ public class DataSourceMetadataHelper {
     /**
      * Validates input parameters and retrieves the DataSourceCluster object.
      *
-     * @param dataSourceName      The name of the data source.
+     * @param dataSourceName         The name of the data source.
      * @param dataSourceMetadataInfo The DataSourceMetadataInfo object.
-     * @param namespaceWorkloadMap  The map containing workload information.
+     * @param namespaceWorkloadMap   The map containing workload information.
      * @return The DataSourceCluster object if validation passes, or null if validation fails.
      */
     private DataSourceCluster validateInputParametersAndGetClusterObject(String dataSourceName, DataSourceMetadataInfo dataSourceMetadataInfo,
@@ -354,12 +354,12 @@ public class DataSourceMetadataHelper {
     /**
      * Updates the workload metadata in the provided DataSourceMetadataInfo object for a specific data source.
      *
-     * @param dataSourceName        The name of the data source to update.
+     * @param dataSourceName         The name of the data source to update.
      * @param dataSourceMetadataInfo The DataSourceMetadataInfo object to update.
-     * @param namespaceWorkloadMap  A map containing namespace as keys and workload data as values.
+     * @param namespaceWorkloadMap   A map containing namespace as keys and workload data as values.
      */
     public void updateWorkloadDataSourceMetadataInfoObject(String dataSourceName, DataSourceMetadataInfo dataSourceMetadataInfo,
-                                                          HashMap<String, HashMap<String, DataSourceWorkload>> namespaceWorkloadMap) {
+                                                           HashMap<String, HashMap<String, DataSourceWorkload>> namespaceWorkloadMap) {
         try {
 
             // Retrieve DataSourceCluster
@@ -371,7 +371,7 @@ public class DataSourceMetadataHelper {
                 return;
             }
 
-            if (null == dataSourceCluster.getDataSourceNamespaceHashMap() || dataSourceCluster.getDataSourceNamespaceHashMap().isEmpty()) {
+            if (null == dataSourceCluster.getNamespaces() || dataSourceCluster.getNamespaces().isEmpty()) {
                 LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.INVALID_DATASOURCE_METADATA_NAMESPACE_DATA);
                 return;
             }
@@ -384,23 +384,24 @@ public class DataSourceMetadataHelper {
                     continue;
                 }
                 // Bulk update workload data for the namespace
-                dataSourceNamespace.setDataSourceWorkloadHashMap(namespaceWorkloadMap.get(namespace));
+                dataSourceNamespace.setWorkloads(namespaceWorkloadMap.get(namespace));
             }
         } catch (Exception e) {
-            LOGGER.error(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.WORKLOAD_METADATA_UPDATE_ERROR+ e.getMessage());
+            LOGGER.error(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.WORKLOAD_METADATA_UPDATE_ERROR + e.getMessage());
         }
     }
+
     /**
      * Updates the container metadata in the provided DataSourceMetadataInfo object for a specific data source.
      *
      * @param dataSourceName         The name of the data source to update.
      * @param dataSourceMetadataInfo The DataSourceMetadataInfo object to update.
      * @param namespaceWorkloadMap   A map containing namespace as keys and workload data as values.
-     * @param workloadContainerMap  A map containing workload names as keys and container data as values.
+     * @param workloadContainerMap   A map containing workload names as keys and container data as values.
      */
     public void updateContainerDataSourceMetadataInfoObject(String dataSourceName, DataSourceMetadataInfo dataSourceMetadataInfo,
-                                                           HashMap<String, HashMap<String, DataSourceWorkload>> namespaceWorkloadMap,
-                                                           HashMap<String, HashMap<String, DataSourceContainer>> workloadContainerMap) {
+                                                            HashMap<String, HashMap<String, DataSourceWorkload>> namespaceWorkloadMap,
+                                                            HashMap<String, HashMap<String, DataSourceContainer>> workloadContainerMap) {
         try {
 
             if (null == workloadContainerMap || workloadContainerMap.isEmpty()) {
@@ -416,7 +417,7 @@ public class DataSourceMetadataHelper {
                 return;
             }
 
-            if (null == dataSourceCluster.getDataSourceNamespaceHashMap() || dataSourceCluster.getDataSourceNamespaceHashMap().isEmpty()) {
+            if (null == dataSourceCluster.getNamespaces() || dataSourceCluster.getNamespaces().isEmpty()) {
                 LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.INVALID_DATASOURCE_METADATA_NAMESPACE_DATA);
                 return;
             }
@@ -438,7 +439,7 @@ public class DataSourceMetadataHelper {
                     if (null == dataSourceWorkload || !workloadContainerMap.containsKey(workloadName)) {
                         continue;
                     }
-                    dataSourceWorkload.setDataSourceContainerHashMap(workloadContainerMap.get(workloadName));
+                    dataSourceWorkload.setContainers(workloadContainerMap.get(workloadName));
                 }
             }
         } catch (Exception e) {

--- a/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceMetadataInfo.java
+++ b/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceMetadataInfo.java
@@ -1,7 +1,5 @@
 package com.autotune.common.data.dataSourceMetadata;
 
-import com.autotune.utils.KruizeConstants;
-import com.google.gson.annotations.SerializedName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,26 +17,28 @@ public class DataSourceMetadataInfo {
      * Key: Data Source name
      * Value: Associated DataSource object
      */
-    @SerializedName(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.DATASOURCES)
-    private HashMap<String, DataSource> dataSourceHashMap;
+    //@SerializedName(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.DATASOURCES)
+    //@JsonProperty(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.DATASOURCES)
+    private HashMap<String, DataSource> datasources;
 
-    public DataSourceMetadataInfo(HashMap<String, DataSource> dataSourceHashMap) {
-        this.dataSourceHashMap = dataSourceHashMap;
+    public DataSourceMetadataInfo(HashMap<String, DataSource> datasources) {
+        this.datasources = datasources;
     }
 
-    public HashMap<String, DataSource> getDataSourceHashMap() {
-        return dataSourceHashMap;
+    public HashMap<String, DataSource> getDatasources() {
+        return datasources;
     }
 
-    public void setDataSourceHashMap(HashMap<String, DataSource> dataSourceHashMap) {
-        if (null == dataSourceHashMap) {
+    public void setDatasources(HashMap<String, DataSource> datasources) {
+        if (null == datasources) {
             LOGGER.debug("No data sources found");
         }
-        this.dataSourceHashMap = dataSourceHashMap;
+        this.datasources = datasources;
     }
+
     public DataSource getDataSourceObject(String dataSourceName) {
-        if (null != dataSourceHashMap && dataSourceHashMap.containsKey(dataSourceName)) {
-            return dataSourceHashMap.get(dataSourceName);
+        if (null != datasources && datasources.containsKey(dataSourceName)) {
+            return datasources.get(dataSourceName);
         }
         return null;
     }
@@ -46,7 +46,7 @@ public class DataSourceMetadataInfo {
     @Override
     public String toString() {
         return "DataSourceMetadataInfo{" +
-                "datasources=" + dataSourceHashMap +
+                "datasources=" + datasources +
                 '}';
     }
 }

--- a/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceNamespace.java
+++ b/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceNamespace.java
@@ -1,7 +1,6 @@
 package com.autotune.common.data.dataSourceMetadata;
 
 import com.autotune.utils.KruizeConstants;
-import com.google.gson.annotations.SerializedName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,39 +12,37 @@ import java.util.HashMap;
  */
 public class DataSourceNamespace {
     private static final Logger LOGGER = LoggerFactory.getLogger(DataSourceNamespace.class);
-    @SerializedName(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.NAMESPACE)
     private String namespace;
 
     /**
      * Key: Workload name
      * Value: Associated DataSourceWorkload object
      */
-    @SerializedName(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.WORKLOADS)
-    private HashMap<String, DataSourceWorkload> workloadHashMap;
+    private HashMap<String, DataSourceWorkload> workloads;
 
-    public DataSourceNamespace(String namespace, HashMap<String, DataSourceWorkload> workloadHashMap) {
+    public DataSourceNamespace(String namespace, HashMap<String, DataSourceWorkload> workloads) {
         this.namespace = namespace;
-        this.workloadHashMap = workloadHashMap;
+        this.workloads = workloads;
     }
 
-    public String getDataSourceNamespaceName() {
+    public String getNamespace() {
         return namespace;
     }
 
-    public HashMap<String, DataSourceWorkload> getDataSourceWorkloadHashMap() {
-        return workloadHashMap;
+    public HashMap<String, DataSourceWorkload> getWorkloads() {
+        return workloads;
     }
 
-    public void setDataSourceWorkloadHashMap(HashMap<String, DataSourceWorkload> workloadHashMap) {
+    public void setWorkloads(HashMap<String, DataSourceWorkload> workloadHashMap) {
         if (null == workloadHashMap) {
             LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.SET_WORKLOAD_MAP_ERROR + "{}", namespace);
         }
-        this.workloadHashMap = workloadHashMap;
+        this.workloads = workloadHashMap;
     }
 
     public DataSourceWorkload getDataSourceWorkloadObject(String workloadName) {
-        if (null != workloadHashMap && workloadHashMap.containsKey(workloadName)) {
-            return workloadHashMap.get(workloadName);
+        if (null != workloads && workloads.containsKey(workloadName)) {
+            return workloads.get(workloadName);
         }
 
         return null;
@@ -55,7 +52,7 @@ public class DataSourceNamespace {
     public String toString() {
         return "DataSourceNamespace{" +
                 "namespace='" + namespace + '\'' +
-                ", workloads=" + workloadHashMap +
+                ", workloads=" + workloads +
                 '}';
     }
 }

--- a/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceWorkload.java
+++ b/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceWorkload.java
@@ -1,6 +1,7 @@
 package com.autotune.common.data.dataSourceMetadata;
 
 import com.autotune.utils.KruizeConstants;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.SerializedName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,36 +15,41 @@ import java.util.HashMap;
 public class DataSourceWorkload {
     private static final Logger LOGGER = LoggerFactory.getLogger(DataSourceWorkload.class);
     @SerializedName(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.WORKLOAD_NAME)
+    @JsonProperty(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.WORKLOAD_NAME)
     private String workloadName;
     @SerializedName(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.WORKLOAD_TYPE)
+    @JsonProperty(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.WORKLOAD_TYPE)
     private String workloadType;
 
     /**
      * Key: Container name
      * Value: Associated DataSourceContainer object
      */
-    @SerializedName(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.CONTAINERS)
-    private HashMap<String, DataSourceContainer> containerHashMap;
+    private HashMap<String, DataSourceContainer> containers;
 
-    public DataSourceWorkload(String workloadName, String workloadType, HashMap<String, DataSourceContainer> containerHashMap) {
+    public DataSourceWorkload(String workloadName, String workloadType, HashMap<String, DataSourceContainer> containers) {
         this.workloadName = workloadName;
         this.workloadType = workloadType;
-        this.containerHashMap = containerHashMap;
+        this.containers = containers;
     }
 
-    public String getDataSourceWorkloadName() {return workloadName;}
-
-    public String getDataSourceWorkloadType() {return workloadType;}
-
-    public HashMap<String, DataSourceContainer> getDataSourceContainerHashMap() {
-        return containerHashMap;
+    public String getWorkloadName() {
+        return workloadName;
     }
 
-    public void setDataSourceContainerHashMap(HashMap<String, DataSourceContainer> containerHashMap) {
+    public String getWorkloadType() {
+        return workloadType;
+    }
+
+    public HashMap<String, DataSourceContainer> getContainers() {
+        return containers;
+    }
+
+    public void setContainers(HashMap<String, DataSourceContainer> containerHashMap) {
         if (containerHashMap == null) {
             LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.SET_CONTAINER_MAP_ERROR + "{}", workloadName);
         }
-        this.containerHashMap = containerHashMap;
+        this.containers = containerHashMap;
     }
 
     @Override
@@ -51,7 +57,7 @@ public class DataSourceWorkload {
         return "DataSourceWorkload{" +
                 "workload_name='" + workloadName + '\'' +
                 ", workload_type='" + workloadType + '\'' +
-                ", conatiners=" + containerHashMap +
+                ", conatiners=" + containers +
                 '}';
     }
 }

--- a/src/main/java/com/autotune/common/datasource/DataSourceManager.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceManager.java
@@ -60,10 +60,10 @@ public class DataSourceManager {
      * Imports Metadata for a specific data source using associated DataSourceInfo.
      *
      * @param dataSourceInfo
-     * @param uniqueKey      this is used as labels in query example container="xyz" namespace="abc"
-     * @param startTime      Get metadata from starttime to endtime
-     * @param endTime        Get metadata from starttime to endtime
-     * @param steps          the interval between data points in a range query
+     * @param uniqueKey        this is used as labels in query example container="xyz" namespace="abc"
+     * @param startTime        Get metadata from starttime to endtime
+     * @param endTime          Get metadata from starttime to endtime
+     * @param steps            the interval between data points in a range query
      * @param includeResources
      * @param excludeResources
      * @return
@@ -299,11 +299,11 @@ public class DataSourceManager {
         try {
             HashMap<String, DataSource> filteredDataSourceHashMap = new HashMap<>();
 
-            DataSource dataSource = dataSourceMetadataInfo.getDataSourceHashMap().get(dataSourceName);
+            DataSource dataSource = dataSourceMetadataInfo.getDatasources().get(dataSourceName);
 
             HashMap<String, DataSourceCluster> filteredClusterHashMap = new HashMap<>();
 
-            for (Map.Entry<String, DataSourceCluster> clusterEntry : dataSource.getDataSourceClusterHashMap().entrySet()) {
+            for (Map.Entry<String, DataSourceCluster> clusterEntry : dataSource.getClusters().entrySet()) {
                 String clusterName = clusterEntry.getKey();
                 DataSourceCluster cluster = clusterEntry.getValue();
 

--- a/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
@@ -64,12 +64,12 @@ public class DataSourceMetadataOperator {
      * <p>
      * Currently supported DataSourceProvider - Prometheus
      *
-     * @param dataSourceInfo The DataSourceInfo object containing information about the data source.
-     * @param uniqueKey      this is used as labels in query example container="xyz" namespace="abc"
-     * @param startTime      Get metadata from starttime to endtime
-     * @param endTime        Get metadata from starttime to endtime
-     * @param steps          the interval between data points in a range query
-     *                                                                                                                                                                                                                                                                         TODO - support multiple data sources
+     * @param dataSourceInfo   The DataSourceInfo object containing information about the data source.
+     * @param uniqueKey        this is used as labels in query example container="xyz" namespace="abc"
+     * @param startTime        Get metadata from starttime to endtime
+     * @param endTime          Get metadata from starttime to endtime
+     * @param steps            the interval between data points in a range query
+     *                                                                                                                                                                                                                                                                                                 TODO - support multiple data sources
      * @param includeResources
      * @param excludeResources
      */
@@ -91,7 +91,7 @@ public class DataSourceMetadataOperator {
                 return null;
             }
             String dataSourceName = dataSourceInfo.getName();
-            HashMap<String, DataSource> dataSourceHashMap = dataSourceMetadataInfo.getDataSourceHashMap();
+            HashMap<String, DataSource> dataSourceHashMap = dataSourceMetadataInfo.getDatasources();
 
             if (null == dataSourceHashMap || !dataSourceHashMap.containsKey(dataSourceName)) {
                 LOGGER.error(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.DATASOURCE_METADATA_DATASOURCE_NOT_AVAILABLE + "{}", dataSourceName);
@@ -115,8 +115,8 @@ public class DataSourceMetadataOperator {
      * @param dataSourceInfo The DataSourceInfo object containing information about the
      *                       data source to be updated.
      *                       <p>
-     *                                                                                                                                                                                                                                                    TODO - Currently Create and Update functions have identical functionalities, based on UI workflow and requirements
-     *                                                                                                                                                                                                                                                           need to further enhance updateDataSourceMetadata() to support namespace, workload level granular updates
+     *                                                                                                                                                                                                                                                                          TODO - Currently Create and Update functions have identical functionalities, based on UI workflow and requirements
+     *                                                                                                                                                                                                                                                                                 need to further enhance updateDataSourceMetadata() to support namespace, workload level granular updates
      */
     public DataSourceMetadataInfo updateDataSourceMetadata(DataSourceInfo dataSourceInfo, String uniqueKey, long startTime,
                                                            long endTime, int steps, Map<String, String> includeResources,
@@ -137,7 +137,7 @@ public class DataSourceMetadataOperator {
                 return;
             }
             String dataSourceName = dataSourceInfo.getName();
-            HashMap<String, DataSource> dataSourceHashMap = dataSourceMetadataInfo.getDataSourceHashMap();
+            HashMap<String, DataSource> dataSourceHashMap = dataSourceMetadataInfo.getDatasources();
 
             if (null == dataSourceHashMap || !dataSourceHashMap.containsKey(dataSourceName)) {
                 LOGGER.debug(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.DATASOURCE_METADATA_DATASOURCE_NOT_AVAILABLE + "{}", dataSourceName);
@@ -153,11 +153,11 @@ public class DataSourceMetadataOperator {
      * Fetches and processes metadata related to namespaces, workloads, and containers of a given datasource and populates the
      * DataSourceMetadataInfo object
      *
-     * @param dataSourceInfo The DataSourceInfo object containing information about the data source
-     * @param uniqueKey      this is used as labels in query example container="xyz" namespace="abc"
-     * @param startTime      Get metadata from starttime to endtime
-     * @param endTime        Get metadata from starttime to endtime
-     * @param steps          the interval between data points in a range query
+     * @param dataSourceInfo   The DataSourceInfo object containing information about the data source
+     * @param uniqueKey        this is used as labels in query example container="xyz" namespace="abc"
+     * @param startTime        Get metadata from starttime to endtime
+     * @param endTime          Get metadata from starttime to endtime
+     * @param steps            the interval between data points in a range query
      * @param includeResources
      * @param excludeResources
      * @return DataSourceMetadataInfo object with populated metadata fields

--- a/src/main/java/com/autotune/common/datasource/DataSourceMetadataValidation.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceMetadataValidation.java
@@ -1,14 +1,16 @@
 package com.autotune.common.datasource;
 
 import com.autotune.analyzer.utils.AnalyzerErrorConstants;
-import com.autotune.common.data.dataSourceMetadata.DataSourceCluster;
 import com.autotune.common.data.dataSourceMetadata.DataSource;
+import com.autotune.common.data.dataSourceMetadata.DataSourceCluster;
 import com.autotune.common.data.dataSourceMetadata.DataSourceMetadataInfo;
 import com.autotune.utils.KruizeConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * DataSourceMetadataValidation class validates the structure and mandatory fields of a DataSourceMetadataInfo object
@@ -48,13 +50,13 @@ public class DataSourceMetadataValidation {
     public void validate(DataSourceMetadataInfo dataSourceMetadataInfo) {
         List<String> missingMandatoryFields = new ArrayList<>();
         try {
-            if (null == dataSourceMetadataInfo || null == dataSourceMetadataInfo.getDataSourceHashMap()) {
+            if (null == dataSourceMetadataInfo || null == dataSourceMetadataInfo.getDatasources()) {
                 String errorMsg = AnalyzerErrorConstants.APIErrors.DSMetadataAPI.DATASOURCE_METADATA_CONNECTION_FAILED;
                 markFailed(errorMsg);
                 return;
             }
 
-            for (Map.Entry<String, DataSource> entry : dataSourceMetadataInfo.getDataSourceHashMap().entrySet()) {
+            for (Map.Entry<String, DataSource> entry : dataSourceMetadataInfo.getDatasources().entrySet()) {
                 DataSource dataSource = entry.getValue();
                 if (null == dataSource.getDataSourceName()) {
                     missingMandatoryFields.add(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.DATASOURCE_NAME);
@@ -81,14 +83,14 @@ public class DataSourceMetadataValidation {
     /**
      * Validates the given DataSource object for mandatory fields like "clusters" and "cluster_name".
      *
-     * @param dataSource the DataSource object to validate.
+     * @param dataSource             the DataSource object to validate.
      * @param missingMandatoryFields the list to which any missing fields will be added.
      */
     private void validateDataSourceCluster(DataSource dataSource, List<String> missingMandatoryFields) {
-        if (null == dataSource.getDataSourceClusterHashMap()) {
+        if (null == dataSource.getClusters()) {
             missingMandatoryFields.add(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.CLUSTERS);
         } else {
-            for (Map.Entry<String, DataSourceCluster> entry : dataSource.getDataSourceClusterHashMap().entrySet()) {
+            for (Map.Entry<String, DataSourceCluster> entry : dataSource.getClusters().entrySet()) {
                 DataSourceCluster dataSourceCluster = entry.getValue();
                 if (null == dataSourceCluster.getDataSourceClusterName()) {
                     missingMandatoryFields.add(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.CLUSTER_NAME);

--- a/src/main/java/com/autotune/database/helper/DBHelpers.java
+++ b/src/main/java/com/autotune/database/helper/DBHelpers.java
@@ -286,12 +286,12 @@ public class DBHelpers {
         String dataSourceName = kruizeMetadata.getDataSourceName();
 
         // Check if the data source already exists
-        if (dataSourceMetadataInfo.getDataSourceHashMap().containsKey(dataSourceName)) {
-            return dataSourceMetadataInfo.getDataSourceHashMap().get(dataSourceName);
+        if (dataSourceMetadataInfo.getDatasources().containsKey(dataSourceName)) {
+            return dataSourceMetadataInfo.getDatasources().get(dataSourceName);
         }
 
         DataSource dataSource = new DataSource(dataSourceName, new HashMap<>());
-        dataSourceMetadataInfo.getDataSourceHashMap().put(dataSourceName, dataSource);
+        dataSourceMetadataInfo.getDatasources().put(dataSourceName, dataSource);
 
         return dataSource;
     }
@@ -307,12 +307,12 @@ public class DBHelpers {
         String clusterName = kruizeMetadata.getClusterName();
 
         // Check if the cluster already exists in the DataSource
-        if (dataSource.getDataSourceClusterHashMap().containsKey(clusterName)) {
-            return dataSource.getDataSourceClusterHashMap().get(clusterName);
+        if (dataSource.getClusters().containsKey(clusterName)) {
+            return dataSource.getClusters().get(clusterName);
         }
 
         DataSourceCluster dataSourceCluster = new DataSourceCluster(clusterName, new HashMap<>());
-        dataSource.getDataSourceClusterHashMap().put(clusterName, dataSourceCluster);
+        dataSource.getClusters().put(clusterName, dataSourceCluster);
 
         return dataSourceCluster;
     }
@@ -328,12 +328,12 @@ public class DBHelpers {
         String namespaceName = kruizeMetadata.getNamespace();
 
         // Check if the namespace already exists in the DataSourceCluster
-        if (dataSourceCluster.getDataSourceNamespaceHashMap().containsKey(namespaceName)) {
-            return dataSourceCluster.getDataSourceNamespaceHashMap().get(namespaceName);
+        if (dataSourceCluster.getNamespaces().containsKey(namespaceName)) {
+            return dataSourceCluster.getNamespaces().get(namespaceName);
         }
 
         DataSourceNamespace dataSourceNamespace = new DataSourceNamespace(namespaceName, new HashMap<>());
-        dataSourceCluster.getDataSourceNamespaceHashMap().put(namespaceName, dataSourceNamespace);
+        dataSourceCluster.getNamespaces().put(namespaceName, dataSourceNamespace);
 
         return dataSourceNamespace;
     }
@@ -353,12 +353,12 @@ public class DBHelpers {
         }
 
         // Check if the workload already exists in the DataSourceNamespace
-        if (dataSourceNamespace.getDataSourceWorkloadHashMap().containsKey(workloadName)) {
-            return dataSourceNamespace.getDataSourceWorkloadHashMap().get(workloadName);
+        if (dataSourceNamespace.getWorkloads().containsKey(workloadName)) {
+            return dataSourceNamespace.getWorkloads().get(workloadName);
         }
 
         DataSourceWorkload dataSourceWorkload = new DataSourceWorkload(workloadName, kruizeMetadata.getWorkloadType(), new HashMap<>());
-        dataSourceNamespace.getDataSourceWorkloadHashMap().put(workloadName, dataSourceWorkload);
+        dataSourceNamespace.getWorkloads().put(workloadName, dataSourceWorkload);
 
         return dataSourceWorkload;
     }
@@ -378,12 +378,12 @@ public class DBHelpers {
         }
 
         // Check if the container already exists in the DataSourceWorkload
-        if (dataSourceWorkload.getDataSourceContainerHashMap().containsKey(containerName)) {
-            return dataSourceWorkload.getDataSourceContainerHashMap().get(containerName);
+        if (dataSourceWorkload.getContainers().containsKey(containerName)) {
+            return dataSourceWorkload.getContainers().get(containerName);
         }
 
         DataSourceContainer dataSourceContainer = new DataSourceContainer(containerName, kruizeMetadata.getContainerImageName());
-        dataSourceWorkload.getDataSourceContainerHashMap().put(containerName, dataSourceContainer);
+        dataSourceWorkload.getContainers().put(containerName, dataSourceContainer);
 
         return dataSourceContainer;
     }
@@ -1205,20 +1205,20 @@ public class DBHelpers {
                         DataSourceContainer dataSourceContainer = getOrCreateDataSourceContainerFromDB(kruizeMetadata, dataSourceWorkload);
 
                         // Update DataSourceMetadataInfo with the DataSource, DataSourceCluster, DataSourceNamespace, DataSourceWorkload, and DataSourceContainer
-                        dataSourceMetadataInfo.getDataSourceHashMap().put(kruizeMetadata.getDataSourceName(), dataSource);
-                        dataSource.getDataSourceClusterHashMap().put(kruizeMetadata.getClusterName(), dataSourceCluster);
-                        dataSourceCluster.getDataSourceNamespaceHashMap().put(kruizeMetadata.getNamespace(), dataSourceNamespace);
+                        dataSourceMetadataInfo.getDatasources().put(kruizeMetadata.getDataSourceName(), dataSource);
+                        dataSource.getClusters().put(kruizeMetadata.getClusterName(), dataSourceCluster);
+                        dataSourceCluster.getNamespaces().put(kruizeMetadata.getNamespace(), dataSourceNamespace);
                         if (null == dataSourceWorkload) {
-                            dataSourceNamespace.setDataSourceWorkloadHashMap(null);
+                            dataSourceNamespace.setWorkloads(null);
                             continue;
                         }
-                        dataSourceNamespace.getDataSourceWorkloadHashMap().put(kruizeMetadata.getWorkloadName(), dataSourceWorkload);
+                        dataSourceNamespace.getWorkloads().put(kruizeMetadata.getWorkloadName(), dataSourceWorkload);
 
                         if (null == dataSourceContainer) {
-                            dataSourceWorkload.setDataSourceContainerHashMap(null);
+                            dataSourceWorkload.setContainers(null);
                             continue;
                         }
-                        dataSourceWorkload.getDataSourceContainerHashMap().put(kruizeMetadata.getContainerName(), dataSourceContainer);
+                        dataSourceWorkload.getContainers().put(kruizeMetadata.getContainerName(), dataSourceContainer);
                     } catch (Exception e) {
                         LOGGER.error("Error occurred while converting to dataSourceMetadataInfo from DB object : {}", e.getMessage());
                         LOGGER.error(e.getMessage());
@@ -1251,13 +1251,13 @@ public class DBHelpers {
                     try {
                         DataSource dataSource = getOrCreateDataSourceFromDB(kruizeMetadata, dataSourceMetadataInfo);
                         DataSourceCluster dataSourceCluster = getOrCreateDataSourceClusterFromDB(kruizeMetadata, dataSource);
-                        dataSourceCluster.setDataSourceNamespaceHashMap(null);
+                        dataSourceCluster.setNamespaces(null);
 
                         // Update DataSourceMetadataInfo with the DataSource and DataSourceCluster
-                        dataSourceMetadataInfo.getDataSourceHashMap()
+                        dataSourceMetadataInfo.getDatasources()
                                 .put(kruizeMetadata.getDataSourceName(), dataSource);
 
-                        dataSource.getDataSourceClusterHashMap()
+                        dataSource.getClusters()
                                 .put(kruizeMetadata.getClusterName(), dataSourceCluster);
 
                     } catch (Exception e) {
@@ -1294,16 +1294,16 @@ public class DBHelpers {
                         DataSource dataSource = getOrCreateDataSourceFromDB(kruizeMetadata, dataSourceMetadataInfo);
                         DataSourceCluster dataSourceCluster = getOrCreateDataSourceClusterFromDB(kruizeMetadata, dataSource);
                         DataSourceNamespace dataSourceNamespace = getOrCreateDataSourceNamespaceFromDB(kruizeMetadata, dataSourceCluster);
-                        dataSourceNamespace.setDataSourceWorkloadHashMap(null);
+                        dataSourceNamespace.setWorkloads(null);
 
                         // Update DataSourceMetadataInfo with the DataSource and DataSourceCluster
-                        dataSourceMetadataInfo.getDataSourceHashMap()
+                        dataSourceMetadataInfo.getDatasources()
                                 .put(kruizeMetadata.getDataSourceName(), dataSource);
 
-                        dataSource.getDataSourceClusterHashMap()
+                        dataSource.getClusters()
                                 .put(kruizeMetadata.getClusterName(), dataSourceCluster);
 
-                        dataSourceCluster.getDataSourceNamespaceHashMap()
+                        dataSourceCluster.getNamespaces()
                                 .put(kruizeMetadata.getNamespace(), dataSourceNamespace);
 
                     } catch (Exception e) {
@@ -1330,16 +1330,16 @@ public class DBHelpers {
                 List<KruizeDSMetadataEntry> kruizeMetadataList = new ArrayList<>();
                 try {
 
-                    for (DataSource dataSource : dataSourceMetadataInfo.getDataSourceHashMap().values()) {
+                    for (DataSource dataSource : dataSourceMetadataInfo.getDatasources().values()) {
                         String dataSourceName = dataSource.getDataSourceName();
 
-                        for (DataSourceCluster dataSourceCluster : dataSource.getDataSourceClusterHashMap().values()) {
+                        for (DataSourceCluster dataSourceCluster : dataSource.getClusters().values()) {
                             String dataSourceClusterName = dataSourceCluster.getDataSourceClusterName();
 
-                            for (DataSourceNamespace dataSourceNamespace : dataSourceCluster.getDataSourceNamespaceHashMap().values()) {
-                                String namespaceName = dataSourceNamespace.getDataSourceNamespaceName();
+                            for (DataSourceNamespace dataSourceNamespace : dataSourceCluster.getNamespaces().values()) {
+                                String namespaceName = dataSourceNamespace.getNamespace();
 
-                                if (null == dataSourceNamespace.getDataSourceWorkloadHashMap()) {
+                                if (null == dataSourceNamespace.getWorkloads()) {
                                     KruizeDSMetadataEntry kruizeMetadata = new KruizeDSMetadataEntry();
                                     kruizeMetadata.setVersion(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoConstants.version);
                                     kruizeMetadata.setDataSourceName(dataSourceName);
@@ -1353,17 +1353,17 @@ public class DBHelpers {
                                     continue;
                                 }
 
-                                for (DataSourceWorkload dataSourceWorkload : dataSourceNamespace.getDataSourceWorkloadHashMap().values()) {
+                                for (DataSourceWorkload dataSourceWorkload : dataSourceNamespace.getWorkloads().values()) {
                                     // handles 'job' workload type with no containers
-                                    if (null == dataSourceWorkload.getDataSourceContainerHashMap()) {
+                                    if (null == dataSourceWorkload.getContainers()) {
                                         KruizeDSMetadataEntry kruizeMetadata = new KruizeDSMetadataEntry();
                                         kruizeMetadata.setVersion(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoConstants.version);
 
                                         kruizeMetadata.setDataSourceName(dataSourceName);
                                         kruizeMetadata.setClusterName(dataSourceClusterName);
                                         kruizeMetadata.setNamespace(namespaceName);
-                                        kruizeMetadata.setWorkloadType(dataSourceWorkload.getDataSourceWorkloadType());
-                                        kruizeMetadata.setWorkloadName(dataSourceWorkload.getDataSourceWorkloadName());
+                                        kruizeMetadata.setWorkloadType(dataSourceWorkload.getWorkloadType());
+                                        kruizeMetadata.setWorkloadName(dataSourceWorkload.getWorkloadName());
 
                                         kruizeMetadata.setContainerName(null);
                                         kruizeMetadata.setContainerImageName(null);
@@ -1372,18 +1372,18 @@ public class DBHelpers {
                                         continue;
                                     }
 
-                                    for (DataSourceContainer dataSourceContainer : dataSourceWorkload.getDataSourceContainerHashMap().values()) {
+                                    for (DataSourceContainer dataSourceContainer : dataSourceWorkload.getContainers().values()) {
                                         KruizeDSMetadataEntry kruizeMetadata = new KruizeDSMetadataEntry();
                                         kruizeMetadata.setVersion(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoConstants.version);
 
                                         kruizeMetadata.setDataSourceName(dataSourceName);
                                         kruizeMetadata.setClusterName(dataSourceClusterName);
                                         kruizeMetadata.setNamespace(namespaceName);
-                                        kruizeMetadata.setWorkloadType(dataSourceWorkload.getDataSourceWorkloadType());
-                                        kruizeMetadata.setWorkloadName(dataSourceWorkload.getDataSourceWorkloadName());
+                                        kruizeMetadata.setWorkloadType(dataSourceWorkload.getWorkloadType());
+                                        kruizeMetadata.setWorkloadName(dataSourceWorkload.getWorkloadName());
 
-                                        kruizeMetadata.setContainerName(dataSourceContainer.getDataSourceContainerName());
-                                        kruizeMetadata.setContainerImageName(dataSourceContainer.getDataSourceContainerImageName());
+                                        kruizeMetadata.setContainerName(dataSourceContainer.getContainerName());
+                                        kruizeMetadata.setContainerImageName(dataSourceContainer.getContainerImageName());
 
                                         kruizeMetadataList.add(kruizeMetadata);
                                     }


### PR DESCRIPTION
## Description

This PR introduces a new BulkAPI format where bulk API recommendation responses are recorded. This feature aims to enhance the BulkAPI functionality by including detailed recommendations within the bulk responses, providing more comprehensive and actionable data.

![image](https://github.com/user-attachments/assets/25d29812-9bb1-44c6-8da9-507f72fb1675)

```json
{"summary":{"status":"IN_PROGRESS","total_experiments":25,"processed_experiments":20,"notifications":null,"job_id":"33fd8c85-95ed-4f0e-bf09-1cfc377169a7","job_start_time":"2025-01-24T13:53:16.632Z","job_end_time":null},"experiments":{"prometheus-1|default|cadvisor|cadvisor(daemonset)|cadvisor":{"name":"prometheus-1|default|cadvisor|cadvisor(daemonset)|cadvisor","status":"PROCESSED","apis":{"create":{"response":{"message":"Experiment registered successfully with Kruize. View registered experiments at /listExperiments","httpcode":201,"documentationLink":"","status":"SUCCESS"}},"recommendations":{"response":[{"cluster_name":"default","experiment_type":"container","kubernetes_objects":[{"type":"daemonset","name":"cadvisor","namespace":"cadvisor","containers":[{"container_image_name":"gcr.io/cadvisor/cadvisor:v0.45.0","container_name":"cadvisor","recommendations":{"version":"1.0","notifications":{"111000":{"type":"info","message":"Recommendations Are Available","code":111000.0}},"data":{"2025-01-24T14:03:17.000Z":{"notifications":{"224001":{"type":"error","message":"Amount field is missing in the Memory Section","code":224001.0},"524002":{"type":"critical","message":"Memory Limit Not Set","code":524002.0},"524001":{"type":"critical","message":"Memory Request Not Set","code":524001.0},"223001":{"type":"error","message":"Amount field is missing in the CPU Section","code":223001.0},"111101":{"type":"info","message":"Short Term Recommendations Available","code":111101.0},"523001":{"type":"critical","message":"CPU Request Not Set","code":523001.0},"423001":{"type":"warning","message":"CPU Limit Not Set","code":423001.0}},"monitoring_end_time":"2025-01-24T14:03:17.000Z","current":{},"recommendation_terms":{"short_term":{"duration_in_hours":24.0,"notifications":{"112101":{"type":"info","message":"Cost Recommendations Available","code":112101.0},"112102":{"type":"info","message":"Performance Recommendations Available","code":112102.0}},"monitoring_start_time":"2025-01-23T14:03:17.000Z","recommendation_engines":{"cost":{"pods_count":1.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":1.372817408E8,"format":"bytes"},"cpu":{"amount":0.21180366781608917,"format":"cores"}},"requests":{"memory":{"amount":1.372817408E8,"format":"bytes"},"cpu":{"amount":0.21180366781608917,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":1.372817408E8,"format":"bytes"},"cpu":{"amount":0.21180366781608917,"format":"cores"}},"requests":{"memory":{"amount":1.372817408E8,"format":"bytes"},"cpu":{"amount":0.21180366781608917,"format":"cores"}}},"notifications":{}},"performance":{"pods_count":1.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":1.372817408E8,"format":"bytes"},"cpu":{"amount":0.21180366781608917,"format":"cores"}},"requests":{"memory":{"amount":1.372817408E8,"format":"bytes"},"cpu":{"amount":0.21180366781608917,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":1.372817408E8,"format":"bytes"},"cpu":{"amount":0.21180366781608917,"format":"cores"}},"requests":{"memory":{"amount":1.372817408E8,"format":"bytes"},"cpu":{"amount":0.21180366781608917,"format":"cores"}}},"notifications":{}}},"plots":{"datapoints":4.0,"plots_data":{"2025-01-24T02:03:17.000Z":{},"2025-01-24T14:03:17.000Z":{"cpuUsage":{"min":0.055704010381263484,"q1":0.17002619230720575,"median":0.174149089376309,"q3":0.18009180388137308,"max":0.19573625517240825,"format":"cores"},"memoryUsage":{"min":1.04599552E8,"q1":1.20733696E8,"median":1.21655296E8,"q3":1.22159104E8,"max":1.24055552E8,"format":"bytes"}},"2025-01-24T08:03:17.000Z":{"cpuUsage":{"min":0.07764516436787933,"q1":0.1722421643678251,"median":0.17591533218393782,"q3":0.18662235057468599,"max":0.21180366781608917,"format":"cores"},"memoryUsage":{"min":1.11681536E8,"q1":1.21647104E8,"median":1.23478016E8,"q3":1.24407808E8,"max":1.24977152E8,"format":"bytes"}},"2025-01-23T20:03:17.000Z":{"cpuUsage":{"min":0.08078723622470793,"q1":0.175108398850643,"median":0.18296969999991936,"q3":0.18506183245212202,"max":0.19458940375010372,"format":"cores"},"memoryUsage":{"min":1.1272192E8,"q1":1.22990592E8,"median":1.23891712E8,"q3":1.24137472E8,"max":1.24895232E8,"format":"bytes"}}}}},"medium_term":{"duration_in_hours":168.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}},"long_term":{"duration_in_hours":360.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}}}}}}}]}],"version":"v2.0","experiment_name":"prometheus-1|default|cadvisor|cadvisor(daemonset)|cadvisor"}]}},"status_history":[{"status":"UNPROCESSED","timestamp":"2025-01-24T13:53:16.835Z"},{"status":"PROCESSED","timestamp":"2025-01-24T13:53:21.346Z"}]},"prometheus-1|default|monitoring|create-partition-cronjob-28918080(job)|kruizecronjob":{"name":"prometheus-1|default|monitoring|create-partition-cronjob-28918080(job)|kruizecronjob","status":"PROCESSED","apis":{"create":{"response":{"message":"Experiment registered successfully with Kruize. View registered experiments at /listExperiments","httpcode":201,"documentationLink":"","status":"SUCCESS"}},"recommendations":{"response":[{"cluster_name":"default","experiment_type":"container","kubernetes_objects":[{"type":"job","name":"create-partition-cronjob-28918080","namespace":"monitoring","containers":[{"container_image_name":"quay.io/kruize/autotune_operator:0.2","container_name":"kruizecronjob","recommendations":{"version":"1.0","notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}},"data":{}}}]}],"version":"v2.0","experiment_name":"prometheus-1|default|monitoring|create-partition-cronjob-28918080(job)|kruizecronjob"}]}},"status_history":[{"status":"UNPROCESSED","timestamp":"2025-01-24T13:53:16.836Z"},{"status":"PROCESSED","timestamp":"2025-01-24T13:53:19.272Z"}]},"prometheus-1|default|monitoring|blackbox-exporter(deployment)|kube-rbac-proxy":{"name":"prometheus-1|default|monitoring|blackbox-exporter(deployment)|kube-rbac-proxy","status":"PROCESSED","apis":{"create":{"response":{"message":"Experiment registered successfully with Kruize. View registered experiments at /listExperiments","httpcode":201,"documentationLink":"","status":"SUCCESS"}},"recommendations":{"response":[{"cluster_name":"default","experiment_type":"container","kubernetes_objects":[{"type":"deployment","name":"blackbox-exporter","namespace":"monitoring","containers":[{"container_image_name":"quay.io/brancz/kube-rbac-proxy:v0.14.2","container_name":"kube-rbac-proxy","recommendations":{"version":"1.0","notifications":{"111000":{"type":"info","message":"Recommendations Are Available","code":111000.0}},"data":{"2025-01-24T14:03:17.000Z":{"notifications":{"224001":{"type":"error","message":"Amount field is missing in the Memory Section","code":224001.0},"524002":{"type":"critical","message":"Memory Limit Not Set","code":524002.0},"524001":{"type":"critical","message":"Memory Request Not Set","code":524001.0},"223001":{"type":"error","message":"Amount field is missing in the CPU Section","code":223001.0},"111101":{"type":"info","message":"Short Term Recommendations Available","code":111101.0},"523001":{"type":"critical","message":"CPU Request Not Set","code":523001.0},"423001":{"type":"warning","message":"CPU Limit Not Set","code":423001.0}},"monitoring_end_time":"2025-01-24T14:03:17.000Z","current":{},"recommendation_terms":{"short_term":{"duration_in_hours":24.0,"notifications":{"112101":{"type":"info","message":"Cost Recommendations Available","code":112101.0},"112102":{"type":"info","message":"Performance Recommendations Available","code":112102.0}},"monitoring_start_time":"2025-01-23T14:03:17.000Z","recommendation_engines":{"cost":{"pods_count":4.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":1.70999808E7,"format":"bytes"},"cpu":{"amount":0.021702393103448788,"format":"cores"}},"requests":{"memory":{"amount":1.70999808E7,"format":"bytes"},"cpu":{"amount":0.021702393103448788,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":1.70999808E7,"format":"bytes"},"cpu":{"amount":0.021702393103448788,"format":"cores"}},"requests":{"memory":{"amount":1.70999808E7,"format":"bytes"},"cpu":{"amount":0.021702393103448788,"format":"cores"}}},"notifications":{}},"performance":{"pods_count":4.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":1.70999808E7,"format":"bytes"},"cpu":{"amount":0.021702393103448788,"format":"cores"}},"requests":{"memory":{"amount":1.70999808E7,"format":"bytes"},"cpu":{"amount":0.021702393103448788,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":1.70999808E7,"format":"bytes"},"cpu":{"amount":0.021702393103448788,"format":"cores"}},"requests":{"memory":{"amount":1.70999808E7,"format":"bytes"},"cpu":{"amount":0.021702393103448788,"format":"cores"}}},"notifications":{}}},"plots":{"datapoints":4.0,"plots_data":{"2025-01-24T02:03:17.000Z":{},"2025-01-24T14:03:17.000Z":{"cpuUsage":{"min":0.002915806392345664,"q1":0.014793527586207498,"median":0.01537070689655188,"q3":0.016552022988505586,"max":0.021702393103448788,"format":"cores"},"memoryUsage":{"min":7755195.733333332,"q1":1.1317248E7,"median":1.2795904E7,"q3":1.2857344E7,"max":1.3041664E7,"format":"bytes"}},"2025-01-24T08:03:17.000Z":{"cpuUsage":{"min":0.007111865971437722,"q1":0.015905648275862834,"median":0.01680889195402365,"q3":0.018896649425288216,"max":0.01956750000000034,"format":"cores"},"memoryUsage":{"min":8323618.133333333,"q1":1.288192E7,"median":1.3668352E7,"q3":1.378304E7,"max":1.4249984E7,"format":"bytes"}},"2025-01-23T20:03:17.000Z":{"cpuUsage":{"min":0.0034152291193579286,"q1":0.01566271945364306,"median":0.01644754367816081,"q3":0.017041910804968367,"max":0.02038184465114376,"format":"cores"},"memoryUsage":{"min":9077145.600000001,"q1":1.3512704E7,"median":1.3590528E7,"q3":1.3627392E7,"max":1.366016E7,"format":"bytes"}}}}},"medium_term":{"duration_in_hours":168.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}},"long_term":{"duration_in_hours":360.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}}}}}}}]}],"version":"v2.0","experiment_name":"prometheus-1|default|monitoring|blackbox-exporter(deployment)|kube-rbac-proxy"}]}},"status_history":[{"status":"UNPROCESSED","timestamp":"2025-01-24T13:53:16.836Z"},{"status":"PROCESSED","timestamp":"2025-01-24T13:53:21.426Z"}]},"prometheus-1|default|monitoring|prometheus-operator(deployment)|prometheus-operator":{"name":"prometheus-1|default|monitoring|prometheus-operator(deployment)|prometheus-operator","status":"PROCESSED","apis":{"create":{"response":{"message":"Experiment registered successfully with Kruize. View registered experiments at /listExperiments","httpcode":201,"documentationLink":"","status":"SUCCESS"}},"recommendations":{"response":[{"cluster_name":"default","experiment_type":"container","kubernetes_objects":[{"type":"deployment","name":"prometheus-operator","namespace":"monitoring","containers":[{"container_image_name":"quay.io/prometheus-operator/prometheus-operator:v0.67.1","container_name":"prometheus-operator","recommendations":{"version":"1.0","notifications":{"111000":{"type":"info","message":"Recommendations Are Available","code":111000.0}},"data":{"2025-01-24T14:03:21.000Z":{"notifications":{"224001":{"type":"error","message":"Amount field is missing in the Memory Section","code":224001.0},"524002":{"type":"critical","message":"Memory Limit Not Set","code":524002.0},"524001":{"type":"critical","message":"Memory Request Not Set","code":524001.0},"223001":{"type":"error","message":"Amount field is missing in the CPU Section","code":223001.0},"111101":{"type":"info","message":"Short Term Recommendations Available","code":111101.0},"523001":{"type":"critical","message":"CPU Request Not Set","code":523001.0},"423001":{"type":"warning","message":"CPU Limit Not Set","code":423001.0}},"monitoring_end_time":"2025-01-24T14:03:21.000Z","current":{},"recommendation_terms":{"short_term":{"duration_in_hours":24.0,"notifications":{"112101":{"type":"info","message":"Cost Recommendations Available","code":112101.0},"112102":{"type":"info","message":"Performance Recommendations Available","code":112102.0}},"monitoring_start_time":"2025-01-23T14:03:21.000Z","recommendation_engines":{"cost":{"pods_count":1.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":5.25090816E7,"format":"bytes"},"cpu":{"amount":0.005362068564930552,"format":"cores"}},"requests":{"memory":{"amount":5.25090816E7,"format":"bytes"},"cpu":{"amount":0.005362068564930552,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":5.25090816E7,"format":"bytes"},"cpu":{"amount":0.005362068564930552,"format":"cores"}},"requests":{"memory":{"amount":5.25090816E7,"format":"bytes"},"cpu":{"amount":0.005362068564930552,"format":"cores"}}},"notifications":{}},"performance":{"pods_count":1.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":5.25090816E7,"format":"bytes"},"cpu":{"amount":0.005362068564930552,"format":"cores"}},"requests":{"memory":{"amount":5.25090816E7,"format":"bytes"},"cpu":{"amount":0.005362068564930552,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":5.25090816E7,"format":"bytes"},"cpu":{"amount":0.005362068564930552,"format":"cores"}},"requests":{"memory":{"amount":5.25090816E7,"format":"bytes"},"cpu":{"amount":0.005362068564930552,"format":"cores"}}},"notifications":{}}},"plots":{"datapoints":4.0,"plots_data":{"2025-01-24T02:03:21.000Z":{},"2025-01-24T14:03:21.000Z":{"cpuUsage":{"min":9.028287356319202E-4,"q1":0.0033519277987271623,"median":0.0037261402298854355,"q3":0.00400848234563639,"max":0.004456737931032986,"format":"cores"},"memoryUsage":{"min":3.3394688E7,"q1":3.9153664E7,"median":4.1455616E7,"q3":4.247552E7,"max":4.3757568E7,"format":"bytes"}},"2025-01-24T08:03:21.000Z":{"cpuUsage":{"min":6.993413424051635E-4,"q1":0.0034480183111899676,"median":0.0035084403850870324,"q3":0.003985572965945733,"max":0.0045387022988496485,"format":"cores"},"memoryUsage":{"min":3.428352E7,"q1":3.9747584E7,"median":3.9817216E7,"q3":4.052992E7,"max":4.1271296E7,"format":"bytes"}},"2025-01-23T20:03:21.000Z":{"cpuUsage":{"min":9.178250510240161E-4,"q1":0.0032716367816089127,"median":0.004071317358985243,"q3":0.004214348740589951,"max":0.005362068564930552,"format":"cores"},"memoryUsage":{"min":3.555328E7,"q1":4.0247296E7,"median":4.1209856E7,"q3":4.1443328E7,"max":4.2729472E7,"format":"bytes"}}}}},"medium_term":{"duration_in_hours":168.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}},"long_term":{"duration_in_hours":360.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}}}}}}}]}],"version":"v2.0","experiment_name":"prometheus-1|default|monitoring|prometheus-operator(deployment)|prometheus-operator"}]}},"status_history":[{"status":"UNPROCESSED","timestamp":"2025-01-24T13:53:16.950Z"},{"status":"PROCESSED","timestamp":"2025-01-24T13:53:24.026Z"}]},"prometheus-1|default|monitoring|kruize(deployment)|kruize":{"name":"prometheus-1|default|monitoring|kruize(deployment)|kruize","status":"PROCESSED","apis":{"create":{"response":{"message":"Experiment registered successfully with Kruize. View registered experiments at /listExperiments","httpcode":201,"documentationLink":"","status":"SUCCESS"}},"recommendations":{"response":[{"cluster_name":"default","experiment_type":"container","kubernetes_objects":[{"type":"deployment","name":"kruize","namespace":"monitoring","containers":[{"container_image_name":"quay.io/dinogun210/autotune_operator:0.3","container_name":"kruize","recommendations":{"version":"1.0","notifications":{"111000":{"type":"info","message":"Recommendations Are Available","code":111000.0}},"data":{"2025-01-24T14:03:21.000Z":{"notifications":{"224001":{"type":"error","message":"Amount field is missing in the Memory Section","code":224001.0},"524002":{"type":"critical","message":"Memory Limit Not Set","code":524002.0},"524001":{"type":"critical","message":"Memory Request Not Set","code":524001.0},"223001":{"type":"error","message":"Amount field is missing in the CPU Section","code":223001.0},"111101":{"type":"info","message":"Short Term Recommendations Available","code":111101.0},"523001":{"type":"critical","message":"CPU Request Not Set","code":523001.0},"423001":{"type":"warning","message":"CPU Limit Not Set","code":423001.0}},"monitoring_end_time":"2025-01-24T14:03:21.000Z","current":{},"recommendation_terms":{"short_term":{"duration_in_hours":24.0,"notifications":{"112101":{"type":"info","message":"Cost Recommendations Available","code":112101.0},"112102":{"type":"info","message":"Performance Recommendations Available","code":112102.0}},"monitoring_start_time":"2025-01-23T14:03:21.000Z","recommendation_engines":{"cost":{"pods_count":1.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":2.809479168E8,"format":"bytes"},"cpu":{"amount":0.05087297090096907,"format":"cores"}},"requests":{"memory":{"amount":2.809479168E8,"format":"bytes"},"cpu":{"amount":0.05087297090096907,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":2.809479168E8,"format":"bytes"},"cpu":{"amount":0.05087297090096907,"format":"cores"}},"requests":{"memory":{"amount":2.809479168E8,"format":"bytes"},"cpu":{"amount":0.05087297090096907,"format":"cores"}}},"notifications":{}},"performance":{"pods_count":1.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":2.809479168E8,"format":"bytes"},"cpu":{"amount":0.05087297090096907,"format":"cores"}},"requests":{"memory":{"amount":2.809479168E8,"format":"bytes"},"cpu":{"amount":0.05087297090096907,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":2.809479168E8,"format":"bytes"},"cpu":{"amount":0.05087297090096907,"format":"cores"}},"requests":{"memory":{"amount":2.809479168E8,"format":"bytes"},"cpu":{"amount":0.05087297090096907,"format":"cores"}}},"notifications":{}}},"plots":{"datapoints":4.0,"plots_data":{"2025-01-24T02:03:21.000Z":{},"2025-01-24T14:03:21.000Z":{"cpuUsage":{"min":4.806666666657596E-4,"q1":0.0024387000000009114,"median":0.005346733333334441,"q3":0.008647266666666079,"max":0.05087297090096907,"format":"cores"},"memoryUsage":{"min":1.5286272E8,"q1":1.53464832E8,"median":2.17882624E8,"q3":2.28814848E8,"max":2.34123264E8,"format":"bytes"}},"2025-01-24T08:03:21.000Z":{"cpuUsage":{"min":3.717666666659625E-4,"q1":0.0020854333333337155,"median":0.002130533333333536,"q3":0.003965799999999338,"max":0.03234940000000013,"format":"cores"},"memoryUsage":{"min":1.55348992E8,"q1":1.56000256E8,"median":1.56073984E8,"q3":1.56246016E8,"max":1.57384704E8,"format":"bytes"}},"2025-01-23T20:03:21.000Z":{"cpuUsage":{"min":5.583333333333939E-4,"q1":0.001919666666666823,"median":0.0021680666666668456,"q3":0.0022993000000004335,"max":0.023592986432880842,"format":"cores"},"memoryUsage":{"min":1.52252416E8,"q1":1.53362432E8,"median":1.5521792E8,"q3":1.55480064E8,"max":1.55635712E8,"format":"bytes"}}}}},"medium_term":{"duration_in_hours":168.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}},"long_term":{"duration_in_hours":360.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}}}}}}}]}],"version":"v2.0","experiment_name":"prometheus-1|default|monitoring|kruize(deployment)|kruize"}]}},"status_history":[{"status":"UNPROCESSED","timestamp":"2025-01-24T13:53:16.959Z"},{"status":"PROCESSED","timestamp":"2025-01-24T13:53:23.709Z"}]},"prometheus-1|default|monitoring|prometheus-k8s(statefulset)|prometheus":{"name":"prometheus-1|default|monitoring|prometheus-k8s(statefulset)|prometheus","status":"PROCESSED","apis":{"create":{"response":{"message":"Experiment registered successfully with Kruize. View registered experiments at /listExperiments","httpcode":201,"documentationLink":"","status":"SUCCESS"}},"recommendations":{"response":[{"cluster_name":"default","experiment_type":"container","kubernetes_objects":[{"type":"statefulset","name":"prometheus-k8s","namespace":"monitoring","containers":[{"container_image_name":"quay.io/prometheus/prometheus:v2.46.0","container_name":"prometheus","recommendations":{"version":"1.0","notifications":{"111000":{"type":"info","message":"Recommendations Are Available","code":111000.0}},"data":{"2025-01-24T14:03:19.000Z":{"notifications":{"224001":{"type":"error","message":"Amount field is missing in the Memory Section","code":224001.0},"524002":{"type":"critical","message":"Memory Limit Not Set","code":524002.0},"524001":{"type":"critical","message":"Memory Request Not Set","code":524001.0},"223001":{"type":"error","message":"Amount field is missing in the CPU Section","code":223001.0},"111101":{"type":"info","message":"Short Term Recommendations Available","code":111101.0},"523001":{"type":"critical","message":"CPU Request Not Set","code":523001.0},"423001":{"type":"warning","message":"CPU Limit Not Set","code":423001.0}},"monitoring_end_time":"2025-01-24T14:03:19.000Z","current":{},"recommendation_terms":{"short_term":{"duration_in_hours":24.0,"notifications":{"112101":{"type":"info","message":"Cost Recommendations Available","code":112101.0},"112102":{"type":"info","message":"Performance Recommendations Available","code":112102.0}},"monitoring_start_time":"2025-01-23T14:03:19.000Z","recommendation_engines":{"cost":{"pods_count":2.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":4.942331904E8,"format":"bytes"},"cpu":{"amount":0.712441681389367,"format":"cores"}},"requests":{"memory":{"amount":4.942331904E8,"format":"bytes"},"cpu":{"amount":0.712441681389367,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":4.942331904E8,"format":"bytes"},"cpu":{"amount":0.712441681389367,"format":"cores"}},"requests":{"memory":{"amount":4.942331904E8,"format":"bytes"},"cpu":{"amount":0.712441681389367,"format":"cores"}}},"notifications":{}},"performance":{"pods_count":2.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":4.942331904E8,"format":"bytes"},"cpu":{"amount":0.712441681389367,"format":"cores"}},"requests":{"memory":{"amount":4.942331904E8,"format":"bytes"},"cpu":{"amount":0.712441681389367,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":4.942331904E8,"format":"bytes"},"cpu":{"amount":0.712441681389367,"format":"cores"}},"requests":{"memory":{"amount":4.942331904E8,"format":"bytes"},"cpu":{"amount":0.712441681389367,"format":"cores"}}},"notifications":{}}},"plots":{"datapoints":4.0,"plots_data":{"2025-01-24T02:03:19.000Z":{},"2025-01-24T14:03:19.000Z":{"cpuUsage":{"min":0.008681722724185856,"q1":0.10405203159890526,"median":0.11200250000001688,"q3":0.1317651078297727,"max":0.712441681389367,"format":"cores"},"memoryUsage":{"min":2.84106752E8,"q1":3.42331392E8,"median":3.90221824E8,"q3":3.9936E8,"max":4.11860992E8,"format":"bytes"}},"2025-01-24T08:03:19.000Z":{"cpuUsage":{"min":0.009046166666666976,"q1":0.08579573333336157,"median":0.08797916736107207,"q3":0.10134933333332204,"max":0.1368762333334113,"format":"cores"},"memoryUsage":{"min":2.81726976E8,"q1":3.29244672E8,"median":3.33094912E8,"q3":3.43638016E8,"max":3.58572032E8,"format":"bytes"}},"2025-01-23T20:03:19.000Z":{"cpuUsage":{"min":0.00955666666656422,"q1":0.09702006599780082,"median":0.10811400000008385,"q3":0.11519956666670624,"max":0.18372489999989436,"format":"cores"},"memoryUsage":{"min":2.7254784E8,"q1":3.29949184E8,"median":3.35568896E8,"q3":3.3906688E8,"max":3.7978112E8,"format":"bytes"}}}}},"medium_term":{"duration_in_hours":168.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}},"long_term":{"duration_in_hours":360.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}}}}}}}]}],"version":"v2.0","experiment_name":"prometheus-1|default|monitoring|prometheus-k8s(statefulset)|prometheus"}]}},"status_history":[{"status":"UNPROCESSED","timestamp":"2025-01-24T13:53:16.963Z"},{"status":"PROCESSED","timestamp":"2025-01-24T13:53:22.050Z"}]},"prometheus-1|default|monitoring|prometheus-adapter(deployment)|prometheus-adapter":{"name":"prometheus-1|default|monitoring|prometheus-adapter(deployment)|prometheus-adapter","status":"PROCESSED","apis":{"create":{"response":{"message":"Experiment registered successfully with Kruize. View registered experiments at /listExperiments","httpcode":201,"documentationLink":"","status":"SUCCESS"}},"recommendations":{"response":[{"cluster_name":"default","experiment_type":"container","kubernetes_objects":[{"type":"deployment","name":"prometheus-adapter","namespace":"monitoring","containers":[{"container_image_name":"registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.11.1","container_name":"prometheus-adapter","recommendations":{"version":"1.0","notifications":{"111000":{"type":"info","message":"Recommendations Are Available","code":111000.0}},"data":{"2025-01-24T14:03:22.000Z":{"notifications":{"224001":{"type":"error","message":"Amount field is missing in the Memory Section","code":224001.0},"524002":{"type":"critical","message":"Memory Limit Not Set","code":524002.0},"524001":{"type":"critical","message":"Memory Request Not Set","code":524001.0},"223001":{"type":"error","message":"Amount field is missing in the CPU Section","code":223001.0},"111101":{"type":"info","message":"Short Term Recommendations Available","code":111101.0},"523001":{"type":"critical","message":"CPU Request Not Set","code":523001.0},"423001":{"type":"warning","message":"CPU Limit Not Set","code":423001.0}},"monitoring_end_time":"2025-01-24T14:03:22.000Z","current":{},"recommendation_terms":{"short_term":{"duration_in_hours":24.0,"notifications":{"112101":{"type":"info","message":"Cost Recommendations Available","code":112101.0},"112102":{"type":"info","message":"Performance Recommendations Available","code":112102.0}},"monitoring_start_time":"2025-01-23T14:03:22.000Z","recommendation_engines":{"cost":{"pods_count":2.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":6.69499392E7,"format":"bytes"},"cpu":{"amount":0.021547172279857692,"format":"cores"}},"requests":{"memory":{"amount":6.69499392E7,"format":"bytes"},"cpu":{"amount":0.021547172279857692,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":6.69499392E7,"format":"bytes"},"cpu":{"amount":0.021547172279857692,"format":"cores"}},"requests":{"memory":{"amount":6.69499392E7,"format":"bytes"},"cpu":{"amount":0.021547172279857692,"format":"cores"}}},"notifications":{}},"performance":{"pods_count":2.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":6.69499392E7,"format":"bytes"},"cpu":{"amount":0.021547172279857692,"format":"cores"}},"requests":{"memory":{"amount":6.69499392E7,"format":"bytes"},"cpu":{"amount":0.021547172279857692,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":6.69499392E7,"format":"bytes"},"cpu":{"amount":0.021547172279857692,"format":"cores"}},"requests":{"memory":{"amount":6.69499392E7,"format":"bytes"},"cpu":{"amount":0.021547172279857692,"format":"cores"}}},"notifications":{}}},"plots":{"datapoints":4.0,"plots_data":{"2025-01-24T08:03:22.000Z":{"cpuUsage":{"min":0.002845799436238371,"q1":0.014847520568322775,"median":0.016027415213101172,"q3":0.01883000709017148,"max":0.021547172279857692,"format":"cores"},"memoryUsage":{"min":3.4902016E7,"q1":5.117952E7,"median":5.3223424E7,"q3":5.5115776E7,"max":5.5791616E7,"format":"bytes"}},"2025-01-23T20:03:22.000Z":{"cpuUsage":{"min":0.003981973025084208,"q1":0.013810772413803182,"median":0.01548539585332443,"q3":0.016380020804292555,"max":0.017183165517249972,"format":"cores"},"memoryUsage":{"min":3.9211008E7,"q1":5.2232192E7,"median":5.2862976E7,"q3":5.3182464E7,"max":5.3510144E7,"format":"bytes"}},"2025-01-24T02:03:22.000Z":{},"2025-01-24T14:03:22.000Z":{"cpuUsage":{"min":0.0032638885057482427,"q1":0.015125765517238855,"median":0.01624466551723935,"q3":0.016841398850563474,"max":0.01934699141194894,"format":"cores"},"memoryUsage":{"min":3.182592E7,"q1":3.848192E7,"median":4.9934336E7,"q3":5.0552832E7,"max":5.2678656E7,"format":"bytes"}}}}},"medium_term":{"duration_in_hours":168.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}},"long_term":{"duration_in_hours":360.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}}}}}}}]}],"version":"v2.0","experiment_name":"prometheus-1|default|monitoring|prometheus-adapter(deployment)|prometheus-adapter"}]}},"status_history":[{"status":"UNPROCESSED","timestamp":"2025-01-24T13:53:17.049Z"},{"status":"PROCESSED","timestamp":"2025-01-24T13:53:24.717Z"}]},"prometheus-1|default|kube-system|kube-proxy(daemonset)|kube-proxy":{"name":"prometheus-1|default|kube-system|kube-proxy(daemonset)|kube-proxy","status":"PROCESSED","apis":{"create":{"response":{"message":"Experiment registered successfully with Kruize. View registered experiments at /listExperiments","httpcode":201,"documentationLink":"","status":"SUCCESS"}},"recommendations":{"response":[{"cluster_name":"default","experiment_type":"container","kubernetes_objects":[{"type":"daemonset","name":"kube-proxy","namespace":"kube-system","containers":[{"container_image_name":"k8s.gcr.io/kube-proxy:v1.24.0","container_name":"kube-proxy","recommendations":{"version":"1.0","notifications":{"111000":{"type":"info","message":"Recommendations Are Available","code":111000.0}},"data":{"2025-01-24T14:03:24.000Z":{"notifications":{"224001":{"type":"error","message":"Amount field is missing in the Memory Section","code":224001.0},"524002":{"type":"critical","message":"Memory Limit Not Set","code":524002.0},"524001":{"type":"critical","message":"Memory Request Not Set","code":524001.0},"223001":{"type":"error","message":"Amount field is missing in the CPU Section","code":223001.0},"111101":{"type":"info","message":"Short Term Recommendations Available","code":111101.0},"523001":{"type":"critical","message":"CPU Request Not Set","code":523001.0},"423001":{"type":"warning","message":"CPU Limit Not Set","code":423001.0}},"monitoring_end_time":"2025-01-24T14:03:24.000Z","current":{},"recommendation_terms":{"short_term":{"duration_in_hours":24.0,"notifications":{"112101":{"type":"info","message":"Cost Recommendations Available","code":112101.0},"112102":{"type":"info","message":"Performance Recommendations Available","code":112102.0}},"monitoring_start_time":"2025-01-23T14:03:24.000Z","recommendation_engines":{"cost":{"pods_count":1.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":2.03177984E7,"format":"bytes"},"cpu":{"amount":0.0054755491849722325,"format":"cores"}},"requests":{"memory":{"amount":2.03177984E7,"format":"bytes"},"cpu":{"amount":0.0054755491849722325,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":2.03177984E7,"format":"bytes"},"cpu":{"amount":0.0054755491849722325,"format":"cores"}},"requests":{"memory":{"amount":2.03177984E7,"format":"bytes"},"cpu":{"amount":0.0054755491849722325,"format":"cores"}}},"notifications":{}},"performance":{"pods_count":1.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":2.03177984E7,"format":"bytes"},"cpu":{"amount":0.0054755491849722325,"format":"cores"}},"requests":{"memory":{"amount":2.03177984E7,"format":"bytes"},"cpu":{"amount":0.0054755491849722325,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":2.03177984E7,"format":"bytes"},"cpu":{"amount":0.0054755491849722325,"format":"cores"}},"requests":{"memory":{"amount":2.03177984E7,"format":"bytes"},"cpu":{"amount":0.0054755491849722325,"format":"cores"}}},"notifications":{}}},"plots":{"datapoints":4.0,"plots_data":{"2025-01-24T08:03:24.000Z":{"cpuUsage":{"min":1.0633333333013677E-5,"q1":0.0011742724757489219,"median":0.0012376412547083439,"q3":0.0013647121570711615,"max":0.005366945564851955,"format":"cores"},"memoryUsage":{"min":1.2660736E7,"q1":1.3062144E7,"median":1.3103104E7,"q3":1.6613376E7,"max":1.7666048E7,"format":"bytes"}},"2025-01-23T20:03:24.000Z":{"cpuUsage":{"min":1.2766666666645202E-5,"q1":0.0011278042601415756,"median":0.0012093069768986167,"q3":0.00459069999999997,"max":0.005451700000000415,"format":"cores"},"memoryUsage":{"min":1.275904E7,"q1":1.2951552E7,"median":1.3000704E7,"q3":1.304576E7,"max":1.4155776E7,"format":"bytes"}},"2025-01-24T02:03:24.000Z":{},"2025-01-24T14:03:24.000Z":{"cpuUsage":{"min":1.233333333251115E-5,"q1":0.001179599999999444,"median":0.0012659666666659556,"q3":0.0013524999999996604,"max":0.0054755491849722325,"format":"cores"},"memoryUsage":{"min":1.57696E7,"q1":1.7117184E7,"median":1.7174528E7,"q3":1.7248256E7,"max":1.8219008E7,"format":"bytes"}}}}},"medium_term":{"duration_in_hours":168.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}},"long_term":{"duration_in_hours":360.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}}}}}}}]}],"version":"v2.0","experiment_name":"prometheus-1|default|kube-system|kube-proxy(daemonset)|kube-proxy"}]}},"status_history":[{"status":"UNPROCESSED","timestamp":"2025-01-24T13:53:17.073Z"},{"status":"PROCESSED","timestamp":"2025-01-24T13:53:26.679Z"}]},"prometheus-1|default|monitoring|kruize-db-deployment(deployment)|kruize-db":{"name":"prometheus-1|default|monitoring|kruize-db-deployment(deployment)|kruize-db","status":"PROCESSED","apis":{"create":{"response":{"message":"Experiment registered successfully with Kruize. View registered experiments at /listExperiments","httpcode":201,"documentationLink":"","status":"SUCCESS"}},"recommendations":{"response":[{"cluster_name":"default","experiment_type":"container","kubernetes_objects":[{"type":"deployment","name":"kruize-db-deployment","namespace":"monitoring","containers":[{"container_image_name":"quay.io/kruizehub/postgres:15.2","container_name":"kruize-db","recommendations":{"version":"1.0","notifications":{"111000":{"type":"info","message":"Recommendations Are Available","code":111000.0}},"data":{"2025-01-24T14:03:23.000Z":{"notifications":{"224001":{"type":"error","message":"Amount field is missing in the Memory Section","code":224001.0},"524002":{"type":"critical","message":"Memory Limit Not Set","code":524002.0},"524001":{"type":"critical","message":"Memory Request Not Set","code":524001.0},"223001":{"type":"error","message":"Amount field is missing in the CPU Section","code":223001.0},"111101":{"type":"info","message":"Short Term Recommendations Available","code":111101.0},"523001":{"type":"critical","message":"CPU Request Not Set","code":523001.0},"423001":{"type":"warning","message":"CPU Limit Not Set","code":423001.0}},"monitoring_end_time":"2025-01-24T14:03:23.000Z","current":{},"recommendation_terms":{"short_term":{"duration_in_hours":24.0,"notifications":{"112101":{"type":"info","message":"Cost Recommendations Available","code":112101.0},"112102":{"type":"info","message":"Performance Recommendations Available","code":112102.0}},"monitoring_start_time":"2025-01-23T14:03:23.000Z","recommendation_engines":{"cost":{"pods_count":1.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":6.42564096E7,"format":"bytes"},"cpu":{"amount":0.012261024632512031,"format":"cores"}},"requests":{"memory":{"amount":6.42564096E7,"format":"bytes"},"cpu":{"amount":0.012261024632512031,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":6.42564096E7,"format":"bytes"},"cpu":{"amount":0.012261024632512031,"format":"cores"}},"requests":{"memory":{"amount":6.42564096E7,"format":"bytes"},"cpu":{"amount":0.012261024632512031,"format":"cores"}}},"notifications":{}},"performance":{"pods_count":1.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":6.42564096E7,"format":"bytes"},"cpu":{"amount":0.012261024632512031,"format":"cores"}},"requests":{"memory":{"amount":6.42564096E7,"format":"bytes"},"cpu":{"amount":0.012261024632512031,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":6.42564096E7,"format":"bytes"},"cpu":{"amount":0.012261024632512031,"format":"cores"}},"requests":{"memory":{"amount":6.42564096E7,"format":"bytes"},"cpu":{"amount":0.012261024632512031,"format":"cores"}}},"notifications":{}}},"plots":{"datapoints":4.0,"plots_data":{"2025-01-24T02:03:23.000Z":{},"2025-01-24T14:03:23.000Z":{"cpuUsage":{"min":2.1000700027157757E-6,"q1":9.460999999996981E-4,"median":0.0010467666666665802,"q3":0.007814766666666629,"max":0.012261024632512031,"format":"cores"},"memoryUsage":{"min":2.4477696E7,"q1":3.815424E7,"median":4.0607744E7,"q3":4.8467968E7,"max":5.3547008E7,"format":"bytes"}},"2025-01-24T08:03:23.000Z":{"cpuUsage":{"min":3.1999999999735945E-6,"q1":6.168999999999869E-4,"median":6.362212073731551E-4,"q3":8.57333333333088E-4,"max":0.007218426052464958,"format":"cores"},"memoryUsage":{"min":3.1309824E7,"q1":3.1322112E7,"median":3.448832E7,"q3":4.8713728E7,"max":4.89472E7,"format":"bytes"}},"2025-01-23T20:03:23.000Z":{"cpuUsage":{"min":7.266666666320513E-6,"q1":8.314333333331092E-4,"median":8.784626154205238E-4,"q3":0.008283099999999877,"max":0.010869433333333707,"format":"cores"},"memoryUsage":{"min":2.6710016E7,"q1":2.6882048E7,"median":2.6882048E7,"q3":4.0312832E7,"max":4.0665088E7,"format":"bytes"}}}}},"medium_term":{"duration_in_hours":168.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}},"long_term":{"duration_in_hours":360.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}}}}}}}]}],"version":"v2.0","experiment_name":"prometheus-1|default|monitoring|kruize-db-deployment(deployment)|kruize-db"}]}},"status_history":[{"status":"UNPROCESSED","timestamp":"2025-01-24T13:53:17.083Z"},{"status":"PROCESSED","timestamp":"2025-01-24T13:53:26.186Z"}]},"prometheus-1|default|monitoring|blackbox-exporter(deployment)|blackbox-exporter":{"name":"prometheus-1|default|monitoring|blackbox-exporter(deployment)|blackbox-exporter","status":"PROCESSED","apis":{"create":{"response":{"message":"Experiment registered successfully with Kruize. View registered experiments at /listExperiments","httpcode":201,"documentationLink":"","status":"SUCCESS"}},"recommendations":{"response":[{"cluster_name":"default","experiment_type":"container","kubernetes_objects":[{"type":"deployment","name":"blackbox-exporter","namespace":"monitoring","containers":[{"container_image_name":"quay.io/prometheus/blackbox-exporter:v0.24.0","container_name":"blackbox-exporter","recommendations":{"version":"1.0","notifications":{"111000":{"type":"info","message":"Recommendations Are Available","code":111000.0}},"data":{"2025-01-24T14:03:24.000Z":{"notifications":{"224001":{"type":"error","message":"Amount field is missing in the Memory Section","code":224001.0},"524002":{"type":"critical","message":"Memory Limit Not Set","code":524002.0},"524001":{"type":"critical","message":"Memory Request Not Set","code":524001.0},"223001":{"type":"error","message":"Amount field is missing in the CPU Section","code":223001.0},"111101":{"type":"info","message":"Short Term Recommendations Available","code":111101.0},"523001":{"type":"critical","message":"CPU Request Not Set","code":523001.0},"423001":{"type":"warning","message":"CPU Limit Not Set","code":423001.0}},"monitoring_end_time":"2025-01-24T14:03:24.000Z","current":{},"recommendation_terms":{"short_term":{"duration_in_hours":24.0,"notifications":{"112101":{"type":"info","message":"Cost Recommendations Available","code":112101.0},"112102":{"type":"info","message":"Performance Recommendations Available","code":112102.0}},"monitoring_start_time":"2025-01-23T14:03:24.000Z","recommendation_engines":{"cost":{"pods_count":1.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":2.23494144E7,"format":"bytes"},"cpu":{"amount":0.0250333313044427,"format":"cores"}},"requests":{"memory":{"amount":2.23494144E7,"format":"bytes"},"cpu":{"amount":0.0250333313044427,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":2.23494144E7,"format":"bytes"},"cpu":{"amount":0.0250333313044427,"format":"cores"}},"requests":{"memory":{"amount":2.23494144E7,"format":"bytes"},"cpu":{"amount":0.0250333313044427,"format":"cores"}}},"notifications":{}},"performance":{"pods_count":1.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":2.23494144E7,"format":"bytes"},"cpu":{"amount":0.0250333313044427,"format":"cores"}},"requests":{"memory":{"amount":2.23494144E7,"format":"bytes"},"cpu":{"amount":0.0250333313044427,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":2.23494144E7,"format":"bytes"},"cpu":{"amount":0.0250333313044427,"format":"cores"}},"requests":{"memory":{"amount":2.23494144E7,"format":"bytes"},"cpu":{"amount":0.0250333313044427,"format":"cores"}}},"notifications":{}}},"plots":{"datapoints":4.0,"plots_data":{"2025-01-24T08:03:24.000Z":{"cpuUsage":{"min":0.013501427356594153,"q1":0.017779382758620087,"median":0.019186177011494533,"q3":0.022857326915744956,"max":0.023836747841020578,"format":"cores"},"memoryUsage":{"min":1.2365824E7,"q1":1.5904768E7,"median":1.675264E7,"q3":1.6932864E7,"max":1.8624512E7,"format":"bytes"}},"2025-01-23T20:03:24.000Z":{"cpuUsage":{"min":0.007361537376308485,"q1":0.01947232758620656,"median":0.021281449845072152,"q3":0.02250044252873628,"max":0.02384679056657844,"format":"cores"},"memoryUsage":{"min":1.1505664E7,"q1":1.5486976E7,"median":1.5998976E7,"q3":1.6134144E7,"max":1.7002496E7,"format":"bytes"}},"2025-01-24T02:03:24.000Z":{},"2025-01-24T14:03:24.000Z":{"cpuUsage":{"min":0.007652346200061203,"q1":0.018847472413793854,"median":0.02123348850574688,"q3":0.02175329080459735,"max":0.0250333313044427,"format":"cores"},"memoryUsage":{"min":1.040384E7,"q1":1.6232448E7,"median":1.6883712E7,"q3":1.724416E7,"max":1.851392E7,"format":"bytes"}}}}},"medium_term":{"duration_in_hours":168.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}},"long_term":{"duration_in_hours":360.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}}}}}}}]}],"version":"v2.0","experiment_name":"prometheus-1|default|monitoring|blackbox-exporter(deployment)|blackbox-exporter"}]}},"status_history":[{"status":"UNPROCESSED","timestamp":"2025-01-24T13:53:17.166Z"},{"status":"PROCESSED","timestamp":"2025-01-24T13:53:27.627Z"}]},"prometheus-1|default|monitoring|node-exporter(daemonset)|node-exporter":{"name":"prometheus-1|default|monitoring|node-exporter(daemonset)|node-exporter","status":"PROCESSED","apis":{"create":{"response":{"message":"Experiment registered successfully with Kruize. View registered experiments at /listExperiments","httpcode":201,"documentationLink":"","status":"SUCCESS"}},"recommendations":{"response":[{"cluster_name":"default","experiment_type":"container","kubernetes_objects":[{"type":"daemonset","name":"node-exporter","namespace":"monitoring","containers":[{"container_image_name":"quay.io/prometheus/node-exporter:v1.6.1","container_name":"node-exporter","recommendations":{"version":"1.0","notifications":{"111000":{"type":"info","message":"Recommendations Are Available","code":111000.0}},"data":{"2025-01-24T14:03:26.000Z":{"notifications":{"224001":{"type":"error","message":"Amount field is missing in the Memory Section","code":224001.0},"524002":{"type":"critical","message":"Memory Limit Not Set","code":524002.0},"524001":{"type":"critical","message":"Memory Request Not Set","code":524001.0},"223001":{"type":"error","message":"Amount field is missing in the CPU Section","code":223001.0},"111101":{"type":"info","message":"Short Term Recommendations Available","code":111101.0},"523001":{"type":"critical","message":"CPU Request Not Set","code":523001.0},"423001":{"type":"warning","message":"CPU Limit Not Set","code":423001.0}},"monitoring_end_time":"2025-01-24T14:03:26.000Z","current":{},"recommendation_terms":{"short_term":{"duration_in_hours":24.0,"notifications":{"112101":{"type":"info","message":"Cost Recommendations Available","code":112101.0},"112102":{"type":"info","message":"Performance Recommendations Available","code":112102.0}},"monitoring_start_time":"2025-01-23T14:03:26.000Z","recommendation_engines":{"cost":{"pods_count":1.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":1.83945216E7,"format":"bytes"},"cpu":{"amount":0.05746417144157686,"format":"cores"}},"requests":{"memory":{"amount":1.83945216E7,"format":"bytes"},"cpu":{"amount":0.05746417144157686,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":1.83945216E7,"format":"bytes"},"cpu":{"amount":0.05746417144157686,"format":"cores"}},"requests":{"memory":{"amount":1.83945216E7,"format":"bytes"},"cpu":{"amount":0.05746417144157686,"format":"cores"}}},"notifications":{}},"performance":{"pods_count":1.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":1.83945216E7,"format":"bytes"},"cpu":{"amount":0.05746417144157686,"format":"cores"}},"requests":{"memory":{"amount":1.83945216E7,"format":"bytes"},"cpu":{"amount":0.05746417144157686,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":1.83945216E7,"format":"bytes"},"cpu":{"amount":0.05746417144157686,"format":"cores"}},"requests":{"memory":{"amount":1.83945216E7,"format":"bytes"},"cpu":{"amount":0.05746417144157686,"format":"cores"}}},"notifications":{}}},"plots":{"datapoints":4.0,"plots_data":{"2025-01-24T08:03:26.000Z":{"cpuUsage":{"min":0.025093921986393063,"q1":0.04651923563219184,"median":0.048111041379311714,"q3":0.052691208045976004,"max":0.05570005066209781,"format":"cores"},"memoryUsage":{"min":1.2345344E7,"q1":1.425408E7,"median":1.486848E7,"q3":1.5118336E7,"max":1.5474688E7,"format":"bytes"}},"2025-01-23T20:03:26.000Z":{"cpuUsage":{"min":0.02126953048084996,"q1":0.0468110634301437,"median":0.04981952481955975,"q3":0.053257817241379686,"max":0.05631338390804694,"format":"cores"},"memoryUsage":{"min":1.3418496E7,"q1":1.5036416E7,"median":1.5204352E7,"q3":1.5245312E7,"max":1.5314944E7,"format":"bytes"}},"2025-01-24T02:03:26.000Z":{},"2025-01-24T14:03:26.000Z":{"cpuUsage":{"min":0.01780148784375647,"q1":0.047948717241377316,"median":0.051393272244585606,"q3":0.052504858620677206,"max":0.05746417144157686,"format":"cores"},"memoryUsage":{"min":1.1030528E7,"q1":1.3316096E7,"median":1.3725696E7,"q3":1.40288E7,"max":1.4454784E7,"format":"bytes"}}}}},"medium_term":{"duration_in_hours":168.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}},"long_term":{"duration_in_hours":360.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}}}}}}}]}],"version":"v2.0","experiment_name":"prometheus-1|default|monitoring|node-exporter(daemonset)|node-exporter"}]}},"status_history":[{"status":"UNPROCESSED","timestamp":"2025-01-24T13:53:17.204Z"},{"status":"PROCESSED","timestamp":"2025-01-24T13:53:28.514Z"}]},"prometheus-1|default|monitoring|alertmanager-main(statefulset)|config-reloader":{"name":"prometheus-1|default|monitoring|alertmanager-main(statefulset)|config-reloader","status":"PROCESSED","apis":{"create":{"response":{"message":"Experiment registered successfully with Kruize. View registered experiments at /listExperiments","httpcode":201,"documentationLink":"","status":"SUCCESS"}},"recommendations":{"response":[{"cluster_name":"default","experiment_type":"container","kubernetes_objects":[{"type":"statefulset","name":"alertmanager-main","namespace":"monitoring","containers":[{"container_image_name":"quay.io/prometheus-operator/prometheus-config-reloader:v0.67.1","container_name":"config-reloader","recommendations":{"version":"1.0","notifications":{"111000":{"type":"info","message":"Recommendations Are Available","code":111000.0}},"data":{"2025-01-24T14:03:26.000Z":{"notifications":{"224001":{"type":"error","message":"Amount field is missing in the Memory Section","code":224001.0},"524002":{"type":"critical","message":"Memory Limit Not Set","code":524002.0},"524001":{"type":"critical","message":"Memory Request Not Set","code":524001.0},"223001":{"type":"error","message":"Amount field is missing in the CPU Section","code":223001.0},"111101":{"type":"info","message":"Short Term Recommendations Available","code":111101.0},"523001":{"type":"critical","message":"CPU Request Not Set","code":523001.0},"423001":{"type":"warning","message":"CPU Limit Not Set","code":423001.0}},"monitoring_end_time":"2025-01-24T14:03:26.000Z","current":{},"recommendation_terms":{"short_term":{"duration_in_hours":24.0,"notifications":{"112101":{"type":"info","message":"Cost Recommendations Available","code":112101.0},"112102":{"type":"info","message":"Performance Recommendations Available","code":112102.0}},"monitoring_start_time":"2025-01-23T14:03:26.000Z","recommendation_engines":{"cost":{"pods_count":6.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":3.51535104E7,"format":"bytes"},"cpu":{"amount":0.15317277011494093,"format":"cores"}},"requests":{"memory":{"amount":3.51535104E7,"format":"bytes"},"cpu":{"amount":0.15317277011494093,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":3.51535104E7,"format":"bytes"},"cpu":{"amount":0.15317277011494093,"format":"cores"}},"requests":{"memory":{"amount":3.51535104E7,"format":"bytes"},"cpu":{"amount":0.15317277011494093,"format":"cores"}}},"notifications":{}},"performance":{"pods_count":6.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":3.51535104E7,"format":"bytes"},"cpu":{"amount":0.15317277011494093,"format":"cores"}},"requests":{"memory":{"amount":3.51535104E7,"format":"bytes"},"cpu":{"amount":0.15317277011494093,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":3.51535104E7,"format":"bytes"},"cpu":{"amount":0.15317277011494093,"format":"cores"}},"requests":{"memory":{"amount":3.51535104E7,"format":"bytes"},"cpu":{"amount":0.15317277011494093,"format":"cores"}}},"notifications":{}}},"plots":{"datapoints":4.0,"plots_data":{"2025-01-24T08:03:26.000Z":{"cpuUsage":{"min":0.056841124414747736,"q1":0.1211781482758645,"median":0.12318570416808575,"q3":0.1382161030642338,"max":0.1413434045977002,"format":"cores"},"memoryUsage":{"min":1.6150528E7,"q1":2.6103808E7,"median":2.6648576E7,"q3":2.7308032E7,"max":2.8381184E7,"format":"bytes"}},"2025-01-23T20:03:26.000Z":{"cpuUsage":{"min":0.02677598809057017,"q1":0.1228491570866002,"median":0.12852606416500703,"q3":0.13413219770114426,"max":0.14903542413792562,"format":"cores"},"memoryUsage":{"min":1.6052224E7,"q1":2.6374144E7,"median":2.7029504E7,"q3":2.7369472E7,"max":2.8049408E7,"format":"bytes"}},"2025-01-24T02:03:26.000Z":{},"2025-01-24T14:03:26.000Z":{"cpuUsage":{"min":0.029955985603706024,"q1":0.11867099840768057,"median":0.13020653333332682,"q3":0.13544000822511737,"max":0.15317277011494093,"format":"cores"},"memoryUsage":{"min":1.6277504E7,"q1":2.6161152E7,"median":2.7426816E7,"q3":2.7967488E7,"max":2.9294592E7,"format":"bytes"}}}}},"medium_term":{"duration_in_hours":168.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}},"long_term":{"duration_in_hours":360.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}}}}}}}]}],"version":"v2.0","experiment_name":"prometheus-1|default|monitoring|alertmanager-main(statefulset)|config-reloader"}]}},"status_history":[{"status":"UNPROCESSED","timestamp":"2025-01-24T13:53:17.223Z"},{"status":"PROCESSED","timestamp":"2025-01-24T13:53:29.352Z"}]},"prometheus-1|default|monitoring|alertmanager-main(statefulset)|alertmanager":{"name":"prometheus-1|default|monitoring|alertmanager-main(statefulset)|alertmanager","status":"PROCESSED","apis":{"create":{"response":{"message":"Experiment registered successfully with Kruize. View registered experiments at /listExperiments","httpcode":201,"documentationLink":"","status":"SUCCESS"}},"recommendations":{"response":[{"cluster_name":"default","experiment_type":"container","kubernetes_objects":[{"type":"statefulset","name":"alertmanager-main","namespace":"monitoring","containers":[{"container_image_name":"quay.io/prometheus/alertmanager:v0.26.0","container_name":"alertmanager","recommendations":{"version":"1.0","notifications":{"111000":{"type":"info","message":"Recommendations Are Available","code":111000.0}},"data":{"2025-01-24T14:03:27.000Z":{"notifications":{"224001":{"type":"error","message":"Amount field is missing in the Memory Section","code":224001.0},"524002":{"type":"critical","message":"Memory Limit Not Set","code":524002.0},"524001":{"type":"critical","message":"Memory Request Not Set","code":524001.0},"223001":{"type":"error","message":"Amount field is missing in the CPU Section","code":223001.0},"111101":{"type":"info","message":"Short Term Recommendations Available","code":111101.0},"523001":{"type":"critical","message":"CPU Request Not Set","code":523001.0},"423001":{"type":"warning","message":"CPU Limit Not Set","code":423001.0}},"monitoring_end_time":"2025-01-24T14:03:27.000Z","current":{},"recommendation_terms":{"short_term":{"duration_in_hours":24.0,"notifications":{"112101":{"type":"info","message":"Cost Recommendations Available","code":112101.0},"112102":{"type":"info","message":"Performance Recommendations Available","code":112102.0}},"monitoring_start_time":"2025-01-23T14:03:27.000Z","recommendation_engines":{"cost":{"pods_count":4.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":3.87366912E7,"format":"bytes"},"cpu":{"amount":0.06938871494252526,"format":"cores"}},"requests":{"memory":{"amount":3.87366912E7,"format":"bytes"},"cpu":{"amount":0.06938871494252526,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":3.87366912E7,"format":"bytes"},"cpu":{"amount":0.06938871494252526,"format":"cores"}},"requests":{"memory":{"amount":3.87366912E7,"format":"bytes"},"cpu":{"amount":0.06938871494252526,"format":"cores"}}},"notifications":{}},"performance":{"pods_count":4.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":3.87366912E7,"format":"bytes"},"cpu":{"amount":0.06938871494252526,"format":"cores"}},"requests":{"memory":{"amount":3.87366912E7,"format":"bytes"},"cpu":{"amount":0.06938871494252526,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":3.87366912E7,"format":"bytes"},"cpu":{"amount":0.06938871494252526,"format":"cores"}},"requests":{"memory":{"amount":3.87366912E7,"format":"bytes"},"cpu":{"amount":0.06938871494252526,"format":"cores"}}},"notifications":{}}},"plots":{"datapoints":4.0,"plots_data":{"2025-01-24T02:03:27.000Z":{},"2025-01-24T14:03:27.000Z":{"cpuUsage":{"min":0.014396534763223598,"q1":0.05712190227398429,"median":0.060289268965516646,"q3":0.062488420002811254,"max":0.06687142413793559,"format":"cores"},"memoryUsage":{"min":1.9204266666666664E7,"q1":2.7783168E7,"median":3.0859264E7,"q3":3.1207424E7,"max":3.1596544E7,"format":"bytes"}},"2025-01-24T08:03:27.000Z":{"cpuUsage":{"min":0.024906381528583297,"q1":0.05849916321839446,"median":0.061013581662704486,"q3":0.06442849915104361,"max":0.06938871494252526,"format":"cores"},"memoryUsage":{"min":2.0930082133333333E7,"q1":3.1137792E7,"median":3.1698944E7,"q3":3.2165888E7,"max":3.2280576E7,"format":"bytes"}},"2025-01-23T20:03:27.000Z":{"cpuUsage":{"min":0.011566470259254065,"q1":0.057677049425280694,"median":0.06056572860080034,"q3":0.06235207904557751,"max":0.06520783743415946,"format":"cores"},"memoryUsage":{"min":2.1699549866666667E7,"q1":3.0498816E7,"median":3.1862784E7,"q3":3.2043008E7,"max":3.2260096E7,"format":"bytes"}}}}},"medium_term":{"duration_in_hours":168.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}},"long_term":{"duration_in_hours":360.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}}}}}}}]}],"version":"v2.0","experiment_name":"prometheus-1|default|monitoring|alertmanager-main(statefulset)|alertmanager"}]}},"status_history":[{"status":"UNPROCESSED","timestamp":"2025-01-24T13:53:17.267Z"},{"status":"PROCESSED","timestamp":"2025-01-24T13:53:30.019Z"}]},"prometheus-1|default|monitoring|prometheus-operator(deployment)|kube-rbac-proxy":{"name":"prometheus-1|default|monitoring|prometheus-operator(deployment)|kube-rbac-proxy","status":"PROCESSED","apis":{"create":{"response":{"message":"Experiment registered successfully with Kruize. View registered experiments at /listExperiments","httpcode":201,"documentationLink":"","status":"SUCCESS"}},"recommendations":{"response":[{"cluster_name":"default","experiment_type":"container","kubernetes_objects":[{"type":"deployment","name":"prometheus-operator","namespace":"monitoring","containers":[{"container_image_name":"quay.io/brancz/kube-rbac-proxy:v0.14.2","container_name":"kube-rbac-proxy","recommendations":{"version":"1.0","notifications":{"111000":{"type":"info","message":"Recommendations Are Available","code":111000.0}},"data":{"2025-01-24T14:03:28.000Z":{"notifications":{"224001":{"type":"error","message":"Amount field is missing in the Memory Section","code":224001.0},"524002":{"type":"critical","message":"Memory Limit Not Set","code":524002.0},"524001":{"type":"critical","message":"Memory Request Not Set","code":524001.0},"223001":{"type":"error","message":"Amount field is missing in the CPU Section","code":223001.0},"111101":{"type":"info","message":"Short Term Recommendations Available","code":111101.0},"523001":{"type":"critical","message":"CPU Request Not Set","code":523001.0},"423001":{"type":"warning","message":"CPU Limit Not Set","code":423001.0}},"monitoring_end_time":"2025-01-24T14:03:28.000Z","current":{},"recommendation_terms":{"short_term":{"duration_in_hours":24.0,"notifications":{"112101":{"type":"info","message":"Cost Recommendations Available","code":112101.0},"112102":{"type":"info","message":"Performance Recommendations Available","code":112102.0}},"monitoring_start_time":"2025-01-23T14:03:28.000Z","recommendation_engines":{"cost":{"pods_count":4.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":1.70999808E7,"format":"bytes"},"cpu":{"amount":0.02038184465114376,"format":"cores"}},"requests":{"memory":{"amount":1.70999808E7,"format":"bytes"},"cpu":{"amount":0.02038184465114376,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":1.70999808E7,"format":"bytes"},"cpu":{"amount":0.02038184465114376,"format":"cores"}},"requests":{"memory":{"amount":1.70999808E7,"format":"bytes"},"cpu":{"amount":0.02038184465114376,"format":"cores"}}},"notifications":{}},"performance":{"pods_count":4.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":1.70999808E7,"format":"bytes"},"cpu":{"amount":0.02038184465114376,"format":"cores"}},"requests":{"memory":{"amount":1.70999808E7,"format":"bytes"},"cpu":{"amount":0.02038184465114376,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":1.70999808E7,"format":"bytes"},"cpu":{"amount":0.02038184465114376,"format":"cores"}},"requests":{"memory":{"amount":1.70999808E7,"format":"bytes"},"cpu":{"amount":0.02038184465114376,"format":"cores"}}},"notifications":{}}},"plots":{"datapoints":4.0,"plots_data":{"2025-01-24T08:03:28.000Z":{"cpuUsage":{"min":0.007904944241512658,"q1":0.015991467816092328,"median":0.01671631777884153,"q3":0.019123560294451548,"max":0.01951220000000027,"format":"cores"},"memoryUsage":{"min":8322798.933333333,"q1":1.288192E7,"median":1.3668352E7,"q3":1.378304E7,"max":1.4249984E7,"format":"bytes"}},"2025-01-23T20:03:28.000Z":{"cpuUsage":{"min":0.0032953410699752147,"q1":0.01566271945364306,"median":0.01644754367816081,"q3":0.017041910804968367,"max":0.02038184465114376,"format":"cores"},"memoryUsage":{"min":9077145.600000001,"q1":1.3512704E7,"median":1.3590528E7,"q3":1.3627392E7,"max":1.366016E7,"format":"bytes"}},"2025-01-24T02:03:28.000Z":{},"2025-01-24T14:03:28.000Z":{"cpuUsage":{"min":0.0030633858725028426,"q1":0.014704806896551188,"median":0.015326525287357246,"q3":0.01627313923667442,"max":0.018774733333333283,"format":"cores"},"memoryUsage":{"min":7755332.266666668,"q1":1.1317248E7,"median":1.2795904E7,"q3":1.2857344E7,"max":1.3041664E7,"format":"bytes"}}}}},"medium_term":{"duration_in_hours":168.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}},"long_term":{"duration_in_hours":360.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}}}}}}}]}],"version":"v2.0","experiment_name":"prometheus-1|default|monitoring|prometheus-operator(deployment)|kube-rbac-proxy"}]}},"status_history":[{"status":"UNPROCESSED","timestamp":"2025-01-24T13:53:17.329Z"},{"status":"PROCESSED","timestamp":"2025-01-24T13:53:31.203Z"}]},"prometheus-1|default|local-path-storage|local-path-provisioner(deployment)|local-path-provisioner":{"name":"prometheus-1|default|local-path-storage|local-path-provisioner(deployment)|local-path-provisioner","status":"PROCESSED","apis":{"create":{"response":{"message":"Experiment registered successfully with Kruize. View registered experiments at /listExperiments","httpcode":201,"documentationLink":"","status":"SUCCESS"}},"recommendations":{"response":[{"cluster_name":"default","experiment_type":"container","kubernetes_objects":[{"type":"deployment","name":"local-path-provisioner","namespace":"local-path-storage","containers":[{"container_image_name":"docker.io/kindest/local-path-provisioner:v0.0.22-kind.0","container_name":"local-path-provisioner","recommendations":{"version":"1.0","notifications":{"111000":{"type":"info","message":"Recommendations Are Available","code":111000.0}},"data":{"2025-01-24T14:03:29.000Z":{"notifications":{"224001":{"type":"error","message":"Amount field is missing in the Memory Section","code":224001.0},"524002":{"type":"critical","message":"Memory Limit Not Set","code":524002.0},"524001":{"type":"critical","message":"Memory Request Not Set","code":524001.0},"223001":{"type":"error","message":"Amount field is missing in the CPU Section","code":223001.0},"111101":{"type":"info","message":"Short Term Recommendations Available","code":111101.0},"523001":{"type":"critical","message":"CPU Request Not Set","code":523001.0},"423001":{"type":"warning","message":"CPU Limit Not Set","code":423001.0}},"monitoring_end_time":"2025-01-24T14:03:29.000Z","current":{},"recommendation_terms":{"short_term":{"duration_in_hours":24.0,"notifications":{"112101":{"type":"info","message":"Cost Recommendations Available","code":112101.0},"112102":{"type":"info","message":"Performance Recommendations Available","code":112102.0}},"monitoring_start_time":"2025-01-23T14:03:29.000Z","recommendation_engines":{"cost":{"pods_count":1.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":1.58957568E7,"format":"bytes"},"cpu":{"amount":0.001194166666667229,"format":"cores"}},"requests":{"memory":{"amount":1.58957568E7,"format":"bytes"},"cpu":{"amount":0.001194166666667229,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":1.58957568E7,"format":"bytes"},"cpu":{"amount":0.001194166666667229,"format":"cores"}},"requests":{"memory":{"amount":1.58957568E7,"format":"bytes"},"cpu":{"amount":0.001194166666667229,"format":"cores"}}},"notifications":{}},"performance":{"pods_count":1.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":1.58957568E7,"format":"bytes"},"cpu":{"amount":0.001194166666667229,"format":"cores"}},"requests":{"memory":{"amount":1.58957568E7,"format":"bytes"},"cpu":{"amount":0.001194166666667229,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":1.58957568E7,"format":"bytes"},"cpu":{"amount":0.001194166666667229,"format":"cores"}},"requests":{"memory":{"amount":1.58957568E7,"format":"bytes"},"cpu":{"amount":0.001194166666667229,"format":"cores"}}},"notifications":{}}},"plots":{"datapoints":4.0,"plots_data":{"2025-01-24T02:03:29.000Z":{},"2025-01-24T14:03:29.000Z":{"cpuUsage":{"min":1.5866666666681796E-4,"q1":9.446666666671415E-4,"median":9.91866666667344E-4,"q3":0.001033933333332963,"max":0.0011412380412687507,"format":"cores"},"memoryUsage":{"min":6955008.0,"q1":1.032192E7,"median":1.0387456E7,"q3":1.1517952E7,"max":1.1526144E7,"format":"bytes"}},"2025-01-24T08:03:29.000Z":{"cpuUsage":{"min":1.7287242908126994E-4,"q1":9.677999999998595E-4,"median":0.0010057001900062755,"q3":0.0010860028667621707,"max":0.001194166666667229,"format":"cores"},"memoryUsage":{"min":6967296.0,"q1":7360512.0,"median":1.3090816E7,"q3":1.3103104E7,"max":1.3139968E7,"format":"bytes"}},"2025-01-23T20:03:29.000Z":{"cpuUsage":{"min":1.622945901807792E-4,"q1":9.365333333335002E-4,"median":0.0010302333333328307,"q3":0.0010877333333335552,"max":0.0011314377145903577,"format":"cores"},"memoryUsage":{"min":1.2857344E7,"q1":1.3058048E7,"median":1.3070336E7,"q3":1.3082624E7,"max":1.3246464E7,"format":"bytes"}}}}},"medium_term":{"duration_in_hours":168.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}},"long_term":{"duration_in_hours":360.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}}}}}}}]}],"version":"v2.0","experiment_name":"prometheus-1|default|local-path-storage|local-path-provisioner(deployment)|local-path-provisioner"}]}},"status_history":[{"status":"UNPROCESSED","timestamp":"2025-01-24T13:53:17.353Z"},{"status":"PROCESSED","timestamp":"2025-01-24T13:53:31.664Z"}]},"prometheus-1|default|kube-system|coredns(deployment)|coredns":{"name":"prometheus-1|default|kube-system|coredns(deployment)|coredns","status":"PROCESSED","apis":{"create":{"response":{"message":"Experiment registered successfully with Kruize. View registered experiments at /listExperiments","httpcode":201,"documentationLink":"","status":"SUCCESS"}},"recommendations":{"response":[{"cluster_name":"default","experiment_type":"container","kubernetes_objects":[{"type":"deployment","name":"coredns","namespace":"kube-system","containers":[{"container_image_name":"k8s.gcr.io/coredns/coredns:v1.8.6","container_name":"coredns","recommendations":{"version":"1.0","notifications":{"111000":{"type":"info","message":"Recommendations Are Available","code":111000.0}},"data":{"2025-01-24T14:03:30.000Z":{"notifications":{"224001":{"type":"error","message":"Amount field is missing in the Memory Section","code":224001.0},"524002":{"type":"critical","message":"Memory Limit Not Set","code":524002.0},"524001":{"type":"critical","message":"Memory Request Not Set","code":524001.0},"223001":{"type":"error","message":"Amount field is missing in the CPU Section","code":223001.0},"111101":{"type":"info","message":"Short Term Recommendations Available","code":111101.0},"523001":{"type":"critical","message":"CPU Request Not Set","code":523001.0},"423001":{"type":"warning","message":"CPU Limit Not Set","code":423001.0}},"monitoring_end_time":"2025-01-24T14:03:30.000Z","current":{},"recommendation_terms":{"short_term":{"duration_in_hours":24.0,"notifications":{"112101":{"type":"info","message":"Cost Recommendations Available","code":112101.0},"112102":{"type":"info","message":"Performance Recommendations Available","code":112102.0}},"monitoring_start_time":"2025-01-23T14:03:30.000Z","recommendation_engines":{"cost":{"pods_count":2.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":4.09632768E7,"format":"bytes"},"cpu":{"amount":0.009647078430713354,"format":"cores"}},"requests":{"memory":{"amount":4.09632768E7,"format":"bytes"},"cpu":{"amount":0.009647078430713354,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":4.09632768E7,"format":"bytes"},"cpu":{"amount":0.009647078430713354,"format":"cores"}},"requests":{"memory":{"amount":4.09632768E7,"format":"bytes"},"cpu":{"amount":0.009647078430713354,"format":"cores"}}},"notifications":{}},"performance":{"pods_count":2.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":4.09632768E7,"format":"bytes"},"cpu":{"amount":0.009647078430713354,"format":"cores"}},"requests":{"memory":{"amount":4.09632768E7,"format":"bytes"},"cpu":{"amount":0.009647078430713354,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":4.09632768E7,"format":"bytes"},"cpu":{"amount":0.009647078430713354,"format":"cores"}},"requests":{"memory":{"amount":4.09632768E7,"format":"bytes"},"cpu":{"amount":0.009647078430713354,"format":"cores"}}},"notifications":{}}},"plots":{"datapoints":4.0,"plots_data":{"2025-01-24T08:03:30.000Z":{"cpuUsage":{"min":0.0012679999999969974,"q1":0.007457966666667441,"median":0.007826827560921078,"q3":0.008081869395645442,"max":0.009531000000000253,"format":"cores"},"memoryUsage":{"min":2.1970944E7,"q1":2.932736E7,"median":3.1035392E7,"q3":3.1739904E7,"max":3.2223232E7,"format":"bytes"}},"2025-01-23T20:03:30.000Z":{"cpuUsage":{"min":0.0013553666666666687,"q1":0.0071355999999999165,"median":0.00742326666666789,"q3":0.008023834127809486,"max":0.008761233333333014,"format":"cores"},"memoryUsage":{"min":2.3240704E7,"q1":3.1469568E7,"median":3.2096256E7,"q3":3.2477184E7,"max":3.4136064E7,"format":"bytes"}},"2025-01-24T02:03:30.000Z":{},"2025-01-24T14:03:30.000Z":{"cpuUsage":{"min":0.0014618512716205797,"q1":0.007134066666662875,"median":0.0075713476217440364,"q3":0.008062433333331379,"max":0.009647078430713354,"format":"cores"},"memoryUsage":{"min":2.1139456E7,"q1":2.7742208E7,"median":2.9351936E7,"q3":3.0162944E7,"max":3.1666176E7,"format":"bytes"}}}}},"medium_term":{"duration_in_hours":168.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}},"long_term":{"duration_in_hours":360.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}}}}}}}]}],"version":"v2.0","experiment_name":"prometheus-1|default|kube-system|coredns(deployment)|coredns"}]}},"status_history":[{"status":"UNPROCESSED","timestamp":"2025-01-24T13:53:17.390Z"},{"status":"PROCESSED","timestamp":"2025-01-24T13:53:32.483Z"}]},"prometheus-1|default|monitoring|prometheus-k8s(statefulset)|config-reloader":{"name":"prometheus-1|default|monitoring|prometheus-k8s(statefulset)|config-reloader","status":"PROCESSED","apis":{"create":{"response":{"message":"Experiment registered successfully with Kruize. View registered experiments at /listExperiments","httpcode":201,"documentationLink":"","status":"SUCCESS"}},"recommendations":{"response":[{"cluster_name":"default","experiment_type":"container","kubernetes_objects":[{"type":"statefulset","name":"prometheus-k8s","namespace":"monitoring","containers":[{"container_image_name":"quay.io/prometheus-operator/prometheus-config-reloader:v0.67.1","container_name":"config-reloader","recommendations":{"version":"1.0","notifications":{"111000":{"type":"info","message":"Recommendations Are Available","code":111000.0}},"data":{"2025-01-24T14:03:31.000Z":{"notifications":{"224001":{"type":"error","message":"Amount field is missing in the Memory Section","code":224001.0},"524002":{"type":"critical","message":"Memory Limit Not Set","code":524002.0},"524001":{"type":"critical","message":"Memory Request Not Set","code":524001.0},"223001":{"type":"error","message":"Amount field is missing in the CPU Section","code":223001.0},"111101":{"type":"info","message":"Short Term Recommendations Available","code":111101.0},"523001":{"type":"critical","message":"CPU Request Not Set","code":523001.0},"423001":{"type":"warning","message":"CPU Limit Not Set","code":423001.0}},"monitoring_end_time":"2025-01-24T14:03:31.000Z","current":{},"recommendation_terms":{"short_term":{"duration_in_hours":24.0,"notifications":{"112101":{"type":"info","message":"Cost Recommendations Available","code":112101.0},"112102":{"type":"info","message":"Performance Recommendations Available","code":112102.0}},"monitoring_start_time":"2025-01-23T14:03:31.000Z","recommendation_engines":{"cost":{"pods_count":6.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":3.51535104E7,"format":"bytes"},"cpu":{"amount":0.15317277011494093,"format":"cores"}},"requests":{"memory":{"amount":3.51535104E7,"format":"bytes"},"cpu":{"amount":0.15317277011494093,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":3.51535104E7,"format":"bytes"},"cpu":{"amount":0.15317277011494093,"format":"cores"}},"requests":{"memory":{"amount":3.51535104E7,"format":"bytes"},"cpu":{"amount":0.15317277011494093,"format":"cores"}}},"notifications":{}},"performance":{"pods_count":6.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":3.51535104E7,"format":"bytes"},"cpu":{"amount":0.15317277011494093,"format":"cores"}},"requests":{"memory":{"amount":3.51535104E7,"format":"bytes"},"cpu":{"amount":0.15317277011494093,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":3.51535104E7,"format":"bytes"},"cpu":{"amount":0.15317277011494093,"format":"cores"}},"requests":{"memory":{"amount":3.51535104E7,"format":"bytes"},"cpu":{"amount":0.15317277011494093,"format":"cores"}}},"notifications":{}}},"plots":{"datapoints":4.0,"plots_data":{"2025-01-24T02:03:31.000Z":{},"2025-01-24T08:03:31.000Z":{"cpuUsage":{"min":0.057322096802661954,"q1":0.1211781482758645,"median":0.12318570416808575,"q3":0.1382161030642338,"max":0.1413434045977002,"format":"cores"},"memoryUsage":{"min":1.6150528E7,"q1":2.6103808E7,"median":2.6648576E7,"q3":2.7308032E7,"max":2.8381184E7,"format":"bytes"}},"2025-01-24T14:03:31.000Z":{"cpuUsage":{"min":0.029471420958060653,"q1":0.11867099840768057,"median":0.13020653333332682,"q3":0.13544000822511737,"max":0.15317277011494093,"format":"cores"},"memoryUsage":{"min":1.6277504E7,"q1":2.6161152E7,"median":2.7426816E7,"q3":2.7967488E7,"max":2.9294592E7,"format":"bytes"}},"2025-01-23T20:03:31.000Z":{"cpuUsage":{"min":0.026332367082339745,"q1":0.1228491570866002,"median":0.12852606416500703,"q3":0.13413219770114426,"max":0.14903542413792562,"format":"cores"},"memoryUsage":{"min":1.6052224E7,"q1":2.6374144E7,"median":2.7029504E7,"q3":2.7369472E7,"max":2.8049408E7,"format":"bytes"}}}}},"medium_term":{"duration_in_hours":168.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}},"long_term":{"duration_in_hours":360.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}}}}}}}]}],"version":"v2.0","experiment_name":"prometheus-1|default|monitoring|prometheus-k8s(statefulset)|config-reloader"}]}},"status_history":[{"status":"UNPROCESSED","timestamp":"2025-01-24T13:53:17.459Z"},{"status":"PROCESSED","timestamp":"2025-01-24T13:53:34.856Z"}]},"prometheus-1|default|monitoring|node-exporter(daemonset)|kube-rbac-proxy":{"name":"prometheus-1|default|monitoring|node-exporter(daemonset)|kube-rbac-proxy","status":"PROCESSED","apis":{"create":{"response":{"message":"Experiment registered successfully with Kruize. View registered experiments at /listExperiments","httpcode":201,"documentationLink":"","status":"SUCCESS"}},"recommendations":{"response":[{"cluster_name":"default","experiment_type":"container","kubernetes_objects":[{"type":"daemonset","name":"node-exporter","namespace":"monitoring","containers":[{"container_image_name":"quay.io/brancz/kube-rbac-proxy:v0.14.2","container_name":"kube-rbac-proxy","recommendations":{"version":"1.0","notifications":{"111000":{"type":"info","message":"Recommendations Are Available","code":111000.0}},"data":{"2025-01-24T14:03:31.000Z":{"notifications":{"224001":{"type":"error","message":"Amount field is missing in the Memory Section","code":224001.0},"524002":{"type":"critical","message":"Memory Limit Not Set","code":524002.0},"524001":{"type":"critical","message":"Memory Request Not Set","code":524001.0},"223001":{"type":"error","message":"Amount field is missing in the CPU Section","code":223001.0},"111101":{"type":"info","message":"Short Term Recommendations Available","code":111101.0},"523001":{"type":"critical","message":"CPU Request Not Set","code":523001.0},"423001":{"type":"warning","message":"CPU Limit Not Set","code":423001.0}},"monitoring_end_time":"2025-01-24T14:03:31.000Z","current":{},"recommendation_terms":{"short_term":{"duration_in_hours":24.0,"notifications":{"112101":{"type":"info","message":"Cost Recommendations Available","code":112101.0},"112102":{"type":"info","message":"Performance Recommendations Available","code":112102.0}},"monitoring_start_time":"2025-01-23T14:03:31.000Z","recommendation_engines":{"cost":{"pods_count":4.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":1.70999808E7,"format":"bytes"},"cpu":{"amount":0.02038184465114376,"format":"cores"}},"requests":{"memory":{"amount":1.70999808E7,"format":"bytes"},"cpu":{"amount":0.02038184465114376,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":1.70999808E7,"format":"bytes"},"cpu":{"amount":0.02038184465114376,"format":"cores"}},"requests":{"memory":{"amount":1.70999808E7,"format":"bytes"},"cpu":{"amount":0.02038184465114376,"format":"cores"}}},"notifications":{}},"performance":{"pods_count":4.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":1.70999808E7,"format":"bytes"},"cpu":{"amount":0.02038184465114376,"format":"cores"}},"requests":{"memory":{"amount":1.70999808E7,"format":"bytes"},"cpu":{"amount":0.02038184465114376,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":1.70999808E7,"format":"bytes"},"cpu":{"amount":0.02038184465114376,"format":"cores"}},"requests":{"memory":{"amount":1.70999808E7,"format":"bytes"},"cpu":{"amount":0.02038184465114376,"format":"cores"}}},"notifications":{}}},"plots":{"datapoints":4.0,"plots_data":{"2025-01-24T02:03:31.000Z":{},"2025-01-24T08:03:31.000Z":{"cpuUsage":{"min":0.007904944241512658,"q1":0.015991467816092328,"median":0.016725637931034987,"q3":0.019123560294451548,"max":0.01951220000000027,"format":"cores"},"memoryUsage":{"min":8322798.933333333,"q1":1.288192E7,"median":1.3668352E7,"q3":1.378304E7,"max":1.4249984E7,"format":"bytes"}},"2025-01-24T14:03:31.000Z":{"cpuUsage":{"min":0.0030337056490962644,"q1":0.014704806896551188,"median":0.015326525287357246,"q3":0.01627313923667442,"max":0.018774733333333283,"format":"cores"},"memoryUsage":{"min":7755332.266666668,"q1":1.1317248E7,"median":1.2795904E7,"q3":1.2857344E7,"max":1.3041664E7,"format":"bytes"}},"2025-01-23T20:03:31.000Z":{"cpuUsage":{"min":0.0032626443292344738,"q1":0.01566271945364306,"median":0.01644754367816081,"q3":0.017041910804968367,"max":0.02038184465114376,"format":"cores"},"memoryUsage":{"min":9077145.600000001,"q1":1.3512704E7,"median":1.3590528E7,"q3":1.3627392E7,"max":1.366016E7,"format":"bytes"}}}}},"medium_term":{"duration_in_hours":168.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}},"long_term":{"duration_in_hours":360.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}}}}}}}]}],"version":"v2.0","experiment_name":"prometheus-1|default|monitoring|node-exporter(daemonset)|kube-rbac-proxy"}]}},"status_history":[{"status":"UNPROCESSED","timestamp":"2025-01-24T13:53:17.475Z"},{"status":"PROCESSED","timestamp":"2025-01-24T13:53:34.293Z"}]},"prometheus-1|default|monitoring|kube-state-metrics(deployment)|kube-rbac-proxy-self":{"name":"prometheus-1|default|monitoring|kube-state-metrics(deployment)|kube-rbac-proxy-self","status":"PROCESSED","apis":{"create":{"response":{"message":"Experiment registered successfully with Kruize. View registered experiments at /listExperiments","httpcode":201,"documentationLink":"","status":"SUCCESS"}},"recommendations":{"response":[{"cluster_name":"default","experiment_type":"container","kubernetes_objects":[{"type":"deployment","name":"kube-state-metrics","namespace":"monitoring","containers":[{"container_image_name":"quay.io/brancz/kube-rbac-proxy:v0.14.2","container_name":"kube-rbac-proxy-self","recommendations":{"version":"1.0","notifications":{"111000":{"type":"info","message":"Recommendations Are Available","code":111000.0}},"data":{"2025-01-24T14:03:32.000Z":{"notifications":{"224001":{"type":"error","message":"Amount field is missing in the Memory Section","code":224001.0},"524002":{"type":"critical","message":"Memory Limit Not Set","code":524002.0},"524001":{"type":"critical","message":"Memory Request Not Set","code":524001.0},"223001":{"type":"error","message":"Amount field is missing in the CPU Section","code":223001.0},"111101":{"type":"info","message":"Short Term Recommendations Available","code":111101.0},"523001":{"type":"critical","message":"CPU Request Not Set","code":523001.0},"423001":{"type":"warning","message":"CPU Limit Not Set","code":423001.0}},"monitoring_end_time":"2025-01-24T14:03:32.000Z","current":{},"recommendation_terms":{"short_term":{"duration_in_hours":24.0,"notifications":{"112101":{"type":"info","message":"Cost Recommendations Available","code":112101.0},"112102":{"type":"info","message":"Performance Recommendations Available","code":112102.0}},"monitoring_start_time":"2025-01-23T14:03:32.000Z","recommendation_engines":{"cost":{"pods_count":1.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":1.24342272E7,"format":"bytes"},"cpu":{"amount":0.017608041385938182,"format":"cores"}},"requests":{"memory":{"amount":1.24342272E7,"format":"bytes"},"cpu":{"amount":0.017608041385938182,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":1.24342272E7,"format":"bytes"},"cpu":{"amount":0.017608041385938182,"format":"cores"}},"requests":{"memory":{"amount":1.24342272E7,"format":"bytes"},"cpu":{"amount":0.017608041385938182,"format":"cores"}}},"notifications":{}},"performance":{"pods_count":1.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":1.24342272E7,"format":"bytes"},"cpu":{"amount":0.017608041385938182,"format":"cores"}},"requests":{"memory":{"amount":1.24342272E7,"format":"bytes"},"cpu":{"amount":0.017608041385938182,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":1.24342272E7,"format":"bytes"},"cpu":{"amount":0.017608041385938182,"format":"cores"}},"requests":{"memory":{"amount":1.24342272E7,"format":"bytes"},"cpu":{"amount":0.017608041385938182,"format":"cores"}}},"notifications":{}}},"plots":{"datapoints":4.0,"plots_data":{"2025-01-24T08:03:32.000Z":{"cpuUsage":{"min":0.010798595402298968,"q1":0.01219379814091242,"median":0.013009303015206917,"q3":0.014856814942528433,"max":0.016528944140064103,"format":"cores"},"memoryUsage":{"min":9785344.0,"q1":1.0027008E7,"median":1.1436032E7,"q3":1.148928E7,"max":1.1554816E7,"format":"bytes"}},"2025-01-24T14:03:32.000Z":{"cpuUsage":{"min":0.0026004803938100168,"q1":0.011271955007120997,"median":0.012758754031517912,"q3":0.013734046585228738,"max":0.015156628735631873,"format":"cores"},"memoryUsage":{"min":9854976.0,"q1":1.0162176E7,"median":1.1149312E7,"q3":1.1718656E7,"max":1.1943936E7,"format":"bytes"}},"2025-01-23T20:03:32.000Z":{"cpuUsage":{"min":0.00347809510969936,"q1":0.012723840226436672,"median":0.013946462157887569,"q3":0.014186589655172475,"max":0.017608041385938182,"format":"cores"},"memoryUsage":{"min":1.1112448E7,"q1":1.1390976E7,"median":1.1431936E7,"q3":1.150976E7,"max":1.1628544E7,"format":"bytes"}},"2025-01-24T02:03:32.000Z":{}}}},"medium_term":{"duration_in_hours":168.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}},"long_term":{"duration_in_hours":360.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}}}}}}}]}],"version":"v2.0","experiment_name":"prometheus-1|default|monitoring|kube-state-metrics(deployment)|kube-rbac-proxy-self"}]}},"status_history":[{"status":"UNPROCESSED","timestamp":"2025-01-24T13:53:17.492Z"},{"status":"PROCESSED","timestamp":"2025-01-24T13:53:35.212Z"}]},"prometheus-1|default|monitoring|kube-state-metrics(deployment)|kube-state-metrics":{"name":"prometheus-1|default|monitoring|kube-state-metrics(deployment)|kube-state-metrics","status":"PROCESSED","apis":{"create":{"response":{"message":"Experiment registered successfully with Kruize. View registered experiments at /listExperiments","httpcode":201,"documentationLink":"","status":"SUCCESS"}},"recommendations":{"response":[{"cluster_name":"default","experiment_type":"container","kubernetes_objects":[{"type":"deployment","name":"kube-state-metrics","namespace":"monitoring","containers":[{"container_image_name":"registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.9.2","container_name":"kube-state-metrics","recommendations":{"version":"1.0","notifications":{"111000":{"type":"info","message":"Recommendations Are Available","code":111000.0}},"data":{"2025-01-24T14:03:34.000Z":{"notifications":{"224001":{"type":"error","message":"Amount field is missing in the Memory Section","code":224001.0},"524002":{"type":"critical","message":"Memory Limit Not Set","code":524002.0},"524001":{"type":"critical","message":"Memory Request Not Set","code":524001.0},"223001":{"type":"error","message":"Amount field is missing in the CPU Section","code":223001.0},"111101":{"type":"info","message":"Short Term Recommendations Available","code":111101.0},"523001":{"type":"critical","message":"CPU Request Not Set","code":523001.0},"423001":{"type":"warning","message":"CPU Limit Not Set","code":423001.0}},"monitoring_end_time":"2025-01-24T14:03:34.000Z","current":{},"recommendation_terms":{"short_term":{"duration_in_hours":24.0,"notifications":{"112101":{"type":"info","message":"Cost Recommendations Available","code":112101.0},"112102":{"type":"info","message":"Performance Recommendations Available","code":112102.0}},"monitoring_start_time":"2025-01-23T14:03:34.000Z","recommendation_engines":{"cost":{"pods_count":1.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":3.74587392E7,"format":"bytes"},"cpu":{"amount":0.0068350226128613,"format":"cores"}},"requests":{"memory":{"amount":3.74587392E7,"format":"bytes"},"cpu":{"amount":0.0068350226128613,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":3.74587392E7,"format":"bytes"},"cpu":{"amount":0.0068350226128613,"format":"cores"}},"requests":{"memory":{"amount":3.74587392E7,"format":"bytes"},"cpu":{"amount":0.0068350226128613,"format":"cores"}}},"notifications":{}},"performance":{"pods_count":1.0,"confidence_level":0.0,"config":{"limits":{"memory":{"amount":3.74587392E7,"format":"bytes"},"cpu":{"amount":0.0068350226128613,"format":"cores"}},"requests":{"memory":{"amount":3.74587392E7,"format":"bytes"},"cpu":{"amount":0.0068350226128613,"format":"cores"}}},"variation":{"limits":{"memory":{"amount":3.74587392E7,"format":"bytes"},"cpu":{"amount":0.0068350226128613,"format":"cores"}},"requests":{"memory":{"amount":3.74587392E7,"format":"bytes"},"cpu":{"amount":0.0068350226128613,"format":"cores"}}},"notifications":{}}},"plots":{"datapoints":4.0,"plots_data":{"2025-01-24T08:03:34.000Z":{"cpuUsage":{"min":0.0014259482758617829,"q1":0.004083851724137416,"median":0.004814499685057345,"q3":0.00537361034482846,"max":0.00649890841160028,"format":"cores"},"memoryUsage":{"min":2.1454848E7,"q1":2.8184576E7,"median":2.8495872E7,"q3":2.9835264E7,"max":3.0277632E7,"format":"bytes"}},"2025-01-24T14:03:34.000Z":{"cpuUsage":{"min":0.0011464114942536874,"q1":0.004451328735632453,"median":0.0053104170868381526,"q3":0.006021678870971587,"max":0.006806382758620186,"format":"cores"},"memoryUsage":{"min":2.1884928E7,"q1":2.6963968E7,"median":2.7594752E7,"q3":2.7942912E7,"max":2.8688384E7,"format":"bytes"}},"2025-01-23T20:03:34.000Z":{"cpuUsage":{"min":6.885989245622923E-4,"q1":0.004145944827584948,"median":0.005652326379262428,"q3":0.006259148596829993,"max":0.0068350226128613,"format":"cores"},"memoryUsage":{"min":2.4244224E7,"q1":2.88768E7,"median":2.9446144E7,"q3":2.967552E7,"max":3.1215616E7,"format":"bytes"}},"2025-01-24T02:03:34.000Z":{}}}},"medium_term":{"duration_in_hours":168.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}},"long_term":{"duration_in_hours":360.0,"notifications":{"120001":{"type":"info","message":"There is not enough data available to generate a recommendation.","code":120001.0}}}}}}}}]}],"version":"v2.0","experiment_name":"prometheus-1|default|monitoring|kube-state-metrics(deployment)|kube-state-metrics"}]}},"status_history":[{"status":"UNPROCESSED","timestamp":"2025-01-24T13:53:17.557Z"},{"status":"PROCESSED","timestamp":"2025-01-24T13:53:36.091Z"}]},"prometheus-1|default|monitoring|blackbox-exporter(deployment)|module-configmap-reloader":{"name":"prometheus-1|default|monitoring|blackbox-exporter(deployment)|module-configmap-reloader","status":"UNPROCESSED","apis":{"create":{"response":{"message":"Experiment registered successfully with Kruize. View registered experiments at /listExperiments","httpcode":201,"documentationLink":"","status":"SUCCESS"}},"recommendations":{"response":null}},"status_history":[{"status":"UNPROCESSED","timestamp":"2025-01-24T13:53:17.557Z"}]},"prometheus-1|default|monitoring|kruize-delete-partition-cronjob-28918080(job)|kruizedeletejob":{"name":"prometheus-1|default|monitoring|kruize-delete-partition-cronjob-28918080(job)|kruizedeletejob","status":"UNPROCESSED","apis":{"create":{"response":{"message":"Experiment registered successfully with Kruize. View registered experiments at /listExperiments","httpcode":201,"documentationLink":"","status":"SUCCESS"}},"recommendations":{"response":null}},"status_history":[{"status":"UNPROCESSED","timestamp":"2025-01-24T13:53:17.601Z"}]},"prometheus-1|default|monitoring|kube-state-metrics(deployment)|kube-rbac-proxy-main":{"name":"prometheus-1|default|monitoring|kube-state-metrics(deployment)|kube-rbac-proxy-main","status":"UNPROCESSED","apis":{"create":{"response":{"message":"Experiment registered successfully with Kruize. View registered experiments at /listExperiments","httpcode":201,"documentationLink":"","status":"SUCCESS"}},"recommendations":{"response":null}},"status_history":[{"status":"UNPROCESSED","timestamp":"2025-01-24T13:53:17.737Z"}]},"prometheus-1|default|monitoring|grafana(deployment)|grafana":{"name":"prometheus-1|default|monitoring|grafana(deployment)|grafana","status":"UNPROCESSED","apis":{"create":{"response":{"message":"Experiment registered successfully with Kruize. View registered experiments at /listExperiments","httpcode":201,"documentationLink":"","status":"SUCCESS"}},"recommendations":{"response":null}},"status_history":[{"status":"UNPROCESSED","timestamp":"2025-01-24T13:53:17.751Z"}]},"prometheus-1|default|kube-system|kindnet(daemonset)|kindnet-cni":{"name":"prometheus-1|default|kube-system|kindnet(daemonset)|kindnet-cni","status":"UNPROCESSED","apis":{"create":{"response":{"message":"Experiment registered successfully with Kruize. View registered experiments at /listExperiments","httpcode":201,"documentationLink":"","status":"SUCCESS"}},"recommendations":{"response":null}},"status_history":[{"status":"UNPROCESSED","timestamp":"2025-01-24T13:53:17.790Z"}]}},"webhook":null,"metadata":{"datasources":{"prometheus-1":{"clusters":{"default":{"namespaces":{"default":{"namespace":"default","workloads":null},"local-path-storage":{"namespace":"local-path-storage","workloads":{"local-path-provisioner":{"containers":{"local-path-provisioner":{"container_name":"local-path-provisioner","container_image_name":"docker.io/kindest/local-path-provisioner:v0.0.22-kind.0"}},"workload_name":"local-path-provisioner","workload_type":"deployment"}}},"cadvisor":{"namespace":"cadvisor","workloads":{"cadvisor":{"containers":{"cadvisor":{"container_name":"cadvisor","container_image_name":"gcr.io/cadvisor/cadvisor:v0.45.0"}},"workload_name":"cadvisor","workload_type":"daemonset"}}},"kube-node-lease":{"namespace":"kube-node-lease","workloads":null},"kube-system":{"namespace":"kube-system","workloads":{"coredns":{"containers":{"coredns":{"container_name":"coredns","container_image_name":"k8s.gcr.io/coredns/coredns:v1.8.6"}},"workload_name":"coredns","workload_type":"deployment"},"kube-proxy":{"containers":{"kube-proxy":{"container_name":"kube-proxy","container_image_name":"k8s.gcr.io/kube-proxy:v1.24.0"}},"workload_name":"kube-proxy","workload_type":"daemonset"},"kindnet":{"containers":{"kindnet-cni":{"container_name":"kindnet-cni","container_image_name":"docker.io/kindest/kindnetd:v20220510-4929dd75"}},"workload_name":"kindnet","workload_type":"daemonset"}}},"monitoring":{"namespace":"monitoring","workloads":{"kube-state-metrics":{"containers":{"kube-state-metrics":{"container_name":"kube-state-metrics","container_image_name":"registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.9.2"},"kube-rbac-proxy-self":{"container_name":"kube-rbac-proxy-self","container_image_name":"quay.io/brancz/kube-rbac-proxy:v0.14.2"},"kube-rbac-proxy-main":{"container_name":"kube-rbac-proxy-main","container_image_name":"quay.io/brancz/kube-rbac-proxy:v0.14.2"}},"workload_name":"kube-state-metrics","workload_type":"deployment"},"node-exporter":{"containers":{"node-exporter":{"container_name":"node-exporter","container_image_name":"quay.io/prometheus/node-exporter:v1.6.1"},"kube-rbac-proxy":{"container_name":"kube-rbac-proxy","container_image_name":"quay.io/brancz/kube-rbac-proxy:v0.14.2"}},"workload_name":"node-exporter","workload_type":"daemonset"},"alertmanager-main":{"containers":{"config-reloader":{"container_name":"config-reloader","container_image_name":"quay.io/prometheus-operator/prometheus-config-reloader:v0.67.1"},"alertmanager":{"container_name":"alertmanager","container_image_name":"quay.io/prometheus/alertmanager:v0.26.0"}},"workload_name":"alertmanager-main","workload_type":"statefulset"},"prometheus-adapter":{"containers":{"prometheus-adapter":{"container_name":"prometheus-adapter","container_image_name":"registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.11.1"}},"workload_name":"prometheus-adapter","workload_type":"deployment"},"grafana":{"containers":{"grafana":{"container_name":"grafana","container_image_name":"docker.io/grafana/grafana:9.5.3"}},"workload_name":"grafana","workload_type":"deployment"},"kruize":{"containers":{"kruize":{"container_name":"kruize","container_image_name":"quay.io/dinogun210/autotune_operator:0.3"}},"workload_name":"kruize","workload_type":"deployment"},"create-partition-cronjob-28918080":{"containers":{"kruizecronjob":{"container_name":"kruizecronjob","container_image_name":"quay.io/kruize/autotune_operator:0.2"}},"workload_name":"create-partition-cronjob-28918080","workload_type":"job"},"kruize-db-deployment":{"containers":{"kruize-db":{"container_name":"kruize-db","container_image_name":"quay.io/kruizehub/postgres:15.2"}},"workload_name":"kruize-db-deployment","workload_type":"deployment"},"prometheus-k8s":{"containers":{"config-reloader":{"container_name":"config-reloader","container_image_name":"quay.io/prometheus-operator/prometheus-config-reloader:v0.67.1"},"prometheus":{"container_name":"prometheus","container_image_name":"quay.io/prometheus/prometheus:v2.46.0"}},"workload_name":"prometheus-k8s","workload_type":"statefulset"},"kruize-delete-partition-cronjob-28918080":{"containers":{"kruizedeletejob":{"container_name":"kruizedeletejob","container_image_name":"quay.io/kruize/autotune_operator:0.2"}},"workload_name":"kruize-delete-partition-cronjob-28918080","workload_type":"job"},"blackbox-exporter":{"containers":{"kube-rbac-proxy":{"container_name":"kube-rbac-proxy","container_image_name":"quay.io/brancz/kube-rbac-proxy:v0.14.2"},"module-configmap-reloader":{"container_name":"module-configmap-reloader","container_image_name":"docker.io/jimmidyson/configmap-reload:v0.5.0"},"blackbox-exporter":{"container_name":"blackbox-exporter","container_image_name":"quay.io/prometheus/blackbox-exporter:v0.24.0"}},"workload_name":"blackbox-exporter","workload_type":"deployment"},"prometheus-operator":{"containers":{"kube-rbac-proxy":{"container_name":"kube-rbac-proxy","container_image_name":"quay.io/brancz/kube-rbac-proxy:v0.14.2"},"prometheus-operator":{"container_name":"prometheus-operator","container_image_name":"quay.io/prometheus-operator/prometheus-operator:v0.67.1"}},"workload_name":"prometheus-operator","workload_type":"deployment"}}},"kube-public":{"namespace":"kube-public","workloads":null}},"dataSourceClusterName":"default","cluster_name":"default"}},"datasource_name":"prometheus-1"}}}}
```

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [x] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
