### PR TITLE
Updated kruize demos test to look for different reco jsons for LM demo

### DIFF
--- a/tests/scripts/kruize_demos_test/kruize_demos_test.sh
+++ b/tests/scripts/kruize_demos_test/kruize_demos_test.sh
@@ -437,7 +437,7 @@ elapsed_time=$(time_diff "${start_time}" "${end_time}")
 echo "Test took ${elapsed_time} seconds to complete" | tee -a ${LOG}
 
 # Clone kruize-demos repo
-#delete_repos "kruize-demos"
+delete_repos "kruize-demos"
 
 if [ "${failed}" -ne 0 ]; then
 	echo "Kruize demos test failed! Check the logs for details" | tee -a ${LOG}


### PR DESCRIPTION
## Description

Running Local monitoring demo with Kruize deployed using operator creates recommendations jsons with different names. Updated the kruize demos test to look for these when LM demo is run in operator mode

- [X] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Tested by running the test manually on OCP

**Test Configuration**
* Kubernetes clusters tested on: openshift

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Adjust kruize demos tests to handle different recommendation JSON filenames for the local monitoring demo when running with the operator.

Bug Fixes:
- Update local monitoring demo test to look for operator-specific recommendation JSON filenames while preserving existing behavior for minikube and kind setup runs.

Tests:
- Relax test cleanup by no longer deleting the cloned kruize-demos repository at the end of the script.