### PR TITLE
5 - Bulkjob Save to DB - Inclusion of JOB_ID while generating recommendations

### DIFF
--- a/src/main/java/com/autotune/analyzer/autoscaler/AutoscalerImpl.java
+++ b/src/main/java/com/autotune/analyzer/autoscaler/AutoscalerImpl.java
@@ -74,7 +74,7 @@ public class AutoscalerImpl implements Autoscaler {
             int calCount = 0;
             String validationMessage = recommendationEngine.validate_local();
             if (validationMessage.isEmpty()) {
-                KruizeObject kruizeObject = recommendationEngine.prepareRecommendations(calCount, null);
+                KruizeObject kruizeObject = recommendationEngine.prepareRecommendations(calCount, null, null);
                 if (kruizeObject.getValidation_data().isSuccess()) {
                     LOGGER.debug(AnalyzerConstants.AutoscalerConstants.InfoMsgs.GENERATED_RECOMMENDATIONS, experimentName);
                     return kruizeObject;

--- a/src/main/java/com/autotune/analyzer/kruizeObject/KruizeObject.java
+++ b/src/main/java/com/autotune/analyzer/kruizeObject/KruizeObject.java
@@ -76,7 +76,7 @@ public final class KruizeObject implements ExperimentTypeAware {
     private ValidationOutputData validation_data;
     private List<K8sObject> kubernetes_objects;
     private Map<String, Terms> terms;
-
+    private transient String bulkJobId;
 
     public KruizeObject(String experimentName,
                         String clusterName,
@@ -200,6 +200,14 @@ public final class KruizeObject implements ExperimentTypeAware {
             // Handles the case where termSettings is null
             throw new InvalidTermException(AnalyzerErrorConstants.APIErrors.CreateExperimentAPI.TERM_SETTINGS_UNDEFINED);
         }
+    }
+
+    public String getBulkJobId() {
+        return bulkJobId;
+    }
+
+    public void setBulkJobId(String bulkJobId) {
+        this.bulkJobId = bulkJobId;
     }
 
     public String getExperimentName() {

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -315,7 +315,7 @@ public class RecommendationEngine {
      * @param calCount The count of incoming requests.
      * @return The KruizeObject containing the prepared recommendations.
      */
-    public KruizeObject prepareRecommendations(int calCount, String target_cluster) throws FetchMetricsError {
+    public KruizeObject prepareRecommendations(int calCount, String target_cluster, String bulkJobID) throws FetchMetricsError {
         Map<String, KruizeObject> mainKruizeExperimentMAP = new ConcurrentHashMap<>();
         Map<String, Terms> terms = new HashMap<>();
         ValidationOutputData validationOutputData;
@@ -326,6 +326,7 @@ public class RecommendationEngine {
             setInterval_end_time(interval_end_time);
         }
         KruizeObject kruizeObject = createKruizeObject(target_cluster);
+        if (null != bulkJobID) kruizeObject.setBulkJobId(bulkJobID);
         if (!kruizeObject.getValidation_data().isSuccess())
             return kruizeObject;
         setKruizeObject(kruizeObject);

--- a/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
@@ -67,7 +67,6 @@ public class Converters {
                         // namespace recommendations experiment type
                         k8sObject = createNamespaceExperiment(kubernetesAPIObject);
                     }
-                    LOGGER.debug("Experiment Type: {}", createExperimentAPIObject.getExperimentType());
                     k8sObjectList.add(k8sObject);
                 }
                 // TODO : some modification to add custom terms and models automatically here

--- a/src/main/java/com/autotune/analyzer/services/GenerateRecommendations.java
+++ b/src/main/java/com/autotune/analyzer/services/GenerateRecommendations.java
@@ -53,6 +53,7 @@ import java.util.List;
 
 import static com.autotune.analyzer.utils.AnalyzerConstants.ServiceConstants.CHARACTER_ENCODING;
 import static com.autotune.analyzer.utils.AnalyzerConstants.ServiceConstants.JSON_CONTENT_TYPE;
+import static com.autotune.utils.KruizeConstants.KRUIZE_BULK_API.JOB_ID;
 
 /**
  *
@@ -95,6 +96,7 @@ public class GenerateRecommendations extends HttpServlet {
             String experiment_name = request.getParameter(KruizeConstants.JSONKeys.EXPERIMENT_NAME);
             String intervalEndTimeStr = request.getParameter(KruizeConstants.JSONKeys.INTERVAL_END_TIME);
             String intervalStartTimeStr = request.getParameter(KruizeConstants.JSONKeys.INTERVAL_START_TIME);
+            String bulkJobID = request.getParameter(JOB_ID);
             Timestamp interval_end_time, interval_start_time;
 
             // create recommendation engine object
@@ -102,7 +104,7 @@ public class GenerateRecommendations extends HttpServlet {
             // validate and create KruizeObject if successful
             String validationMessage = recommendationEngine.validate_local();
             if (validationMessage.isEmpty()) {
-                KruizeObject kruizeObject = recommendationEngine.prepareRecommendations(calCount, AnalyzerConstants.LOCAL);   // todo target cluster is set to LOCAL always
+                KruizeObject kruizeObject = recommendationEngine.prepareRecommendations(calCount, AnalyzerConstants.LOCAL, bulkJobID);   // todo target cluster is set to LOCAL always
                 if (kruizeObject.getValidation_data().isSuccess()) {
                     LOGGER.debug("UpdateRecommendations API request count: {} success", calCount);
                     interval_end_time = Utils.DateUtils.getTimeStampFrom(KruizeConstants.DateFormats.STANDARD_JSON_DATE_FORMAT,

--- a/src/main/java/com/autotune/analyzer/services/ListExperiments.java
+++ b/src/main/java/com/autotune/analyzer/services/ListExperiments.java
@@ -440,9 +440,9 @@ public class ListExperiments extends HttpServlet {
                     new ExperimentDBService().loadRecommendationsFromDBByName(mKruizeExperimentMap, experimentName);
             } else {
                 if (experimentName == null || experimentName.isEmpty())
-                    new ExperimentDBService().loadAllLMRecommendations(mKruizeExperimentMap);
+                    new ExperimentDBService().loadAllLMRecommendations(mKruizeExperimentMap, null);
                 else
-                    new ExperimentDBService().loadLMRecommendationsFromDBByName(mKruizeExperimentMap, experimentName);
+                    new ExperimentDBService().loadLMRecommendationsFromDBByName(mKruizeExperimentMap, experimentName, null);
             }
         } catch (Exception e) {
             LOGGER.error("Failed to load saved recommendations data: {} ", e.getMessage());

--- a/src/main/java/com/autotune/analyzer/services/ListRecommendations.java
+++ b/src/main/java/com/autotune/analyzer/services/ListRecommendations.java
@@ -58,6 +58,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import static com.autotune.analyzer.utils.AnalyzerConstants.ServiceConstants.CHARACTER_ENCODING;
 import static com.autotune.analyzer.utils.AnalyzerConstants.ServiceConstants.JSON_CONTENT_TYPE;
+import static com.autotune.utils.KruizeConstants.KRUIZE_BULK_API.JOB_ID;
 
 /**
  * Rest API used to recommend right configuration.
@@ -85,6 +86,7 @@ public class ListRecommendations extends HttpServlet {
         String latestRecommendation = request.getParameter(AnalyzerConstants.ServiceConstants.LATEST);
         String monitoringEndTime = request.getParameter(KruizeConstants.JSONKeys.MONITORING_END_TIME);
         String rm = request.getParameter(AnalyzerConstants.ServiceConstants.RM);
+        String bulkJobID = request.getParameter(JOB_ID);
         Timestamp monitoringEndTimestamp = null;
         Map<String, KruizeObject> mKruizeExperimentMap = new ConcurrentHashMap<String, KruizeObject>();
 
@@ -114,7 +116,7 @@ public class ListRecommendations extends HttpServlet {
                     if (rmTable) {
                         new ExperimentDBService().loadExperimentAndRecommendationsFromDBByName(mKruizeExperimentMap, experimentName);
                     } else {
-                        new ExperimentDBService().loadLMExperimentAndRecommendationsFromDBByName(mKruizeExperimentMap, experimentName);
+                        new ExperimentDBService().loadLMExperimentAndRecommendationsFromDBByName(mKruizeExperimentMap, experimentName, bulkJobID);
                     }
                 } catch (Exception e) {
                     LOGGER.error("Loading saved experiment {} failed: {} ", experimentName, e.getMessage());
@@ -165,7 +167,7 @@ public class ListRecommendations extends HttpServlet {
                     if (rmTable) {
                         new ExperimentDBService().loadAllExperimentsAndRecommendations(mKruizeExperimentMap);
                     } else {
-                        new ExperimentDBService().loadAllLMExperimentsAndRecommendations(mKruizeExperimentMap);
+                        new ExperimentDBService().loadAllLMExperimentsAndRecommendations(mKruizeExperimentMap, bulkJobID);
                     }
                 } catch (Exception e) {
                     LOGGER.error("Loading saved experiment {} failed: {} ", experimentName, e.getMessage());
@@ -209,7 +211,6 @@ public class ListRecommendations extends HttpServlet {
                 List<ListRecommendationsAPIObject> recommendationList = new ArrayList<>();
                 for (KruizeObject ko : kruizeObjectList) {
                     try {
-                        LOGGER.debug(ko.getKubernetes_objects().toString());
                         ListRecommendationsAPIObject listRecommendationsAPIObject = Converters.KruizeObjectConverters.
                                 convertKruizeObjectToListRecommendationSO(
                                         ko,

--- a/src/main/java/com/autotune/analyzer/services/UpdateRecommendations.java
+++ b/src/main/java/com/autotune/analyzer/services/UpdateRecommendations.java
@@ -102,7 +102,7 @@ public class UpdateRecommendations extends HttpServlet {
             // validate and create KruizeObject if successful
             String validationMessage = recommendationEngine.validate();
             if (validationMessage.isEmpty()) {
-                KruizeObject kruizeObject = recommendationEngine.prepareRecommendations(calCount, REMOTE);
+                KruizeObject kruizeObject = recommendationEngine.prepareRecommendations(calCount, REMOTE, null);
                 if (kruizeObject.getValidation_data().isSuccess()) {
                     LOGGER.debug(String.format(AnalyzerErrorConstants.APIErrors.UpdateRecommendationsAPI.UPDATE_RECOMMENDATIONS_SUCCESS_COUNT, calCount));
                     interval_end_time = Utils.DateUtils.getTimeStampFrom(KruizeConstants.DateFormats.STANDARD_JSON_DATE_FORMAT,

--- a/src/main/java/com/autotune/database/dao/ExperimentDAO.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAO.java
@@ -65,7 +65,7 @@ public interface ExperimentDAO {
     // If Kruize restarts load all recommendations
     List<KruizeRecommendationEntry> loadAllRecommendations() throws Exception;
 
-    List<KruizeLMRecommendationEntry> loadAllLMRecommendations() throws Exception;
+    List<KruizeLMRecommendationEntry> loadAllLMRecommendations(String bulkJobID) throws Exception;
 
     // If Kruize restarts load all performance profiles
     List<KruizePerformanceProfileEntry> loadAllPerformanceProfiles() throws Exception;
@@ -94,7 +94,7 @@ public interface ExperimentDAO {
     List<KruizeRecommendationEntry> loadRecommendationsByExperimentName(String experimentName) throws Exception;
 
     // Load all recommendations of a particular experiment
-    List<KruizeLMRecommendationEntry> loadLMRecommendationsByExperimentName(String experimentName) throws Exception;
+    List<KruizeLMRecommendationEntry> loadLMRecommendationsByExperimentName(String experimentName, String bulkJobId) throws Exception;
 
     // Load a single Performance Profile based on name
     List<KruizePerformanceProfileEntry> loadPerformanceProfileByName(String performanceProfileName) throws Exception;

--- a/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
@@ -1106,14 +1106,21 @@ public class ExperimentDAOImpl implements ExperimentDAO {
     }
 
     @Override
-    public List<KruizeLMRecommendationEntry> loadAllLMRecommendations() throws Exception {
+    public List<KruizeLMRecommendationEntry> loadAllLMRecommendations(String bulkJobId) throws Exception {
         List<KruizeLMRecommendationEntry> recommendationEntries = null;
         String statusValue = "failure";
         Timer.Sample timerLoadAllRec = Timer.start(MetricsConfig.meterRegistry());
         try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
-            recommendationEntries = session.createQuery(
-                    DBConstants.SQLQUERY.SELECT_FROM_LM_RECOMMENDATIONS,
-                    KruizeLMRecommendationEntry.class).list();
+            if (null != bulkJobId || bulkJobId != "") {
+                recommendationEntries = session.createQuery(SELECT_FROM_LM_RECOMMENDATIONS_BY_JOB_ID,
+                                KruizeLMRecommendationEntry.class)
+                        .setParameter(JOB_ID, bulkJobId)
+                        .list();
+            } else {
+                recommendationEntries = session.createQuery(
+                        DBConstants.SQLQUERY.SELECT_FROM_LM_RECOMMENDATIONS,
+                        KruizeLMRecommendationEntry.class).list();
+            }
             statusValue = "success";
         } catch (Exception e) {
             LOGGER.error("Not able to load recommendations due to {}", e.getMessage());
@@ -1373,13 +1380,20 @@ public class ExperimentDAOImpl implements ExperimentDAO {
     }
 
     @Override
-    public List<KruizeLMRecommendationEntry> loadLMRecommendationsByExperimentName(String experimentName) throws Exception {
+    public List<KruizeLMRecommendationEntry> loadLMRecommendationsByExperimentName(String experimentName, String bulkJobId) throws Exception {
         List<KruizeLMRecommendationEntry> recommendationEntries = null;
         String statusValue = "failure";
         Timer.Sample timerLoadRecExpName = Timer.start(MetricsConfig.meterRegistry());
         try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
-            recommendationEntries = session.createQuery(DBConstants.SQLQUERY.SELECT_FROM_LM_RECOMMENDATIONS_BY_EXP_NAME, KruizeLMRecommendationEntry.class)
-                    .setParameter("experimentName", experimentName).list();
+            if (null != bulkJobId) {
+                recommendationEntries = session.createQuery(SELECT_FROM_LM_RECOMMENDATIONS_BY_EXP_NAME_BY_JOB_ID, KruizeLMRecommendationEntry.class)
+                        .setParameter("experimentName", experimentName)
+                        .setParameter(JOB_ID, bulkJobId)
+                        .list();
+            } else {
+                recommendationEntries = session.createQuery(DBConstants.SQLQUERY.SELECT_FROM_LM_RECOMMENDATIONS_BY_EXP_NAME, KruizeLMRecommendationEntry.class)
+                        .setParameter("experimentName", experimentName).list();
+            }
             statusValue = "success";
         } catch (Exception e) {
             LOGGER.error("Not able to load recommendations due to {}", e.getMessage());

--- a/src/main/java/com/autotune/database/helper/DBHelpers.java
+++ b/src/main/java/com/autotune/database/helper/DBHelpers.java
@@ -63,6 +63,7 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 
 import static com.autotune.analyzer.experiment.ExperimentInitiator.getErrorMap;
+import static com.autotune.utils.KruizeConstants.KRUIZE_BULK_API.JOB_ID;
 
 /**
  * Helper functions used by the DB to create entity objects.
@@ -611,7 +612,10 @@ public class DBHelpers {
                         }
                     }
                     kruizeRecommendationEntry.setInterval_end_time(endInterval);
-                    Map k8sObjectsMap = Map.of(KruizeConstants.JSONKeys.KUBERNETES_OBJECTS, listRecommendationsAPIObject.getKubernetesObjects());
+                    Map<String, Object> k8sObjectsMap = new HashMap<>();
+                    k8sObjectsMap.put(KruizeConstants.JSONKeys.KUBERNETES_OBJECTS, listRecommendationsAPIObject.getKubernetesObjects());
+                    if (null != kruizeObject.getBulkJobId())
+                        k8sObjectsMap.put(JOB_ID, kruizeObject.getBulkJobId());
                     String k8sObjectString = gson.toJson(k8sObjectsMap);
                     ObjectMapper objectMapper = new ObjectMapper();
                     DateFormat df = new SimpleDateFormat(KruizeConstants.DateFormats.STANDARD_JSON_DATE_FORMAT);

--- a/src/main/java/com/autotune/database/service/ExperimentDBService.java
+++ b/src/main/java/com/autotune/database/service/ExperimentDBService.java
@@ -136,10 +136,10 @@ public class ExperimentDBService {
         }
     }
 
-    public void loadAllLMRecommendations(Map<String, KruizeObject> mainKruizeExperimentMap) throws Exception {
+    public void loadAllLMRecommendations(Map<String, KruizeObject> mainKruizeExperimentMap, String bulkJobId) throws Exception {
         ExperimentInterface experimentInterface = new ExperimentInterfaceImpl();
         // Load Recommendations from DB and save to local
-        List<KruizeLMRecommendationEntry> recommendationEntries = experimentDAO.loadAllLMRecommendations();
+        List<KruizeLMRecommendationEntry> recommendationEntries = experimentDAO.loadAllLMRecommendations(bulkJobId);
         if (null != recommendationEntries && !recommendationEntries.isEmpty()) {
             List<ListRecommendationsAPIObject> recommendationsAPIObjects = null;
             try {
@@ -272,10 +272,10 @@ public class ExperimentDBService {
         }
     }
 
-    public void loadLMRecommendationsFromDBByName(Map<String, KruizeObject> mainKruizeExperimentMap, String experimentName) throws Exception {
+    public void loadLMRecommendationsFromDBByName(Map<String, KruizeObject> mainKruizeExperimentMap, String experimentName, String bulkJobId) throws Exception {
         ExperimentInterface experimentInterface = new ExperimentInterfaceImpl();
         // Load Recommendations from DB and save to local
-        List<KruizeLMRecommendationEntry> recommendationEntries = experimentDAO.loadLMRecommendationsByExperimentName(experimentName);
+        List<KruizeLMRecommendationEntry> recommendationEntries = experimentDAO.loadLMRecommendationsByExperimentName(experimentName, bulkJobId);
         if (null != recommendationEntries && !recommendationEntries.isEmpty()) {
             List<ListRecommendationsAPIObject> recommendationsAPIObjects
                     = null;
@@ -550,11 +550,11 @@ public class ExperimentDBService {
         loadRecommendationsFromDBByName(mainKruizeExperimentMap, experimentName);
     }
 
-    public void loadLMExperimentAndRecommendationsFromDBByName(Map<String, KruizeObject> mainKruizeExperimentMap, String experimentName) throws Exception {
+    public void loadLMExperimentAndRecommendationsFromDBByName(Map<String, KruizeObject> mainKruizeExperimentMap, String experimentName, String bulkJobId) throws Exception {
 
         loadLMExperimentFromDBByName(mainKruizeExperimentMap, experimentName);
 
-        loadLMRecommendationsFromDBByName(mainKruizeExperimentMap, experimentName);
+        loadLMRecommendationsFromDBByName(mainKruizeExperimentMap, experimentName, bulkJobId);
     }
 
     public void loadPerformanceProfileFromDBByName(Map<String, PerformanceProfile> performanceProfileMap, String performanceProfileName) throws Exception {
@@ -623,11 +623,11 @@ public class ExperimentDBService {
         loadAllRecommendations(mainKruizeExperimentMap);
     }
 
-    public void loadAllLMExperimentsAndRecommendations(Map<String, KruizeObject> mainKruizeExperimentMap) throws Exception {
+    public void loadAllLMExperimentsAndRecommendations(Map<String, KruizeObject> mainKruizeExperimentMap, String bulkJobId) throws Exception {
 
         loadAllLMExperiments(mainKruizeExperimentMap);
 
-        loadAllLMRecommendations(mainKruizeExperimentMap);
+        loadAllLMRecommendations(mainKruizeExperimentMap, bulkJobId);
     }
 
     public boolean updateExperimentStatus(KruizeObject kruizeObject, AnalyzerConstants.ExperimentStatus status) {


### PR DESCRIPTION
## Description
To retrieve job details related to experiments and their recommendations, it is essential to save the job_id along with the recommendations. Since the job_id is transient in nature, it should not impact the structure of the recommendations JSON. This PR focuses on incorporating job_id as an optional parameter when generating recommendation.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [x] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [x] Dependent changes merged
- [x] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
