### PR TITLE
Add experiment_type for remote monitoring experiments

### DIFF
--- a/design/CreateExperiment.md
+++ b/design/CreateExperiment.md
@@ -7,6 +7,8 @@ tuned.
 
 * experiment_name \
   A unique string name is specified for identifying individual experiments.
+* experiment_type \
+  An optional string used to indicate whether the experiment is of type `namespace` or `container`. If no experiment type is specified, it will default to `container`.
 * deployment_name \
   Stay tuned
 * namespace \

--- a/design/KruizeLocalAPI.md
+++ b/design/KruizeLocalAPI.md
@@ -2685,7 +2685,7 @@ If no experiment type is specified, it will default to `container`.
   "kubernetes_objects": [
     {
         "namespaces": {
-            "namespace_name": "test-multiple-import"
+            "namespace": "test-multiple-import"
       }
     }
   ],
@@ -3993,7 +3993,7 @@ When `interval_end_time` is not specified, Kruize will determine the latest time
         "namespace": "default",
         "containers": [],
         "namespaces": {
-          "namespace_name": "default",
+          "namespace": "default",
           "recommendations": {
             "version": "1.0",
             "notifications": {

--- a/design/MonitoringModeAPI.md
+++ b/design/MonitoringModeAPI.md
@@ -117,6 +117,10 @@ or above the 98th percentile, and memory usage is at the 100th percentile.
 This is quick guide instructions to create experiments using input JSON as follows. For a more detailed guide,
 see [Create Experiment](/design/CreateExperiment.md)
 
+**Note :** The `experiment_type` field in the JSON is optional and can be used to
+indicate whether the experiment is of type `namespace` or `container`.
+If no experiment type is specified, it will default to `container`.
+
 **Request**
 `POST /createExperiment`
 
@@ -128,89 +132,6 @@ see [Create Experiment](/design/CreateExperiment.md)
 
 ### Example Request
 
-```json
-[
-  {
-    "version": "v2.0",
-    "experiment_name": "quarkus-resteasy-autotune-min-http-response-time-db",
-    "cluster_name": "cluster-one-division-bell",
-    "performance_profile": "resource-optimization-openshift",
-    "mode": "monitor",
-    "target_cluster": "remote",
-    "kubernetes_objects": [
-      {
-        "type": "deployment",
-        "name": "tfb-qrh-deployment",
-        "namespace": "default",
-        "containers": [
-          {
-            "container_image_name": "kruize/tfb-db:1.15",
-            "container_name": "tfb-server-0"
-          },
-          {
-            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
-            "container_name": "tfb-server-1"
-          }
-        ]
-      }
-    ],
-    "trial_settings": {
-      "measurement_duration": "15min"
-    },
-    "recommendation_settings": {
-      "threshold": "0.1"
-    }
-  }
-]
-```
-
-</details>
-
-**Request with `experiment_type` field**
-
-The `experiment_type` field in the JSON is optional and can be used to
-indicate whether the experiment is of type `namespace` or `container`.
-If no experiment type is specified, it will default to `container`.
-
-<details>
-  <summary><b>Example Request with experiment_type - `namespace`</b></summary>
-  The `experiment_type` field in the JSON is optional and can be used to 
-indicate whether the experiment is of type `namespace` or `container`. 
-If no experiment type is specified, it will default to `container`.
-
-### EXAMPLE REQUEST
-```json
-[
-  {
-    "version": "v2.0",
-    "experiment_name": "namespace-experiment-demo",
-    "cluster_name": "cluster-one-division-bell",
-    "performance_profile": "resource-optimization-openshift",
-    "mode": "monitor",
-    "target_cluster": "remote",
-    "experiment_type": "namespace",
-    "kubernetes_objects": [
-      {
-          "namespaces": {
-              "namespace": "namespace-demo"
-        }
-      }
-    ],
-    "trial_settings": {
-      "measurement_duration": "15min"
-    },
-    "recommendation_settings": {
-      "threshold": "0.1"
-    }
-  }
-]
-```
-</details>
-
-<details>
-  <summary><b>Example Request with experiment_type - `container`</b></summary>
-
-### EXAMPLE REQUEST
 ```json
 [
   {
@@ -247,7 +168,9 @@ If no experiment type is specified, it will default to `container`.
   }
 ]
 ```
+
 </details>
+
 
 **Response**
 

--- a/design/MonitoringModeAPI.md
+++ b/design/MonitoringModeAPI.md
@@ -192,7 +192,7 @@ If no experiment type is specified, it will default to `container`.
     "kubernetes_objects": [
       {
           "namespaces": {
-              "namespace_name": "namespace-demo"
+              "namespace": "namespace-demo"
         }
       }
     ],

--- a/design/MonitoringModeAPI.md
+++ b/design/MonitoringModeAPI.md
@@ -166,6 +166,88 @@ see [Create Experiment](/design/CreateExperiment.md)
 
 </details>
 
+**Request with `experiment_type` field**
+
+The `experiment_type` field in the JSON is optional and can be used to
+indicate whether the experiment is of type `namespace` or `container`.
+If no experiment type is specified, it will default to `container`.
+
+<details>
+  <summary><b>Example Request with experiment_type - `namespace`</b></summary>
+  The `experiment_type` field in the JSON is optional and can be used to 
+indicate whether the experiment is of type `namespace` or `container`. 
+If no experiment type is specified, it will default to `container`.
+
+### EXAMPLE REQUEST
+```json
+[
+  {
+    "version": "v2.0",
+    "experiment_name": "namespace-experiment-demo",
+    "cluster_name": "cluster-one-division-bell",
+    "performance_profile": "resource-optimization-openshift",
+    "mode": "monitor",
+    "target_cluster": "remote",
+    "experiment_type": "namespace",
+    "kubernetes_objects": [
+      {
+          "namespaces": {
+              "namespace_name": "namespace-demo"
+        }
+      }
+    ],
+    "trial_settings": {
+      "measurement_duration": "15min"
+    },
+    "recommendation_settings": {
+      "threshold": "0.1"
+    }
+  }
+]
+```
+</details>
+
+<details>
+  <summary><b>Example Request with experiment_type - `container`</b></summary>
+
+### EXAMPLE REQUEST
+```json
+[
+  {
+    "version": "v2.0",
+    "experiment_name": "quarkus-resteasy-autotune-min-http-response-time-db",
+    "cluster_name": "cluster-one-division-bell",
+    "performance_profile": "resource-optimization-openshift",
+    "mode": "monitor",
+    "target_cluster": "remote",
+    "experiment_type": "container",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0"
+          },
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1"
+          }
+        ]
+      }
+    ],
+    "trial_settings": {
+      "measurement_duration": "15min"
+    },
+    "recommendation_settings": {
+      "threshold": "0.1"
+    }
+  }
+]
+```
+</details>
 
 **Response**
 
@@ -597,7 +679,7 @@ The acceptable formats are `Bytes, bytes, KiB, MiB, GiB, TiB, PiB, EiB, Ki, Mi, 
 
 `GET /listExperiments`
 
-`curl -H 'Accept: application/json' http://<URL>:<PORT>/listExperiments?experiment_name=<experiment_name>`
+`curl -H 'Accept: application/json' http://<URL>:<PORT>/listExperiments?rm=true&experiment_name=<experiment_name>`
 
 Returns the experiment details of the specified experiment
 <br><br><br>
@@ -605,7 +687,7 @@ Returns the experiment details of the specified experiment
 
 `GET /listExperiments`
 
-`curl -H 'Accept: application/json' http://<URL>:<PORT>/listExperiments?results=true`
+`curl -H 'Accept: application/json' http://<URL>:<PORT>/listExperiments?rm=true&results=true`
 
 Returns the latest result of all the experiments
 
@@ -625,6 +707,7 @@ Returns the latest result of all the experiments
     "experiment_id": "f0007796e65c999d843bebd447c2fbaa6aaf9127c614da55e333cd6bdb628a74",
     "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db_0",
     "cluster_name": "cluster-one-division-bell",
+    "experiment_type": "container",
     "mode": "monitor",
     "target_cluster": "remote",
     "status": "IN_PROGRESS",
@@ -760,6 +843,7 @@ Returns the latest result of all the experiments
     "experiment_id": "ab0a31a522cebdde52561482300d078ed1448fa7b75834fa216677d1d9d5cda6",
     "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db_1",
     "cluster_name": "cluster-one-division-bell",
+    "experiment_type": "container",
     "mode": "monitor",
     "target_cluster": "remote",
     "status": "IN_PROGRESS",
@@ -810,7 +894,7 @@ Returns the latest result of all the experiments
 
 `GET /listExperiments`
 
-`curl -H 'Accept: application/json' http://<URL>:<PORT>/listExperiments?results=true&experiment_name=<experiment_name>`
+`curl -H 'Accept: application/json' http://<URL>:<PORT>/listExperiments?rm=true&results=true&experiment_name=<experiment_name>`
 
 Returns the latest result of the specified experiment
 <br><br>
@@ -819,7 +903,7 @@ Returns the latest result of the specified experiment
 
 `GET /listExperiments`
 
-`curl -H 'Accept: application/json' http://<URL>:<PORT>/listExperiments?results=true&latest=false`
+`curl -H 'Accept: application/json' http://<URL>:<PORT>/listExperiments?rm=true&results=true&latest=false`
 
 Returns all the results of all the experiments
 
@@ -837,6 +921,7 @@ Returns all the results of all the experiments
     "experiment_id": "f0007796e65c999d843bebd447c2fbaa6aaf9127c614da55e333cd6bdb628a74",
     "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db_0",
     "cluster_name": "cluster-one-division-bell",
+    "experiment_type": "container",
     "mode": "monitor",
     "target_cluster": "remote",
     "status": "IN_PROGRESS",
@@ -1066,7 +1151,7 @@ Returns all the results of all the experiments
 
 `GET /listExperiments`
 
-`curl -H 'Accept: application/json' http://<URL>:<PORT>/listExperiments?results=true&latest=false&experiment_name=<experiment_name>`
+`curl -H 'Accept: application/json' http://<URL>:<PORT>/listExperiments?rm=true&results=true&latest=false&experiment_name=<experiment_name>`
 
 Returns all the results of the specific experiment
 <br><br>
@@ -1074,7 +1159,7 @@ Returns all the results of the specific experiment
 
 `GET /listExperiments`
 
-`curl -H 'Accept: application/json' http://<URL>:<PORT>/listExperiments?recommendations=true`
+`curl -H 'Accept: application/json' http://<URL>:<PORT>/listExperiments?rm=true&recommendations=true`
 
 Returns the latest recommendations of all the experiments
 
@@ -1092,6 +1177,7 @@ Returns the latest recommendations of all the experiments
     "experiment_id": "f0007796e65c999d843bebd447c2fbaa6aaf9127c614da55e333cd6bdb628a74",
     "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db_0",
     "cluster_name": "cluster-one-division-bell",
+    "experiment_type": "container",
     "mode": "monitor",
     "target_cluster": "remote",
     "status": "IN_PROGRESS",
@@ -1261,6 +1347,7 @@ Returns the latest recommendations of all the experiments
     "experiment_id": "ab0a31a522cebdde52561482300d078ed1448fa7b75834fa216677d1d9d5cda6",
     "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db_1",
     "cluster_name": "cluster-one-division-bell",
+    "experiment_type": "container",
     "mode": "monitor",
     "target_cluster": "remote",
     "status": "IN_PROGRESS",
@@ -1332,7 +1419,7 @@ Returns the latest recommendations of all the experiments
 
 `GET /listExperiments`
 
-`curl -H 'Accept: application/json' http://<URL>:<PORT>/listExperiments?recommendations=true&experiment_name=<experiment_name>`
+`curl -H 'Accept: application/json' http://<URL>:<PORT>/listExperiments?rm=true&recommendations=true&experiment_name=<experiment_name>`
 
 Returns the latest recommendations of the specified experiment with no results
 <br><br>
@@ -1341,7 +1428,7 @@ Returns the latest recommendations of the specified experiment with no results
 
 `GET /listExperiments`
 
-`curl -H 'Accept: application/json' http://<URL>:<PORT>/listExperiments?recommendations=true&latest=false`
+`curl -H 'Accept: application/json' http://<URL>:<PORT>/listExperiments?rm=true&recommendations=true&latest=false`
 
 Returns all the recommendations of all the experiments
 
@@ -1359,6 +1446,7 @@ Returns all the recommendations of all the experiments
     "experiment_id": "f0007796e65c999d843bebd447c2fbaa6aaf9127c614da55e333cd6bdb628a74",
     "experiment_name": "quarkus-resteasy-kruize-min-http-response-time-db_0",
     "cluster_name": "cluster-one-division-bell",
+    "experiment_type": "container",
     "mode": "monitor",
     "target_cluster": "remote",
     "status": "IN_PROGRESS",
@@ -1637,7 +1725,7 @@ Returns all the recommendations of all the experiments
 
 `GET /listExperiments`
 
-`curl -H 'Accept: application/json' http://<URL>:<PORT>/listExperiments?recommendations=true&latest=false&experiment_name=<experiment_name>`
+`curl -H 'Accept: application/json' http://<URL>:<PORT>/listExperiments?rm=true&recommendations=true&latest=false&experiment_name=<experiment_name>`
 
 Returns all the recommendations of the specified experiment
 <br><br>
@@ -1645,7 +1733,7 @@ Returns all the recommendations of the specified experiment
 
 `GET /listExperiments`
 
-`curl -H 'Accept: application/json' http://<URL>:<PORT>/listExperiments?recommendations=true&results=true`
+`curl -H 'Accept: application/json' http://<URL>:<PORT>/listExperiments?rm=true&recommendations=true&results=true`
 
 Returns the latest recommendations and the results of all the experiments.
 <br><br>
@@ -1653,7 +1741,7 @@ Returns the latest recommendations and the results of all the experiments.
 
 `GET /listExperiments`
 
-`curl -H 'Accept: application/json' http://<URL>:<PORT>/listExperiments?recommendations=true&results=true&latest=false`
+`curl -H 'Accept: application/json' http://<URL>:<PORT>/listExperiments?rm=true&recommendations=true&results=true&latest=false`
 
 Returns all the recommendations and all the results of all the experiments.
 <br><br>
@@ -1662,7 +1750,7 @@ name parameter**
 
 `GET /listExperiments`
 
-`curl -H 'Accept: application/json' http://<URL>:<PORT>/listExperiments?recommendations=true&results=true&latest=false`
+`curl -H 'Accept: application/json' http://<URL>:<PORT>/listExperiments?rm=true&recommendations=true&results=true&latest=false`
 
 Returns all the recommendations and all the results of the specified experiment.
 <br><br>

--- a/manifests/autotune/performance-profiles/resource_optimization_openshift.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_openshift.json
@@ -1,9 +1,5 @@
 {
-  "apiVersion": "recommender.com/v1",
-  "kind": "KruizePerformanceProfile",
-  "metadata": {
-    "name": "resource-optimization-openshift"
-  },
+  "name": "resource-optimization-openshift",
   "profile_version": 1,
   "k8s_type": "openshift",
   "slo": {
@@ -21,11 +17,11 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg(kube_pod_container_resource_requests{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", container=\"$CONTAINER_NAME$\", namespace=\"$NAMESPACE\", resource=\"cpu\", unit=\"core\"})"
+            "query": "avg by(container, namespace)(kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", container=\"$CONTAINER_NAME$\", namespace=\"$NAMESPACE\", resource=\"cpu\", unit=\"core\"})"
           },
           {
             "function": "sum",
-            "query": "sum(kube_pod_container_resource_requests{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", container=\"$CONTAINER_NAME$\", namespace=\"$NAMESPACE\", resource=\"cpu\", unit=\"core\"})"
+            "query": "sum by(container, namespace)(kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", container=\"$CONTAINER_NAME$\", namespace=\"$NAMESPACE\", resource=\"cpu\", unit=\"core\"})"
           }
         ]
       },
@@ -37,11 +33,11 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg(kube_pod_container_resource_limits{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", container=\"$CONTAINER_NAME$\", namespace=\"$NAMESPACE\", resource=\"cpu\", unit=\"core\"})"
+            "query": "avg by(container, namespace)(kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", container=\"$CONTAINER_NAME$\", namespace=\"$NAMESPACE\", resource=\"cpu\", unit=\"core\"})"
           },
           {
             "function": "sum",
-            "query": "sum(kube_pod_container_resource_limits{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", container=\"$CONTAINER_NAME$\", namespace=\"$NAMESPACE$\", resource=\"cpu\", unit=\"core\"})"
+            "query": "avg by(container, namespace)(kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", container=\"$CONTAINER_NAME$\", namespace=\"$NAMESPACE$\", resource=\"cpu\", unit=\"core\"})"
           }
         ]
       },
@@ -53,42 +49,42 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=\"$NAMESPACE$\", container=”$CONTAINER_NAME$”}[15m]))",
+            "query": "avg by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=”$CONTAINER_NAME$”}[15m]))",
             "versions": "<=4.8"
           },
           {
             "function": "avg",
-            "query": "avg(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=\"$NAMESPACE$\", container=”$CONTAINER_NAME$”}[15m]))",
+            "query": "avg by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=”$CONTAINER_NAME$”}[15m]))",
             "versions": ">4.9"
           },
           {
             "function": "min",
-            "query": "min(min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[15m]))",
-            "versions": "<4.8"
+            "query": "min by(container, namespace)(min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[15m]))",
+            "versions": "<=4.8"
           },
           {
             "function": "min",
-            "query": "min(min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[15m]))",
+            "query": "min by(container, namespace)(min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[15m]))",
             "versions": ">4.9"
           },
           {
             "function": "max",
-            "query": "max(max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[15m]))",
+            "query": "max by(container, namespace)(max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[15m]))",
             "versions": "<=4.8"
           },
           {
             "function": "max",
-            "query": "max(max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[15m]))",
+            "query": "max by(container, namespace)(max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[15m]))",
             "versions": ">4.9"
           },
           {
             "function": "sum",
-            "query": "sum(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[15m]))",
+            "query": "sum by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[15m]))",
             "versions": "<=4.8"
           },
           {
             "function": "sum",
-            "query": "sum(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[15m]))",
+            "query": "sum by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[15m]))",
             "versions": ">4.9"
           }
         ]
@@ -101,15 +97,15 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg(rate(container_cpu_cfs_throttled_seconds_total{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=\"$NAMESPACE$\", container=”$CONTAINER_NAME$”}[15m]))"
+            "query": "avg by(container,namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=”$CONTAINER_NAME$”}[15m]))"
           },
           {
             "function": "max",
-            "query": "max(rate(container_cpu_cfs_throttled_seconds_total{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=\"$NAMESPACE$\", container=”$CONTAINER_NAME$”}[15m]))"
+            "query": "max by(container,namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=”$CONTAINER_NAME$”}[15m]))"
           },
           {
             "function": "sum",
-            "query": "sum(rate(container_cpu_cfs_throttled_seconds_total{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=\"$NAMESPACE$\", container=”$CONTAINER_NAME$”}[15m]))"
+            "query": "sum by(container,namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=”$CONTAINER_NAME$”}[15m]))"
           }
         ]
       },
@@ -121,11 +117,11 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg(kube_pod_container_resource_requests{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", container=”$CONTAINER_NAME$”, namespace=”$NAMESPACE”, resource=\"memory\", unit=\"byte\"})"
+            "query": "avg by(container,namespace)(kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", container=”$CONTAINER_NAME$”, namespace=”$NAMESPACE”, resource=\"memory\", unit=\"byte\"})"
           },
           {
             "function": "sum",
-            "query": "sum(kube_pod_container_resource_requests{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", container=”$CONTAINER_NAME$”, namespace=”$NAMESPACE”, resource=\"memory\", unit=\"byte\"})"
+            "query": "sum by(container,namespace)(kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", container=”$CONTAINER_NAME$”, namespace=”$NAMESPACE”, resource=\"memory\", unit=\"byte\"})"
           }
         ]
       },
@@ -137,11 +133,11 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg(kube_pod_container_resource_limits{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", container=\"$CONTAINER_NAME$\", namespace=\"$NAMESPACE\", resource=\"memory\", unit=\"byte\"})"
+            "query": "avg by(container,namespace)(kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", container=\"$CONTAINER_NAME$\", namespace=\"$NAMESPACE\", resource=\"memory\", unit=\"byte\"})"
           },
           {
             "function": "sum",
-            "query": "sum(kube_pod_container_resource_limits{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", container=”$CONTAINER_NAME$”, namespace=”$NAMESPACE”, resource=\"memory\", unit=\"byte\"})"
+            "query": "sum by(container,namespace)(kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", container=”$CONTAINER_NAME$”, namespace=”$NAMESPACE”, resource=\"memory\", unit=\"byte\"})"
           }
         ]
       },
@@ -153,19 +149,19 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg(avg_over_time(container_memory_working_set_bytes{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=$NAMESPACE$, container=”$CONTAINER_NAME$”}[15m]))"
+            "query": "avg by(container,namespace)(avg_over_time(container_memory_working_set_bytes{container!=\"\", container!=\"POD\", pod!=\"\", namespace=$NAMESPACE$, container=”$CONTAINER_NAME$”}[15m]))"
           },
           {
             "function": "min",
-            "query": "min(min_over_time(container_memory_working_set_bytes{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=$NAMESPACE$, container=\"$CONTAINER_NAME$\"}[15m]))"
+            "query": "min by(container,namespace)(min_over_time(container_memory_working_set_bytes{container!=\"\", container!=\"POD\", pod!=\"\", namespace=$NAMESPACE$, container=\"$CONTAINER_NAME$\"}[15m]))"
           },
           {
             "function": "max",
-            "query": "max(max_over_time(container_memory_working_set_bytes{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=$NAMESPACE$, container=\"$CONTAINER_NAME$\"}[15m]))"
+            "query": "max by(container,namespace)(max_over_time(container_memory_working_set_bytes{container!=\"\", container!=\"POD\", pod!=\"\", namespace=$NAMESPACE$, container=\"$CONTAINER_NAME$\"}[15m]))"
           },
           {
             "function": "sum",
-            "query": "sum(avg_over_time(container_memory_working_set_bytes{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=$NAMESPACE$, container=\"$CONTAINER_NAME$\"}[15m]))"
+            "query": "sum by(container,namespace)(avg_over_time(container_memory_working_set_bytes{container!=\"\", container!=\"POD\", pod!=\"\", namespace=$NAMESPACE$, container=\"$CONTAINER_NAME$\"}[15m]))"
           }
         ]
       },
@@ -177,19 +173,19 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg(avg_over_time(container_memory_rss{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=$NAMESPACE$, container=”$CONTAINER_NAME$”}[15m]))"
+            "query": "avg by(container,namespace)(avg_over_time(container_memory_rss{container!=\"\", container!=\"POD\", pod!=\"\", namespace=$NAMESPACE$, container=”$CONTAINER_NAME$”}[15m]))"
           },
           {
             "function": "min",
-            "query": "min(min_over_time(container_memory_rss{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=$NAMESPACE$, container=\"$CONTAINER_NAME$\"}[15m]))"
+            "query": "min by(container,namespace)(min_over_time(container_memory_rss{container!=\"\", container!=\"POD\", pod!=\"\", namespace=$NAMESPACE$, container=\"$CONTAINER_NAME$\"}[15m]))"
           },
           {
             "function": "max",
-            "query": "max(max_over_time(container_memory_rss{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=$NAMESPACE$, container=\"$CONTAINER_NAME$\"}[15m]))"
+            "query": "max by(container,namespace)(max_over_time(container_memory_rss{container!=\"\", container!=\"POD\", pod!=\"\", namespace=$NAMESPACE$, container=\"$CONTAINER_NAME$\"}[15m]))"
           },
           {
             "function": "sum",
-            "query": "sum(avg_over_time(container_memory_rss{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=$NAMESPACE$, container=”$CONTAINER_NAME$”}[15m]))"
+            "query": "sum by(container,namespace)(avg_over_time(container_memory_rss{container!=\"\", container!=\"POD\", pod!=\"\", namespace=$NAMESPACE$, container=”$CONTAINER_NAME$”}[15m]))"
           }
         ]
       },
@@ -249,15 +245,15 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg_over_time(sum by(namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+            "query": "avg_over_time(sum by(namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[15m:])"
           },
           {
             "function": "max",
-            "query": "max_over_time(sum by(namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+            "query": "max_over_time(sum by(namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[15m:])"
           },
           {
             "function": "min",
-            "query": "min_over_time(sum by(namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+            "query": "min_over_time(sum by(namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[15m:])"
           }
         ]
       },
@@ -269,15 +265,15 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"}[5m]))[$MEASUREMENT_DURATION_IN_MIN$m:])"
+            "query": "avg_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"}[5m]))[15m:])"
           },
           {
             "function": "max",
-            "query": "max_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"}[5m]))[$MEASUREMENT_DURATION_IN_MIN$m:])"
+            "query": "max_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"}[5m]))[15m:])"
           },
           {
             "function": "min",
-            "query": "min_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"}[5m]))[$MEASUREMENT_DURATION_IN_MIN$m:])"
+            "query": "min_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"}[5m]))[15m:])"
           }
         ]
       },
@@ -289,15 +285,15 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+            "query": "avg_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[15m:])"
           },
           {
             "function": "max",
-            "query": "max_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+            "query": "max_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[15m:])"
           },
           {
             "function": "min",
-            "query": "min_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+            "query": "min_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[15m:])"
           }
         ]
       },
@@ -309,15 +305,15 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg_over_time(sum by(namespace) (container_memory_rss{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+            "query": "avg_over_time(sum by(namespace) (container_memory_rss{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[15m:])"
           },
           {
             "function": "max",
-            "query": "max_over_time(sum by(namespace) (container_memory_rss{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+            "query": "max_over_time(sum by(namespace) (container_memory_rss{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[15m:])"
           },
           {
             "function": "min",
-            "query": "min_over_time(sum by(namespace) (container_memory_rss{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+            "query": "min_over_time(sum by(namespace) (container_memory_rss{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[15m:])"
           }
         ]
       },
@@ -329,11 +325,11 @@
         "aggregation_functions": [
           {
             "function": "max",
-            "query": "max_over_time(sum by(namespace) ((kube_pod_info{namespace=\"$NAMESPACE$\"}))[$MEASUREMENT_DURATION_IN_MIN$m:])"
+            "query": "max_over_time(sum by(namespace) ((kube_pod_info{namespace=\"$NAMESPACE$\"}))[15m:])"
           },
           {
             "function": "avg",
-            "query": "avg_over_time(sum by(namespace) ((kube_pod_info{namespace=\"$NAMESPACE$\"}))[$MEASUREMENT_DURATION_IN_MIN$m:])"
+            "query": "avg_over_time(sum by(namespace) ((kube_pod_info{namespace=\"$NAMESPACE$\"}))[15m:])"
           }
         ]
       },
@@ -345,11 +341,11 @@
         "aggregation_functions": [
           {
             "function": "max",
-            "query": "max_over_time(sum by(namespace) ((kube_pod_status_phase{phase=\"Running\"}))[$MEASUREMENT_DURATION_IN_MIN$m:])"
+            "query": "max_over_time(sum by(namespace) ((kube_pod_status_phase{phase=\"Running\"}))[15m:])"
           },
           {
             "function": "avg",
-            "query": "avg_over_time(sum by(namespace) ((kube_pod_status_phase{phase=\"Running\"}))[$MEASUREMENT_DURATION_IN_MIN$m:])"
+            "query": "avg_over_time(sum by(namespace) ((kube_pod_status_phase{phase=\"Running\"}))[15m:])"
           }
         ]
       },

--- a/manifests/autotune/performance-profiles/resource_optimization_openshift.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_openshift.json
@@ -1,0 +1,370 @@
+{
+  "apiVersion": "recommender.com/v1",
+  "kind": "KruizePerformanceProfile",
+  "metadata": {
+    "name": "resource-optimization-openshift"
+  },
+  "profile_version": 1,
+  "k8s_type": "openshift",
+  "slo": {
+    "slo_class": "resource_usage",
+    "direction": "minimize",
+    "objective_function": {
+      "function_type": "source"
+    },
+    "function_variables": [
+      {
+        "name": "cpuRequest",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg(kube_pod_container_resource_requests{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", container=\"$CONTAINER_NAME$\", namespace=\"$NAMESPACE\", resource=\"cpu\", unit=\"core\"})"
+          },
+          {
+            "function": "sum",
+            "query": "sum(kube_pod_container_resource_requests{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", container=\"$CONTAINER_NAME$\", namespace=\"$NAMESPACE\", resource=\"cpu\", unit=\"core\"})"
+          }
+        ]
+      },
+      {
+        "name": "cpuLimit",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg(kube_pod_container_resource_limits{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", container=\"$CONTAINER_NAME$\", namespace=\"$NAMESPACE\", resource=\"cpu\", unit=\"core\"})"
+          },
+          {
+            "function": "sum",
+            "query": "sum(kube_pod_container_resource_limits{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", container=\"$CONTAINER_NAME$\", namespace=\"$NAMESPACE$\", resource=\"cpu\", unit=\"core\"})"
+          }
+        ]
+      },
+      {
+        "name": "cpuUsage",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=\"$NAMESPACE$\", container=”$CONTAINER_NAME$”}[15m]))",
+            "versions": "<=4.8"
+          },
+          {
+            "function": "avg",
+            "query": "avg(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=\"$NAMESPACE$\", container=”$CONTAINER_NAME$”}[15m]))",
+            "versions": ">4.9"
+          },
+          {
+            "function": "min",
+            "query": "min(min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[15m]))",
+            "versions": "<4.8"
+          },
+          {
+            "function": "min",
+            "query": "min(min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[15m]))",
+            "versions": ">4.9"
+          },
+          {
+            "function": "max",
+            "query": "max(max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[15m]))",
+            "versions": "<=4.8"
+          },
+          {
+            "function": "max",
+            "query": "max(max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[15m]))",
+            "versions": ">4.9"
+          },
+          {
+            "function": "sum",
+            "query": "sum(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[15m]))",
+            "versions": "<=4.8"
+          },
+          {
+            "function": "sum",
+            "query": "sum(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[15m]))",
+            "versions": ">4.9"
+          }
+        ]
+      },
+      {
+        "name": "cpuThrottle",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg(rate(container_cpu_cfs_throttled_seconds_total{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=\"$NAMESPACE$\", container=”$CONTAINER_NAME$”}[15m]))"
+          },
+          {
+            "function": "max",
+            "query": "max(rate(container_cpu_cfs_throttled_seconds_total{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=\"$NAMESPACE$\", container=”$CONTAINER_NAME$”}[15m]))"
+          },
+          {
+            "function": "sum",
+            "query": "sum(rate(container_cpu_cfs_throttled_seconds_total{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=\"$NAMESPACE$\", container=”$CONTAINER_NAME$”}[15m]))"
+          }
+        ]
+      },
+      {
+        "name": "memoryRequest",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg(kube_pod_container_resource_requests{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", container=”$CONTAINER_NAME$”, namespace=”$NAMESPACE”, resource=\"memory\", unit=\"byte\"})"
+          },
+          {
+            "function": "sum",
+            "query": "sum(kube_pod_container_resource_requests{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", container=”$CONTAINER_NAME$”, namespace=”$NAMESPACE”, resource=\"memory\", unit=\"byte\"})"
+          }
+        ]
+      },
+      {
+        "name": "memoryLimit",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg(kube_pod_container_resource_limits{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", container=\"$CONTAINER_NAME$\", namespace=\"$NAMESPACE\", resource=\"memory\", unit=\"byte\"})"
+          },
+          {
+            "function": "sum",
+            "query": "sum(kube_pod_container_resource_limits{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", container=”$CONTAINER_NAME$”, namespace=”$NAMESPACE”, resource=\"memory\", unit=\"byte\"})"
+          }
+        ]
+      },
+      {
+        "name": "memoryUsage",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg(avg_over_time(container_memory_working_set_bytes{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=$NAMESPACE$, container=”$CONTAINER_NAME$”}[15m]))"
+          },
+          {
+            "function": "min",
+            "query": "min(min_over_time(container_memory_working_set_bytes{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=$NAMESPACE$, container=\"$CONTAINER_NAME$\"}[15m]))"
+          },
+          {
+            "function": "max",
+            "query": "max(max_over_time(container_memory_working_set_bytes{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=$NAMESPACE$, container=\"$CONTAINER_NAME$\"}[15m]))"
+          },
+          {
+            "function": "sum",
+            "query": "sum(avg_over_time(container_memory_working_set_bytes{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=$NAMESPACE$, container=\"$CONTAINER_NAME$\"}[15m]))"
+          }
+        ]
+      },
+      {
+        "name": "memoryRSS",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg(avg_over_time(container_memory_rss{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=$NAMESPACE$, container=”$CONTAINER_NAME$”}[15m]))"
+          },
+          {
+            "function": "min",
+            "query": "min(min_over_time(container_memory_rss{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=$NAMESPACE$, container=\"$CONTAINER_NAME$\"}[15m]))"
+          },
+          {
+            "function": "max",
+            "query": "max(max_over_time(container_memory_rss{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=$NAMESPACE$, container=\"$CONTAINER_NAME$\"}[15m]))"
+          },
+          {
+            "function": "sum",
+            "query": "sum(avg_over_time(container_memory_rss{pod=~\"$DEPLOYMENT_NAME$-[^-]*-[^-]*$\", namespace=$NAMESPACE$, container=”$CONTAINER_NAME$”}[15m]))"
+          }
+        ]
+      },
+      {
+        "name": "namespaceCpuRequest",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "sum",
+            "query": "sum by (namespace) (kube_resourcequota{namespace=\"$NAMESPACE$\", resource=\"requests.cpu\", type=\"hard\"})"
+          }
+        ]
+      },
+      {
+        "name": "namespaceCpuLimit",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "sum",
+            "query": "sum by (namespace) (kube_resourcequota{namespace=\"$NAMESPACE$\", resource=\"limits.cpu\", type=\"hard\"})"
+          }
+        ]
+      },
+      {
+        "name": "namespaceMemoryRequest",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "sum",
+            "query": "sum by (namespace) (kube_resourcequota{namespace=\"$NAMESPACE$\", resource=\"requests.memory\", type=\"hard\"})"
+          }
+        ]
+      },
+      {
+        "name": "namespaceMemoryLimit",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "sum",
+            "query": "sum by (namespace) (kube_resourcequota{namespace=\"$NAMESPACE$\", resource=\"limits.memory\", type=\"hard\"})"
+          }
+        ]
+      },
+      {
+        "name": "namespaceCpuUsage",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg_over_time(sum by(namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          },
+          {
+            "function": "max",
+            "query": "max_over_time(sum by(namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          },
+          {
+            "function": "min",
+            "query": "min_over_time(sum by(namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          }
+        ]
+      },
+      {
+        "name": "namespaceCpuThrottle",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"}[5m]))[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          },
+          {
+            "function": "max",
+            "query": "max_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"}[5m]))[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          },
+          {
+            "function": "min",
+            "query": "min_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"}[5m]))[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          }
+        ]
+      },
+      {
+        "name": "namespaceMemoryUsage",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          },
+          {
+            "function": "max",
+            "query": "max_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          },
+          {
+            "function": "min",
+            "query": "min_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          }
+        ]
+      },
+      {
+        "name": "namespaceMemoryRSS",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg_over_time(sum by(namespace) (container_memory_rss{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          },
+          {
+            "function": "max",
+            "query": "max_over_time(sum by(namespace) (container_memory_rss{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          },
+          {
+            "function": "min",
+            "query": "min_over_time(sum by(namespace) (container_memory_rss{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          }
+        ]
+      },
+      {
+        "name": "namespaceTotalPods",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "max",
+            "query": "max_over_time(sum by(namespace) ((kube_pod_info{namespace=\"$NAMESPACE$\"}))[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          },
+          {
+            "function": "avg",
+            "query": "avg_over_time(sum by(namespace) ((kube_pod_info{namespace=\"$NAMESPACE$\"}))[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          }
+        ]
+      },
+      {
+        "name": "namespaceRunningPods",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "max",
+            "query": "max_over_time(sum by(namespace) ((kube_pod_status_phase{phase=\"Running\"}))[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          },
+          {
+            "function": "avg",
+            "query": "avg_over_time(sum by(namespace) ((kube_pod_status_phase{phase=\"Running\"}))[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          }
+        ]
+      },
+      {
+        "name": "namespaceMaxDate",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "max",
+            "query": "max(last_over_time(timestamp((sum by (namespace) (container_cpu_usage_seconds_total{namespace=\"$NAMESPACE$\"})) > 0 )[15d:]))"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/manifests/autotune/performance-profiles/resource_optimization_openshift.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_openshift.json
@@ -37,7 +37,7 @@
           },
           {
             "function": "sum",
-            "query": "avg by(container, namespace)(kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", container=\"$CONTAINER_NAME$\", namespace=\"$NAMESPACE$\", resource=\"cpu\", unit=\"core\"})"
+            "query": "sum by(container, namespace)(kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", container=\"$CONTAINER_NAME$\", namespace=\"$NAMESPACE$\", resource=\"cpu\", unit=\"core\"})"
           }
         ]
       },

--- a/manifests/autotune/performance-profiles/resource_optimization_openshift.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_openshift.yaml
@@ -209,3 +209,168 @@ slo:
     # Sum of memory RSS for a contianer in all pods of a deployment
     - function: sum
       query: 'sum(avg_over_time(container_memory_rss{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace=$NAMESPACE$, container=”$CONTAINER_NAME$”}[15m]))'
+
+    ## namespace related queries
+
+    # Namespace quota for CPU requests
+    # Show namespace quota for CPU requests in cores for a namespace
+  - name: namespaceCpuRequest
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "namespace"
+    aggregation_functions:
+    # sum of all cpu request quotas for a namespace in cores
+    - function: sum
+      query: 'sum by (namespace) (kube_resourcequota{namespace="$NAMESPACE$", resource="requests.cpu", type="hard"})'
+
+    # Namespace quota for CPU limits
+    # Show namespace quota for CPU limits in cores for a namespace
+  - name: namespaceCpuLimit
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "namespace"
+    aggregation_functions:
+    # sum of all cpu limits quotas for a namespace in cores
+    - function: sum
+      query: 'sum by (namespace) (kube_resourcequota{namespace="$NAMESPACE$", resource="limits.cpu", type="hard"})'
+
+
+    # Namespace quota for memory requests
+    # Show namespace quota for memory requests in bytes for a namespace
+  - name: namespaceMemoryRequest
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "namespace"
+    aggregation_functions:
+    # sum of all memory requests quotas for a namespace in bytes
+    - function: sum
+      query: 'sum by (namespace) (kube_resourcequota{namespace="$NAMESPACE$", resource="requests.memory", type="hard"})'
+
+
+    # Namespace quota for memory limits
+    # Show namespace quota for memory limits in bytes for a namespace
+  - name: namespaceMemoryLimit
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "namespace"
+    aggregation_functions:
+    # sum of all memory limits quotas for a namespace in bytes
+    - function: sum
+      query: 'sum by (namespace) (kube_resourcequota{namespace="$NAMESPACE$", resource="limits.memory", type="hard"})'
+
+
+    # Namespace CPU usage
+    # Show cpu usages in cores for a namespace
+  - name: namespaceCpuUsage
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "namespace"
+    aggregation_functions:
+    # average cpu usages in cores for a namespace
+    - function: avg
+      query: 'avg_over_time(sum by(namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+    # maximum cpu usages in cores for a namespace
+    - function: max
+      query: 'max_over_time(sum by(namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+    # minimum cpu usages in cores for a namespace
+    - function: min
+      query: 'min_over_time(sum by(namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+
+    # Namespace CPU Throttle
+    # Show cpu throttle in cores for a namespace
+  - name: namespaceCpuThrottle
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "namespace"
+    aggregation_functions:
+    # average cpu throttle in cores for a namespace
+    - function: avg
+      query: 'avg_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""}[5m]))[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+    # maximum cpu throttle in cores for a namespace
+    - function: max
+      query: 'max_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""}[5m]))[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+    # minimum cpu throttle in cores for a namespace
+    - function: min
+      query: 'min_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""}[5m]))[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+
+    # Namespace memory usage
+    # Show memory usages in bytes for a namespace
+  - name: namespaceMemoryUsage
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "namespace"
+    aggregation_functions:
+    # average memory usage in bytes for a namespace
+    - function: avg
+      query: 'avg_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+    # maximum memory usage in bytes for a namespace
+    - function: max
+      query: 'max_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+    # minimum memory usage in bytes for a namespace
+    - function: min
+      query: 'min_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+
+    # Namespace memory rss value
+    # Show memory rss in bytes for a namespace
+  - name: namespaceMemoryRSS
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "namespace"
+    aggregation_functions:
+    # average memory rss in bytes for a namespace
+    - function: avg
+      query: 'avg_over_time(sum by(namespace) (container_memory_rss{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+    # maximum memory rss in bytes for a namespace
+    - function: max
+      query: 'max_over_time(sum by(namespace) (container_memory_rss{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+    # minimum memory rss in bytes for a namespace
+    - function: min
+      query: 'min_over_time(sum by(namespace) (container_memory_rss{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+
+    # Show total pods in a namespace
+  - name: namespaceTotalPods
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "namespace"
+    aggregation_functions:
+    # maximum total pods in a namespace
+    - function: max
+      query: 'max_over_time(sum by(namespace) ((kube_pod_info{namespace="$NAMESPACE$"}))[$MEASUREMENT_DURATION_IN_MIN$m:])'
+    # average total pods in a namespace
+    - function: avg
+      query: 'avg_over_time(sum by(namespace) ((kube_pod_info{namespace="$NAMESPACE$"}))[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+
+    # Show total running pods in a namespace
+  - name: namespaceRunningPods
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "namespace"
+    aggregation_functions:
+    # maximum total pods in a namespace
+    - function: max
+      query: 'max_over_time(sum by(namespace) ((kube_pod_status_phase{phase="Running"}))[$MEASUREMENT_DURATION_IN_MIN$m:])'
+    # average total pods in a namespace
+    - function: avg
+      query: 'avg_over_time(sum by(namespace) ((kube_pod_status_phase{phase="Running"}))[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+    # Show last activity for a namespace
+  - name: namespaceMaxDate
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "namespace"
+    aggregation_functions:
+    - function: max
+      query: 'max(last_over_time(timestamp((sum by (namespace) (container_cpu_usage_seconds_total{namespace="$NAMESPACE$"})) > 0 )[15d:]))'

--- a/manifests/autotune/performance-profiles/resource_optimization_openshift.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_openshift.yaml
@@ -23,11 +23,11 @@ slo:
 
     aggregation_functions:
     - function: 'avg'
-      query: 'avg(kube_pod_container_resource_requests{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", container="$CONTAINER_NAME$", namespace="$NAMESPACE", resource="cpu", unit="core"})'
+      query: 'avg by(container, namespace)(kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
 
     # Show sum of cpu requests in bytes for a container in a deployment
     - function: 'sum'
-      query: 'sum(kube_pod_container_resource_requests{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", container="$CONTAINER_NAME$", namespace="$NAMESPACE", resource="cpu", unit="core"})'
+      query: 'sum by(container, namespace)(kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
 
 
   # CPU Limit
@@ -39,11 +39,11 @@ slo:
 
     aggregation_functions:
     - function: avg
-      query: 'avg(kube_pod_container_resource_limits{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", container="$CONTAINER_NAME$", namespace="$NAMESPACE", resource="cpu", unit="core"})'
+      query: 'avg by(container, namespace)(kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
 
     # Show sum of cpu limits in bytes for a container in a deployment
     - function: sum
-      query: 'sum(kube_pod_container_resource_limits{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", container="$CONTAINER_NAME$", namespace="$NAMESPACE$", resource="cpu", unit="core"})'
+      query: 'avg by(container, namespace)(kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
 
 
   # CPU Usage
@@ -65,45 +65,45 @@ slo:
     # For openshift versions <=4.8
     aggregation_functions:
     - function: avg
-      query: 'avg(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace="$NAMESPACE$", container=”$CONTAINER_NAME$”}[15m]))'
+      query: 'avg by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[15m]))'
       versions: "<=4.8"
 
     # For openshift versions >=4.9
     - function: avg
-      query: 'avg(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace="$NAMESPACE$", container=”$CONTAINER_NAME$”}[15m]))'
+      query: 'avg by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container=”$CONTAINER_NAME$”}[15m]))'
       versions: ">4.9"
 
     # Approx minimum CPU per container in a deployment
     # For openshift versions <=4.8
     - function: min
-      query: 'min(min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[15m]))'
+      query: 'min by(container, namespace)(min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[15m]))'
       versions: "<=4.8"
 
     # For openshift versions >=4.9
     - function: min
-      query: 'min(min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[15m]))'
+      query: 'min by(container, namespace)(min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[15m]))'
       versions: ">4.9"
 
     # Approx maximum CPU per container in a deployment
     # For openshift versions <=4.8
     - function: max
-      query: 'max(max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[15m]))'
+      query: 'max by(container, namespace)(max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[15m]))'
       versions: "<=4.8"
 
     # For openshift versions >=4.9
     - function: max
-      query: 'max(max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[15m]))'
+      query: 'max by(container, namespace)(max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[15m]))'
       versions: ">4.9"
 
     # Sum of CPU usage for a container in all pods of a deployment
     # For openshift versions <=4.8
     - function: sum
-      query: 'sum(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[15m]))'
+      query: 'sum by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[15m]))'
       versions: "<=4.8"
 
     # For openshift versions >=4.9
     - function: sum
-      query: 'sum(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[15m]))'
+      query: 'sum by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[15m]))'
       versions: ">4.9"
 
 
@@ -116,15 +116,15 @@ slo:
     aggregation_functions:
     # Average CPU throttling per container in a deployment
     - function: avg
-      query: 'avg(rate(container_cpu_cfs_throttled_seconds_total{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace="$NAMESPACE$", container=”$CONTAINER_NAME$”}[15m]))'
+      query: 'avg by(container, namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container=”$CONTAINER_NAME$”}[15m]))'
 
     # Maximum CPU throttling per container in a deployment
     - function: max
-      query: 'max(rate(container_cpu_cfs_throttled_seconds_total{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace="$NAMESPACE$", container=”$CONTAINER_NAME$”}[15m]))'
+      query: 'max by(container, namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container=”$CONTAINER_NAME$”}[15m]))'
 
     # Sum of CPU throttling for a container in all pods of a deployment
     - function: sum
-      query: 'sum(rate(container_cpu_cfs_throttled_seconds_total{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace="$NAMESPACE$", container=”$CONTAINER_NAME$”}[15m]))'
+      query: 'sum by(container, namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container=”$CONTAINER_NAME$”}[15m]))'
 
 
 
@@ -139,11 +139,11 @@ slo:
 
     aggregation_functions:
     - function: avg
-      query: 'avg(kube_pod_container_resource_requests{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", container=”$CONTAINER_NAME$”, namespace=”$NAMESPACE”, resource="memory", unit="byte"})'
+      query: 'avg by(container, namespace)(kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
 
     # Show sum of memory requests in bytes for a container in a deployment
     - function: sum
-      query: 'sum(kube_pod_container_resource_requests{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", container=”$CONTAINER_NAME$”, namespace=”$NAMESPACE”, resource="memory", unit="byte"})'
+      query: 'sum by(container, namespace)(kube_pod_container_resource_requests{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
 
 
   # Memory Limit
@@ -155,11 +155,11 @@ slo:
 
     aggregation_functions:
     - function: avg
-      query: 'avg(kube_pod_container_resource_limits{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", container="$CONTAINER_NAME$", namespace="$NAMESPACE", resource="memory", unit="byte"})'
+      query: 'avg by(container, namespace)(kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
 
     # Show sum of memory limits in bytes for a container in a deployment
     - function: sum
-      query: 'sum(kube_pod_container_resource_limits{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", container=”$CONTAINER_NAME$”, namespace=”$NAMESPACE”, resource="memory", unit="byte"})'
+      query: 'sum by(container, namespace)(kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="memory", unit="byte", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
 
 
   # Memory Usage
@@ -171,19 +171,19 @@ slo:
 
     aggregation_functions:
     - function: avg
-      query: 'avg(avg_over_time(container_memory_working_set_bytes{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace=$NAMESPACE$, container=”$CONTAINER_NAME$”}[15m]))'
+      query: 'avg by(container, namespace)(avg_over_time(container_memory_working_set_bytes{container!="", container!="POD", pod!="", namespace=$NAMESPACE$, container=”$CONTAINER_NAME$”}[15m]))'
 
     # Approx minimum memory per container in a deployment
     - function: min
-      query: 'min(min_over_time(container_memory_working_set_bytes{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace=$NAMESPACE$, container="$CONTAINER_NAME$"}[15m]))'
+      query: 'min by(container, namespace)(min_over_time(container_memory_working_set_bytes{container!="", container!="POD", pod!="", namespace=$NAMESPACE$, container="$CONTAINER_NAME$"}[15m]))'
 
     # Approx maximum memory per container in a deployment
     - function: max
-      query: 'max(max_over_time(container_memory_working_set_bytes{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace=$NAMESPACE$, container="$CONTAINER_NAME$"}[15m]))'
+      query: 'max by(container, namespace)(max_over_time(container_memory_working_set_bytes{container!="", container!="POD", pod!="", namespace=$NAMESPACE$, container="$CONTAINER_NAME$"}[15m]))'
 
     # Sum of memory usage for a contianer in all pods of a deployment
     - function: sum
-      query: 'sum(avg_over_time(container_memory_working_set_bytes{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace=$NAMESPACE$, container="$CONTAINER_NAME$"}[15m]))'
+      query: 'sum by(container, namespace)(avg_over_time(container_memory_working_set_bytes{container!="", container!="POD", pod!="", namespace=$NAMESPACE$, container="$CONTAINER_NAME$"}[15m]))'
 
 
   # 2.4 Memory RSS
@@ -195,20 +195,20 @@ slo:
     aggregation_functions:
     # Average memory RSS per container in a deployment
     - function: avg
-      query: 'avg(avg_over_time(container_memory_rss{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace=$NAMESPACE$, container=”$CONTAINER_NAME$”}[15m]))'
+      query: 'avg by(container, namespace)(avg_over_time(container_memory_rss{container!="", container!="POD", pod!="", namespace=$NAMESPACE$, container=”$CONTAINER_NAME$”}[15m]))'
 
     # Approx minimum memory RSS per container in a deployment
     - function: min
-      query: 'min(min_over_time(container_memory_rss{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace=$NAMESPACE$, container="$CONTAINER_NAME$"}[15m]))'
+      query: 'min by(container, namespace)(min_over_time(container_memory_rss{container!="", container!="POD", pod!="", namespace=$NAMESPACE$, container="$CONTAINER_NAME$"}[15m]))'
 
 
     # Approx maximum memory RSS per container in a deployment
     - function: max
-      query: 'max(max_over_time(container_memory_rss{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace=$NAMESPACE$, container="$CONTAINER_NAME$"}[15m]))'
+      query: 'max by(container, namespace)(max_over_time(container_memory_rss{container!="", container!="POD", pod!="", namespace=$NAMESPACE$, container="$CONTAINER_NAME$"}[15m]))'
 
     # Sum of memory RSS for a contianer in all pods of a deployment
     - function: sum
-      query: 'sum(avg_over_time(container_memory_rss{pod=~"$DEPLOYMENT_NAME$-[^-]*-[^-]*$", namespace=$NAMESPACE$, container=”$CONTAINER_NAME$”}[15m]))'
+      query: 'sum by(container, namespace)(avg_over_time(container_memory_rss{container!="", container!="POD", pod!="", namespace=$NAMESPACE$, container=”$CONTAINER_NAME$”}[15m]))'
 
     ## namespace related queries
 
@@ -268,15 +268,15 @@ slo:
     aggregation_functions:
     # average cpu usages in cores for a namespace
     - function: avg
-      query: 'avg_over_time(sum by(namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+      query: 'avg_over_time(sum by(namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[15m:])'
 
     # maximum cpu usages in cores for a namespace
     - function: max
-      query: 'max_over_time(sum by(namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+      query: 'max_over_time(sum by(namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[15m:])'
 
     # minimum cpu usages in cores for a namespace
     - function: min
-      query: 'min_over_time(sum by(namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+      query: 'min_over_time(sum by(namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[15m:])'
 
 
     # Namespace CPU Throttle
@@ -288,15 +288,15 @@ slo:
     aggregation_functions:
     # average cpu throttle in cores for a namespace
     - function: avg
-      query: 'avg_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""}[5m]))[$MEASUREMENT_DURATION_IN_MIN$m:])'
+      query: 'avg_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""}[5m]))[15m:])'
 
     # maximum cpu throttle in cores for a namespace
     - function: max
-      query: 'max_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""}[5m]))[$MEASUREMENT_DURATION_IN_MIN$m:])'
+      query: 'max_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""}[5m]))[15m:])'
 
     # minimum cpu throttle in cores for a namespace
     - function: min
-      query: 'min_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""}[5m]))[$MEASUREMENT_DURATION_IN_MIN$m:])'
+      query: 'min_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""}[5m]))[15m:])'
 
 
     # Namespace memory usage
@@ -308,15 +308,15 @@ slo:
     aggregation_functions:
     # average memory usage in bytes for a namespace
     - function: avg
-      query: 'avg_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+      query: 'avg_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[15m:])'
 
     # maximum memory usage in bytes for a namespace
     - function: max
-      query: 'max_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+      query: 'max_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[15m:])'
 
     # minimum memory usage in bytes for a namespace
     - function: min
-      query: 'min_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+      query: 'min_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[15m:])'
 
 
     # Namespace memory rss value
@@ -328,15 +328,15 @@ slo:
     aggregation_functions:
     # average memory rss in bytes for a namespace
     - function: avg
-      query: 'avg_over_time(sum by(namespace) (container_memory_rss{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+      query: 'avg_over_time(sum by(namespace) (container_memory_rss{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[15m:])'
 
     # maximum memory rss in bytes for a namespace
     - function: max
-      query: 'max_over_time(sum by(namespace) (container_memory_rss{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+      query: 'max_over_time(sum by(namespace) (container_memory_rss{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[15m:])'
 
     # minimum memory rss in bytes for a namespace
     - function: min
-      query: 'min_over_time(sum by(namespace) (container_memory_rss{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+      query: 'min_over_time(sum by(namespace) (container_memory_rss{namespace="$NAMESPACE$", container!="", container!="POD", pod!=""})[15m:])'
 
 
     # Show total pods in a namespace
@@ -347,10 +347,10 @@ slo:
     aggregation_functions:
     # maximum total pods in a namespace
     - function: max
-      query: 'max_over_time(sum by(namespace) ((kube_pod_info{namespace="$NAMESPACE$"}))[$MEASUREMENT_DURATION_IN_MIN$m:])'
+      query: 'max_over_time(sum by(namespace) ((kube_pod_info{namespace="$NAMESPACE$"}))[15m:])'
     # average total pods in a namespace
     - function: avg
-      query: 'avg_over_time(sum by(namespace) ((kube_pod_info{namespace="$NAMESPACE$"}))[$MEASUREMENT_DURATION_IN_MIN$m:])'
+      query: 'avg_over_time(sum by(namespace) ((kube_pod_info{namespace="$NAMESPACE$"}))[15m:])'
 
 
     # Show total running pods in a namespace
@@ -361,10 +361,10 @@ slo:
     aggregation_functions:
     # maximum total pods in a namespace
     - function: max
-      query: 'max_over_time(sum by(namespace) ((kube_pod_status_phase{phase="Running"}))[$MEASUREMENT_DURATION_IN_MIN$m:])'
+      query: 'max_over_time(sum by(namespace) ((kube_pod_status_phase{phase="Running"}))[15m:])'
     # average total pods in a namespace
     - function: avg
-      query: 'avg_over_time(sum by(namespace) ((kube_pod_status_phase{phase="Running"}))[$MEASUREMENT_DURATION_IN_MIN$m:])'
+      query: 'avg_over_time(sum by(namespace) ((kube_pod_status_phase{phase="Running"}))[15m:])'
 
     # Show last activity for a namespace
   - name: namespaceMaxDate

--- a/manifests/autotune/performance-profiles/resource_optimization_openshift.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_openshift.yaml
@@ -43,7 +43,7 @@ slo:
 
     # Show sum of cpu limits in bytes for a container in a deployment
     - function: sum
-      query: 'avg by(container, namespace)(kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      query: 'sum by(container, namespace)(kube_pod_container_resource_limits{container!="", container!="POD", pod!="", resource="cpu", unit="core", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
 
 
   # CPU Usage

--- a/migrations/kruize_experiments_ddl.sql
+++ b/migrations/kruize_experiments_ddl.sql
@@ -2,7 +2,7 @@ create table IF NOT EXISTS kruize_experiments (experiment_id varchar(255) not nu
 create table IF NOT EXISTS kruize_performance_profiles (name varchar(255) not null, k8s_type varchar(255), profile_version float(53) not null, slo jsonb, primary key (name));
 create table IF NOT EXISTS kruize_recommendations (interval_end_time timestamp(6) not null, experiment_name varchar(255) not null, cluster_name varchar(255), extended_data jsonb, version varchar(255), primary key (experiment_name, interval_end_time)) PARTITION BY RANGE (interval_end_time);
 create table IF NOT EXISTS kruize_results (interval_start_time timestamp(6) not null, interval_end_time timestamp(6) not null, experiment_name varchar(255) not null, cluster_name varchar(255) , duration_minutes float(53) not null, extended_data jsonb, meta_data jsonb, version varchar(255), primary key (experiment_name, interval_end_time, interval_start_time)) PARTITION BY RANGE (interval_end_time);
-alter table if exists kruize_experiments add constraint UK_experiment_name unique (experiment_name);
+alter table if exists kruize_experiments add constraint UK_experiment_name unique (experiment_name), add column experiment_type varchar(255);
 create index IF NOT EXISTS idx_recommendation_experiment_name on kruize_recommendations (experiment_name);
 create index IF NOT EXISTS idx_recommendation_interval_end_time on kruize_recommendations (interval_end_time);
 create index IF NOT EXISTS idx_result_experiment_name on kruize_results (experiment_name);

--- a/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
+++ b/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
@@ -388,7 +388,7 @@ public class ExperimentValidation {
                 }
 
                 // Namespace experiment validation for both remote and local monitoring
-                if (expObj.getExperimentType().equals(AnalyzerConstants.ExperimentType.NAMESPACE)){
+                if (expObj.getExperimentType().equals(AnalyzerConstants.ExperimentType.NAMESPACE)) {
                     for (K8sObject k8sObject : expObj.getKubernetes_objects()) {
                         if (null == k8sObject.getNamespaceData()) {
                             errorMsg = errorMsg.concat(String.format(AnalyzerErrorConstants.APIErrors.CreateExperimentAPI.MISSING_NAMESPACE_DATA, expObj.getExperimentType().toString()));

--- a/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
+++ b/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
@@ -385,7 +385,7 @@ public class ExperimentValidation {
                                 errorMsg = errorMsg.concat(String.format(AnalyzerErrorConstants.APIErrors.CreateExperimentAPI.MISSING_NAMESPACE_DATA, expObj.getExperimentType().toString()));
                                 missingNamespaceData = true;
                             } else if (null == k8sObject.getNamespaceData().getNamespace_name()) {
-                                errorMsg = errorMsg.concat(String.format(AnalyzerErrorConstants.APIErrors.CreateExperimentAPI.MISSING_NAMESPACE_NAME, expObj.getExperimentType().toString()));
+                                errorMsg = errorMsg.concat(String.format(AnalyzerErrorConstants.APIErrors.CreateExperimentAPI.MISSING_NAMESPACE, expObj.getExperimentType().toString()));
                                 missingNamespaceData = true;
                             }
                         }

--- a/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
+++ b/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
@@ -379,21 +379,24 @@ public class ExperimentValidation {
                                 break;
                             }
                         }
-                    } else if (expObj.getExperimentType().equals(AnalyzerConstants.ExperimentType.NAMESPACE)){
-                        for (K8sObject k8sObject : expObj.getKubernetes_objects()) {
-                            if(null == k8sObject.getNamespaceData()) {
-                                errorMsg = errorMsg.concat(String.format(AnalyzerErrorConstants.APIErrors.CreateExperimentAPI.MISSING_NAMESPACE_DATA, expObj.getExperimentType().toString()));
-                                missingNamespaceData = true;
-                            } else if (null == k8sObject.getNamespaceData().getNamespace_name()) {
-                                errorMsg = errorMsg.concat(String.format(AnalyzerErrorConstants.APIErrors.CreateExperimentAPI.MISSING_NAMESPACE, expObj.getExperimentType().toString()));
-                                missingNamespaceData = true;
-                            }
-                        }
                     }
                 } else if (expObj.getExperiment_usecase_type().isLocal_monitoring()) {
                     if (null == expObj.getDataSource()) {
                         errorMsg = errorMsg.concat(String.format(LOCAL_MONITORING_DATASOURCE_MANDATORY, expObj.getExperimentName()));
                         missingLocalDatasource = true;
+                    }
+                }
+
+                // Namespace experiment validation for both remote and local monitoring
+                if (expObj.getExperimentType().equals(AnalyzerConstants.ExperimentType.NAMESPACE)){
+                    for (K8sObject k8sObject : expObj.getKubernetes_objects()) {
+                        if (null == k8sObject.getNamespaceData()) {
+                            errorMsg = errorMsg.concat(String.format(AnalyzerErrorConstants.APIErrors.CreateExperimentAPI.MISSING_NAMESPACE_DATA, expObj.getExperimentType().toString()));
+                            missingNamespaceData = true;
+                        } else if (null == k8sObject.getNamespaceData().getNamespace_name()) {
+                            errorMsg = errorMsg.concat(String.format(AnalyzerErrorConstants.APIErrors.CreateExperimentAPI.MISSING_NAMESPACE, expObj.getExperimentType().toString()));
+                            missingNamespaceData = true;
+                        }
                     }
                 }
 

--- a/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
@@ -134,11 +134,11 @@ public class Converters {
         // Generates K8sObject for namespace type experiments from KubernetesAPIObject
         public static K8sObject createNamespaceExperiment(KubernetesAPIObject kubernetesAPIObject) {
             K8sObject k8sObject = new K8sObject();
-            k8sObject.setNamespace(kubernetesAPIObject.getNamespaceAPIObjects().getnamespace());
+            k8sObject.setNamespace(kubernetesAPIObject.getNamespaceAPIObjects().getNamespace());
             HashMap<String, ContainerData> containerDataHashMap = new HashMap<>();
             k8sObject.setContainerDataMap(containerDataHashMap);
             NamespaceAPIObject namespaceAPIObject = kubernetesAPIObject.getNamespaceAPIObjects();
-            k8sObject.setNamespaceData(new NamespaceData(namespaceAPIObject.getnamespace(), new NamespaceRecommendations(), null));
+            k8sObject.setNamespaceData(new NamespaceData(namespaceAPIObject.getNamespace(), new NamespaceRecommendations(), null));
             return k8sObject;
         }
 

--- a/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.gson.Gson;
 import org.json.JSONArray;
-import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -135,11 +134,11 @@ public class Converters {
         // Generates K8sObject for namespace type experiments from KubernetesAPIObject
         public static K8sObject createNamespaceExperiment(KubernetesAPIObject kubernetesAPIObject) {
             K8sObject k8sObject = new K8sObject();
-            k8sObject.setNamespace(kubernetesAPIObject.getNamespaceAPIObjects().getnamespace_name());
+            k8sObject.setNamespace(kubernetesAPIObject.getNamespaceAPIObjects().getnamespace());
             HashMap<String, ContainerData> containerDataHashMap = new HashMap<>();
             k8sObject.setContainerDataMap(containerDataHashMap);
             NamespaceAPIObject namespaceAPIObject = kubernetesAPIObject.getNamespaceAPIObjects();
-            k8sObject.setNamespaceData(new NamespaceData(namespaceAPIObject.getnamespace_name(), new NamespaceRecommendations(), null));
+            k8sObject.setNamespaceData(new NamespaceData(namespaceAPIObject.getnamespace(), new NamespaceRecommendations(), null));
             return k8sObject;
         }
 

--- a/src/main/java/com/autotune/analyzer/serviceObjects/NamespaceAPIObject.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/NamespaceAPIObject.java
@@ -12,14 +12,14 @@ import java.util.List;
  * This NamespaceAPIObject class simulates the NamespaceData class for the create experiment and list experiment API
  */
 public class NamespaceAPIObject {
-    @SerializedName(KruizeConstants.JSONKeys.NAMESPACE_NAME)
-    private String namespaceName;
+    @SerializedName(KruizeConstants.JSONKeys.NAMESPACE)
+    private String namespace;
     @SerializedName(KruizeConstants.JSONKeys.RECOMMENDATIONS)
     private NamespaceRecommendations namespaceRecommendations;
     private List<Metric> metrics;
 
-    public NamespaceAPIObject(String namespaceName, NamespaceRecommendations namespaceRecommendations, List<Metric> metrics) {
-        this.namespaceName = namespaceName;
+    public NamespaceAPIObject(String namespace, NamespaceRecommendations namespaceRecommendations, List<Metric> metrics) {
+        this.namespace = namespace;
         this.namespaceRecommendations = namespaceRecommendations;
         this.metrics = metrics;
     }
@@ -31,9 +31,9 @@ public class NamespaceAPIObject {
      * Returns the name of the namespace
      * @return String containing the name of the namespace
      */
-    @JsonProperty(KruizeConstants.JSONKeys.NAMESPACE_NAME)
-    public String getnamespace_name() {
-        return namespaceName;
+    @JsonProperty(KruizeConstants.JSONKeys.NAMESPACE)
+    public String getnamespace() {
+        return namespace;
     }
 
     /**
@@ -56,7 +56,7 @@ public class NamespaceAPIObject {
     @Override
     public String toString() {
         return "NamespaceObject{" +
-                "namespaceName='" + namespaceName + '\'' +
+                "namespace='" + namespace + '\'' +
                 ", namespaceRecommendations=" + namespaceRecommendations +
                 ", metrics=" + metrics +
                 '}';

--- a/src/main/java/com/autotune/analyzer/serviceObjects/NamespaceAPIObject.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/NamespaceAPIObject.java
@@ -32,7 +32,7 @@ public class NamespaceAPIObject {
      * @return String containing the name of the namespace
      */
     @JsonProperty(KruizeConstants.JSONKeys.NAMESPACE)
-    public String getnamespace() {
+    public String getNamespace() {
         return namespace;
     }
 
@@ -41,7 +41,7 @@ public class NamespaceAPIObject {
      * @return namespace recommendations object containing the recommendations for a namespace
      */
     @JsonProperty(KruizeConstants.JSONKeys.RECOMMENDATIONS)
-    public NamespaceRecommendations getnamespaceRecommendations() {
+    public NamespaceRecommendations getNamespaceRecommendations() {
         return namespaceRecommendations;
     }
 

--- a/src/main/java/com/autotune/analyzer/services/CreateExperiment.java
+++ b/src/main/java/com/autotune/analyzer/services/CreateExperiment.java
@@ -117,9 +117,6 @@ public class CreateExperiment extends HttpServlet {
                             if (null != kubernetesAPIObject.getContainerAPIObjects()) {
                                 throw new InvalidExperimentType(AnalyzerErrorConstants.APIErrors.CreateExperimentAPI.CONTAINER_DATA_NOT_NULL_FOR_NAMESPACE_EXP);
                             }
-                            if (AnalyzerConstants.REMOTE.equalsIgnoreCase(createExperimentAPIObject.getTargetCluster())) {
-                                throw new InvalidExperimentType(AnalyzerErrorConstants.APIErrors.CreateExperimentAPI.NAMESPACE_EXP_NOT_SUPPORTED_FOR_REMOTE);
-                            }
                         }
                     }
                     KruizeObject kruizeObject = Converters.KruizeObjectConverters.convertCreateExperimentAPIObjToKruizeObject(createExperimentAPIObject);

--- a/src/main/java/com/autotune/analyzer/services/CreateExperiment.java
+++ b/src/main/java/com/autotune/analyzer/services/CreateExperiment.java
@@ -32,6 +32,8 @@ import com.autotune.database.service.ExperimentDBService;
 import com.autotune.utils.MetricsConfig;
 import com.autotune.utils.Utils;
 import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSyntaxException;
 import io.micrometer.core.instrument.Timer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -147,12 +149,12 @@ public class CreateExperiment extends HttpServlet {
                     sendErrorResponse(inputData, response, null, invalidKruizeObject.getValidation_data().getErrorCode(), invalidKruizeObject.getValidation_data().getMessage());
                 }
             }
+        } catch (InvalidExperimentType | JsonParseException e) {
+            sendErrorResponse(inputData, response, null, HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
         } catch (Exception e) {
             e.printStackTrace();
             LOGGER.error("Unknown exception caught: " + e.getMessage());
             sendErrorResponse(inputData, response, e, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Internal Server Error: " + e.getMessage());
-        } catch (InvalidExperimentType e) {
-            sendErrorResponse(inputData, response, null, HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
         } finally {
             if (null != timerCreateExp) {
                 MetricsConfig.timerCreateExp = MetricsConfig.timerBCreateExp.tag("status", statusValue).register(MetricsConfig.meterRegistry());

--- a/src/main/java/com/autotune/analyzer/services/ListExperiments.java
+++ b/src/main/java/com/autotune/analyzer/services/ListExperiments.java
@@ -89,9 +89,9 @@ public class ListExperiments extends HttpServlet {
 
             // adding namespace recommendations to K8sObject
             NamespaceData namespaceData = new NamespaceData();
-            if (kubernetesAPIObject.getNamespaceAPIObjects() != null && kubernetesAPIObject.getNamespaceAPIObjects().getnamespaceRecommendations() != null) {
+            if (kubernetesAPIObject.getNamespaceAPIObjects() != null && kubernetesAPIObject.getNamespaceAPIObjects().getNamespaceRecommendations() != null) {
                 namespaceData.setNamespace_name(kubernetesAPIObject.getNamespace());
-                namespaceData.setNamespaceRecommendations(kubernetesAPIObject.getNamespaceAPIObjects().getnamespaceRecommendations());
+                namespaceData.setNamespaceRecommendations(kubernetesAPIObject.getNamespaceAPIObjects().getNamespaceRecommendations());
                 k8sObject.setNamespaceData(namespaceData);
             }
 

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
@@ -195,6 +195,7 @@ public class AnalyzerErrorConstants {
             public static final String WHITESPACE_NOT_ALLOWED = "Whitespace can not be entered as a term or model value ";
             public static final String MISSING_NAMESPACE_DATA = "Missing NamespaceData for %s experimentType";
             public static final String MISSING_NAMESPACE_NAME = "Missing `namespace_name` for %s experimentType";
+            public static final String INVALID_EXPERIMENT_TYPE = "Invalid experiment_type : %s";
 
             private CreateExperimentAPI() {
 

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
@@ -193,6 +193,9 @@ public class AnalyzerErrorConstants {
             public static final String INVALID_MODEL_NAME = " model name is not supported. Use cost or performance.";
             public static final String MULTIPLE_MODELS_UNSUPPORTED = "Multiple models are currently not supported for auto or recreate mode.";
             public static final String WHITESPACE_NOT_ALLOWED = "Whitespace can not be entered as a term or model value ";
+            public static final String MISSING_NAMESPACE_DATA = "Missing NamespaceData for %s experimentType";
+            public static final String MISSING_NAMESPACE_NAME = "Missing `namespace_name` for %s experimentType";
+
             private CreateExperimentAPI() {
 
             }

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
@@ -194,7 +194,7 @@ public class AnalyzerErrorConstants {
             public static final String MULTIPLE_MODELS_UNSUPPORTED = "Multiple models are currently not supported for auto or recreate mode.";
             public static final String WHITESPACE_NOT_ALLOWED = "Whitespace can not be entered as a term or model value ";
             public static final String MISSING_NAMESPACE_DATA = "Missing NamespaceData for experimentType: %s";
-            public static final String MISSING_NAMESPACE_NAME = "Missing namespace_name for experimentType: %s";
+            public static final String MISSING_NAMESPACE = "Missing namespace for experimentType: %s";
             public static final String INVALID_EXPERIMENT_TYPE = "Invalid experiment_type : %s";
 
             private CreateExperimentAPI() {

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
@@ -193,8 +193,8 @@ public class AnalyzerErrorConstants {
             public static final String INVALID_MODEL_NAME = " model name is not supported. Use cost or performance.";
             public static final String MULTIPLE_MODELS_UNSUPPORTED = "Multiple models are currently not supported for auto or recreate mode.";
             public static final String WHITESPACE_NOT_ALLOWED = "Whitespace can not be entered as a term or model value ";
-            public static final String MISSING_NAMESPACE_DATA = "Missing NamespaceData for %s experimentType";
-            public static final String MISSING_NAMESPACE_NAME = "Missing `namespace_name` for %s experimentType";
+            public static final String MISSING_NAMESPACE_DATA = "Missing NamespaceData for experimentType: %s";
+            public static final String MISSING_NAMESPACE_NAME = "Missing namespace_name for experimentType: %s";
             public static final String INVALID_EXPERIMENT_TYPE = "Invalid experiment_type : %s";
 
             private CreateExperimentAPI() {

--- a/src/main/java/com/autotune/analyzer/utils/ExperimentTypeUtil.java
+++ b/src/main/java/com/autotune/analyzer/utils/ExperimentTypeUtil.java
@@ -45,7 +45,11 @@ public class ExperimentTypeUtil {
         public AnalyzerConstants.ExperimentType deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
             String experimentType = json.getAsString();
             if (experimentType != null) {
-                return AnalyzerConstants.ExperimentType.valueOf(experimentType.toUpperCase());
+                try {
+                    return AnalyzerConstants.ExperimentType.valueOf(experimentType.toUpperCase());
+                } catch (IllegalArgumentException e) {
+                    throw new JsonParseException(String.format(AnalyzerErrorConstants.APIErrors.CreateExperimentAPI.INVALID_EXPERIMENT_TYPE, experimentType), e);
+                }
             }
             return null;
         }

--- a/src/main/java/com/autotune/database/helper/DBHelpers.java
+++ b/src/main/java/com/autotune/database/helper/DBHelpers.java
@@ -222,20 +222,20 @@ public class DBHelpers {
                         // Set namespace recommendations
                         if (null == kubernetesAPIObject.getNamespaceAPIObjects())
                             continue;
-                        if (null == kubernetesAPIObject.getNamespaceAPIObjects().getnamespaceRecommendations().getData())
+                        if (null == kubernetesAPIObject.getNamespaceAPIObjects().getNamespaceRecommendations().getData())
                             continue;
                         if (null == namespaceData.getNamespaceRecommendations()) {
-                            namespaceData.setNamespaceRecommendations(Utils.getClone(kubernetesAPIObject.getNamespaceAPIObjects().getnamespaceRecommendations(), NamespaceRecommendations.class));
+                            namespaceData.setNamespaceRecommendations(Utils.getClone(kubernetesAPIObject.getNamespaceAPIObjects().getNamespaceRecommendations(), NamespaceRecommendations.class));
                         } else {
                             NamespaceRecommendations namespaceRecommendations = namespaceData.getNamespaceRecommendations();
                             namespaceRecommendations.setVersion(listRecommendationsAPIObject.getApiVersion());
                             if (null == namespaceRecommendations.getData()) {
-                                namespaceData.setNamespaceRecommendations(Utils.getClone(kubernetesAPIObject.getNamespaceAPIObjects().getnamespaceRecommendations(), NamespaceRecommendations.class));
+                                namespaceData.setNamespaceRecommendations(Utils.getClone(kubernetesAPIObject.getNamespaceAPIObjects().getNamespaceRecommendations(), NamespaceRecommendations.class));
                             } else {
                                 namespaceRecommendations.getNotificationMap().clear();
-                                namespaceRecommendations.getNotificationMap().putAll(kubernetesAPIObject.getNamespaceAPIObjects().getnamespaceRecommendations().getNotificationMap());
+                                namespaceRecommendations.getNotificationMap().putAll(kubernetesAPIObject.getNamespaceAPIObjects().getNamespaceRecommendations().getNotificationMap());
                                 HashMap<Timestamp, MappedRecommendationForTimestamp> data = namespaceRecommendations.getData();
-                                data.putAll(kubernetesAPIObject.getNamespaceAPIObjects().getnamespaceRecommendations().getData());
+                                data.putAll(kubernetesAPIObject.getNamespaceAPIObjects().getNamespaceRecommendations().getData());
                             }
                         }
                     } else {
@@ -537,7 +537,7 @@ public class DBHelpers {
                     // todo : what happens if two k8 objects or Containers with different timestamp
                     for (KubernetesAPIObject k8sObject : listRecommendationsAPIObject.getKubernetesObjects()) {
                         if (listRecommendationsAPIObject.isNamespaceExperiment()) {
-                            endInterval = k8sObject.getNamespaceAPIObjects().getnamespaceRecommendations().getData().keySet().stream().max(Timestamp::compareTo).get();
+                            endInterval = k8sObject.getNamespaceAPIObjects().getNamespaceRecommendations().getData().keySet().stream().max(Timestamp::compareTo).get();
                         } else {
                             for (ContainerAPIObject containerAPIObject : k8sObject.getContainerAPIObjects()) {
                                 endInterval = containerAPIObject.getContainerRecommendations().getData().keySet().stream().max(Timestamp::compareTo).get();
@@ -604,7 +604,7 @@ public class DBHelpers {
                     // todo : what happens if two k8 objects or Containers with different timestamp
                     for (KubernetesAPIObject k8sObject : listRecommendationsAPIObject.getKubernetesObjects()) {
                         if (listRecommendationsAPIObject.isNamespaceExperiment()) {
-                            endInterval = k8sObject.getNamespaceAPIObjects().getnamespaceRecommendations().getData().keySet().stream().max(Timestamp::compareTo).get();
+                            endInterval = k8sObject.getNamespaceAPIObjects().getNamespaceRecommendations().getData().keySet().stream().max(Timestamp::compareTo).get();
                         } else {
                             for (ContainerAPIObject containerAPIObject : k8sObject.getContainerAPIObjects()) {
                                 endInterval = containerAPIObject.getContainerRecommendations().getData().keySet().stream().max(Timestamp::compareTo).get();

--- a/src/main/java/com/autotune/database/table/KruizeExperimentEntry.java
+++ b/src/main/java/com/autotune/database/table/KruizeExperimentEntry.java
@@ -39,6 +39,7 @@ import org.hibernate.type.SqlTypes;
  * status: An enum representing the status of the experiment, defined in AnalyzerConstants.ExperimentStatus.
  * extended_data: A JSON object representing extended data for the experiment.
  * meta_data: A string representing metadata for the experiment.
+ * experimentType: A string representing the type of the experiment
  * The ExperimentDetail class also has getters and setters for all its fields.
  */
 @Entity
@@ -63,6 +64,8 @@ public class KruizeExperimentEntry {
     private JsonNode extended_data;
     @JdbcTypeCode(SqlTypes.JSON)
     private JsonNode meta_data;
+    @Enumerated(EnumType.STRING)
+    private AnalyzerConstants.ExperimentType experiment_type;
 
 //    TODO: update KruizeDSMetadataEntry
 
@@ -173,5 +176,12 @@ public class KruizeExperimentEntry {
         this.datasource = datasource;
     }
 
+    public AnalyzerConstants.ExperimentType getExperiment_type() {
+        return experiment_type;
+    }
+
+    public void setExperiment_type(AnalyzerConstants.ExperimentType experiment_type) {
+        this.experiment_type = experiment_type;
+    }
 
 }

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -181,7 +181,6 @@ public class KruizeConstants {
         // Deployments Section
         public static final String DEPLOYMENTS = "deployments";
         public static final String NAMESPACE = "namespace";
-        public static final String NAMESPACE_NAME = "namespace_name";
         public static final String POD_METRICS = "pod_metrics";
         public static final String CONTAINER_METRICS = "container_metrics";
         public static final String METRICS = "metrics";


### PR DESCRIPTION
## Description

This PR has the following changes :

- Add `experiment_type` field in remote monitoring experiments
-  Supports namespace experiments
- Add namespace queries in `PerformanceProfile` and creates a JSON file for the same.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [x] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [x] Documentation updated
- [ ] Tests added or updated

## Additional information

docker image: `quay.io/shbirada/create_exp_changes:latest`
