### PR TITLE
[DailyByte]: Avoid creating un-referenced objects in loop

### DIFF
--- a/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
@@ -304,12 +304,12 @@ public class Converters {
                         metricsMap.put(AnalyzerConstants.MetricName.valueOf(metric.getName()), metric);
                         MetricResults metricResults = metric.getMetricResult();
                         metricResults.setName(metric.getName());
-                        IntervalResults intervalResults = new IntervalResults(updateResultsAPIObject.startTimestamp,
-                                updateResultsAPIObject.endTimestamp);
                         metricResultsHashMap.put(AnalyzerConstants.MetricName.valueOf(metric.getName()), metricResults);
-                        intervalResults.setMetricResultsMap(metricResultsHashMap);
-                        resultsMap.put(updateResultsAPIObject.getEndTimestamp(), intervalResults);
                     }
+                    IntervalResults intervalResults = new IntervalResults(updateResultsAPIObject.startTimestamp,
+                            updateResultsAPIObject.endTimestamp);
+                    intervalResults.setMetricResultsMap(metricResultsHashMap);
+                    resultsMap.put(updateResultsAPIObject.getEndTimestamp(), intervalResults);
                     containerData.setResults(resultsMap);
                     containerDataHashMap.put(containerData.getContainer_name(), containerData);
                 }


### PR DESCRIPTION
## Description

Interval Results object is getting created inside the loop which set's the metric result hashmap
For each metric we are not only updating the map but also the reference in interval results,
So it's like the same map is being referenced in different interval result objects and the
object created in the final iteration will be stored in resultsMap, all the objects created earlier
will be dereferenced internally in JVM which will be removed in the next GC cycle, Object creation is
costly operation and maintaining it till GC to happen will impact the temporary memory consumption.
So this needs to be optimised in a way that per timestamp, we create interval results only once and
populate it with all the metrics which are added in the map and then we attach the interval results to resultsMap

Fixes #1583 

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
