### PR TITLE
Automated requests and limits setting to different values for scale test

### DIFF
--- a/tests/scripts/remote_monitoring_tests/scale_test/remote_monitoring_scale_test_bulk.sh
+++ b/tests/scripts/remote_monitoring_tests/scale_test/remote_monitoring_scale_test_bulk.sh
@@ -97,10 +97,11 @@ function kruize_scale_test_remote_patch() {
 	        sed -i 's/\([[:space:]]*\)\(memory:\)[[:space:]]*".*"/\1\2 "2Gi"/; s/\([[:space:]]*\)\(cpu:\)[[:space:]]*".*"/\1\2 "2"/' "${KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT}"
 	else
 		# Replace memory requests and limits for Kruize to 4Gi and 8Gi respectively for scale test
-		sed -i -e '/requests:/,/limits:/ { s/memory: "768Mi"/memory: "4Gi"/ }' -e '/limits:/,/resources:/ { s/memory: "768Mi"/memory: "8Gi"/ }' "${KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT}"
+		sed -i '/- name: kruize$/,/ports:/{/requests:/,/limits:/{/memory:/s/"[^"]*"/"4Gi"/}; /limits:/,/ports:/{/memory:/s/"[^"]*"/"8Gi"/}}' "${KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT}"
 
 		# Replace memory requests and limits for Kruize DB to 10Gi and 30 Gi respectively for scale test
-                sed -i -e '/requests:/,/limits:/ { s/memory: "100Mi"/memory: "10Gi"/ }' -e '/limits:/,/resources:/ { s/memory: "100Mi"/memory: "30Gi"/ }' "${KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT}"
+		sed -i '/- name: kruize-db$/,/ports:/{/requests:/,/limits:/{/memory:/s/"[^"]*"/"10Gi"/}; /limits:/,/ports:/{/memory:/s/"[^"]*"/"30Gi"/}}' "${KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT}"
+
                 sed -i 's/\([[:space:]]*\)\(cpu:\)[[:space:]]*".*"/\1\2 "2"/' "${KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT}"
                 cp "${KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT}" "${LOG_DIR}"
 	fi


### PR DESCRIPTION
## Description

Automated requests and limits setting to different values for scale test

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Tested this manually by running the scale test

**Test Configuration**
* Kubernetes clusters tested on: openshift

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Summary by Sourcery

Adjust scale test deployment script to use higher, distinct resource requests and limits for Kruize components during remote monitoring scale tests.

New Features:
- Configure separate memory requests and limits for Kruize and Kruize DB containers specifically for scale test runs.

Enhancements:
- Quote deployment manifest paths in sed commands for safer handling and copy the patched manifest to the log directory for debugging and traceability.