### PR TITLE
Fix namespace kubernetes_object nomenclature in local monitoring tests

### DIFF
--- a/tests/scripts/helpers/list_reco_json_local_monitoring_schema.py
+++ b/tests/scripts/helpers/list_reco_json_local_monitoring_schema.py
@@ -464,7 +464,7 @@ list_reco_namespace_json_local_monitoring_schema = {
                         "namespaces": {
                             "type": "object",
                             "properties": {
-                                "namespace_name": {
+                                "namespace": {
                                     "type": "string"
                                 },
                                 "recommendations": {
@@ -1179,7 +1179,7 @@ list_reco_namespace_json_local_monitoring_schema = {
                                 }
                             },
                             "required": [
-                                "namespace_name",
+                                "namespace",
                                 "recommendations"
                             ]
                         },

--- a/tests/scripts/helpers/utils.py
+++ b/tests/scripts/helpers/utils.py
@@ -548,7 +548,7 @@ def validate_kubernetes_obj(create_exp_kubernetes_obj, update_results_kubernetes
 def validate_local_monitoring_kubernetes_obj(create_exp_kubernetes_obj,
                             list_reco_kubernetes_obj, expected_duration_in_hours, test_name, experiment_type):
     if experiment_type == NAMESPACE_EXPERIMENT_TYPE:
-        assert list_reco_kubernetes_obj["namespaces"]["namespace_name"] == create_exp_kubernetes_obj["namespaces"]["namespace_name"]
+        assert list_reco_kubernetes_obj["namespaces"]["namespace"] == create_exp_kubernetes_obj["namespaces"]["namespace"]
         list_reco_namespace = list_reco_kubernetes_obj["namespaces"]
         create_exp_namespace = create_exp_kubernetes_obj["namespaces"]
         validate_local_monitoring_namespace(create_exp_namespace, list_reco_namespace, expected_duration_in_hours, test_name)
@@ -770,8 +770,8 @@ def validate_local_monitoring_container(create_exp_container, list_reco_containe
 def validate_local_monitoring_namespace(create_exp_namespace, list_reco_namespace, expected_duration_in_hours, test_name):
     # Validate namespace name
     if create_exp_namespace != None and list_reco_namespace != None:
-        assert create_exp_namespace["namespace_name"] == list_reco_namespace["namespace_name"], \
-            f"Namespace names did not match! Actual -  {list_reco_namespace['namespace_name']} Expected - {create_exp_namespace['namespace_name']}"
+        assert create_exp_namespace["namespace"] == list_reco_namespace["namespace"], \
+            f"Namespace names did not match! Actual -  {list_reco_namespace['namespace']} Expected - {create_exp_namespace['namespace']}"
 
     if expected_duration_in_hours == None:
         duration_in_hours = 0.0

--- a/tests/scripts/local_monitoring_tests/json_files/create_exp_template.json
+++ b/tests/scripts/local_monitoring_tests/json_files/create_exp_template.json
@@ -13,7 +13,7 @@
 		"name": "{{name}}",
 		"namespace": "{{namespace}}",
 		"namespaces": {
-			"namespace_name": "{{namespace_name}}"
+			"namespace": "{{namespace_name}}"
 		},
 		"containers": [{
 			"container_image_name": "{{container_image_name}}",

--- a/tests/scripts/local_monitoring_tests/json_files/create_multiple_namespace_exp.json
+++ b/tests/scripts/local_monitoring_tests/json_files/create_multiple_namespace_exp.json
@@ -12,7 +12,7 @@
     "kubernetes_objects": [
       {
         "namespaces": {
-          "namespace_name": "default"
+          "namespace": "default"
         }
       }
     ],
@@ -36,7 +36,7 @@
     "kubernetes_objects": [
       {
         "namespaces": {
-          "namespace_name": "test-multiple-import"
+          "namespace": "test-multiple-import"
         }
       }
     ],

--- a/tests/scripts/local_monitoring_tests/rest_apis/test_create_experiment.py
+++ b/tests/scripts/local_monitoring_tests/rest_apis/test_create_experiment.py
@@ -88,7 +88,7 @@ def test_create_exp_valid_tests(test_name, expected_status_code, version, experi
         json_content[0]["kubernetes_objects"][0].pop("namespace")
     if json_content[0]["kubernetes_objects"][0]["containers"][0]["container_image_name"] == "None":
         json_content[0]["kubernetes_objects"][0].pop("containers")
-    if json_content[0]["kubernetes_objects"][0]["namespaces"]["namespace_name"] == "None":
+    if json_content[0]["kubernetes_objects"][0]["namespaces"]["namespace"] == "None":
         json_content[0]["kubernetes_objects"][0].pop("namespaces")
     if json_content[0]["experiment_type"] == "None":
         json_content[0].pop("experiment_type")
@@ -128,7 +128,6 @@ def test_create_exp_valid_tests(test_name, expected_status_code, version, experi
         ("invalid_both_container_and_namespace_container_exp_type", ERROR_STATUS_CODE, CREATE_EXP_CONTAINER_EXP_CONTAINS_NAMESPACE,"v2.0", "tfb-workload-namespace", "default", "resource-optimization-local-monitoring", "cluster-metadata-local-monitoring", "monitor", "local", "prometheus-1", "container", "deployment", "tfb-qrh-sample", "default", "default", "kruize/tfb-qrh:1.13.2.F_et17", "tfb-server", "15min", "0.1"),
         ("invalid_namespace_exp_type_with_only_containers", ERROR_STATUS_CODE, CREATE_EXP_NAMESPACE_EXP_CONTAINS_CONTAINER,"v2.0", "tfb-workload-namespace", "default", "resource-optimization-local-monitoring", "cluster-metadata-local-monitoring", "monitor", "local", "prometheus-1", "namespace", "deployment", "tfb-qrh-sample", "default", None, "kruize/tfb-qrh:1.13.2.F_et17", "tfb-server", "15min", "0.1"),
         ("invalid_container_exp_type_with_only_namespace", ERROR_STATUS_CODE, CREATE_EXP_CONTAINER_EXP_CONTAINS_NAMESPACE,"v2.0", "tfb-workload-namespace", "default", "resource-optimization-local-monitoring", "cluster-metadata-local-monitoring", "monitor", "local", "prometheus-1", "container", None, None, None, "default", None, None, "15min", "0.1"),
-        ("invalid_namespace_exp_with_remote_cluster", ERROR_STATUS_CODE, CREATE_EXP_NAMESPACE_EXP_NOT_SUPPORTED_FOR_REMOTE,"v2.0", "tfb-workload-namespace", "default", "resource-optimization-local-monitoring", "cluster-metadata-local-monitoring", "monitor", "remote", "prometheus-1", "namespace", None, None, None, "default", None, None, "15min", "0.1"),
         ("invalid_namespace_exp_with_auto_mode", ERROR_STATUS_CODE, CREATE_EXP_NAMESPACE_EXP_NOT_SUPPORTED_FOR_VPA_MODE,"v2.0", "tfb-workload-namespace-auto", "default", "resource-optimization-local-monitoring", "cluster-metadata-local-monitoring", "auto", "local", "prometheus-1", "namespace", None, None, None, "default", None, None, "15min", "0.1"),
         ("invalid_namespace_exp_with_recreate_mode", ERROR_STATUS_CODE, CREATE_EXP_NAMESPACE_EXP_NOT_SUPPORTED_FOR_VPA_MODE,"v2.0", "tfb-workload-namespace-recreate", "default", "resource-optimization-local-monitoring", "cluster-metadata-local-monitoring", "recreate", "local", "prometheus-1", "namespace", None, None, None, "default", None, None, "15min", "0.1"),
         ("invalid_auto_mode_exp_with_exp_type_remote_cluster", ERROR_STATUS_CODE, CREATE_EXP_VPA_NOT_SUPPORTED_FOR_REMOTE, "v2.0", "tfb-auto-container-exp-remote", "default", "resource-optimization-local-monitoring", "cluster-metadata-local-monitoring", "auto", "remote", "prometheus-1", None, "deployment", "tfb-qrh-sample", "default", None, "kruize/tfb-qrh:1.13.2.F_et17", "tfb-server", "15min", "0.1"),
@@ -192,7 +191,7 @@ def test_create_exp_invalid_tests(test_name, expected_status_code, expected_erro
         json_content[0]["kubernetes_objects"][0].pop("namespace")
     if json_content[0]["kubernetes_objects"][0]["containers"][0]["container_image_name"] == "None":
         json_content[0]["kubernetes_objects"][0].pop("containers")
-    if json_content[0]["kubernetes_objects"][0]["namespaces"]["namespace_name"] == "None":
+    if json_content[0]["kubernetes_objects"][0]["namespaces"]["namespace"] == "None":
             json_content[0]["kubernetes_objects"][0].pop("namespaces")
     if json_content[0]["experiment_type"] == "None":
         json_content[0].pop("experiment_type")

--- a/tests/scripts/local_monitoring_tests/rest_apis/test_import_metadata.py
+++ b/tests/scripts/local_monitoring_tests/rest_apis/test_import_metadata.py
@@ -199,11 +199,11 @@ def test_repeated_metadata_import(cluster_type):
     validate_list_metadata_parameters(import_metadata_json, list_metadata_json, cluster_name=cluster_name, namespace="testing")
 
     delete_namespace("testing")
-    time.sleep(15)
+    time.sleep(45)
 
     create_namespace("repeated-metadata-import")
     create_namespace("local-monitoring-test")
-    time.sleep(30)
+    time.sleep(45)
 
     # Import metadata using the specified json
     response = import_metadata(input_json_file)

--- a/tests/scripts/local_monitoring_tests/rest_apis/test_import_metadata.py
+++ b/tests/scripts/local_monitoring_tests/rest_apis/test_import_metadata.py
@@ -173,7 +173,7 @@ def test_repeated_metadata_import(cluster_type):
     print("delete metadata = ", response.status_code)
 
     create_namespace("testing")
-    time.sleep(30)
+    time.sleep(45)
 
     # Import metadata using the specified json
     response = import_metadata(input_json_file)

--- a/tests/scripts/local_monitoring_tests/rest_apis/test_list_recommendations.py
+++ b/tests/scripts/local_monitoring_tests/rest_apis/test_list_recommendations.py
@@ -272,7 +272,7 @@ def test_accelerator_recommendation_if_exists(
 
     if json_content[0]["kubernetes_objects"][0]["type"] == "None":
         json_content[0]["kubernetes_objects"][0].pop("type")
-    if json_content[0]["kubernetes_objects"][0]["namespaces"]["namespace_name"] == "None":
+    if json_content[0]["kubernetes_objects"][0]["namespaces"]["namespace"] == "None":
         json_content[0]["kubernetes_objects"][0].pop("namespaces")
     if json_content[0]["kubernetes_objects"][0]["containers"][0]["container_name"] == "None":
         json_content[0]["kubernetes_objects"][0].pop("containers")

--- a/tests/scripts/local_monitoring_tests/rest_apis/test_namespace_reco_e2e_workflow.py
+++ b/tests/scripts/local_monitoring_tests/rest_apis/test_namespace_reco_e2e_workflow.py
@@ -185,7 +185,7 @@ def test_list_recommendations_namespace_exps(cluster_type):
     ns1_exp_json_file = tmp_json_file_1
 
     json_content[0]["experiment_name"] = "test-ns2"
-    json_content[0]["kubernetes_objects"][0]["namespaces"]["namespace_name"] = "ns2"
+    json_content[0]["kubernetes_objects"][0]["namespaces"]["namespace"] = "ns2"
 
     # Write the final JSON to the temp file
     with open(tmp_json_file_2, mode="w", encoding="utf-8") as message:
@@ -195,7 +195,7 @@ def test_list_recommendations_namespace_exps(cluster_type):
     ns2_exp_json_file = tmp_json_file_2
 
     json_content[0]["experiment_name"] = "test-ns3"
-    json_content[0]["kubernetes_objects"][0]["namespaces"]["namespace_name"] = "ns3"
+    json_content[0]["kubernetes_objects"][0]["namespaces"]["namespace"] = "ns3"
 
     # Write the final JSON to the temp file
     with open(tmp_json_file_3, mode="w", encoding="utf-8") as message:


### PR DESCRIPTION
## Description

This PR includes the changes for namespace kubernetes_objects in the local monitoring tests, replacing `namespace_name` with `namespace` as the key.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes
- [x] Tests update

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite: local monitoring 

**Test Configuration**
* Kubernetes clusters tested on: Openshift

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [x] Tests added or updated

## Additional information

Test results: 
[pr_1582_local_monitoring_tests.zip](https://github.com/user-attachments/files/20520720/pr_1582_local_monitoring_tests.zip)

![image](https://github.com/user-attachments/assets/b901029b-a379-43ef-b3ec-76de02470520)

