### PR TITLE
Add UpdatePerfProfile endpoint

### DIFF
--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -215,6 +215,7 @@ data:
       "experimentNameFormat" : "%datasource%|%clustername%|%namespace%|%workloadname%(%workloadtype%)|%containername%",
       "bulkapilimit" : 1000,
       "isKafkaEnabled" : "false",
+      "perfProfileSupportedVersion" : 2.0,
       "hibernate": {
         "dialect": "org.hibernate.dialect.PostgreSQLDialect",
         "driver": "org.postgresql.Driver",

--- a/src/main/java/com/autotune/analyzer/Analyzer.java
+++ b/src/main/java/com/autotune/analyzer/Analyzer.java
@@ -57,6 +57,7 @@ public class Analyzer {
         context.addServlet(ListRecommendations.class, ServerContext.RECOMMEND_RESULTS);
         context.addServlet(PerformanceProfileService.class, ServerContext.CREATE_PERF_PROFILE);
         context.addServlet(PerformanceProfileService.class, ServerContext.LIST_PERF_PROFILES);
+        context.addServlet(PerformanceProfileService.class, ServerContext.UPDATE_PERF_PROFILE);
         context.addServlet(MetricProfileService.class, ServerContext.CREATE_METRIC_PROFILE);
         context.addServlet(MetricProfileService.class, ServerContext.LIST_METRIC_PROFILES);
         context.addServlet(MetricProfileService.class, ServerContext.DELETE_METRIC_PROFILE);

--- a/src/main/java/com/autotune/analyzer/services/PerformanceProfileService.java
+++ b/src/main/java/com/autotune/analyzer/services/PerformanceProfileService.java
@@ -30,6 +30,7 @@ import com.autotune.common.data.ValidationOutputData;
 import com.autotune.common.data.metrics.Metric;
 import com.autotune.common.data.system.info.device.DeviceDetails;
 import com.autotune.database.service.ExperimentDBService;
+import com.autotune.operator.KruizeDeploymentInfo;
 import com.google.gson.ExclusionStrategy;
 import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
@@ -159,17 +160,84 @@ public class PerformanceProfileService extends HttpServlet {
     }
 
     /**
-     * TODO: Need to implement
      * Update Performance Profile
      *
-     * @param req
-     * @param resp
+     * @param request
+     * @param response
      * @throws ServletException
      * @throws IOException
      */
     @Override
-    protected void doPut(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        super.doPut(req, resp);
+    protected void doPut(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        try {
+            // Parse incoming JSON
+            String inputData = request.getReader().lines().collect(Collectors.joining());
+            PerformanceProfile incomingPerfProfile = Converters.KruizeObjectConverters.convertInputJSONToCreatePerfProfile(inputData);
+            String profileName = incomingPerfProfile.getName();
+
+            ValidationOutputData validationOutputData = PerformanceProfileUtil.validateAndAddProfile(performanceProfilesMap, incomingPerfProfile);
+            if (validationOutputData.isSuccess()) {
+                // Fetch existing profile
+                try {
+                    new ExperimentDBService().loadPerformanceProfileFromDBByName(performanceProfilesMap, profileName);
+                }  catch (Exception e) {
+                    throw new Exception("Failed to load performance profile from the DB: {} "+ e.getMessage());
+                }
+                // Return 404 if the profile is not present
+                if (null ==  performanceProfilesMap.get(profileName)) {
+                    sendErrorResponse(
+                            response,
+                            null,
+                            HttpServletResponse.SC_NOT_FOUND,
+                            String.format("Performance Profile '%s' not found. Use POST to create a new profile.", profileName)
+                    );
+                    return;
+                }
+
+                // Compare version — only allow update if the version is matching with the current supported one
+                if (incomingPerfProfile.getProfile_version() != KruizeDeploymentInfo.perf_profile_supported_version) {
+                    sendErrorResponse(
+                            response,
+                            null,
+                            HttpServletResponse.SC_CONFLICT,
+                            String.format(
+                                    "Update rejected: the provided version (%.1f) is older than the current version (%.1f) for profile '%s'.",
+                                    incomingPerfProfile.getProfile_version(),
+                                    KruizeDeploymentInfo.perf_profile_supported_version,
+                                    profileName
+                            )
+                    );
+                    return;
+                }
+
+                // Perform update
+                ValidationOutputData updatedInDB = new ExperimentDBService().updatePerformanceProfileInDB(incomingPerfProfile);
+
+                if (updatedInDB.isSuccess()) {
+                    LOGGER.info("Updated Performance Profile '{}' to version {}", profileName, incomingPerfProfile.getProfile_version());
+
+                    performanceProfilesMap.put(incomingPerfProfile.getName(), incomingPerfProfile);
+                    getServletContext().setAttribute(AnalyzerConstants.PerformanceProfileConstants.PERF_PROFILE_MAP, performanceProfilesMap);
+                    LOGGER.debug("Updated Performance Profile : {} into the DB with version: {}",
+                            incomingPerfProfile.getName(), incomingPerfProfile.getProfile_version());
+                    sendSuccessResponse(
+                            response,
+                            String.format("Performance Profile '%s' updated successfully to version %.1f.",
+                                    profileName, incomingPerfProfile.getProfile_version())
+                    );
+                } else {
+                    sendErrorResponse(response, null, HttpServletResponse.SC_BAD_REQUEST, updatedInDB.getMessage());
+                }
+
+            } else {
+                sendErrorResponse(response, null, validationOutputData.getErrorCode(), validationOutputData.getMessage());
+            }
+
+        } catch (Exception e) {
+            sendErrorResponse(response, e, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+        } catch (InvalidValueException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**

--- a/src/main/java/com/autotune/database/dao/ExperimentDAO.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAO.java
@@ -161,4 +161,6 @@ public interface ExperimentDAO {
     void deleteBulkJobByID(String jobId);
 
     boolean updateExperimentDates(Set<String> experimentNames, Timestamp currentTimestamp) throws Exception;
+
+    ValidationOutputData updatePerformanceProfileInDB(KruizePerformanceProfileEntry kruizePerformanceProfileEntry);
 }

--- a/src/main/java/com/autotune/database/service/ExperimentDBService.java
+++ b/src/main/java/com/autotune/database/service/ExperimentDBService.java
@@ -395,6 +395,23 @@ public class ExperimentDBService {
     }
 
     /**
+     * Updates Performance Profile in KruizePerformanceProfileEntry
+     *
+     * @param performanceProfile PerformanceProfile object to be updated
+     * @return ValidationOutputData object
+     */
+    public ValidationOutputData updatePerformanceProfileInDB(PerformanceProfile performanceProfile) {
+        ValidationOutputData validationOutputData = new ValidationOutputData(false, null, null);
+        try {
+            KruizePerformanceProfileEntry kruizePerformanceProfileEntry = DBHelpers.Converters.KruizeObjectConverters.convertPerfProfileObjToPerfProfileDBObj(performanceProfile);
+            validationOutputData = this.experimentDAO.updatePerformanceProfileInDB(kruizePerformanceProfileEntry);
+        } catch (Exception e) {
+            LOGGER.error("Not able to update Performance Profile due to {}", e.getMessage());
+        }
+        return validationOutputData;
+    }
+
+    /**
      * Adds Metric Profile to kruizeMetricProfileEntry
      *
      * @param metricProfile Metric profile object to be added

--- a/src/main/java/com/autotune/operator/KruizeDeploymentInfo.java
+++ b/src/main/java/com/autotune/operator/KruizeDeploymentInfo.java
@@ -105,6 +105,7 @@ public class KruizeDeploymentInfo {
     public static String kafka_response_filter_include = System.getenv("KAFKA_RESPONSE_FILTER_INCLUDE");
     public static String kafka_response_filter_exclude = System.getenv("KAFKA_RESPONSE_FILTER_EXCLUDE");
     public static Integer kafka_thread_pool_size = 3;
+    public static Double perf_profile_supported_version = 2.0;
 
 
     private KruizeDeploymentInfo() {

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -780,6 +780,7 @@ public class KruizeConstants {
         public static final String METADATA_PROFILE_FILE_PATH = "metadataProfileFilePath";
         public static final String METRIC_PROFILE_FILE_PATH = "metricProfileFilePath";
         public static final String IS_KAFKA_ENABLED = "isKafkaEnabled";
+        public static final String PERF_PROFILE_SUPPORTED_VERSION = "perfProfileSupportedVersion";
     }
 
     public static final class RecommendationEngineConstants {

--- a/src/main/java/com/autotune/utils/MetricsConfig.java
+++ b/src/main/java/com/autotune/utils/MetricsConfig.java
@@ -29,7 +29,7 @@ public class MetricsConfig {
     public static Timer.Builder timerBLoadRecExpName, timerBLoadResultsExpName, timerBLoadExpName, timerBLoadRecExpNameDate, timerBBoxPlots;
     public static Timer.Builder timerBLoadAllRec, timerBLoadAllExp, timerBLoadAllResults;
     public static Timer.Builder timerBAddRecDB, timerBAddResultsDB, timerBAddExpDB, timerBAddBulkResultsDB, timerBLoadBulkJobId, timerBUpdateBulkJobId, timerBSaveBulkJobDB, timerBaddBulkJob;
-    public static Timer.Builder timerBAddPerfProfileDB, timerBLoadPerfProfileName, timerBLoadAllPerfProfiles;
+    public static Timer.Builder timerBAddPerfProfileDB, timerBLoadPerfProfileName, timerBLoadAllPerfProfiles, timerBUpdatePerfProfileDB;
     public static Counter.Builder timerBKruizeNotifications, timerBBulkJobs;
     public static PrometheusMeterRegistry meterRegistry;
     public static Timer timerListDS, timerImportDSMetadata, timerListDSMetadata;
@@ -39,6 +39,8 @@ public class MetricsConfig {
     public static Timer.Builder timerBAddMetadataProfileDB, timerBLoadMetadataProfileName, timerBLoadAllMetadataProfiles, timerBUpdateMetadataProfileDB;
     public static Timer timerUpdateMetadataProfile;
     public static Timer.Builder timerBUpdateMetadataProfile;
+    public static Timer timerUpdatePerfProfile;
+    public static Timer.Builder timerBUpdatePerfProfile;
 
     private static MetricsConfig INSTANCE;
     public String API_METRIC_DESC = "Time taken for Kruize APIs";
@@ -100,6 +102,8 @@ public class MetricsConfig {
         timerBUpdateMetadataProfileDB = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method", "updateMetadataProfileToDB");
 
         timerBUpdateMetadataProfile = Timer.builder("kruizeAPI").description(API_METRIC_DESC).tag("api", "updateMetadataProfile").tag("method", "PUT");
+        timerBUpdatePerfProfileDB = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method", "updatePerformanceProfileInDB");
+        timerBUpdatePerfProfile = Timer.builder("kruizeAPI").description(API_METRIC_DESC).tag("api", "updatePerformanceProfile").tag("method", "PUT");
 
         new ClassLoaderMetrics().bindTo(meterRegistry);
         new ProcessorMetrics().bindTo(meterRegistry);

--- a/src/main/java/com/autotune/utils/ServerContext.java
+++ b/src/main/java/com/autotune/utils/ServerContext.java
@@ -43,6 +43,7 @@ public class ServerContext {
     public static final String RECOMMEND_RESULTS = ROOT_CONTEXT + "listRecommendations";
     public static final String CREATE_PERF_PROFILE = ROOT_CONTEXT + "createPerformanceProfile";
     public static final String LIST_PERF_PROFILES = ROOT_CONTEXT + "listPerformanceProfiles";
+    public static final String UPDATE_PERF_PROFILE = ROOT_CONTEXT + "updatePerformanceProfile";
     public static final String CREATE_METRIC_PROFILE = ROOT_CONTEXT + "createMetricProfile";
     public static final String LIST_METRIC_PROFILES = ROOT_CONTEXT + "listMetricProfiles";
     public static final String DELETE_METRIC_PROFILE = ROOT_CONTEXT + "deleteMetricProfile";


### PR DESCRIPTION
## Description

This PR emables the updatePerformanceProfile endpoint to let the users upgrade the performance profile to newer versions.
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Test Image: `quay.io/khansaad/autotune_operator:update-profile`