### PR TITLE
ETBIDB-2: Adds experiment_type field as big int and updates the DB entry object and helpers

### DIFF
--- a/migrations/kruize_experiments_ddl.sql
+++ b/migrations/kruize_experiments_ddl.sql
@@ -2,7 +2,7 @@ create table IF NOT EXISTS kruize_experiments (experiment_id varchar(255) not nu
 create table IF NOT EXISTS kruize_performance_profiles (name varchar(255) not null, k8s_type varchar(255), profile_version float(53) not null, slo jsonb, primary key (name));
 create table IF NOT EXISTS kruize_recommendations (interval_end_time timestamp(6) not null, experiment_name varchar(255) not null, cluster_name varchar(255), extended_data jsonb, version varchar(255), primary key (experiment_name, interval_end_time)) PARTITION BY RANGE (interval_end_time);
 create table IF NOT EXISTS kruize_results (interval_start_time timestamp(6) not null, interval_end_time timestamp(6) not null, experiment_name varchar(255) not null, cluster_name varchar(255) , duration_minutes float(53) not null, extended_data jsonb, meta_data jsonb, version varchar(255), primary key (experiment_name, interval_end_time, interval_start_time)) PARTITION BY RANGE (interval_end_time);
-alter table if exists kruize_experiments add constraint UK_experiment_name unique (experiment_name), add column experiment_type varchar(255);
+alter table if exists kruize_experiments add constraint UK_experiment_name unique (experiment_name), add column experiment_type bigint not null default 1;
 create index IF NOT EXISTS idx_recommendation_experiment_name on kruize_recommendations (experiment_name);
 create index IF NOT EXISTS idx_recommendation_interval_end_time on kruize_recommendations (interval_end_time);
 create index IF NOT EXISTS idx_result_experiment_name on kruize_results (experiment_name);

--- a/src/main/java/com/autotune/database/helper/DBHelpers.java
+++ b/src/main/java/com/autotune/database/helper/DBHelpers.java
@@ -30,6 +30,7 @@ import com.autotune.analyzer.recommendations.objects.MappedRecommendationForTime
 import com.autotune.analyzer.serviceObjects.*;
 import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.analyzer.utils.AnalyzerErrorConstants;
+import com.autotune.analyzer.utils.ExperimentTypeUtil;
 import com.autotune.analyzer.utils.GsonUTCDateAdapter;
 import com.autotune.common.auth.AuthenticationConfig;
 import com.autotune.common.data.dataSourceMetadata.*;
@@ -799,6 +800,7 @@ public class DBHelpers {
                         CreateExperimentAPIObject apiObj = new Gson().fromJson(extended_data_rawJson, CreateExperimentAPIObject.class);
                         apiObj.setExperiment_id(entry.getExperiment_id());
                         apiObj.setStatus(entry.getStatus());
+                        apiObj.setExperimentType(ExperimentTypeUtil.getExperimentTypeFromBitMask(entry.getExperiment_type()));
                         createExperimentAPIObjects.add(apiObj);
                     } catch (Exception e) {
                         LOGGER.error("Error in converting to apiObj from db object due to : {}", e.getMessage());

--- a/src/main/java/com/autotune/database/table/KruizeExperimentEntry.java
+++ b/src/main/java/com/autotune/database/table/KruizeExperimentEntry.java
@@ -16,6 +16,7 @@
 package com.autotune.database.table;
 
 import com.autotune.analyzer.utils.AnalyzerConstants;
+import com.autotune.analyzer.utils.ExperimentTypeUtil;
 import com.autotune.database.helper.GenerateExperimentID;
 import com.autotune.database.table.lm.KruizeLMExperimentEntry;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -64,8 +65,7 @@ public class KruizeExperimentEntry {
     private JsonNode extended_data;
     @JdbcTypeCode(SqlTypes.JSON)
     private JsonNode meta_data;
-    @Enumerated(EnumType.STRING)
-    private AnalyzerConstants.ExperimentType experiment_type;
+    private long experiment_type;
 
 //    TODO: update KruizeDSMetadataEntry
 
@@ -82,6 +82,7 @@ public class KruizeExperimentEntry {
         this.datasource = kruizeLMExperimentEntry.getDatasource();
         this.extended_data = kruizeLMExperimentEntry.getExtended_data();
         this.meta_data = kruizeLMExperimentEntry.getMeta_data();
+        this.experiment_type = ExperimentTypeUtil.getBitMaskForExperimentType(kruizeLMExperimentEntry.getExperiment_type());
     }
 
     public KruizeExperimentEntry() {
@@ -176,11 +177,11 @@ public class KruizeExperimentEntry {
         this.datasource = datasource;
     }
 
-    public AnalyzerConstants.ExperimentType getExperiment_type() {
+    public long getExperiment_type() {
         return experiment_type;
     }
 
-    public void setExperiment_type(AnalyzerConstants.ExperimentType experiment_type) {
+    public void setExperiment_type(long experiment_type) {
         this.experiment_type = experiment_type;
     }
 


### PR DESCRIPTION
## Description

This PR:

- is part of the series of PR's which are raised with the tag ETBIDB [Experiment Type as Big Interger in DataBase]
- contains the changes which are part of DRAFT PR #1616 
- PR is built on top of #1623 
- needs to be merged after merging #1623


This PR adds the DB table changes, where we alter the DB table `kruize_experiments` by adding a new column `experiment_type` as `bigint` and maintain the `default` value as `1`

We also update the respective mapping objects with DB, i.e `KruizeExperimentEntry` and also respective DB helper functions to maintain the value as `long` instead of an `enum`

The converters are also updated to convert from `long` to `enum` while extracting from DB object and `enum` to `long` while writing to the DB object.



Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [x] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
