### PR TITLE
Enable testing demos with kruize operator as default

### DIFF
--- a/tests/scripts/kruize_demos_test/kruize_demos_test.md
+++ b/tests/scripts/kruize_demos_test/kruize_demos_test.md
@@ -31,8 +31,8 @@ Where values for kruize_demos_test.sh are:
 ```
 Usage: 
         [ -c ] : cluster_type. Supports minikube, kind and openshift cluster-type
-        [ -i ] : kruize image. Default - quay.io/kruize/autotune:mvp_demo
-        [ -o ] : Kruize operator image. Default - quay.io/kruize/kruize-operator:0.0.2
+        [ -i ] : kruize image. Default - quay.io/kruizehub/autotune-test-image:mvp_demo
+        [ -o ] : Kruize operator image. Default - It will use the latest kruize operator image
 	    [ -a ] : Kruize demos git repo URL. Default - https://github.com/kruize/kruize-demos.git
         [ -b ] : Kruize demos git repo branch. Default - main
         [ -t ] : Kruize demo to run. Default - all (valid values - all/local_monitoring/remote_monitoring/bulk/vpa)

--- a/tests/scripts/kruize_demos_test/kruize_demos_test.sh
+++ b/tests/scripts/kruize_demos_test/kruize_demos_test.sh
@@ -28,8 +28,8 @@ NAMESPACE=monitoring
 demo=all
 
 target="crc"
-KRUIZE_IMAGE="quay.io/kruize/autotune:mvp_demo"
-KRUIZE_OPERATOR_IMAGE="quay.io/kruize/kruize-operator:0.0.2"
+KRUIZE_IMAGE="quay.io/kruizehub/autotune-test-image:mvp_demo"
+KRUIZE_OPERATOR_IMAGE=""
 KRUIZE_OPERATOR=1
 failed=0
 
@@ -42,8 +42,8 @@ function usage() {
 	echo
 	echo "Usage: -c cluster_type[minikube|openshift] [-i Kruize image] [-o Kruize operator image] [ -t demo ] [-r <resultsdir path>] [-a Kruize demos git repo URL] [-b Kruize demos branch] [-k]"
 	echo "c = supports minikube, kind and openshift cluster-type"
-	echo "i = kruize image. Default - quay.io/kruize/autotune:mvp_demo"
-	echo "o = Kruize operator image. Default - quay.io/kruize/kruize-operator:0.0.2"
+	echo "i = kruize image. Default - quay.io/kruizehub/autotune-test-image:mvp_demo"
+	echo "o = Kruize operator image. Default - It will use the latest kruize operator image"
 	echo "a = Kruize demos git repo URL. Default - https://github.com/kruize/kruize-demos.git"
 	echo "b = Kruize demos git repo branch. Default - main"
 	echo "t = Kruize demo to run. Default - all (valid values - all/local_monitoring/remote_monitoring/bulk/vpa)"


### PR DESCRIPTION
## Description

Enable testing demos with kruize operator as default as it now supported on kind/minikube and included -k option to run with manifests

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Tested manually on kind cluster

**Test Configuration**
* Kubernetes clusters tested on: kind

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Enable Kruize demos test script to use the Kruize operator by default and add configurability for operator usage and bulk demo wait time.

New Features:
- Default to running demos with the Kruize operator enabled, with an option to disable it and use deploy scripts instead.
- Allow configuring a wait time for metrics availability before generating recommendations in the bulk demo.

Enhancements:
- Improve robustness of Kruize pod log collection by selecting the pod via label and handling missing pods gracefully.
- Update demo test command construction to skip operator image and flags for incompatible demo types and modes.
- Document the new operator toggle flag in the Kruize demos test usage guide.