### PR TITLE
Updated scale test remote patch

### DIFF
--- a/tests/scripts/remote_monitoring_tests/scale_test/remote_monitoring_scale_test_bulk.sh
+++ b/tests/scripts/remote_monitoring_tests/scale_test/remote_monitoring_scale_test_bulk.sh
@@ -83,6 +83,16 @@ function get_kruize_service_log() {
         kubectl logs -f ${kruize_pod} -n ${NAMESPACE} > ${log} 2>&1 &
 }
 
+#
+# Switch to default values for isROSEnabled & local flags in the code (isROSEnabled is true for RM)
+#
+function kruize_scale_test_remote_patch() {
+	CRC_DIR="./manifests/crc/default-db-included-installation"
+	KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT="${CRC_DIR}/openshift/kruize-crc-openshift.yaml"
+
+	sed -i -E 's/"isROSEnabled": "false",?\s*//g; s/"local": "true",?\s*//g'  ${KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT}
+}
+
 while getopts r:i:u:d:t:n:m:s:l:f:b:e:q:c:h gopts
 do
 	case ${gopts} in
@@ -156,7 +166,7 @@ if [ ${kruize_setup} == true ]; then
 	echo "Removing isROSEnabled=false and local=true"
 	cluster_type=${CLUSTER_TYPE}
 	pushd ${KRUIZE_REPO} > /dev/null
-		kruize_remote_patch
+		kruize_scale_test_remote_patch
         	echo "./deploy.sh -c ${CLUSTER_TYPE} -i ${KRUIZE_IMAGE} -m ${target} -t >> ${KRUIZE_SETUP_LOG}" | tee -a ${LOG}
 		./deploy.sh -c ${CLUSTER_TYPE} -i ${KRUIZE_IMAGE} -m ${target} -t >> ${KRUIZE_SETUP_LOG} 2>&1
 


### PR DESCRIPTION
## Description

Added a separate function into scale test instead of the generic one as it overwrites the resources cpu/mem settings set manually while running the scale test.


### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Tested manually to check only the flags are modified.

- [X] Scale test


**Test Configuration**
* Kubernetes clusters tested on: openshift

## Checklist :dart:

- [X] Followed coding guidelines
- [X] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [X] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
