### PR TITLE
Update query-builder to use double quotes

### DIFF
--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -389,10 +389,10 @@ spec:
               value: ""
           resources:
             requests:
-              memory: "2Gi"
+              memory: "768Mi"
               cpu: "0.7"
             limits:
-              memory: "2Gi"
+              memory: "768Mi"
               cpu: "0.7"
           ports:
             - name: kruize-port

--- a/tests/scripts/common/common_functions.sh
+++ b/tests/scripts/common/common_functions.sh
@@ -1008,3 +1008,17 @@ function kruize_local_datasource_manifest_patch() {
 		fi
 	fi
 }
+
+#
+# Update kruize cpu/memory resources, PV storage for openshift
+#
+function kruize_local_patch() {
+	CRC_DIR="./manifests/crc/default-db-included-installation"
+	KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT="${CRC_DIR}/openshift/kruize-crc-openshift.yaml"
+	KRUIZE_CRC_DEPLOY_MANIFEST_MINIKUBE="${CRC_DIR}/minikube/kruize-crc-minikube.yaml"
+
+	if [ ${cluster_type} == "openshift" ]; then
+		sed -i 's/\([[:space:]]*\)\(storage:\)[[:space:]]*[0-9]\+Mi/\1\2 1Gi/' ${KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT}
+		sed -i 's/\([[:space:]]*\)\(memory:\)[[:space:]]*".*"/\1\2 "2Gi"/; s/\([[:space:]]*\)\(cpu:\)[[:space:]]*".*"/\1\2 "2"/' ${KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT}
+	fi
+}

--- a/tests/scripts/local_monitoring_tests/local_monitoring_tests.sh
+++ b/tests/scripts/local_monitoring_tests/local_monitoring_tests.sh
@@ -65,6 +65,8 @@ function local_monitoring_tests() {
 			kruize_local_ros_patch
 			# check for 'servicename' and 'datasource_namespace' input variables
 			kruize_local_datasource_manifest_patch
+			# increase cpu/memory resources, PV storage for openshift
+			kruize_local_patch
 			echo "Setting up kruize..." | tee -a ${LOG}
 			echo "${KRUIZE_SETUP_LOG}"
 			setup "${KRUIZE_POD_LOG}" >> ${KRUIZE_SETUP_LOG} 2>&1


### PR DESCRIPTION
## Description

- Updated the filterbuilder logic to use double quotes for empty string comparisons.
- Added a patch for local monitoring functional tests to increase resource: `memory: 2 Gi, cpu: 2 cores and PV storage: 1Gi` to avoid `OOMKilled` errors

Fixes #1788 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Bug Fixes:
- Correct empty-string filter expression to use double quotes instead of single quotes in dynamically constructed queries.