### PR TITLE
Fix vulnerabilities reported by upgrading to latest ubi & kafka client packages

### DIFF
--- a/Dockerfile.autotune
+++ b/Dockerfile.autotune
@@ -16,7 +16,7 @@
 ##########################################################
 #            Build Docker Image
 ##########################################################
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1749489516 as mvnbuild-jdk21
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1753762263 as mvnbuild-jdk21
 ARG USER=autotune
 ARG AUTOTUNE_HOME=/home/$USER
 
@@ -48,7 +48,7 @@ RUN jlink --strip-debug --compress 2 --no-header-files --no-man-pages --module-p
 #            Runtime Docker Image
 ##########################################################
 # Use ubi-minimal as the base image
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1749489516
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1753762263
 
 ARG AUTOTUNE_VERSION
 ARG USER=autotune

--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.9.0</version>
+            <version>3.9.1</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
## Description

Fixing vulnerabilities reported in july report

- Updaed RH UBI 9 minimal version to 9.6-1753762263 as it contains the fixes for CVEs in glibc*, libarchive, krb5-libs
- Updated kafka-clients to 3.9.1

https://issues.redhat.com/browse/KRUIZE-815

Fixes # (issue)

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Verified the fixed package versions are present in the UBI image. Also built the docker image & checked the quay scan report

**Test Configuration**
* Kubernetes clusters tested on: minikube

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated
