### PR TITLE
Update the query names to match the autotune implementations

### DIFF
--- a/design/MetricProfileAPI.md
+++ b/design/MetricProfileAPI.md
@@ -457,7 +457,7 @@ This is quick guide instructions to create metric profile using input JSON as fo
                 ]
             },
             {
-                "name": "gpuCoreUsage",
+                "name": "acceleratorCoreUsage",
                 "datasource": "prometheus",
                 "value_type": "double",
                 "kubernetes_object": "container",
@@ -480,7 +480,7 @@ This is quick guide instructions to create metric profile using input JSON as fo
                 ]
             },
             {
-                "name": "gpuMemoryUsage",
+                "name": "acceleratorMemoryUsage",
                 "datasource": "prometheus",
                 "value_type": "double",
                 "kubernetes_object": "container",
@@ -967,7 +967,7 @@ List metric profiles output JSON as follows.
                     }
                 },
                 {
-                    "name": "gpuCoreUsage",
+                    "name": "acceleratorCoreUsage",
                     "datasource": "prometheus",
                     "value_type": "double",
                     "kubernetes_object": "container",
@@ -990,7 +990,7 @@ List metric profiles output JSON as follows.
                     }
                 },
                 {
-                    "name": "gpuMemoryUsage",
+                    "name": "acceleratorMemoryUsage",
                     "datasource": "prometheus",
                     "value_type": "double",
                     "kubernetes_object": "container",

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.json
@@ -414,7 +414,7 @@
         ]
       },
       {
-        "name": "gpuCoreUsage",
+        "name": "acceleratorCoreUsage",
         "datasource": "prometheus",
         "value_type": "double",
         "kubernetes_object": "container",
@@ -434,7 +434,7 @@
         ]
       },
       {
-        "name": "gpuMemoryUsage",
+        "name": "acceleratorMemoryUsage",
         "datasource": "prometheus",
         "value_type": "double",
         "kubernetes_object": "container",
@@ -450,6 +450,26 @@
           {
             "function": "min",
             "query": "min by (Hostname,device,modelName,UUID,exported_container,exported_namespace) (min_over_time(DCGM_FI_DEV_MEM_COPY_UTIL{exported_namespace=\"$NAMESPACE$\",exported_container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          }
+        ]
+      },
+      {
+        "name": "acceleratorFrameBufferUsage",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg by (Hostname,device,GPU_I_PROFILE,modelName,UUID) (avg_over_time(DCGM_FI_DEV_FB_USED{UUID=\"$UUID$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          },
+          {
+            "function": "max",
+            "query": "max by (Hostname,device,GPU_I_PROFILE,modelName,UUID) (max_over_time(DCGM_FI_DEV_FB_USED{UUID=\"$UUID$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          },
+          {
+            "function": "min",
+            "query": "min by (Hostname,device,GPU_I_PROFILE,modelName,UUID) (min_over_time(DCGM_FI_DEV_FB_USED{UUID=\"$UUID$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           }
         ]
       }

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.yaml
@@ -415,7 +415,7 @@ slo:
   # GPU Related metrics
 
   # GPU Core Usage
-  - name: gpuCoreUsage
+  - name: acceleratorCoreUsage
     datasource: prometheus
     value_type: "double"
     kubernetes_object: "container"
@@ -434,7 +434,7 @@ slo:
         query: 'min by (Hostname,device,modelName,UUID,exported_container,exported_namespace) (min_over_time(DCGM_FI_DEV_GPU_UTIL{exported_namespace="$NAMESPACE$",exported_container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m])'
 
   # GPU Memory usage
-  - name: gpuMemoryUsage
+  - name: acceleratorMemoryUsage
     datasource: prometheus
     value_type: "double"
     kubernetes_object: "container"
@@ -451,3 +451,22 @@ slo:
       # Minimum of GPU Memory Usage  Percentage for a container in a deployment
       - function: min
         query: 'min by (Hostname,device,modelName,UUID,exported_container,exported_namespace) (min_over_time(DCGM_FI_DEV_MEM_COPY_UTIL{exported_namespace="$NAMESPACE$",exported_container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m])'
+
+    # GPU Frame Buffer Usage
+  - name: acceleratorFrameBufferUsage
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "container"
+
+    aggregation_functions:
+      # Average Frame Buffer Usage per GPU
+      - function: avg
+        query: 'avg by (Hostname,device,GPU_I_PROFILE,modelName,UUID) (avg_over_time(DCGM_FI_DEV_FB_USED{UUID="$UUID$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+
+      # Maximum Frame Buffer Usage per GPU
+      - function: max
+        query: 'max by (Hostname,device,GPU_I_PROFILE,modelName,UUID) (max_over_time(DCGM_FI_DEV_FB_USED{UUID="$UUID$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+
+      # Minimum Frame Buffer Usage per GPU
+      - function: min
+        query: 'min by (Hostname,device,GPU_I_PROFILE,modelName,UUID) (min_over_time(DCGM_FI_DEV_FB_USED{UUID="$UUID$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.json
@@ -391,7 +391,7 @@
         ]
       },
       {
-        "name": "gpuCoreUsage",
+        "name": "acceleratorCoreUsage",
         "datasource": "prometheus",
         "value_type": "double",
         "kubernetes_object": "container",
@@ -411,7 +411,7 @@
         ]
       },
       {
-        "name": "gpuMemoryUsage",
+        "name": "acceleratorMemoryUsage",
         "datasource": "prometheus",
         "value_type": "double",
         "kubernetes_object": "container",
@@ -427,6 +427,26 @@
           {
             "function": "min",
             "query": "min by (Hostname,device,modelName,UUID,exported_container,exported_namespace) (min_over_time(DCGM_FI_DEV_MEM_COPY_UTIL{exported_namespace=\"$NAMESPACE$\",exported_container=\"$CONTAINER_NAME$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          }
+        ]
+      },
+      {
+        "name": "acceleratorFrameBufferUsage",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg by (Hostname,device,GPU_I_PROFILE,modelName,UUID) (avg_over_time(DCGM_FI_DEV_FB_USED{UUID=\"$UUID$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          },
+          {
+            "function": "max",
+            "query": "max by (Hostname,device,GPU_I_PROFILE,modelName,UUID) (max_over_time(DCGM_FI_DEV_FB_USED{UUID=\"$UUID$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          },
+          {
+            "function": "min",
+            "query": "min by (Hostname,device,GPU_I_PROFILE,modelName,UUID) (min_over_time(DCGM_FI_DEV_FB_USED{UUID=\"$UUID$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           }
         ]
       }

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.yaml
@@ -376,10 +376,10 @@ slo:
       query: 'max(last_over_time(timestamp((sum by (namespace) (container_cpu_usage_seconds_total{namespace="$NAMESPACE$"})) > 0 )[15d:]))'
 
 
-    # GPU Related metrics
+  # GPU Related metrics
 
-    # GPU Core Usage
-  - name: gpuCoreUsage
+  # GPU Core Usage
+  - name: acceleratorCoreUsage
     datasource: prometheus
     value_type: "double"
     kubernetes_object: "container"
@@ -397,8 +397,8 @@ slo:
       - function: min
         query: 'min by (Hostname,device,modelName,UUID,exported_container,exported_namespace) (min_over_time(DCGM_FI_DEV_GPU_UTIL{exported_namespace="$NAMESPACE$",exported_container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m])'
 
-    # GPU Memory usage
-  - name: gpuMemoryUsage
+  # GPU Memory usage
+  - name: acceleratorMemoryUsage
     datasource: prometheus
     value_type: "double"
     kubernetes_object: "container"
@@ -415,4 +415,22 @@ slo:
       # Minimum of GPU Memory Usage  Percentage for a container in a deployment
       - function: min
         query: 'min by (Hostname,device,modelName,UUID,exported_container,exported_namespace) (min_over_time(DCGM_FI_DEV_MEM_COPY_UTIL{exported_namespace="$NAMESPACE$",exported_container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m])'
-      
+
+  # GPU Frame Buffer Usage
+  - name: acceleratorFrameBufferUsage
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "container"
+
+    aggregation_functions:
+      # Average Frame Buffer Usage per GPU
+      - function: avg
+        query: 'avg by (Hostname,device,GPU_I_PROFILE,modelName,UUID) (avg_over_time(DCGM_FI_DEV_FB_USED{UUID="$UUID$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+
+      # Maximum Frame Buffer Usage per GPU
+      - function: max
+        query: 'max by (Hostname,device,GPU_I_PROFILE,modelName,UUID) (max_over_time(DCGM_FI_DEV_FB_USED{UUID="$UUID$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+
+      # Minimum Frame Buffer Usage per GPU
+      - function: min
+        query: 'min by (Hostname,device,GPU_I_PROFILE,modelName,UUID) (min_over_time(DCGM_FI_DEV_FB_USED{UUID="$UUID$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'


### PR DESCRIPTION
## Description

Autotune has updated the naming convention of queries from `gpu` to `accelerator` while making updates to the remote monitoring usecase. As part of it the RM related json and yaml's are updated but the LM related metric profile is still carrying the name of query's as `gpu`. This PR adds the changes for naming convention changes for local monitoring profiles as well.

Fixes #1608 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
