### PR TITLE
ETBIDB-1: Adds the Experiment bitmask and bitmask to enum converters

### DIFF
--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -256,7 +256,61 @@ public class AnalyzerConstants {
         CONTAINER,  // For container-level experiments
         NAMESPACE,  // For namespace-level experiments
         CLUSTER,    // For cluster-wide experiments
-        APPLICATION // For application-specific experiments
+        WORKLOAD // For application-specific experiments
+    }
+
+    /**
+     * This enum holds the positional flags which are used by experiment type
+     */
+    public enum ExperimentBitMask {
+        // Infra Bits [0-15]
+        CONTAINER_BIT(0),
+        POD_BIT(1),
+        WORKLOAD_BIT(2),
+        NAMESPACE_BIT(3),
+        NAMESPACE_GROUP_BIT(4),
+        CLUSTER_BIT(5),
+
+        // Resource Bits [16-31]
+        CPU_BIT(16),
+        MEMORY_BIT(17),
+        STORAGE_BIT(18),
+        NETWORK_BIT(19),
+        ACCELERATOR_BIT(20),
+
+        // Runtime Bits [32-47]
+        JVM_BIT(32);
+
+        private final int position;
+
+        ExperimentBitMask(int position) {
+            this.position = position;
+        }
+
+        public int getPosition() {
+            return position;
+        }
+
+        /**
+         * Returns a long with this bit set: 1L << position
+         */
+        public long getMask() {
+            return 1L << position;
+        }
+
+        /**
+         * Checks if this bit is set in the given long value.
+         */
+        public boolean isSet(long value) {
+            return (value & getMask()) != 0;
+        }
+
+        /**
+         * Sets this bit in the given value and returns the updated long.
+         */
+        public long setBit(long value) {
+            return value | getMask();
+        }
     }
 
     public static final class AcceleratorConstants {

--- a/src/main/java/com/autotune/analyzer/utils/ExperimentTypeUtil.java
+++ b/src/main/java/com/autotune/analyzer/utils/ExperimentTypeUtil.java
@@ -54,4 +54,107 @@ public class ExperimentTypeUtil {
             return null;
         }
     }
+
+    /**
+     * Checks if the particular experiment is a container experiment by checking if
+     * the container bit is set.
+     *
+     * Refer: AnalyserConstants.ExperimentBitMask ENUM
+     *
+     * Returns true if the 0th BIT (Container Bit) is set
+     * Returns false if the oth BIT (Container Bit) is NOT set
+     * @param experimentBitset
+     * @return
+     */
+    public static boolean isContainerExperiment(long experimentBitset) {
+        return AnalyzerConstants.ExperimentBitMask.CONTAINER_BIT.isSet(experimentBitset);
+    }
+
+    /**
+     * Checks if the particular experiment is a namespace experiment by checking if
+     * the namespace bit is set
+     *
+     * Refer: AnalyserConstants.ExperimentBitMask ENUM
+     *
+     * Returns true if the 3rd BIT (Namespace Bit) is set
+     * Returns false if the 3rd BIT (Namespace Bit) is NOT set
+     * @param experimentBitset
+     * @return
+     */
+    public static boolean isNamespaceExperiment(long experimentBitset) {
+        return AnalyzerConstants.ExperimentBitMask.NAMESPACE_BIT.isSet(experimentBitset);
+    }
+
+    /**
+     * Converts the ExperimentType Enum value to the bit mask by setting appropriate bit
+     * @param type
+     * @return
+     */
+    public static long getBitMaskForExperimentType(AnalyzerConstants.ExperimentType type) {
+        if (type == null) return 0L;
+
+        switch (type) {
+            case CONTAINER:
+                return AnalyzerConstants.ExperimentBitMask.CONTAINER_BIT.getMask();
+            case WORKLOAD:
+                return AnalyzerConstants.ExperimentBitMask.WORKLOAD_BIT.getMask();
+            case NAMESPACE:
+                return AnalyzerConstants.ExperimentBitMask.NAMESPACE_BIT.getMask();
+            case CLUSTER:
+                return AnalyzerConstants.ExperimentBitMask.CLUSTER_BIT.getMask();
+            default:
+                return 0L;
+        }
+    }
+
+
+    /**
+     * Converts the bitmask to experiment type enum value
+     *
+     * NOTE: Only the infra bits [0-7] are checked to convert to experiment type enum
+     * Refer: AnalyserConstants.ExperimentBitMask ENUM
+     * @param bitMask
+     * @return
+     */
+    public static AnalyzerConstants.ExperimentType getExperimentTypeFromBitMask(long bitMask) {
+        // Should Ideally return NULL but assumes that it's container if nothing set
+        if  (bitMask == 0) return AnalyzerConstants.ExperimentType.CONTAINER;
+
+        if (AnalyzerConstants.ExperimentBitMask.CONTAINER_BIT.isSet(bitMask)) {
+            return AnalyzerConstants.ExperimentType.CONTAINER;
+        }
+
+        if (AnalyzerConstants.ExperimentBitMask.WORKLOAD_BIT.isSet(bitMask)) {
+            return AnalyzerConstants.ExperimentType.WORKLOAD;
+        }
+
+        if (AnalyzerConstants.ExperimentBitMask.NAMESPACE_BIT.isSet(bitMask)) {
+            return AnalyzerConstants.ExperimentType.NAMESPACE;
+        }
+
+        if (AnalyzerConstants.ExperimentBitMask.CLUSTER_BIT.isSet(bitMask)) {
+            return AnalyzerConstants.ExperimentType.CLUSTER;
+        }
+        // Should Ideally return NULL but assumes that it's container if nothing set
+        return AnalyzerConstants.ExperimentType.CONTAINER;
+    }
+
+    /**
+     * Set the particular bit to the mask
+     * @param currentMask
+     * @param type
+     * @return
+     */
+    public static long setExperimentBit(long currentMask, AnalyzerConstants.ExperimentType type) {
+        return currentMask | getBitMaskForExperimentType(type);
+    }
+
+    // TODO: Need to be updated when we need to generate the bitset based on many attributes
+    // other than just container or namespace type, Method signature changes, after you pass more args for deciding the
+    // bitset, Please proceed changing all the callers if the signature is changed.
+    public static long getExperimentType(AnalyzerConstants.ExperimentType experimentType) {
+        long bitset = 0L;
+        bitset = setExperimentBit(bitset, experimentType);
+        return bitset;
+    }
 }


### PR DESCRIPTION
## Description

This PR is part of the series of PR's which are raised with the tag ETBIDB [Experiment Type as Big Interger in DataBase]

This PR contains the changes which are part of DRAFT PR #1616  

This PR adds the required enum's and respective converters for enum to long and long to enum wrt experiment type.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
