### PR TITLE
Fix to trigger test on push for master branch

### DIFF
--- a/.github/workflows/test-on-push.yaml
+++ b/.github/workflows/test-on-push.yaml
@@ -4,7 +4,7 @@ name: Test on Push
 on:
   # Triggers the workflow on push event but only for the mvp_demo branch
   push:
-    branches: [ mvp_demo ]
+    branches: [ mvp_demo, master]
     paths-ignore:
       - 'docs/**'
       - 'design/**'


### PR DESCRIPTION
## Description

This pr fixes the githbu workflow to also trigger test on push for the master branch which is required for the readme status badge. 

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

tested this on my personal repository https://github.com/bhanvimenghani/autotune/commit/d0004fdf580a70154bc67e604b907ca3942cb6d2

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
