### PR TITLE
Add functional tests for the request_id feature

### DIFF
--- a/tests/scripts/helpers/kruize.py
+++ b/tests/scripts/helpers/kruize.py
@@ -126,7 +126,7 @@ def update_results(result_json_file, logging=True):
 
 
 # Description: This function generates recommendation for the given experiment_name , start time and end time .
-def update_recommendations(experiment_name, startTime, endTime):
+def update_recommendations(experiment_name, startTime, endTime, request_id=None):
     print("\n************************************************************")
     print("\nUpdating the recommendation \n for %s for dates Start-time: %s and End-time: %s..." % (
         experiment_name, startTime, endTime))
@@ -137,6 +137,8 @@ def update_recommendations(experiment_name, startTime, endTime):
         queryString = queryString + "&interval_end_time=%s" % (endTime)
     if startTime:
         queryString = queryString + "&interval_start_time=%s" % (startTime)
+    if request_id is not None:
+        queryString = queryString + "&request_id=%s" % (request_id)
 
     url = URL + "/updateRecommendations?%s" % (queryString)
     print("URL = ", url)

--- a/tests/scripts/remote_monitoring_tests/rest_apis/test_update_recommendations.py
+++ b/tests/scripts/remote_monitoring_tests/rest_apis/test_update_recommendations.py
@@ -663,3 +663,209 @@ def test_update_valid_namespace_recommendations(cluster_type):
         response = delete_experiment(json_file)
         print("delete exp = ", response.status_code)
         assert response.status_code == SUCCESS_STATUS_CODE
+
+
+@pytest.mark.sanity
+@pytest.mark.requestId
+def test_update_recommendations_with_valid_request_id(cluster_type):
+    '''
+      Creates Experiment +
+      update results for 0.5 hrs +
+      update recommendation experiment_name, interval_end_time as parameters along with a random valid request_id
+          Expected : recommendation should be available for the timestamp provided
+          Expected : plots data should be available
+      '''
+    input_json_file = "../json_files/create_exp.json"
+    result_json_file = "../json_files/update_results.json"
+
+    find = []
+    json_data = json.load(open(input_json_file))
+
+    find.append(json_data[0]['experiment_name'])
+    find.append(json_data[0]['kubernetes_objects'][0]['name'])
+    find.append(json_data[0]['kubernetes_objects'][0]['namespace'])
+
+    form_kruize_url(cluster_type)
+    num_exps = 1
+    num_res = 2
+    # Create experiment using the specified json
+    for i in range(num_exps):
+        create_exp_json_file = "/tmp/create_exp_" + str(i) + ".json"
+        generate_json(find, input_json_file, create_exp_json_file, i)
+
+        # Delete the experiment
+        response = delete_experiment(create_exp_json_file)
+        print("delete exp = ", response.status_code)
+
+        # Create the experiment
+        response = create_experiment(create_exp_json_file)
+
+        data = response.json()
+        print("message = ", data['message'])
+        assert response.status_code == SUCCESS_STATUS_CODE
+        assert data['status'] == SUCCESS_STATUS
+        assert data['message'] == CREATE_EXP_SUCCESS_MSG
+
+        # Update results for the experiment
+        update_results_json_file = "/tmp/update_results_" + str(i) + ".json"
+
+        result_json_arr = []
+        # Get the experiment name
+        json_data = json.load(open(create_exp_json_file))
+        experiment_name = json_data[0]['experiment_name']
+        interval_start_time = get_datetime()
+        for j in range(num_res):
+            update_timestamps = True
+            generate_json(find, result_json_file, update_results_json_file, i, update_timestamps)
+            result_json = read_json_data_from_file(update_results_json_file)
+            if j == 0:
+                start_time = interval_start_time
+            else:
+                start_time = end_time
+
+            result_json[0]['interval_start_time'] = start_time
+            end_time = increment_timestamp_by_given_mins(start_time, 15)
+            result_json[0]['interval_end_time'] = end_time
+
+            write_json_data_to_file(update_results_json_file, result_json)
+            result_json_arr.append(result_json[0])
+            response = update_results(update_results_json_file, False)
+
+            data = response.json()
+            print("message = ", data['message'])
+            assert response.status_code == SUCCESS_STATUS_CODE
+            assert data['status'] == SUCCESS_STATUS
+            assert data['message'] == UPDATE_RESULTS_SUCCESS_MSG
+
+        # Expecting that we have recommendations after two results
+        # validate the flow with the request_id param
+        request_id = generate_request_id(32)
+        response = update_recommendations(experiment_name, None, end_time, request_id)
+        data = response.json()
+        assert response.status_code == SUCCESS_STATUS_CODE
+        assert data[0]['experiment_name'] == experiment_name
+        assert data[0]['kubernetes_objects'][0]['containers'][0]['recommendations']['notifications']['111000'][
+                   'message'] == 'Recommendations Are Available'
+        response = list_recommendations(experiment_name, rm=True)
+        if response.status_code == SUCCESS_200_STATUS_CODE:
+            recommendation_json = response.json()
+            recommendation_section = recommendation_json[0]["kubernetes_objects"][0]["containers"][0][
+                "recommendations"]
+            high_level_notifications = recommendation_section["notifications"]
+            # Check if duration
+            assert INFO_RECOMMENDATIONS_AVAILABLE_CODE in high_level_notifications
+            data_section = recommendation_section["data"]
+            short_term_recommendation = data_section[str(end_time)]["recommendation_terms"]["short_term"]
+            short_term_notifications = short_term_recommendation["notifications"]
+            for notification in short_term_notifications.values():
+                assert notification["type"] != "error"
+
+        # Validate the json against the json schema
+        list_reco_json = response.json()
+        errorMsg = validate_list_reco_json(list_reco_json, list_reco_json_schema)
+        assert errorMsg == ""
+
+        # Validate the json values
+        create_exp_json = read_json_data_from_file(create_exp_json_file)
+        update_results_json = []
+        update_results_json.append(result_json_arr[len(result_json_arr) - 1])
+
+        expected_duration_in_hours = SHORT_TERM_DURATION_IN_HRS_MIN
+        validate_reco_json(create_exp_json[0], update_results_json, list_reco_json[0], expected_duration_in_hours)
+
+    # Delete all the experiments
+    for i in range(num_exps):
+        json_file = "/tmp/create_exp_" + str(i) + ".json"
+        response = delete_experiment(json_file)
+        print("delete exp = ", response.status_code)
+        assert response.status_code == SUCCESS_STATUS_CODE
+
+
+@pytest.mark.negative
+@pytest.mark.requestId
+@pytest.mark.parametrize("invalid_request_id", [
+    "", "abc123", generate_request_id(33), "1234567890abcdef!@#$%^&*()", " " * 32
+])
+def test_update_recommendations_with_invalid_request_id(cluster_type, invalid_request_id):
+    '''
+      Creates Experiment +
+      update results for 0.5 hrs +
+      update recommendation experiment_name, interval_end_time as parameters along with multiple invalid request_id
+          Expected : updateRecommendations API should fail with 400 error
+      '''
+    input_json_file = "../json_files/create_exp.json"
+    result_json_file = "../json_files/update_results.json"
+
+    find = []
+    json_data = json.load(open(input_json_file))
+
+    find.append(json_data[0]['experiment_name'])
+    find.append(json_data[0]['kubernetes_objects'][0]['name'])
+    find.append(json_data[0]['kubernetes_objects'][0]['namespace'])
+
+    form_kruize_url(cluster_type)
+    num_exps = 1
+    num_res = 2
+    # Create experiment using the specified json
+    for i in range(num_exps):
+        create_exp_json_file = "/tmp/create_exp_" + str(i) + ".json"
+        generate_json(find, input_json_file, create_exp_json_file, i)
+
+        # Delete the experiment
+        response = delete_experiment(create_exp_json_file)
+        print("delete exp = ", response.status_code)
+
+        # Create the experiment
+        response = create_experiment(create_exp_json_file)
+
+        data = response.json()
+        print("message = ", data['message'])
+        assert response.status_code == SUCCESS_STATUS_CODE
+        assert data['status'] == SUCCESS_STATUS
+        assert data['message'] == CREATE_EXP_SUCCESS_MSG
+
+        # Update results for the experiment
+        update_results_json_file = "/tmp/update_results_" + str(i) + ".json"
+
+        result_json_arr = []
+        # Get the experiment name
+        json_data = json.load(open(create_exp_json_file))
+        experiment_name = json_data[0]['experiment_name']
+        interval_start_time = get_datetime()
+        for j in range(num_res):
+            update_timestamps = True
+            generate_json(find, result_json_file, update_results_json_file, i, update_timestamps)
+            result_json = read_json_data_from_file(update_results_json_file)
+            if j == 0:
+                start_time = interval_start_time
+            else:
+                start_time = end_time
+
+            result_json[0]['interval_start_time'] = start_time
+            end_time = increment_timestamp_by_given_mins(start_time, 15)
+            result_json[0]['interval_end_time'] = end_time
+
+            write_json_data_to_file(update_results_json_file, result_json)
+            result_json_arr.append(result_json[0])
+            response = update_results(update_results_json_file, False)
+
+            data = response.json()
+            print("message = ", data['message'])
+            assert response.status_code == SUCCESS_STATUS_CODE
+            assert data['status'] == SUCCESS_STATUS
+            assert data['message'] == UPDATE_RESULTS_SUCCESS_MSG
+
+        # After at least two results, expecting that we have recommendations
+        # validate the flow with the invalid request_id param
+        response = update_recommendations(experiment_name, None, end_time, invalid_request_id)
+        data = response.json()
+        assert response.status_code == ERROR_STATUS_CODE
+        assert data['status'] == ERROR_STATUS
+        assert data['message'] == INVALID_REQUEST_ID
+
+    # Delete all the experiments
+    for i in range(num_exps):
+        json_file = "/tmp/create_exp_" + str(i) + ".json"
+        response = delete_experiment(json_file)
+        print("delete exp = ", response.status_code)
+        assert response.status_code == SUCCESS_STATUS_CODE


### PR DESCRIPTION
## Description

This PR contains functional tests for the `request_id` feature added as part of the PR #1620 

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: Openshift

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

```
$ pytest -m requestId -v --html=/tmp/req-id.html --cluster_type openshift
============================================================ test session starts ============================================================
platform linux -- Python 3.13.5, pytest-8.4.1, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.13.5', 'Platform': 'Linux-6.15.6-200.fc42.x86_64-x86_64-with-glibc2.41', 'Packages': {'pytest': '8.4.1', 'pluggy': '1.6.0'}, 'Plugins': {'metadata': '3.1.1', 'html': '3.2.0', 'anyio': '4.9.0'}, 'JAVA_HOME': '/home/saakhan/Documents/java/jdk-17.0.1+12'}
rootdir: /home/saakhan/Saad/Autotune/Tasks/request-id-tests/autotune/tests/scripts/remote_monitoring_tests
configfile: pytest.ini
plugins: metadata-3.1.1, html-3.2.0, anyio-4.9.0
collected 440 items / 422 deselected / 18 selected                                                                                          

test_create_experiment.py::test_create_exp_with_valid_request_id PASSED                                                               [  5%]
test_create_experiment.py::test_create_exp_with_invalid_request_id[] PASSED                                                           [ 11%]
test_create_experiment.py::test_create_exp_with_invalid_request_id[abc123] PASSED                                                     [ 16%]
test_create_experiment.py::test_create_exp_with_invalid_request_id[zABkkM9D0aKG2vZWcPQueCoum5o00NjEj] PASSED                          [ 22%]
test_create_experiment.py::test_create_exp_with_invalid_request_id[1234567890abcdef!@#$%^&*()] PASSED                                 [ 27%]
test_create_experiment.py::test_create_exp_with_invalid_request_id[                                ] PASSED                           [ 33%]
test_update_recommendations.py::test_update_recommendations_with_valid_request_id PASSED                                              [ 38%]
test_update_recommendations.py::test_update_recommendations_with_invalid_request_id[] PASSED                                          [ 44%]
test_update_recommendations.py::test_update_recommendations_with_invalid_request_id[abc123] PASSED                                    [ 50%]
test_update_recommendations.py::test_update_recommendations_with_invalid_request_id[q6sDBkyA5MTV0uodBR1yB2xRXau2uPEgY] PASSED         [ 55%]
test_update_recommendations.py::test_update_recommendations_with_invalid_request_id[1234567890abcdef!@#$%^&*()] PASSED                [ 61%]
test_update_recommendations.py::test_update_recommendations_with_invalid_request_id[                                ] PASSED          [ 66%]
test_update_results.py::test_update_results_with_valid_request_id PASSED                                                              [ 72%]
test_update_results.py::test_update_results_with_invalid_request_id[] PASSED                                                          [ 77%]
test_update_results.py::test_update_results_with_invalid_request_id[abc123] PASSED                                                    [ 83%]
test_update_results.py::test_update_results_with_invalid_request_id[pmo3hwL7N8PiG6tNpgYJ9dkPat2jVBTDr] PASSED                         [ 88%]
test_update_results.py::test_update_results_with_invalid_request_id[1234567890abcdef!@#$%^&*()] PASSED                                [ 94%]
test_update_results.py::test_update_results_with_invalid_request_id[                                ] PASSED                          [100%]

----------------------------------------------- generated html file: file:///tmp/req-id.html ------------------------------------------------
============================================== 18 passed, 422 deselected in 134.81s (0:02:14) ===============================================

```