### PR TITLE
ETBIDB-3: Adds the changes for kruize object, adds adapter to solve the list experiment issue

### DIFF
--- a/src/main/java/com/autotune/analyzer/adapters/KruizeObjectAdapter.java
+++ b/src/main/java/com/autotune/analyzer/adapters/KruizeObjectAdapter.java
@@ -1,0 +1,23 @@
+package com.autotune.analyzer.adapters;
+
+import com.autotune.analyzer.kruizeObject.KruizeObject;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import java.lang.reflect.Type;
+
+public class KruizeObjectAdapter implements JsonSerializer<KruizeObject> {
+    @Override
+    public JsonElement serialize(KruizeObject obj, Type typeOfSrc, JsonSerializationContext context) {
+        JsonObject jsonObject = context.serialize(obj).getAsJsonObject();
+
+        // Replace the experiment_type field
+        String typeStr = obj.getExperimentTypeString();
+        jsonObject.remove("experiment_type");
+        jsonObject.addProperty("experiment_type", typeStr);
+
+        return jsonObject;
+    }
+}

--- a/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
+++ b/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
@@ -21,6 +21,7 @@ import com.autotune.analyzer.performanceProfiles.PerformanceProfile;
 import com.autotune.analyzer.recommendations.ContainerRecommendations;
 import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.analyzer.utils.AnalyzerErrorConstants;
+import com.autotune.analyzer.utils.ExperimentTypeUtil;
 import com.autotune.common.data.ValidationOutputData;
 import com.autotune.common.data.metrics.Metric;
 import com.autotune.common.data.result.ContainerData;
@@ -373,7 +374,7 @@ public class ExperimentValidation {
                 String depType = "";
                 if (expObj.getExperiment_usecase_type().isRemote_monitoring()) {
                     // In case of RM, kubernetes_obj is mandatory
-                    if (expObj.getExperimentType().equals(AnalyzerConstants.ExperimentType.CONTAINER)) {
+                    if (AnalyzerConstants.ExperimentBitMask.CONTAINER_BIT.isSet(expObj.getExperimentType())) {
                         mandatoryDeploymentSelector = Collections.singletonList(AnalyzerConstants.KUBERNETES_OBJECTS);
                         // check for valid k8stype
                         for (K8sObject k8sObject : expObj.getKubernetes_objects()) {
@@ -395,15 +396,27 @@ public class ExperimentValidation {
                     }
                 }
                 // Namespace experiment validation for both remote and local monitoring
-                if (expObj.getExperimentType().equals(AnalyzerConstants.ExperimentType.NAMESPACE)){
+                if (AnalyzerConstants.ExperimentBitMask.NAMESPACE_BIT.isSet(expObj.getExperimentType())){
                     for (K8sObject k8sObject : expObj.getKubernetes_objects()) {
                         if (null == k8sObject.getNamespaceDataMap() || k8sObject.getNamespaceDataMap().isEmpty()) {
-                            errorMsg = errorMsg.concat(String.format(AnalyzerErrorConstants.APIErrors.CreateExperimentAPI.MISSING_NAMESPACE_DATA, expObj.getExperimentType().toString()));
+                            errorMsg = errorMsg.concat(
+                                    String.format(
+                                            AnalyzerErrorConstants.APIErrors.CreateExperimentAPI.MISSING_NAMESPACE_DATA,
+                                            ExperimentTypeUtil.getExperimentTypeFromBitMask(
+                                                    expObj.getExperimentType()
+                                            ).toString()
+                                    ));
                             missingNamespaceData = true;
                         } else {
                             for (NamespaceData namespaceData : k8sObject.getNamespaceDataMap().values()) {
                                 if (null == namespaceData.getNamespace_name()) {
-                                    errorMsg = errorMsg.concat(String.format(AnalyzerErrorConstants.APIErrors.CreateExperimentAPI.MISSING_NAMESPACE, expObj.getExperimentType().toString()));
+                                    errorMsg = errorMsg.concat(
+                                            String.format(
+                                                    AnalyzerErrorConstants.APIErrors.CreateExperimentAPI.MISSING_NAMESPACE,
+                                                    ExperimentTypeUtil.getExperimentTypeFromBitMask(
+                                                            expObj.getExperimentType()
+                                                    ).toString()
+                                            ));
                                     missingNamespaceData = true;
                                     break;
                                 }

--- a/src/main/java/com/autotune/analyzer/kruizeObject/KruizeObject.java
+++ b/src/main/java/com/autotune/analyzer/kruizeObject/KruizeObject.java
@@ -41,7 +41,7 @@ import java.util.Map;
  * <p>
  * Refer to examples dir for a reference AutotuneObject yaml.
  */
-public final class KruizeObject implements ExperimentTypeAware {
+public final class KruizeObject {
 
     @SerializedName("version")
     private String apiVersion;
@@ -53,8 +53,7 @@ public final class KruizeObject implements ExperimentTypeAware {
     @SerializedName("datasource")
     private String datasource;
     @SerializedName(KruizeConstants.JSONKeys.EXPERIMENT_TYPE) //TODO: to be used in future
-    @JsonAdapter(ExperimentTypeUtil.ExperimentTypeSerializer.class)
-    private AnalyzerConstants.ExperimentType experimentType;
+    private long experimentType;
     @SerializedName("default_updater")
     private String defaultUpdater;
     private String namespace;               // TODO: Currently adding it at this level with an assumption that there is only one entry in k8s object needs to be changed
@@ -370,11 +369,11 @@ public final class KruizeObject implements ExperimentTypeAware {
         this.datasource = datasource;
     }
 
-    public AnalyzerConstants.ExperimentType getExperimentType() {
+    public long getExperimentType() {
         return experimentType;
     }
 
-    public void setExperimentType(AnalyzerConstants.ExperimentType experimentType) {
+    public void setExperimentType(long experimentType) {
         this.experimentType = experimentType;
     }
 
@@ -425,12 +424,12 @@ public final class KruizeObject implements ExperimentTypeAware {
                 '}';
     }
 
-    @Override
+
     public boolean isNamespaceExperiment() {
         return ExperimentTypeUtil.isNamespaceExperiment(experimentType);
     }
 
-    @Override
+
     public boolean isContainerExperiment() {
         return ExperimentTypeUtil.isContainerExperiment(experimentType);
     }
@@ -452,5 +451,10 @@ public final class KruizeObject implements ExperimentTypeAware {
 
         return ((double) measurement_duration * minDataPoints
                 / (KruizeConstants.TimeConv.NO_OF_HOURS_PER_DAY * KruizeConstants.TimeConv.NO_OF_MINUTES_PER_HOUR));
+    }
+
+    public String getExperimentTypeString() {
+        AnalyzerConstants.ExperimentType type = ExperimentTypeUtil.getExperimentTypeFromBitMask(this.experimentType);
+        return type.toString().toLowerCase();
     }
 }

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -19,6 +19,7 @@ import com.autotune.analyzer.recommendations.term.Terms;
 import com.autotune.analyzer.recommendations.utils.RecommendationUtils;
 import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.analyzer.utils.AnalyzerErrorConstants;
+import com.autotune.analyzer.utils.ExperimentTypeUtil;
 import com.autotune.common.data.ValidationOutputData;
 import com.autotune.common.data.metrics.*;
 import com.autotune.common.data.result.ContainerData;
@@ -2044,8 +2045,11 @@ public class RecommendationEngine {
 
                 }
 
-                List<Metric> namespaceMetricList = filterMetricsBasedOnExpTypeAndK8sObject(metricProfile,
-                        AnalyzerConstants.MetricName.namespaceMaxDate.name(), kruizeObject.getExperimentType());
+                List<Metric> namespaceMetricList = filterMetricsBasedOnExpTypeAndK8sObject(
+                        metricProfile,
+                        AnalyzerConstants.MetricName.namespaceMaxDate.name(),
+                        ExperimentTypeUtil.getExperimentTypeFromBitMask(kruizeObject.getExperimentType())
+                );
 
                 // Iterate over metrics and aggregation functions
                 for (Metric metricEntry : namespaceMetricList) {
@@ -2276,8 +2280,11 @@ public class RecommendationEngine {
                     MetricResults metricResults = null;
                     MetricAggregationInfoResults metricAggregationInfoResults = null;
 
-                    List<Metric> metricList = filterMetricsBasedOnExpTypeAndK8sObject(metricProfile,
-                            AnalyzerConstants.MetricName.maxDate.name(), kruizeObject.getExperimentType());
+                    List<Metric> metricList = filterMetricsBasedOnExpTypeAndK8sObject(
+                            metricProfile,
+                            AnalyzerConstants.MetricName.maxDate.name(),
+                            ExperimentTypeUtil.getExperimentTypeFromBitMask(kruizeObject.getExperimentType())
+                    );
 
                     List<String> acceleratorFunctions = Arrays.asList(
                             AnalyzerConstants.MetricName.acceleratorCoreUsage.toString(),

--- a/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
@@ -9,6 +9,7 @@ import com.autotune.analyzer.recommendations.NamespaceRecommendations;
 import com.autotune.analyzer.recommendations.objects.MappedRecommendationForTimestamp;
 import com.autotune.analyzer.recommendations.utils.RecommendationUtils;
 import com.autotune.analyzer.utils.AnalyzerConstants;
+import com.autotune.analyzer.utils.ExperimentTypeUtil;
 import com.autotune.common.data.ValidationOutputData;
 import com.autotune.common.data.metrics.*;
 import com.autotune.common.data.result.ContainerData;
@@ -79,7 +80,7 @@ public class Converters {
                 kruizeObject.setMode(createExperimentAPIObject.getMode());
                 kruizeObject.setPerformanceProfile(createExperimentAPIObject.getPerformanceProfile());
                 kruizeObject.setDataSource(createExperimentAPIObject.getDatasource());
-                kruizeObject.setExperimentType(createExperimentAPIObject.getExperimentType());
+                kruizeObject.setExperimentType(ExperimentTypeUtil.getExperimentType(createExperimentAPIObject.getExperimentType()));
                 kruizeObject.setSloInfo(createExperimentAPIObject.getSloInfo());
                 kruizeObject.setTrial_settings(createExperimentAPIObject.getTrialSettings());
                 RecommendationSettings recommendationSettings = new RecommendationSettings();
@@ -158,7 +159,9 @@ public class Converters {
                 listRecommendationsAPIObject.setApiVersion(AnalyzerConstants.VersionConstants.APIVersionConstants.CURRENT_LIST_RECOMMENDATIONS_VERSION);
                 listRecommendationsAPIObject.setExperimentName(kruizeObject.getExperimentName());
                 listRecommendationsAPIObject.setClusterName(kruizeObject.getClusterName());
-                listRecommendationsAPIObject.setExperimentType(kruizeObject.getExperimentType());
+                listRecommendationsAPIObject.setExperimentType(
+                        ExperimentTypeUtil.getExperimentTypeFromBitMask(kruizeObject.getExperimentType())
+                );
                 List<KubernetesAPIObject> kubernetesAPIObjects = new ArrayList<>();
                 KubernetesAPIObject kubernetesAPIObject;
 

--- a/src/main/java/com/autotune/analyzer/serviceObjects/verification/validators/KubernetesElementsValidator.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/verification/validators/KubernetesElementsValidator.java
@@ -87,7 +87,7 @@ public class KubernetesElementsValidator implements ConstraintValidator<Kubernet
             String kubeObjNameSpaceInKruizeObject = kruizeObject.getKubernetes_objects().get(0).getNamespace();
             String kubeObjNameSpaceInResultsData = resultData.getKubernetes_objects().get(0).getNamespace();
 
-            if (kruizeObject.getExperimentType().equals(AnalyzerConstants.ExperimentType.CONTAINER)) {
+            if (AnalyzerConstants.ExperimentBitMask.CONTAINER_BIT.isSet(kruizeObject.getExperimentType())) {
                 if (kubeObjNameSpaceInKruizeObject != null && !kubeObjNameSpaceInKruizeObject.equals(kubeObjNameSpaceInResultsData)) {
                     kubeObjsMisMatch = true;
                     errorMsg = errorMsg.concat(

--- a/src/main/java/com/autotune/database/helper/DBHelpers.java
+++ b/src/main/java/com/autotune/database/helper/DBHelpers.java
@@ -616,7 +616,9 @@ public class DBHelpers {
                     kruizeRecommendationEntry.setVersion(KruizeConstants.KRUIZE_RECOMMENDATION_API_VERSION.LATEST.getVersionNumber());
                     kruizeRecommendationEntry.setExperiment_name(listRecommendationsAPIObject.getExperimentName());
                     kruizeRecommendationEntry.setCluster_name(listRecommendationsAPIObject.getClusterName());
-                    kruizeRecommendationEntry.setExperimentType(kruizeObject.getExperimentType().name());
+                    kruizeRecommendationEntry.setExperimentType(
+                            ExperimentTypeUtil.getExperimentTypeFromBitMask(kruizeObject.getExperimentType()).name()
+                    );
 
                     Timestamp endInterval = null;
                     // todo : what happens if two k8 objects or Containers with different timestamp
@@ -756,7 +758,9 @@ public class DBHelpers {
                     listRecommendationsAPIObject.setClusterName(kruizeObject.getClusterName());
                     listRecommendationsAPIObject.setExperimentName(kruizeObject.getExperimentName());
                     listRecommendationsAPIObject.setKubernetesObjects(kubernetesAPIObjectList);
-                    listRecommendationsAPIObject.setExperimentType(kruizeObject.getExperimentType());
+                    listRecommendationsAPIObject.setExperimentType(
+                            ExperimentTypeUtil.getExperimentTypeFromBitMask(kruizeObject.getExperimentType())
+                    );
                 }
                 return listRecommendationsAPIObject;
             }


### PR DESCRIPTION
## Description

This PR:

- is part of the series of PR's which are raised with the tag ETBIDB [Experiment Type as Big Interger in DataBase]
- contains the changes which are part of DRAFT PR #1616 
- PR is built on top of #1624 
- needs to be merged after merging #1624 

**CAUTION: MERGE ONLY IF KRUIZE OBJECT CHANGES ARE NEEDED**

This PR has the changes for `KruizeObject` to maintain `experiment_type` as `long` internally.

Currently the usage scope for this changes are limited to check if the container and namespace bits are set. Which we will be doing while extracting from DB and setting `enum`

The advantage of this changes can be seen if we are extensively using bit check instead of enum compare when we add more flags and use it across all kruize subsystems like autotune and recommendation generator. Currently these changes might not give any added advantage and adds a conversion overhead in case of `ListExperiments`

**PLEASE MERGE THIS ONLY IF IT'S NECESSARY RIGHT NOW**

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
