### PR TITLE
Prereq scripts for runtime recommendations

### DIFF
--- a/scripts/enable_kube_state_metrics_labels.sh
+++ b/scripts/enable_kube_state_metrics_labels.sh
@@ -1,3 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
 #!/bin/bash
 set -euo pipefail
 

--- a/scripts/enable_user_workload_monitoring_openshift.sh
+++ b/scripts/enable_user_workload_monitoring_openshift.sh
@@ -1,3 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
 #!/bin/bash
 set -euo pipefail
 


### PR DESCRIPTION
## Description

Two prereq scripts for openshift and kind/minikube to generate runtime recommendations.
1. To enable user workload monitoring on openshift.
2. To enable kube-state-metrics labels.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes
- [X] Script Updates

## How has this been tested?
Tested on local environment.

**Test Configuration**
* Kubernetes clusters tested on: 
kind, minikube and openshift

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Add helper scripts to prepare Kubernetes clusters for runtime recommendations by enabling user workload monitoring on OpenShift and configuring kube-state-metrics label collection.

New Features:
- Introduce a script to enable user workload monitoring via the OpenShift cluster monitoring config.
- Introduce a script to add kube-state-metrics metric-labels-allowlist arguments, with auto-detection of the deployment when not specified.