### PR TITLE
Update docker file with a newer maven version

### DIFF
--- a/Dockerfile.autotune
+++ b/Dockerfile.autotune
@@ -25,7 +25,7 @@ RUN microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y jav
      && microdnf clean all 
 
 RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz https://dlcdn.apache.org/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz https://dlcdn.apache.org/maven/maven-3/3.9.10/binaries/apache-maven-3.9.10-bin.tar.gz \
   && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
   && rm -f /tmp/apache-maven.tar.gz \
   && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn


### PR DESCRIPTION
## Description

This PR updates the maven version in the docker file to support version `3.9.10`

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: Built the image locally.

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Logs showing the change is working as expected

```
$ ./build.sh -i khansaad/autotune_operator:mvn-version-test
There is no tracking information for the current branch.
Please specify which branch you want to merge with.
See git-pull(1) for details.

    git pull <remote> <branch>

If you wish to set tracking information for this branch you can do so with:

    git branch --set-upstream-to=<remote>/<branch> mvn-version-upgrade

Cleanup any previous kruize images...done
--pull --no-cache
--format=docker not supported
[+] Building 124.8s (23/23) FINISHED                                                             docker:default
 => [internal] load build definition from Dockerfile.autotune                                              0.0s
 => => transferring dockerfile: 4.78kB                                                                     0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 19)                            0.0s
 => [internal] load metadata for registry.access.redhat.com/ubi9/ubi-minimal:9.6-1747218906                2.5s
 => [internal] load .dockerignore                                                                          0.0s
 => => transferring context: 2B                                                                            0.0s
 => [internal] load build context                                                                          0.0s
 => => transferring context: 2.51MB                                                                        0.0s
 => [mvnbuild-jdk21  1/10] FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1747218906@sha256:92b1d57  7.5s
 => => resolve registry.access.redhat.com/ubi9/ubi-minimal:9.6-1747218906@sha256:92b1d5747a93608b6adb64df  0.0s
 => => sha256:92b1d5747a93608b6adb64dfd54515c3c5a360802db4706765ff3d8470df6290 897B / 897B                 0.0s
 => => sha256:aca8052836f670988f68139b46ddc6bacded7c40bd49962971ee5e3b1f8bc1f8 505B / 505B                 0.0s
 => => sha256:e43c1a24fb3754c0dd2dec1bcd7e75f71f191b93545e8126439e8547aff7fe30 5.06kB / 5.06kB             0.0s
 => => sha256:a080cada37e9f7003fcfc13eb6b0d19a9d6c4bfa9b3a9cb9ef46b184cfa60e43 39.65MB / 39.65MB           7.1s
 => => extracting sha256:a080cada37e9f7003fcfc13eb6b0d19a9d6c4bfa9b3a9cb9ef46b184cfa60e43                  0.4s
 => [stage-1 2/9] RUN microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y tzdata op  16.1s
 => [mvnbuild-jdk21  2/10] RUN microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y   66.7s
 => [stage-1 3/9] WORKDIR /home/autotune/app                                                               0.1s
 => [stage-1 4/9] RUN microdnf -y install shadow-utils     && useradd -u 1001 -s /usr/sbin/nologin defau  11.1s
 => [mvnbuild-jdk21  3/10] RUN mkdir -p /usr/share/maven /usr/share/maven/ref   && curl -fsSL -o /tmp/apa  1.4s 
 => [mvnbuild-jdk21  4/10] WORKDIR /home/autotune/src/autotune                                             0.1s 
 => [mvnbuild-jdk21  5/10] COPY pom.xml /home/autotune/src/autotune/                                       0.1s 
 => [mvnbuild-jdk21  6/10] RUN mvn -f pom.xml install dependency:copy-dependencies                        29.7s 
 => [mvnbuild-jdk21  7/10] COPY src /home/autotune/src/autotune/src/                                       0.1s 
 => [mvnbuild-jdk21  8/10] RUN mvn -f pom.xml clean package                                                8.1s 
 => [mvnbuild-jdk21  9/10] COPY migrations target/bin/migrations                                           0.1s 
 => [mvnbuild-jdk21 10/10] RUN jlink --strip-debug --compress 2 --no-header-files --no-man-pages --module  6.8s 
 => [stage-1 5/9] COPY --chown=1001:0 --from=mvnbuild-jdk21 /home/autotune/src/autotune/jre/ /home/autotu  0.1s
 => [stage-1 6/9] COPY --chown=1001:0 --from=mvnbuild-jdk21 /home/autotune/src/autotune/target/ /home/aut  0.2s
 => [stage-1 7/9] COPY manifests/autotune/performance-profiles/resource_optimization_local_monitoring.jso  0.0s
 => [stage-1 8/9] COPY manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.json /  0.0s
 => [stage-1 9/9] RUN chmod -R +x /home/autotune/app/target/bin/                                           0.6s
 => exporting to image                                                                                     0.3s
 => => exporting layers                                                                                    0.3s
 => => writing image sha256:a8317425bc0352d99b9eab6428fa81148db19668de18dbc51490187fae8ff26b               0.0s
 => => naming to docker.io/khansaad/autotune_operator:mvn-version-test                                     0.0s
khansaad/autotune_operator             mvn-version-test   a8317425bc03   Less than a second ago   313MB
```