### PR TITLE
Update tests and docs integrating metadata_profile

### DIFF
--- a/design/BulkAPI.md
+++ b/design/BulkAPI.md
@@ -94,9 +94,11 @@ progress of the job.
   an experiment-processing job. Once a job is completed, this webhook will be triggered to send an HTTP request to the
   URL defined in the bulk request payload.
 
-- **metadata_profile:** Name of the metadata profile to import the cluster metadata
+- **metadata_profile:** Name of the metadata profile to import the cluster metadata. This is a mandatory field `metadata_profile` 
+  should be installed / created before invoking bulk API.
 
-- **measurement_duration:** The historic data duration to fetch the cluster metadata
+- **measurement_duration:** The historic data duration to fetch the cluster metadata. This is an optional field, if not 
+  specified `15min` as default measurement_duration value is considered.
 
 ### Success Response
 

--- a/design/BulkAPI.md
+++ b/design/BulkAPI.md
@@ -57,7 +57,7 @@ progress of the job.
     "end": "2024-11-15T23:59:59.000Z"
   },
   "datasource": "Cbank1Xyz",
-  "metadata_profile": "cluster_metadata_local_monitoring",
+  "metadata_profile": "cluster-metadata-local-monitoring",
   "measurement_duration": "15min",
   "experiment_types": [
     "container",
@@ -1010,7 +1010,7 @@ and include sections, matching the format above.
       }
     }
   },
-  "metadata_profile": "cluster_metadata_local_monitoring",
+  "metadata_profile": "cluster-metadata-local-monitoring",
   "measurement_duration": "15min"
 }
 ```

--- a/design/BulkAPI.md
+++ b/design/BulkAPI.md
@@ -57,6 +57,8 @@ progress of the job.
     "end": "2024-11-15T23:59:59.000Z"
   },
   "datasource": "Cbank1Xyz",
+  "metadata_profile": "cluster_metadata_local_monitoring",
+  "measurement_duration": "15min",
   "experiment_types": [
     "container",
     "namespace"
@@ -91,6 +93,10 @@ progress of the job.
   status of
   an experiment-processing job. Once a job is completed, this webhook will be triggered to send an HTTP request to the
   URL defined in the bulk request payload.
+
+- **metadata_profile:** Name of the metadata profile to import the cluster metadata
+
+- **measurement_duration:** The historic data duration to fetch the cluster metadata
 
 ### Success Response
 
@@ -1003,7 +1009,9 @@ and include sections, matching the format above.
         "cluster_id": "ABG"
       }
     }
-  }
+  },
+  "metadata_profile": "cluster_metadata_local_monitoring",
+  "measurement_duration": "15min"
 }
 ```
 

--- a/design/KruizeLocalAPI.md
+++ b/design/KruizeLocalAPI.md
@@ -230,7 +230,9 @@ This is quick guide instructions to import metadata using input JSON as follows.
 ```json
 {
   "version": "v1.0",
-  "datasource_name": "prometheus-1"
+  "datasource_name": "prometheus-1",
+  "metadata_profile": "cluster_metadata_local_monitoring",
+  "measurement_duration": "15min"
 }
 ```
 

--- a/design/KruizeLocalAPI.md
+++ b/design/KruizeLocalAPI.md
@@ -231,7 +231,7 @@ This is quick guide instructions to import metadata using input JSON as follows.
 {
   "version": "v1.0",
   "datasource_name": "prometheus-1",
-  "metadata_profile": "cluster_metadata_local_monitoring",
+  "metadata_profile": "cluster-metadata-local-monitoring",
   "measurement_duration": "15min"
 }
 ```

--- a/tests/scripts/helpers/kruize.py
+++ b/tests/scripts/helpers/kruize.py
@@ -18,8 +18,6 @@ import json
 import requests
 import subprocess
 
-from helpers.utils import *
-
 def get_kruize_url():
     return URL
 
@@ -525,7 +523,7 @@ def get_bulk_job_status(job_id,include=None,logger=None):
     msg = f"Equivalent cURL command : {curl_command_include}"
     log_message(msg, logger)
 
-    response = requests.get(url_include)
+    response = requests.get(getJobIDURL)
 
     msg = f"Include GET Response Status Code: {response.status_code}"
     log_message(msg, logger)
@@ -600,43 +598,3 @@ def list_metadata_profiles(name=None, verbose=None, logging=True):
         print(response.text)
         print("\n************************************************************")
     return response
-
-def delete_and_create_metadata_profile():
-    metadata_profile_dir = get_metadata_profile_dir()
-
-    metadata_profile_json_file = metadata_profile_dir / 'bulk_cluster_metadata_local_monitoring.json'
-    json_data = json.load(open(metadata_profile_json_file))
-    metadata_profile_name = json_data['metadata']['name']
-
-    response = delete_metadata_profile(metadata_profile_name)
-    print("delete metadata profile = ", response.status_code)
-
-    # Create metadata profile using the specified json
-    response = create_metadata_profile(metadata_profile_json_file)
-
-    data = response.json()
-    print(data['message'])
-
-    assert response.status_code == SUCCESS_STATUS_CODE
-    assert data['status'] == SUCCESS_STATUS
-    assert data['message'] == CREATE_METADATA_PROFILE_SUCCESS_MSG % metadata_profile_name
-
-def delete_and_create_metric_profile():
-    metric_profile_dir = get_metric_profile_dir()
-
-    metric_profile_json_file = metric_profile_dir / 'resource_optimization_local_monitoring.json'
-    json_data = json.load(open(metric_profile_json_file))
-    metric_profile_name = json_data['metadata']['name']
-
-    response = delete_metric_profile(metric_profile_json_file)
-    print("delete metric profile = ", response.status_code)
-
-    # Create metric profile using the specified json
-    response = create_metric_profile(metric_profile_json_file)
-
-    data = response.json()
-    print(data['message'])
-
-    assert response.status_code == SUCCESS_STATUS_CODE
-    assert data['status'] == SUCCESS_STATUS
-    assert data['message'] == CREATE_METRIC_PROFILE_SUCCESS_MSG % metric_profile_name

--- a/tests/scripts/helpers/kruize.py
+++ b/tests/scripts/helpers/kruize.py
@@ -18,6 +18,8 @@ import json
 import requests
 import subprocess
 
+from helpers.utils import *
+
 def get_kruize_url():
     return URL
 
@@ -598,3 +600,23 @@ def list_metadata_profiles(name=None, verbose=None, logging=True):
         print(response.text)
         print("\n************************************************************")
     return response
+
+def delete_and_create_metadata_profile():
+    metadata_profile_dir = get_metadata_profile_dir()
+
+    metadata_profile_json_file = metadata_profile_dir / 'cluster_metadata_local_monitoring.json'
+    json_data = json.load(open(metadata_profile_json_file))
+    metadata_profile_name = json_data['metadata']['name']
+
+    response = delete_metadata_profile(metadata_profile_name)
+    print("delete metadata profile = ", response.status_code)
+
+    # Create metadata profile using the specified json
+    response = create_metadata_profile(metadata_profile_json_file)
+
+    data = response.json()
+    print(data['message'])
+
+    assert response.status_code == SUCCESS_STATUS_CODE
+    assert data['status'] == SUCCESS_STATUS
+    assert data['message'] == CREATE_METADATA_PROFILE_SUCCESS_MSG % metadata_profile_name

--- a/tests/scripts/helpers/kruize.py
+++ b/tests/scripts/helpers/kruize.py
@@ -604,7 +604,7 @@ def list_metadata_profiles(name=None, verbose=None, logging=True):
 def delete_and_create_metadata_profile():
     metadata_profile_dir = get_metadata_profile_dir()
 
-    metadata_profile_json_file = metadata_profile_dir / 'cluster_metadata_local_monitoring.json'
+    metadata_profile_json_file = metadata_profile_dir / 'bulk_cluster_metadata_local_monitoring.json'
     json_data = json.load(open(metadata_profile_json_file))
     metadata_profile_name = json_data['metadata']['name']
 
@@ -620,3 +620,23 @@ def delete_and_create_metadata_profile():
     assert response.status_code == SUCCESS_STATUS_CODE
     assert data['status'] == SUCCESS_STATUS
     assert data['message'] == CREATE_METADATA_PROFILE_SUCCESS_MSG % metadata_profile_name
+
+def delete_and_create_metric_profile():
+    metric_profile_dir = get_metric_profile_dir()
+
+    metric_profile_json_file = metric_profile_dir / 'resource_optimization_local_monitoring.json'
+    json_data = json.load(open(metric_profile_json_file))
+    metric_profile_name = json_data['metadata']['name']
+
+    response = delete_metric_profile(metric_profile_json_file)
+    print("delete metric profile = ", response.status_code)
+
+    # Create metric profile using the specified json
+    response = create_metric_profile(metric_profile_json_file)
+
+    data = response.json()
+    print(data['message'])
+
+    assert response.status_code == SUCCESS_STATUS_CODE
+    assert data['status'] == SUCCESS_STATUS
+    assert data['message'] == CREATE_METRIC_PROFILE_SUCCESS_MSG % metric_profile_name

--- a/tests/scripts/helpers/utils.py
+++ b/tests/scripts/helpers/utils.py
@@ -256,6 +256,8 @@ update_results_test_data = {
 import_metadata_test_data = {
     "version": "v1.0",
     "datasource_name": "prometheus-1",
+    "metadata_profile": "cluster-metadata-local-monitoring",
+    "measurement_duration": "15min"
 }
 
 test_type = {"blank": "", "null": "null", "invalid": "xyz"}
@@ -288,6 +290,10 @@ def generate_test_data(csvfile, test_data, api_name):
                 test_name = t + "_" + key
                 status_code = 400
                 if api_name == "create_exp" and (test_name == "invalid_experiment_name" or test_name == "invalid_cluster_name"):
+                    status_code = 201
+
+                if api_name == "import_metadata" and (test_name == "invalid_version" or test_name == "blank_version" or
+                test_name == "invalid_measurement_duration" or test_name == "blank_measurement_duration" or test_name == "null_measurement_duration"):
                     status_code = 201
 
                 data.append(test_name)

--- a/tests/scripts/local_monitoring_tests/Local_monitoring_tests.md
+++ b/tests/scripts/local_monitoring_tests/Local_monitoring_tests.md
@@ -116,6 +116,7 @@ Here are the test scenarios:
 The above tests are developed using pytest framework and the tests are run using shell script wrapper that does the following:
 - Deploys kruize in non-CRD mode using the [deploy script](https://github.com/kruize/autotune/blob/master/deploy.sh) from the autotune repo
 - Creates a resource optimization metric profile using the [createMetricProfile API](/design/MetricProfileAPI.md)
+- Creates cluster metadata profile using the [createMetadataProfile API](/design/MetadataProfileAPI.md)
 - Runs the above tests using pytest
 
 ### **Bulk API tests**
@@ -176,7 +177,8 @@ To run only the sanity local monitoring tests,
 Local monitoring tests can also be run without using the test_autotune.sh. To do this, follow the below steps:
 
 - Deploy Kruize using the deploy.sh from the kruize autotune repo
-- Create the performance profile by using the [createPerformanceProfile API](/design/PerformanceProfileAPI.md)
+- Create the metric profile by using the [createMetricProfile API](/design/MetricProfileAPI.md)
+- Create the metadata profile by using the [createMetadataProfile API](/design/MetadataProfileAPI.md)
 - cd <KRUIZE_REPO>/tests/scripts/local_monitoring_tests
 - python3 -m pip install --user -r requirements.txt
 - cd rest_apis

--- a/tests/scripts/local_monitoring_tests/json_files/bulk_input.json
+++ b/tests/scripts/local_monitoring_tests/json_files/bulk_input.json
@@ -13,5 +13,7 @@
       "labels": {}
     }
   },
-  "datasource": "thanos"
+  "datasource": "thanos",
+  "metadata_profile": "cluster-metadata-local-monitoring",
+  "measurement_duration": "15min"
 }

--- a/tests/scripts/local_monitoring_tests/json_files/bulk_input_timerange.json
+++ b/tests/scripts/local_monitoring_tests/json_files/bulk_input_timerange.json
@@ -17,5 +17,7 @@
   "time_range": {
 	"start": "2025-01-03T00:00:00.000Z",
 	"end": "2025-01-04T00:00:00.000Z"
-  }
+  },
+  "metadata_profile": "cluster-metadata-local-monitoring",
+  "measurement_duration": "15min"
 }

--- a/tests/scripts/local_monitoring_tests/json_files/import_metadata.json
+++ b/tests/scripts/local_monitoring_tests/json_files/import_metadata.json
@@ -1,5 +1,7 @@
 {
   "version": "v1.0",
-  "datasource_name": "prometheus-1"
+  "datasource_name": "prometheus-1",
+  "metadata_profile": "cluster-metadata-local-monitoring",
+  "measurement_duration": "15min"
 }
 

--- a/tests/scripts/local_monitoring_tests/json_files/import_metadata_mandatory.json
+++ b/tests/scripts/local_monitoring_tests/json_files/import_metadata_mandatory.json
@@ -1,4 +1,5 @@
 {
   "version": "v1.0",
-  "datasource_name": "prometheus-1"
+  "datasource_name": "prometheus-1",
+  "metadata_profile": "cluster-metadata-local-monitoring"
 }

--- a/tests/scripts/local_monitoring_tests/json_files/import_metadata_template.json
+++ b/tests/scripts/local_monitoring_tests/json_files/import_metadata_template.json
@@ -1,4 +1,6 @@
 {
   "version": "{{version}}",
-  "datasource_name": "{{datasource_name}}"
+  "datasource_name": "{{datasource_name}}",
+  "metadata_profile": "{{metadata_profile}}",
+  "measurement_duration": "{{measurement_duration}}"
 }

--- a/tests/scripts/local_monitoring_tests/json_files/thanos_import_metadata.json
+++ b/tests/scripts/local_monitoring_tests/json_files/thanos_import_metadata.json
@@ -1,4 +1,6 @@
 {
   "version": "v1.0",
-  "datasource_name": "thanos"
+  "datasource_name": "thanos",
+  "metadata_profile": "cluster-metadata-local-monitoring",
+  "measurement_duration": "15min"
 }

--- a/tests/scripts/local_monitoring_tests/rest_apis/test_bulkAPI.py
+++ b/tests/scripts/local_monitoring_tests/rest_apis/test_bulkAPI.py
@@ -62,6 +62,8 @@ def test_bulk_post_request(cluster_type, bulk_request_payload, expected_job_id_p
     form_kruize_url(cluster_type)
     URL = get_kruize_url()
 
+    delete_and_create_metric_profile()
+
     # list and validate default metric profile
     metric_profile_input_json_file = metric_profile_dir / 'resource_optimization_local_monitoring.json'
     json_data = json.load(open(metric_profile_input_json_file))
@@ -74,6 +76,8 @@ def test_bulk_post_request(cluster_type, bulk_request_payload, expected_job_id_p
 
     errorMsg = validate_list_metric_profiles_json(metric_profile_json, list_metric_profiles_schema)
     assert errorMsg == ""
+
+    delete_and_create_metadata_profile()
 
     # list and validate default metadata profile
     metadata_profile_input_json_file = metadata_profile_dir / 'bulk_cluster_metadata_local_monitoring.json'

--- a/tests/scripts/local_monitoring_tests/rest_apis/test_import_metadata.py
+++ b/tests/scripts/local_monitoring_tests/rest_apis/test_import_metadata.py
@@ -27,7 +27,8 @@ from jinja2 import Environment, FileSystemLoader
 
 mandatory_fields = [
     ("version", ERROR_STATUS_CODE, ERROR_STATUS),
-    ("datasource_name", ERROR_STATUS_CODE, ERROR_STATUS)
+    ("datasource_name", ERROR_STATUS_CODE, ERROR_STATUS),
+    ("metadata_profile", ERROR_STATUS_CODE, ERROR_STATUS)
 ]
 
 csvfile = "/tmp/import_metadata_test_data.csv"
@@ -41,6 +42,8 @@ def test_import_metadata(cluster_type):
     input_json_file = "../json_files/import_metadata.json"
 
     form_kruize_url(cluster_type)
+
+    delete_and_create_metadata_profile()
 
     response = delete_metadata(input_json_file)
     print("delete metadata = ", response.status_code)
@@ -59,9 +62,9 @@ def test_import_metadata(cluster_type):
 
 @pytest.mark.negative
 @pytest.mark.parametrize(
-    "test_name, expected_status_code, version, datasource_name",
+    "test_name, expected_status_code, version, datasource_name, metadata_profile, measurement_duration",
     generate_test_data(csvfile, import_metadata_test_data, "import_metadata"))
-def test_import_metadata_invalid_test(test_name, expected_status_code, version, datasource_name, cluster_type):
+def test_import_metadata_invalid_test(test_name, expected_status_code, version, datasource_name, metadata_profile, measurement_duration, cluster_type):
     """
     Test Description: This test validates the response status code of POST dsmtedata API against
     invalid input (blank, null, empty) for the json parameters.
@@ -74,6 +77,8 @@ def test_import_metadata_invalid_test(test_name, expected_status_code, version, 
     print("tmp_json_file = ", tmp_json_file)
 
     form_kruize_url(cluster_type)
+
+    delete_and_create_metadata_profile()
 
     environment = Environment(loader=FileSystemLoader("../json_files/"))
     template = environment.get_template("import_metadata_template.json")
@@ -89,6 +94,8 @@ def test_import_metadata_invalid_test(test_name, expected_status_code, version, 
     content = template.render(
         version=version,
         datasource_name=datasource_name,
+        metadata_profile=metadata_profile,
+        measurement_duration=measurement_duration
     )
     with open(tmp_json_file, mode="w", encoding="utf-8") as message:
         message.write(content)
@@ -112,6 +119,7 @@ def test_import_metadata_invalid_test(test_name, expected_status_code, version, 
 def test_import_metadata_mandatory_fields(cluster_type, field, expected_status_code, expected_status):
     form_kruize_url(cluster_type)
 
+    delete_and_create_metadata_profile()
     # Import metadata using the specified json
     json_file = "/tmp/import_metadata.json"
     input_json_file = "../json_files/import_metadata_mandatory.json"
@@ -158,6 +166,8 @@ def test_repeated_metadata_import(cluster_type):
     print("datasource_name = ", datasource_name)
 
     form_kruize_url(cluster_type)
+
+    delete_and_create_metadata_profile()
 
     response = delete_metadata(input_json_file)
     print("delete metadata = ", response.status_code)
@@ -243,6 +253,8 @@ def test_repeated_metadata_import_without_datasource_connection(cluster_type):
     print("datasource_name = ", datasource_name)
 
     form_kruize_url(cluster_type)
+
+    delete_and_create_metadata_profile()
 
     response = delete_metadata(input_json_file)
     print("delete metadata = ", response.status_code)

--- a/tests/scripts/local_monitoring_tests/rest_apis/test_namespace_reco_e2e_workflow.py
+++ b/tests/scripts/local_monitoring_tests/rest_apis/test_namespace_reco_e2e_workflow.py
@@ -45,8 +45,11 @@ from helpers.list_reco_json_local_monitoring_schema import *
 from helpers.list_reco_json_validate import *
 from helpers.import_metadata_json_validate import *
 from jinja2 import Environment, FileSystemLoader
+from helpers.list_metadata_profiles_validate import *
+from helpers.list_metadata_profiles_schema import *
 
 metric_profile_dir = get_metric_profile_dir()
+metadata_profile_dir = get_metadata_profile_dir()
 
 
 @pytest.mark.test_e2e
@@ -77,6 +80,34 @@ def test_list_recommendations_namespace_exps(cluster_type):
 
     # Validate the json against the json schema
     errorMsg = validate_list_datasources_json(list_datasources_json, list_datasources_json_schema)
+    assert errorMsg == ""
+
+    # Install metadata profile
+    metadata_profile_json_file = metadata_profile_dir / 'bulk_cluster_metadata_local_monitoring.json'
+    json_data = json.load(open(metadata_profile_json_file))
+    metadata_profile_name = json_data['metadata']['name']
+
+    response = delete_metadata_profile(metadata_profile_name)
+    print("delete metadata profile = ", response.status_code)
+
+    # Create metadata profile using the specified json
+    response = create_metadata_profile(metadata_profile_json_file)
+
+    data = response.json()
+    print(data['message'])
+
+    assert response.status_code == SUCCESS_STATUS_CODE
+    assert data['status'] == SUCCESS_STATUS
+
+    assert data['message'] == CREATE_METADATA_PROFILE_SUCCESS_MSG % metadata_profile_name
+
+    response = list_metadata_profiles(name=metadata_profile_name, logging=False)
+    metadata_profile_json = response.json()
+
+    assert response.status_code == SUCCESS_200_STATUS_CODE
+
+    # Validate the json against the json schema
+    errorMsg = validate_list_metadata_profiles_json(metadata_profile_json, list_metadata_profiles_schema)
     assert errorMsg == ""
 
 


### PR DESCRIPTION
## Description

This PR has following changes:
- Updates `dsmetadata` and `bulk` API input JSONs in local monitoring adding new `metadata_profile` field
- Updates documentation to include `metadata_profile` field

Note: Has dependency on PR #1444 to be merged first.


### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes
- [x] Tests update

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite: Local monitoring 

**Test Configuration**
* Kubernetes clusters tested on: Openshift

## Checklist :dart:

- [x] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [x] Documentation updated
- [x] Tests added or updated

## Additional information

Test results: 
[PR_1541_local_monitoring_tests.zip](https://github.com/user-attachments/files/19342030/PR_1541_local_monitoring_tests.zip)

docker image: `quay.io/shbirada/integrate_metadata_api:v1`
