### PR TITLE
Updated the hotspot query

### DIFF
--- a/design/sample-jsons/layers/hotspot-layer.json
+++ b/design/sample-jsons/layers/hotspot-layer.json
@@ -11,7 +11,7 @@
       {
         "type": "query",
         "datasource": "prometheus-1",
-	"query": "jvm_memory_used_bytes{area=\"heap\",id=~\".+Eden.+\"}",
+	"query": "jvm_memory_used_bytes{area=\"heap\",id=~\"Eden.+\"}",
         "key": "pod",
         "non_null_is_present": true
       }


### PR DESCRIPTION
## Description

Updated the hotspot query to work with OCP.   However, this query doesn't work with kind cluster.  

Adding multiple detectors like below didn't work with hackathon kruize image, so for now, adding the query that works with OCP

```
 "detectors": [
      {
        "type": "query",
        "datasource": "prometheus-1",
        "query": "jvm_memory_used_bytes{area=\"heap\",id=~\"Eden.+\"}",
        "key": "pod",
        "non_null_is_present": true
      },
      {
        "type": "query",
        "datasource": "prometheus-1",
        "query": "jvm_memory_used_bytes{area=\"heap\",id=~\".+Eden.+\"}",
        "key": "pod",
        "non_null_is_present": true
      }
    ]
```

## Summary by Sourcery

Enhancements:
- Adjust hotspot-layer configuration to use an OCP-compatible JVM memory used bytes query and corresponding detector setup.