### PR TITLE
Fix issue with Datasource in case of No-Auth config

### DIFF
--- a/src/main/java/com/autotune/database/helper/DBHelpers.java
+++ b/src/main/java/com/autotune/database/helper/DBHelpers.java
@@ -1124,18 +1124,22 @@ public class DBHelpers {
                     try {
                         DataSourceInfo dataSourceInfo;
                         AuthenticationConfig authConfig = null;
+                        JSONObject authJson = null;
                         if (kruizeDataSource.getKruizeAuthenticationEntry() != null) {
                             try {
                                 JsonNode credentialsNode = kruizeDataSource.getKruizeAuthenticationEntry().getCredentials();
                                 String authType = kruizeDataSource.getKruizeAuthenticationEntry().getAuthenticationType();
                                 // Parse the JsonNode credentials into a JSONObject
-                                JSONObject credentialsJson = new JSONObject(credentialsNode.toString());
-                                JSONObject authJson = new JSONObject()
-                                        .put(KruizeConstants.AuthenticationConstants.AUTHENTICATION_TYPE, authType)
-                                        .put(KruizeConstants.AuthenticationConstants.AUTHENTICATION_CREDENTIALS, credentialsJson);
+                                if (!credentialsNode.toString().equalsIgnoreCase(AnalyzerConstants.NULL)) {
+                                    JSONObject credentialsJson = new JSONObject(credentialsNode.toString());
+                                    authJson = new JSONObject()
+                                            .put(KruizeConstants.AuthenticationConstants.AUTHENTICATION_TYPE, authType)
+                                            .put(KruizeConstants.AuthenticationConstants.AUTHENTICATION_CREDENTIALS, credentialsJson);
+                                }
                                 authConfig = AuthenticationConfig.createAuthenticationConfigObject(authJson);
                             } catch (Exception e) {
-                                LOGGER.debug("GSON failed to convert the DB Json object in convertKruizeDataSourceToDataSourceObject");
+                                e.printStackTrace();
+                                LOGGER.error("GSON failed to convert the DB Json object in convertKruizeDataSourceToDataSourceObject");
                             }
                         }
                         if (kruizeDataSource.getServiceName().isEmpty() && null != kruizeDataSource.getUrl()) {


### PR DESCRIPTION
## Description

This PR fixes the issue which arises when no auth datasource config is saved in the DB and read back. 

Fixes # (issue) #1473 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [x] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: Minikube

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [x] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
