### PR TITLE
Add OpenJ9 layer and combination rulesets

### DIFF
--- a/design/sample-jsons/layers/openj9-layer.json
+++ b/design/sample-jsons/layers/openj9-layer.json
@@ -1,0 +1,56 @@
+{
+  "apiVersion": "recommender.com/v1",
+  "kind": "KruizeLayer",
+  "metadata": {
+    "name": "openj9",
+    "description": "OpenJ9 JVM tuning"
+  },
+  "layer_presence": {
+    "presence": "detectable",
+    "detectors": [
+      {
+        "type": "query",
+        "datasource": "prometheus-1",
+        "query": "jvm_memory_max_bytes{area=\"heap\",id=\"tenured-LOA\",container=\"$CONTAINER$\"}",
+        "key": "pod",
+        "non_null_is_present": true
+      }
+    ]
+  },
+  "tunables": {
+    "maxram-percentage": {
+      "metadata": {
+        "name": "maxram-percentage",
+        "description": "JVM heap as % of container memory limit",
+        "expression": "+XX:MaxRAMPercentage={(tunable:openj9/maxram-percentage).value}",
+        "value_type": "double",
+        "unit": "percent",
+        "type": "range",
+        "type_def": {
+          "bounds": {
+            "lower": 10,
+            "upper": 90,
+            "step": 1
+          }
+        }
+      },
+      "depends_on": {
+        "tunables": [
+          "container/memory-limit"
+        ],
+        "metrics": [
+          "memory-usage",
+          "openj9-tenured-loa",
+          "openj9-tenured-soa"
+        ]
+      },
+      "calculations": [
+        {
+          "target": "value",
+          "expr": "clamp(100.0 * percentile((metric:memory-usage), 0.95) / max(1e-6, (tunable:container/memory-limit).value * (1.0 - min(env.NON_HEAP_RATIO ?: 0.30, 0.80)) * 1.05), bounds.lower, bounds.upper)",
+          "fallback": 70
+        }
+      ]
+    }
+  }
+}

--- a/design/sample-jsons/rulesets/container-hotspot.json
+++ b/design/sample-jsons/rulesets/container-hotspot.json
@@ -1,0 +1,58 @@
+{
+  "apiVersion": "recommender.com/v1",
+  "kind": "KruizeRuleset",
+  "metadata": {
+    "name": "container-hotspot"
+  },
+  "rulesets": {
+    "stack": {
+      "layers": [
+        {
+          "name": "container",
+          "required": true
+        },
+        {
+          "name": "hotspot",
+          "required": true
+        }
+      ]
+    },
+    "dependencies": [
+      {
+        "primary": "tunable:container/memory-limit",
+        "dependants": [
+          "tunable:container/memory-request",
+          "tunable:hotspot/maxram-percentage"
+        ]
+      },
+      {
+        "primary": "tunable:container/cpu-limit",
+        "dependants": [
+          "tunable:container/cpu-request",
+          "tunable:hotspot/gc-policy"
+        ]
+      }
+    ],
+    "rules": {
+      "layers": {
+        "container": {
+          "tunables": {
+            "cpu-limit": [
+              {
+                "name": "cpu-limit-not-above-namespace-quota",
+                "phase": "final",
+                "expr": "(value <= ((metric:namespace-cpu-limit).sum ?: bounds.upper))",
+                "on_violation": {
+                  "fix": "min(value, (metric:namespace-cpu-limit).sum)"
+                },
+                "message": "cpu-limit capped to namespaceCpuLimit"
+              }
+            ]
+          }
+        },
+        "hotspot": {},
+        "quarkus": {}
+      }
+    }
+  }
+}

--- a/design/sample-jsons/rulesets/container-openj9-quarkus.json
+++ b/design/sample-jsons/rulesets/container-openj9-quarkus.json
@@ -1,0 +1,62 @@
+{
+  "apiVersion": "recommender.com/v1",
+  "kind": "KruizeRuleset",
+  "metadata": {
+    "name": "container-openj9-quarkus"
+  },
+  "rulesets": {
+    "stack": {
+      "layers": [
+        {
+          "name": "container",
+          "required": true
+        },
+        {
+          "name": "openj9",
+          "required": true
+        },
+        {
+          "name": "quarkus",
+          "required": true
+        }
+      ]
+    },
+    "dependencies": [
+      {
+        "primary": "tunable:container/memory-limit",
+        "dependants": [
+          "tunable:container/memory-request",
+          "tunable:openj9/maxram-percentage"
+        ]
+      },
+      {
+        "primary": "tunable:container/cpu-limit",
+        "dependants": [
+          "tunable:container/cpu-request",
+          "tunable:quarkus/core-threads"
+        ]
+      }
+    ],
+    "rules": {
+      "layers": {
+        "container": {
+          "tunables": {
+            "cpu-limit": [
+              {
+                "name": "cpu-limit-not-above-namespace-quota",
+                "phase": "final",
+                "expr": "(value <= ((metric:namespace-cpu-limit).sum ?: bounds.upper))",
+                "on_violation": {
+                  "fix": "min(value, (metric:namespace-cpu-limit).sum)"
+                },
+                "message": "cpu-limit capped to namespaceCpuLimit"
+              }
+            ]
+          }
+        },
+        "hotspot": {},
+        "quarkus": {}
+      }
+    }
+  }
+}

--- a/design/sample-jsons/rulesets/container-openj9.json
+++ b/design/sample-jsons/rulesets/container-openj9.json
@@ -1,0 +1,57 @@
+{
+  "apiVersion": "recommender.com/v1",
+  "kind": "KruizeRuleset",
+  "metadata": {
+    "name": "container-openj9"
+  },
+  "rulesets": {
+    "stack": {
+      "layers": [
+        {
+          "name": "container",
+          "required": true
+        },
+        {
+          "name": "openj9",
+          "required": true
+        }
+      ]
+    },
+    "dependencies": [
+      {
+        "primary": "tunable:container/memory-limit",
+        "dependants": [
+          "tunable:container/memory-request",
+          "tunable:openj9/maxram-percentage"
+        ]
+      },
+      {
+        "primary": "tunable:container/cpu-limit",
+        "dependants": [
+          "tunable:container/cpu-request"
+        ]
+      }
+    ],
+    "rules": {
+      "layers": {
+        "container": {
+          "tunables": {
+            "cpu-limit": [
+              {
+                "name": "cpu-limit-not-above-namespace-quota",
+                "phase": "final",
+                "expr": "(value <= ((metric:namespace-cpu-limit).sum ?: bounds.upper))",
+                "on_violation": {
+                  "fix": "min(value, (metric:namespace-cpu-limit).sum)"
+                },
+                "message": "cpu-limit capped to namespaceCpuLimit"
+              }
+            ]
+          }
+        },
+        "hotspot": {},
+        "quarkus": {}
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the OpenJ9 layer and also possible combination of rulesets

`container-hotspot`
`container-openj9`
`container-openj9-quarkus`