### PR TITLE
adds crud operations & list rule sets with name parameter

### DIFF
--- a/src/main/java/com/autotune/analyzer/services/ListRuleSets.java
+++ b/src/main/java/com/autotune/analyzer/services/ListRuleSets.java
@@ -23,8 +23,19 @@ public class ListRuleSets extends HttpServlet {
         response.setCharacterEncoding(CHARACTER_ENCODING);
 
         try {
+            // check name is present
+            String ruleSetName = request.getParameter("name");
+
             // Load all rulesets from DB
-            List<KruizeLMRuleSetEntry> ruleSets = new ExperimentDAOImpl().loadAllRuleSet();
+            List<KruizeLMRuleSetEntry> ruleSets;
+
+            if (ruleSetName == null || ruleSetName.isEmpty()) {
+                // load all
+                ruleSets = new ExperimentDAOImpl().loadAllRuleSet();
+            } else {
+                // load by name
+                ruleSets = new ExperimentDAOImpl().loadRuleSetByName(ruleSetName);
+            }
 
             // Convert to clean JSON using ObjectMapper
             ObjectMapper objectMapper = new ObjectMapper();

--- a/src/main/java/com/autotune/database/dao/ExperimentDAO.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAO.java
@@ -175,8 +175,20 @@ public interface ExperimentDAO {
     // load layer by name
     List<KruizeLMLayerEntry> loadLayerByName(String name) throws Exception;
 
+    // add rule set to DB
     public ValidationOutputData addRuleSetToDB(KruizeLMRuleSetEntry kruizeLMRuleSetEntry);
 
+    // load all rule set
     List<KruizeLMRuleSetEntry> loadAllRuleSet() throws Exception;
+
+    // load rule set by name
+    List<KruizeLMRuleSetEntry> loadRuleSetByName(String name) throws Exception;
+
+    // update rule set
+    public ValidationOutputData updateRuleSetToDB(KruizeLMRuleSetEntry kruizeLMRuleSetEntry);
+
+    // delete rule set by name
+    public ValidationOutputData deleteRuleSetByName(String name) throws Exception;
+
 
 }


### PR DESCRIPTION
## Description

GET   /listRuleSets?name=<name> 
Update    | PUT   | /createRuleSet            
Delete     | DELETE  | /createRuleSet?name=<name>

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
