### PR TITLE
Adds Validation checks

### DIFF
--- a/src/main/java/com/autotune/analyzer/performanceProfiles/utils/PerformanceProfileUtil.java
+++ b/src/main/java/com/autotune/analyzer/performanceProfiles/utils/PerformanceProfileUtil.java
@@ -209,7 +209,7 @@ public class PerformanceProfileUtil {
                 // if the metrics data is not present, set corresponding validation message and skip adding the current namespace data
                 if (namespaceAPIObject.getMetrics() == null) {
                     errorReasons.add(String.format(
-                            AnalyzerErrorConstants.AutotuneObjectErrors.MISSING_METRICS,
+                            AnalyzerErrorConstants.AutotuneObjectErrors.MISSING_METRICS_NAMESPACE,
                             namespaceAPIObject.getNamespace(),
                             updateResultsAPIObject.getExperimentName()
                     ));

--- a/src/main/java/com/autotune/analyzer/serviceObjects/verification/validators/KubernetesElementsValidator.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/verification/validators/KubernetesElementsValidator.java
@@ -59,23 +59,23 @@ public class KubernetesElementsValidator implements ConstraintValidator<Kubernet
             // Check if Kubernetes Object Namespaces is matched
             if (kruizeObject.getExperimentType().equals(AnalyzerConstants.ExperimentType.NAMESPACE)) {
                 // Validate the absence of type, name and namespace objects
-                for (K8sObject obj : resultData.getKubernetes_objects()) {
-                    String kubeObjTypeInResultData = obj.getType();
-                    String kubeObjNameInResultsData = obj.getName();
-                    String kubeObjNameSpaceInResultsData = obj.getNamespace();
+                // Assuming that there is only one Kubernetes object
+                String kubeObjTypeInResultData = resultData.getKubernetes_objects().get(0).getType();
+                String kubeObjNameInResultsData = resultData.getKubernetes_objects().get(0).getName();
+                String kubeObjNameSpaceInResultsData = resultData.getKubernetes_objects().get(0).getNamespace();
 
-                    if (kubeObjTypeInResultData != null && kubeObjNameInResultsData != null && kubeObjNameSpaceInResultsData != null) {
-                        kubeObjsMisMatch = true;
-                        errorMsg = errorMsg.concat(
-                                String.format(
-                                        AnalyzerErrorConstants.AutotuneObjectErrors.MISSING_NAMESPACE_SPECIFIC_UPDATE_RESULTS_FIELDS,
-                                        expName
-                                ));
-                    }
+                if (kubeObjTypeInResultData != null && kubeObjNameInResultsData != null && kubeObjNameSpaceInResultsData != null) {
+                    kubeObjsMisMatch = true;
+                    errorMsg = errorMsg.concat(
+                            String.format(
+                                    AnalyzerErrorConstants.AutotuneObjectErrors.MISSING_NAMESPACE_SPECIFIC_UPDATE_RESULTS_FIELDS,
+                                    expName
+                            ));
                 }
             }
 
             // Check if Kubernetes Object Type is matched
+            // Assuming that there is only one Kubernetes object
             String kubeObjTypeInKruizeObject = kruizeObject.getKubernetes_objects().get(0).getType();
             String kubeObjTypeInResultData = resultData.getKubernetes_objects().get(0).getType();
 
@@ -91,6 +91,7 @@ public class KubernetesElementsValidator implements ConstraintValidator<Kubernet
             }
 
             // Check if Kubernetes Object Name is matched
+            // Assuming that there is only one Kubernetes object
             String kubeObjNameInKruizeObject = kruizeObject.getKubernetes_objects().get(0).getName();
             String kubeObjNameInResultsData = resultData.getKubernetes_objects().get(0).getName();
 
@@ -107,6 +108,7 @@ public class KubernetesElementsValidator implements ConstraintValidator<Kubernet
 
 
             // Check if Kubernetes Object NameSpace is matched
+            // Assuming that there is only one Kubernetes object
             String kubeObjNameSpaceInKruizeObject = kruizeObject.getKubernetes_objects().get(0).getNamespace();
             String kubeObjNameSpaceInResultsData = resultData.getKubernetes_objects().get(0).getNamespace();
 
@@ -123,6 +125,7 @@ public class KubernetesElementsValidator implements ConstraintValidator<Kubernet
                 }
             }
             // Validate blank or null container names and image names
+            // Assuming that there is only one Kubernetes object
             List<ContainerData> resultContainers = new ArrayList<>();
             if (resultData.getKubernetes_objects() != null && !resultData.getKubernetes_objects().isEmpty() &&
                     resultData.getKubernetes_objects().get(0) != null && resultData.getKubernetes_objects().get(0).getContainerDataMap() != null) {
@@ -139,7 +142,7 @@ public class KubernetesElementsValidator implements ConstraintValidator<Kubernet
             }
 
             // Validate for blank or null Namespace Name
-
+            // Assuming that there is only one Kubernetes object
             List<NamespaceData> resultNamespaces = new ArrayList<>();
             if (resultData.getKubernetes_objects() != null && !resultData.getKubernetes_objects().isEmpty() &&
                     resultData.getKubernetes_objects().get(0) != null && resultData.getKubernetes_objects().get(0).getNamespaceDataMap() != null) {

--- a/src/main/java/com/autotune/analyzer/serviceObjects/verification/validators/KubernetesElementsValidator.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/verification/validators/KubernetesElementsValidator.java
@@ -67,7 +67,7 @@ public class KubernetesElementsValidator implements ConstraintValidator<Kubernet
                     kubeObjsMisMatch = true;
                     errorMsg = errorMsg.concat(
                             String.format(
-                                    "Kubernetes Object Type, Name, Namespace Present. Expected Namespace-level Update Results fields, Found Container-level Update Results fields for experiment: %s \n",
+                                    AnalyzerErrorConstants.AutotuneObjectErrors.MISSING_NAMESPACE_SPECIFIC_UPDATE_RESULTS_FIELDS,
                                     expName
                             ));
                 }

--- a/src/main/java/com/autotune/analyzer/serviceObjects/verification/validators/KubernetesElementsValidator.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/verification/validators/KubernetesElementsValidator.java
@@ -17,6 +17,7 @@ package com.autotune.analyzer.serviceObjects.verification.validators;
 
 import com.autotune.analyzer.kruizeObject.KruizeObject;
 import com.autotune.analyzer.serviceObjects.Converters;
+import com.autotune.analyzer.serviceObjects.KubernetesAPIObject;
 import com.autotune.analyzer.serviceObjects.UpdateResultsAPIObject;
 import com.autotune.analyzer.serviceObjects.verification.annotators.KubernetesElementsCheck;
 import com.autotune.analyzer.utils.AnalyzerConstants;
@@ -57,19 +58,20 @@ public class KubernetesElementsValidator implements ConstraintValidator<Kubernet
 
             // Check if Kubernetes Object Namespaces is matched
             if (kruizeObject.getExperimentType().equals(AnalyzerConstants.ExperimentType.NAMESPACE)) {
-                // it's a namespace experiment type then type, name, namespace should not be present
+                // Validate the absence of type, name and namespace objects
+                for (K8sObject obj : resultData.getKubernetes_objects()) {
+                    String kubeObjTypeInResultData = obj.getType();
+                    String kubeObjNameInResultsData = obj.getName();
+                    String kubeObjNameSpaceInResultsData = obj.getNamespace();
 
-                String kubeObjTypeInResultData = resultData.getKubernetes_objects().get(0).getType();
-                String kubeObjNameInResultsData = resultData.getKubernetes_objects().get(0).getName();
-                String kubeObjNameSpaceInResultsData = resultData.getKubernetes_objects().get(0).getNamespace();
-
-                if (kubeObjTypeInResultData != null && kubeObjNameInResultsData != null && kubeObjNameSpaceInResultsData != null) {
-                    kubeObjsMisMatch = true;
-                    errorMsg = errorMsg.concat(
-                            String.format(
-                                    AnalyzerErrorConstants.AutotuneObjectErrors.MISSING_NAMESPACE_SPECIFIC_UPDATE_RESULTS_FIELDS,
-                                    expName
-                            ));
+                    if (kubeObjTypeInResultData != null && kubeObjNameInResultsData != null && kubeObjNameSpaceInResultsData != null) {
+                        kubeObjsMisMatch = true;
+                        errorMsg = errorMsg.concat(
+                                String.format(
+                                        AnalyzerErrorConstants.AutotuneObjectErrors.MISSING_NAMESPACE_SPECIFIC_UPDATE_RESULTS_FIELDS,
+                                        expName
+                                ));
+                    }
                 }
             }
 

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
@@ -96,6 +96,7 @@ public class AnalyzerErrorConstants {
         public static final String WRONG_TIMESTAMP = "The Start time should precede the End time!";
         public static final String MEASUREMENT_DURATION_ERROR = "Interval duration cannot be less than or greater than measurement_duration by more than " + KruizeConstants.TimeConv.MEASUREMENT_DURATION_THRESHOLD_SECONDS + " seconds";
         public static final String MISSING_METRICS = "Metric data is not present for container : %s for experiment: %s. ";
+        public static final String MISSING_METRICS_NAMESPACE = "Metric data is not present for namespace : %s for experiment: %s. ";
         public static final String BLANK_AGGREGATION_INFO_VALUE = " cannot be negative or blank for the metric variable: ";
         public static final String UNSUPPORTED_FORMAT = " Format value should be among these values: ".concat(KruizeSupportedTypes.SUPPORTED_FORMATS.toString());
         public static final String UNSUPPORTED_METRIC = "Metric variable name should be among these values: ".concat(Arrays.toString(AnalyzerConstants.MetricName.values()));

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
@@ -117,7 +117,7 @@ public class AnalyzerErrorConstants {
         public static final String INVALID_METADATA_PROFILE_NAME = "MetadataProfile 'name' field is either null or empty!";
         public static final String INVALID_METRICS_FOUND = "Invalid metrics found for experiment - %s: %s";
         public static final String MISSING_MANDATORY_PARAMETERS = "Missing one of the following mandatory parameters for experiment - %s : %s";
-        public static final String MISSING_NAMESPACE_SPECIFIC_UPDATE_RESULTS_FIELDS = "Kubernetes Object Type, Name, Namespace Present. Expected Namespace-level Update Results fields, Found Container-level Update Results fields for experiment: %s ";
+        public static final String MISSING_NAMESPACE_SPECIFIC_UPDATE_RESULTS_FIELDS = "Expected namespace-level results, but found type, name, and namespace for experiment: %s.";
 
 
         private AutotuneObjectErrors() {

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
@@ -117,6 +117,7 @@ public class AnalyzerErrorConstants {
         public static final String INVALID_METADATA_PROFILE_NAME = "MetadataProfile 'name' field is either null or empty!";
         public static final String INVALID_METRICS_FOUND = "Invalid metrics found for experiment - %s: %s";
         public static final String MISSING_MANDATORY_PARAMETERS = "Missing one of the following mandatory parameters for experiment - %s : %s";
+        public static final String MISSING_NAMESPACE_SPECIFIC_UPDATE_RESULTS_FIELDS = "Kubernetes Object Type, Name, Namespace Present. Expected Namespace-level Update Results fields, Found Container-level Update Results fields for experiment: %s ";
 
 
         private AutotuneObjectErrors() {

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
@@ -106,6 +106,7 @@ public class AnalyzerErrorConstants {
         public static final String VERSION_MISMATCH = "Version number mismatch found. Expected: %s , Found: %s";
         public static final String NULL_OR_BLANK_CONTAINER_IMAGE_NAME = "container_image_name cannot be null or blank";
         public static final String NULL_OR_BLANK_CONTAINER_NAME = "container_name cannot be null or blank";
+        public static final String NULL_OR_BLANK_NAMESPACE_NAME = "namespace_name cannot be null or blank";
         public static final String EXPERIMENT_AND_INTERVAL_END_TIME = " for experiment : %s interval_end_time: %s";
         public static final String LOCAL_MONITORING_DATASOURCE_MANDATORY = "Experiment %s: datasource mandatory for Local Monitoring type";
         public static final String LOAD_METADATA_PROFILE_FAILURE = "Loading saved Metadata Profile %s failed: %s";


### PR DESCRIPTION
## Description

1.  Fix error msg for missing namespace metrics (changes from container to namespace)
2.  Adds validation check for null/ blank namespace (name)
3.  Add validation for container update results being applied to namespace experiment edge case (added experiment type validation for nsp experiment)

Quay img with changes : quay.io/bmenghan/validate:v1

Fixes # (issue)

### Type of change

- [x] Bug fix / Validations added
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 
These have been tested against the negative test cases for update results namespace mentioned in pr #1603 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [x] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [x] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
