### PR TITLE
Check for auto or recreate mode to query instaslice object

### DIFF
--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -2155,16 +2155,31 @@ public class RecommendationEngine {
             Double measurementDurationMinutesInDouble = kruizeObject.getTrial_settings().getMeasurement_durationMinutes_inDouble();
             List<K8sObject> kubernetes_objects = kruizeObject.getKubernetes_objects();
 
+            boolean isAutoExperiment = false;
+
+            if (null != kruizeObject.getMode()) {
+                // Check if the experiment is of type auto or recreate
+                isAutoExperiment = (AnalyzerConstants.AUTO.equalsIgnoreCase(kruizeObject.getMode()) ||
+                        AnalyzerConstants.RECREATE.equalsIgnoreCase(kruizeObject.getMode()));
+            }
+
             for (K8sObject k8sObject : kubernetes_objects) {
                 String namespace = k8sObject.getNamespace();
                 String workload = k8sObject.getName();
                 String workload_type = k8sObject.getType();
                 HashMap<String, ContainerData> containerDataMap = k8sObject.getContainerDataMap();
 
-                // Check if the instaslice has created MIG's for the workloads
-                InstasliceHelper instasliceHelper = InstasliceHelper.getInstance();
-                String gpuUUID = instasliceHelper.getUUID(namespace, workload);
-                String gpuProfile = instasliceHelper.getMIGProfile(namespace, workload);
+
+                String gpuUUID = null;
+                String gpuProfile = null;
+
+                // Check if it's recreate or auto to query instaslice
+                if (isAutoExperiment) {
+                    // Check if the instaslice has created MIG's for the workloads
+                    InstasliceHelper instasliceHelper = InstasliceHelper.getInstance();
+                    gpuUUID = instasliceHelper.getUUID(namespace, workload);
+                    gpuProfile = instasliceHelper.getMIGProfile(namespace, workload);
+                }
 
                 for (Map.Entry<String, ContainerData> entry : containerDataMap.entrySet()) {
                     ContainerData containerData = entry.getValue();


### PR DESCRIPTION
## Description

`InstasliceHelper` comes into play only if the experiment mode is of type `auto` or `recreate`. Earlier instaslice objects are queried even in the case of `monitor` mode. This change limits the unnecessary invocations of kubernetes api's to query instaslice objects.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
