### PR TITLE
[Bug fix] Fix load recommendations for local monitoring

### DIFF
--- a/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
@@ -1113,7 +1113,7 @@ public class ExperimentDAOImpl implements ExperimentDAO {
         String statusValue = "failure";
         Timer.Sample timerLoadAllRec = Timer.start(MetricsConfig.meterRegistry());
         try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
-            if (null != bulkJobId || bulkJobId != "") {
+            if (null != bulkJobId && !bulkJobId.isEmpty()) {
                 recommendationEntries = session.createQuery(SELECT_FROM_LM_RECOMMENDATIONS_BY_JOB_ID,
                                 KruizeLMRecommendationEntry.class)
                         .setParameter(JOB_ID, bulkJobId)

--- a/tests/scripts/local_monitoring_tests/fault_tolerant_test/kruize_pod_restart_test.py
+++ b/tests/scripts/local_monitoring_tests/fault_tolerant_test/kruize_pod_restart_test.py
@@ -109,7 +109,7 @@ def main(argv):
     # Fetch listExperiments
     list_exp_json_file_before = list_exp_json_dir + "/list_exp_json_before.json"
     # assign params to be passed in listExp
-    results = "true"
+    results = "false"
     recommendations = "true"
     latest = "false"
     experiment_name = None
@@ -181,7 +181,7 @@ def main(argv):
 
     # Fetch listExperiments
     list_exp_json_file_after = list_exp_json_dir + "/list_exp_json_after.json"
-    results = "true"
+    results = "false"
     recommendations = "true"
     latest = "false"
     experiment_name = None


### PR DESCRIPTION
## Description

This PR fixes the conditional check for  `bulkJobId` used for loading all local monitoring recommendations by `/listExperiments` API

- Sets `results="false"` in local monitoring fault tolerant tests as `Results` are not supported in local monitoring 

Fixes #1552 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [x] Functional testsuite: Tested with local monitoring, fault tolerant tests

**Test Configuration**
* Kubernetes clusters tested on: Openshift

## Checklist :dart:

- [x] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

docker image: `quay.io/shbirada/fix-recomm:v1`
