### PR TITLE
Restore local flag check

### DIFF
--- a/src/main/java/com/autotune/Autotune.java
+++ b/src/main/java/com/autotune/Autotune.java
@@ -124,44 +124,45 @@ public class Autotune {
             // Read and execute the DDLs here
             executeDDLs(AnalyzerConstants.ROS_DDL_SQL);
 
-            LOGGER.debug("Now running kruize local DDL's ");
-            executeDDLs(AnalyzerConstants.KRUIZE_LOCAL_DDL_SQL);
-            // load available datasources from db
-            loadDataSourcesFromDB();
+            if (KruizeDeploymentInfo.local == true) {
+                LOGGER.debug("Now running kruize local DDL's ");
+                executeDDLs(AnalyzerConstants.KRUIZE_LOCAL_DDL_SQL);
+                // load available datasources from db
+                loadDataSourcesFromDB();
 
-            // setting up DataSources
-            try {
-                setUpDataSources();
-            } catch (Exception e) {
-                LOGGER.error(DATASOURCE_CONNECTION_FAILED, e.getMessage());
-            }
-
-            // checking available DataSources
-            checkAvailableDataSources();
-            // load available metric profiles from db
-            loadMetricProfilesFromDB();
-            if (KruizeDeploymentInfo.is_ros_enabled && KruizeDeploymentInfo.local) {
-                // setting up metric profile
+                // setting up DataSources
                 try {
-                    setUpMetricProfile();
+                    setUpDataSources();
                 } catch (Exception e) {
-                    LOGGER.error(SET_UP_DEFAULT_METRIC_PROFILE_ERROR, e.getMessage());
+                    LOGGER.error(DATASOURCE_CONNECTION_FAILED, e.getMessage());
                 }
-            }
 
-            // load available metadata profiles from db
-            loadMetadataProfilesFromDB();
-            if (KruizeDeploymentInfo.is_ros_enabled && KruizeDeploymentInfo.local) {
-                // setting up metadata profile
-                try {
-                    setUpMetadataProfile();
-                } catch (Exception e) {
-                    LOGGER.error(SET_UP_DEFAULT_METADATA_PROFILE_ERROR, e.getMessage());
+                // checking available DataSources
+                checkAvailableDataSources();
+                // load available metric profiles from db
+                loadMetricProfilesFromDB();
+                if (KruizeDeploymentInfo.is_ros_enabled) {
+                    // setting up metric profile
+                    try {
+                        setUpMetricProfile();
+                    } catch (Exception e) {
+                        LOGGER.error(SET_UP_DEFAULT_METRIC_PROFILE_ERROR, e.getMessage());
+                    }
                 }
-            }
-            // start updater service
-            startAutoscalerService();
 
+                // load available metadata profiles from db
+                loadMetadataProfilesFromDB();
+                if (KruizeDeploymentInfo.is_ros_enabled) {
+                    // setting up metadata profile
+                    try {
+                        setUpMetadataProfile();
+                    } catch (Exception e) {
+                        LOGGER.error(SET_UP_DEFAULT_METADATA_PROFILE_ERROR, e.getMessage());
+                    }
+                }
+                // start updater service
+                startAutoscalerService();
+            }
             // close the existing session factory before recreating
             KruizeHibernateUtil.closeSessionFactory();
             //Regenerate a Hibernate session following the creation of new tables

--- a/src/main/java/com/autotune/Autotune.java
+++ b/src/main/java/com/autotune/Autotune.java
@@ -140,7 +140,7 @@ public class Autotune {
             checkAvailableDataSources();
             // load available metric profiles from db
             loadMetricProfilesFromDB();
-            if (KruizeDeploymentInfo.is_ros_enabled) {
+            if (KruizeDeploymentInfo.is_ros_enabled && KruizeDeploymentInfo.local) {
                 // setting up metric profile
                 try {
                     setUpMetricProfile();
@@ -151,7 +151,7 @@ public class Autotune {
 
             // load available metadata profiles from db
             loadMetadataProfilesFromDB();
-            if (KruizeDeploymentInfo.is_ros_enabled) {
+            if (KruizeDeploymentInfo.is_ros_enabled && KruizeDeploymentInfo.local) {
                 // setting up metadata profile
                 try {
                     setUpMetadataProfile();


### PR DESCRIPTION
## Description

This PR restores check for `local` flag before executing `kruize_local_ddl.sql`. This is a temporary change required to avoid breaking ROS production and will be removed later.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: Openshift

## Checklist :dart:

- [x] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

docker image: `quay.io/shbirada/pr_1545:local_flag`
