### PR TITLE
Update Ubuntu version in GitHub actions

### DIFF
--- a/.github/workflows/get-pr-number.yaml
+++ b/.github/workflows/get-pr-number.yaml
@@ -8,7 +8,7 @@ on:
    
 jobs:
   get_pr_number:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       output1: ${{ steps.pr.outputs.pr_number }}
     steps:

--- a/.github/workflows/rm-release-test.yaml
+++ b/.github/workflows/rm-release-test.yaml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.3.0
+        uses: manusa/actions-setup-minikube@v2.13.1
         with:
-          minikube version: 'v1.16.0'
-          kubernetes version: 'v1.19.2'
+          minikube version: 'v1.35.0'
+          kubernetes version: 'v1.32.0'
       - uses: actions/checkout@v4
         with:
           repository: kruize/autotune

--- a/.github/workflows/rm-release-test.yaml
+++ b/.github/workflows/rm-release-test.yaml
@@ -15,8 +15,8 @@ jobs:
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.13.1
         with:
-          minikube version: 'v1.35.0'
-          kubernetes version: 'v1.32.0'
+          minikube version: 'v1.31.2'
+          kubernetes version: 'v1.21.6'
       - uses: actions/checkout@v4
         with:
           repository: kruize/autotune

--- a/.github/workflows/rm-release-test.yaml
+++ b/.github/workflows/rm-release-test.yaml
@@ -9,7 +9,7 @@ on:
         
 jobs:
   releasetest:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Setup Minikube

--- a/.github/workflows/rm-release-test.yaml
+++ b/.github/workflows/rm-release-test.yaml
@@ -9,7 +9,7 @@ on:
         
 jobs:
   releasetest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Setup Minikube

--- a/.github/workflows/test-on-comment.yaml
+++ b/.github/workflows/test-on-comment.yaml
@@ -13,7 +13,7 @@ jobs:
       workflow_url: ${{ steps.workflow_run_info.outputs.url }}
       workflow_id: ${{ steps.workflow_run_info.outputs.id }}
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Get workflow run info
         run: |

--- a/.github/workflows/test-on-comment.yaml
+++ b/.github/workflows/test-on-comment.yaml
@@ -13,7 +13,7 @@ jobs:
       workflow_url: ${{ steps.workflow_run_info.outputs.url }}
       workflow_id: ${{ steps.workflow_run_info.outputs.id }}
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Get workflow run info
         run: |
@@ -98,7 +98,7 @@ jobs:
            retention-days: 2
 
   reportFailure:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [functest]
     if: failure()
     steps:
@@ -119,7 +119,7 @@ jobs:
           })
 
   reportCancelled:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [functest]
     if: cancelled()
     steps:
@@ -140,7 +140,7 @@ jobs:
           })
           
   reportSuccess:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [functest]
     if: success()
     steps:

--- a/.github/workflows/test-on-comment.yaml
+++ b/.github/workflows/test-on-comment.yaml
@@ -50,10 +50,10 @@ jobs:
           ref: refs/pull/${{ github.event.issue.number }}/head
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.3.0
+        uses: manusa/actions-setup-minikube@v2.13.1
         with:
-          minikube version: 'v1.16.0'
-          kubernetes version: 'v1.19.2'
+          minikube version: 'v1.35.0'
+          kubernetes version: 'v1.32.0'
 
       - name: Build crc
         run: |

--- a/.github/workflows/test-on-comment.yaml
+++ b/.github/workflows/test-on-comment.yaml
@@ -52,8 +52,8 @@ jobs:
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.13.1
         with:
-          minikube version: 'v1.35.0'
-          kubernetes version: 'v1.32.0'
+          minikube version: 'v1.31.2'
+          kubernetes version: 'v1.21.6'
 
       - name: Build crc
         run: |

--- a/.github/workflows/test-on-pr.yaml
+++ b/.github/workflows/test-on-pr.yaml
@@ -17,7 +17,7 @@ jobs:
   # This workflow builds the kruize image and runs an end-to-end test to validate the remote monitoring workflow
   build_crc:
     # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -77,7 +77,7 @@ jobs:
 
   test_crc_manifest_build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/test-on-pr.yaml
+++ b/.github/workflows/test-on-pr.yaml
@@ -27,8 +27,8 @@ jobs:
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.13.1
         with:
-          minikube version: 'v1.35.0'
-          kubernetes version: 'v1.32.0'
+          minikube version: 'v1.31.2'
+          kubernetes version: 'v1.21.6'
       - name: Build crc
         run: |
           echo Build crc
@@ -85,8 +85,8 @@ jobs:
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.13.1
         with:
-          minikube version: 'v1.35.0'
-          kubernetes version: 'v1.32.0'
+          minikube version: 'v1.31.2'
+          kubernetes version: 'v1.21.6'
 
       - name: Check cluster info on minikube
         run: |

--- a/.github/workflows/test-on-pr.yaml
+++ b/.github/workflows/test-on-pr.yaml
@@ -17,7 +17,7 @@ jobs:
   # This workflow builds the kruize image and runs an end-to-end test to validate the remote monitoring workflow
   build_crc:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -77,7 +77,7 @@ jobs:
 
   test_crc_manifest_build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/test-on-pr.yaml
+++ b/.github/workflows/test-on-pr.yaml
@@ -25,10 +25,10 @@ jobs:
         with:
           repository: kruize/autotune
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.3.0
+        uses: manusa/actions-setup-minikube@v2.13.1
         with:
-          minikube version: 'v1.16.0'
-          kubernetes version: 'v1.19.2'
+          minikube version: 'v1.35.0'
+          kubernetes version: 'v1.32.0'
       - name: Build crc
         run: |
           echo Build crc
@@ -83,10 +83,10 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.3.0
+        uses: manusa/actions-setup-minikube@v2.13.1
         with:
-          minikube version: 'v1.16.0'
-          kubernetes version: 'v1.19.2'
+          minikube version: 'v1.35.0'
+          kubernetes version: 'v1.32.0'
 
       - name: Check cluster info on minikube
         run: |

--- a/.github/workflows/test-on-push.yaml
+++ b/.github/workflows/test-on-push.yaml
@@ -22,7 +22,7 @@ jobs:
   build_job:
     needs: get_pr
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -50,7 +50,7 @@ jobs:
   deploy_crc:
     # The type of runner that the job will run on
     needs: [build_job, get_pr]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/test-on-push.yaml
+++ b/.github/workflows/test-on-push.yaml
@@ -59,10 +59,10 @@ jobs:
         run: |
            echo "PR_NUMBER=${{ needs.get_pr.outputs.pr_number }}" >> $GITHUB_ENV
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.3.0
+        uses: manusa/actions-setup-minikube@v2.13.1
         with:
-          minikube version: 'v1.16.0'
-          kubernetes version: 'v1.19.2'
+          minikube version: 'v1.35.0'
+          kubernetes version: 'v1.32.0'
       - name: Display cluster info
         run: |
           kubectl cluster-info

--- a/.github/workflows/test-on-push.yaml
+++ b/.github/workflows/test-on-push.yaml
@@ -61,8 +61,8 @@ jobs:
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.13.1
         with:
-          minikube version: 'v1.35.0'
-          kubernetes version: 'v1.32.0'
+          minikube version: 'v1.31.2'
+          kubernetes version: 'v1.21.6'
       - name: Display cluster info
         run: |
           kubectl cluster-info

--- a/.github/workflows/test-on-push.yaml
+++ b/.github/workflows/test-on-push.yaml
@@ -22,7 +22,7 @@ jobs:
   build_job:
     needs: get_pr
     # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -50,7 +50,7 @@ jobs:
   deploy_crc:
     # The type of runner that the job will run on
     needs: [build_job, get_pr]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it


### PR DESCRIPTION
## Description

This PR has the following changes:
-  Replaces deprecated `ubuntu-20.04` workflows image label with `ubuntu-24.04` in GitHub actions.
-  Updates minikube and kubernetes version: `minikube version: 'v1.31.2'` , `kubernetes version: 'v1.21.6'` (as the current versions work with Ubuntu 18 or 20 deprecated versions)

Issue [11101](https://github.com/actions/runner-images/issues/11101) describing the deprecation of Ubuntu 20.04 by 2025-04-15

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated
- [x] PR checks

## Additional information
.
