### PR TITLE
Fix the inter-leaving of kafka messages in different topics

### DIFF
--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -371,7 +371,7 @@ spec:
             - name: KAFKA_TOPICS
               value: "recommendations-topic,error-topic,summary-topic"
             - name: KAFKA_RESPONSE_FILTER_INCLUDE
-              value: "summary"
+              value: "experiments|status|apis|recommendations|response|status_history"
             - name: KAFKA_RESPONSE_FILTER_EXCLUDE
               value: ""
           resources:

--- a/src/main/java/com/autotune/analyzer/workerimpl/KruizeKafkaManager.java
+++ b/src/main/java/com/autotune/analyzer/workerimpl/KruizeKafkaManager.java
@@ -82,7 +82,10 @@ public class KruizeKafkaManager {
             }
             String kafkaMessage = BulkService.filterJson(jobData, kafkaIncludeFilter, kafkaExcludeFilter, experimentName);
             LOGGER.debug("Publishing Kafka Message for experiment {} in topic : {}", experimentName, topic);
-            publish(new KruizeKafka(topic, kafkaMessage));
+            // synchronize the publish call to avoid inter-leaving of messages
+            synchronized (this) {
+                publish(new KruizeKafka(topic, kafkaMessage));
+            }
             experiment.setStatus(KruizeConstants.KRUIZE_BULK_API.NotificationConstants.Status.PUBLISHED);
         } catch (Exception e) {
             LOGGER.error(e.getMessage());


### PR DESCRIPTION
## Description

During Kafka demo runs, we observed that messages were interleaved between `recommendations-topic` and `summary-topic`. This PR resolves the issue by ensuring that each thread correctly handles the topic variable, preventing unintended cross-publishing.

- Also, default value of the `KAFKA_RESPONSE_FILTER_INCLUDE` is changed from `summary` to actual recommendations response

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
