### PR TITLE
Calculate replicas with memory metrics first

### DIFF
--- a/src/main/java/com/autotune/analyzer/recommendations/model/CostBasedRecommendationModel.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/model/CostBasedRecommendationModel.java
@@ -127,7 +127,7 @@ public class CostBasedRecommendationModel implements RecommendationModel {
             double cpuRequestIntervalMax;
             double cpuRequestIntervalMin;
             double cpuUsagePod = 0;
-            int numPods;
+            int numPods = 0;
 
             // Use the Max value when available, if not use the Avg
             double cpuUsage = (cpuUsageMax > 0) ? cpuUsageMax : cpuUsageAvg;

--- a/src/main/java/com/autotune/analyzer/recommendations/model/CostBasedRecommendationModel.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/model/CostBasedRecommendationModel.java
@@ -140,7 +140,7 @@ public class CostBasedRecommendationModel implements RecommendationModel {
             } else {
                 // Sum/Avg should give us the number of pods
                 if (0 != memUsageAvg) {
-                    numPods = (int) Math.ceil(memUsageSum / memUsageAvg);
+                    numPods = (int) Math.round(memUsageSum / memUsageAvg);
                 }
                 if (0 == numPods && 0 != cpuUsageAvg) {
                     numPods = (int) Math.ceil(cpuUsageSum / cpuUsageAvg);
@@ -251,7 +251,7 @@ public class CostBasedRecommendationModel implements RecommendationModel {
         int numPods = 0;
 
         if (0 != memUsageAvg) {
-            numPods = (int) Math.ceil(memUsageSum / memUsageAvg);
+            numPods = (int) Math.round(memUsageSum / memUsageAvg);
         }
         if (0 == numPods && 0 != cpuUsageAvg) {
             numPods = (int) Math.ceil(cpuUsageSum / cpuUsageAvg);
@@ -261,6 +261,7 @@ public class CostBasedRecommendationModel implements RecommendationModel {
         }
         memUsageMax = Math.max(memUsage, memUsageMax);
         // traverse over a stream of positive values and find the minimum value
+
         memUsageMin = Stream.of(memUsage, memUsageMax, memUsageMin)
                 .filter(value -> value > 0.0)
                 .min(Double::compare)
@@ -367,7 +368,7 @@ public class CostBasedRecommendationModel implements RecommendationModel {
             cpuRequestInterval = cpuUsageTotal;
         } else {
             if (0 != memUsageAvg) {
-                numPods = (int) Math.ceil(memUsageSum / memUsageAvg);
+                numPods = (int) Math.round(memUsageSum / memUsageAvg);
             }
             if (numPods ==0 & 0 != cpuUsageAvg) {
                 numPods = (int) Math.ceil(cpuUsageSum / cpuUsageAvg);

--- a/src/main/java/com/autotune/analyzer/recommendations/model/PerformanceBasedRecommendationModel.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/model/PerformanceBasedRecommendationModel.java
@@ -139,7 +139,7 @@ public class PerformanceBasedRecommendationModel implements RecommendationModel 
                     int numPods = 0;
 
                     if (0 != memUsageAvg) {
-                        numPods = (int) Math.ceil(memUsageSum / memUsageAvg);
+                        numPods = (int) Math.round(memUsageSum / memUsageAvg);
                     }
                     // If numPods is still zero, could be because there is no MEM info
                     // We can use cpu data to calculate pods, this is not as reliable as mem

--- a/src/main/java/com/autotune/analyzer/recommendations/model/PerformanceBasedRecommendationModel.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/model/PerformanceBasedRecommendationModel.java
@@ -138,15 +138,15 @@ public class PerformanceBasedRecommendationModel implements RecommendationModel 
                     double memUsage = 0;
                     int numPods = 0;
 
-                    if (0 != cpuUsageAvg) {
-                        numPods = (int) Math.ceil(cpuUsageSum / cpuUsageAvg);
+                    if (0 != memUsageAvg) {
+                        numPods = (int) Math.ceil(memUsageSum / memUsageAvg);
                     }
-                    // If numPods is still zero, could be because there is no CPU info
-                    // We can use mem data to calculate pods, this is not as reliable as cpu
+                    // If numPods is still zero, could be because there is no MEM info
+                    // We can use cpu data to calculate pods, this is not as reliable as mem
                     // but better than nothing!
                     if (0 == numPods) {
-                        if (0 != memUsageAvg) {
-                            numPods = (int) Math.ceil(memUsageSum / memUsageAvg);
+                        if (0 != cpuUsageAvg) {
+                            numPods = (int) Math.ceil(cpuUsageSum / cpuUsageAvg);
                         }
                     }
                     if (0 < numPods) {


### PR DESCRIPTION
## Description

Calculate replicas with memory metrics first instead of cpu metrics and fix no.of pods.
When cpu usage metrics are low, and when they are rounded off to lower no.of decimal points - chances of getting the sum and avg values of cpuUsage metrics to be same which makes calculated no.of pods to be 1 eventhough there could be multiple replicas.

Fixes # (issue)

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [X] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 
minikube

## Checklist :dart:

- [X] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
