### PR TITLE
rateLimit changes

### DIFF
--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -20,7 +20,6 @@ package com.autotune.utils;
 import com.autotune.analyzer.kruizeObject.CreateExperimentConfigBean;
 import com.autotune.analyzer.serviceObjects.BulkJobStatus;
 import com.autotune.analyzer.utils.AnalyzerConstants;
-import org.apache.kafka.common.protocol.types.Field;
 
 import java.text.SimpleDateFormat;
 import java.util.Locale;
@@ -70,6 +69,7 @@ public class KruizeConstants {
         public static final String UPDATE_RECOMMENDATIONS_FAILURE = "UpdateRecommendations API failure response, experiment_name: %s and intervalEndTimeStr : %s";
         public static final String UPDATE_RECOMMENDATIONS_RESPONSE = "Update Recommendation API response: %s";
         public static final String UPDATE_RECOMMENDATIONS_FAILURE_MSG = "UpdateRecommendations API failed for experiment_name: %s and intervalEndTimeStr : %s due to %s";
+        public static final String RATE_LIMIT_EXCEEDED = "Rate limit exceeded. Server is busy. Please try again later.";
     }
 
     public static class MetricProfileAPIMessages {
@@ -638,16 +638,15 @@ public class KruizeConstants {
         }
 
         public static class RecommendationErrorMsgs {
-            private RecommendationErrorMsgs() {
-
-            }
-
             public static final String AMT_FORMAT_IS_NULL = "Invalid input: 'amount' and 'format' cannot be null";
             public static final String CPU_UNSUPPORTED_FORMAT = "Unsupported format for CPU conversion: ";
             public static final String ACCELERATOR_UNSUPPORTED_FORMAT = "Unsupported format for Accelerator conversion: ";
             public static final String INPUT_NULL = "Input object cannot be null";
             public static final String VALUE_NEGATIVE = "Value cannot be negative";
             public static final String INVALID_MEM_FORMAT = "Invalid format: Supported formats are bytes, KB, KiB, MB, MiB, GB, GiB, etc.";
+            private RecommendationErrorMsgs() {
+
+            }
         }
     }
 

--- a/src/main/java/com/autotune/utils/filter/QueueSizeRateLimitFilter.java
+++ b/src/main/java/com/autotune/utils/filter/QueueSizeRateLimitFilter.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2021 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package com.autotune.utils.filter;
+
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.concurrent.BlockingQueue;
+
+import static com.autotune.utils.KruizeConstants.APIMessages.RATE_LIMIT_EXCEEDED;
+import static com.autotune.utils.KruizeConstants.JSONKeys.ERROR;
+
+public class QueueSizeRateLimitFilter implements Filter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(QueueSizeRateLimitFilter.class);
+    private final BlockingQueue<Runnable> queue;
+
+    public QueueSizeRateLimitFilter(BlockingQueue<Runnable> queue) {
+        this.queue = queue;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        LOGGER.debug("QueueSizeRateLimitFilter doFilter queue size: {} ", queue.remainingCapacity());
+        if (queue.remainingCapacity() == 0) {
+            HttpServletResponse httpResp = (HttpServletResponse) response;
+            httpResp.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+            httpResp.setContentType("application/json");
+            JSONObject jsonObject = new JSONObject();
+            jsonObject.put(ERROR, RATE_LIMIT_EXCEEDED);
+            httpResp.getWriter().write(jsonObject.toString());
+            return;
+        }
+
+        chain.doFilter(request, response);
+    }
+}


### PR DESCRIPTION
## Description


This Jira ticket tracks the implementation of rate limiting mechanisms in Kruize to prevent API abuse and ensure system stability.

Objective:

Introduce rate limiting for Kruize APIs to:

Prevent overloading the backend services.

Protect shared resources from excessive requests.

Provide fair usage across clients.

Scope:

Add rate limiting at the API gateway or service level.

Define global and per-client rate limit thresholds (e.g., X requests per minute).

Respond with appropriate HTTP status codes (e.g., 429 Too Many Requests) when limits are exceeded.

Optional: Add retry-after header for clients.

Logging and monitoring of rate-limited events.

Configuration support via environment variables or config files.

Add unit and integration tests to validate rate limiting behavior.

Out of Scope (for now):

Dynamic quota management.

Per-user authentication-based throttling (unless already available).

Acceptance Criteria:

APIs enforce the configured request limits.

Clients exceeding limits receive proper responses.

Rate limits are configurable without code changes.

No adverse impact on existing functionality.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
