### PR TITLE
Fixed CVEs with os libraries and netty-codec-http2

### DIFF
--- a/Dockerfile.autotune
+++ b/Dockerfile.autotune
@@ -16,7 +16,7 @@
 ##########################################################
 #            Build Docker Image
 ##########################################################
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1753762263 as mvnbuild-jdk21
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1755695350 as mvnbuild-jdk21
 ARG USER=autotune
 ARG AUTOTUNE_HOME=/home/$USER
 
@@ -48,7 +48,7 @@ RUN jlink --strip-debug --compress 2 --no-header-files --no-man-pages --module-p
 #            Runtime Docker Image
 ##########################################################
 # Use ubi-minimal as the base image
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1753762263
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1755695350
 
 ARG AUTOTUNE_VERSION
 ARG USER=autotune

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>autotune</artifactId>
     <version>0.7</version>
     <properties>
-        <fabric8-version>7.0.0</fabric8-version>
+        <fabric8-version>7.3.1</fabric8-version>
         <org-json-version>20240303</org-json-version>
         <jetty-version>12.0.12</jetty-version>
         <slf4j-version>2.17.1</slf4j-version>
@@ -25,7 +25,7 @@
         <hibernatecp30-version>6.1.7.Final</hibernatecp30-version>
         <hibernate-Validator>8.0.1.Final</hibernate-Validator>
         <micrometer-version>1.9.9</micrometer-version>
-        <awssdk-version>2.30.26</awssdk-version>
+        <awssdk-version>2.33.0</awssdk-version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
## Description

Fixed CVEs with os libraries reported in aug 2025 report and netty-codec-http2

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Built the image and confirmed using quay scan report for the absence of CVEs

**Test Configuration**
* Kubernetes clusters tested on: minikube

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

