### PR TITLE
Updated link to download maven

### DIFF
--- a/Dockerfile.autotune
+++ b/Dockerfile.autotune
@@ -25,7 +25,7 @@ RUN microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y jav
      && microdnf clean all 
 
 RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz https://apache.osuosl.org/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz https://dlcdn.apache.org/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz \
   && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
   && rm -f /tmp/apache-maven.tar.gz \
   && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn


### PR DESCRIPTION
## Description

Updated maven link as the previous link is down - https://apache.osuosl.org/maven/maven-3/

Fixes # (issue)

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Tested manually by building kruize docker image

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
