### PR TITLE
Add misssing perf-profile-name constant

### DIFF
--- a/tests/scripts/helpers/utils.py
+++ b/tests/scripts/helpers/utils.py
@@ -224,6 +224,7 @@ TERMS_NOTIFICATION_CODES = {
 
 NAMESPACE_EXPERIMENT_TYPE = "namespace"
 CONTAINER_EXPERIMENT_TYPE = "container"
+PERF_PROFILE_NAME = "resource-optimization-openshift"
 
 # version,experiment_name,cluster_name,performance_profile,mode,target_cluster,type,name,namespace,container_image_name,container_name,measurement_duration,threshold
 create_exp_test_data = {


### PR DESCRIPTION
## Description

This PR adds back the `PERF_PROFILE_NAME` constant which was mistakenly removed on rebasing #1708 
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [x] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: Minikube

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Tests:
- Reintroduce the PERF_PROFILE_NAME constant in test utilities to support performance-related test data generation.