### PR TITLE
Filter results at term level and process the calc for pod count

### DIFF
--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -106,8 +106,8 @@ public class RecommendationEngine {
             return null;
         }
 
-        double minPods = Double.MIN_VALUE;
-        double maxPods = Double.MAX_VALUE;
+        double minPods = Double.MAX_VALUE;
+        double maxPods = Double.MIN_VALUE;
         double totalPods = 0;
         int count = 0;
 

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -106,14 +106,13 @@ public class RecommendationEngine {
             return null;
         }
 
-        double minPods = Double.MAX_VALUE;
-        double maxPods = Double.MIN_VALUE;
+        double minPods = Double.MIN_VALUE;
+        double maxPods = Double.MAX_VALUE;
         double totalPods = 0;
         int count = 0;
 
         for (IntervalResults interval : filteredResultsMap.values()) {
-            Map<AnalyzerConstants.MetricName, MetricResults> metrics =
-                    interval.getMetricResultsMap();
+            Map<AnalyzerConstants.MetricName, MetricResults> metrics = interval.getMetricResultsMap();
             if (metrics == null || metrics.isEmpty())
                 continue;
             Double pods = extractPods(metrics, AnalyzerConstants.MetricName.cpuUsage);

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -99,6 +99,70 @@ public class RecommendationEngine {
         return (int) Math.ceil(max_pods_cpu);
     }
 
+    private static Map<AnalyzerConstants.Aggregates, Integer> getPodStats(
+            Map<Timestamp, IntervalResults> filteredResultsMap) {
+
+        if (filteredResultsMap == null || filteredResultsMap.isEmpty()) {
+            return null;
+        }
+
+        double minPods = Double.MAX_VALUE;
+        double maxPods = Double.MIN_VALUE;
+        double totalPods = 0;
+        int count = 0;
+
+        for (IntervalResults interval : filteredResultsMap.values()) {
+            Map<AnalyzerConstants.MetricName, MetricResults> metrics =
+                    interval.getMetricResultsMap();
+            if (metrics == null || metrics.isEmpty())
+                continue;
+            Double pods = extractPods(metrics, AnalyzerConstants.MetricName.cpuUsage);
+            if (pods == null) {
+                pods = extractPods(metrics, AnalyzerConstants.MetricName.memoryUsage);
+            }
+            if (pods == null)
+                continue;
+            minPods = Math.min(minPods, pods);
+            maxPods = Math.max(maxPods, pods);
+            totalPods += pods;
+            count++;
+        }
+
+        if (count == 0) {
+            return null;
+        }
+
+        Map<AnalyzerConstants.Aggregates, Integer> result = new HashMap<>();
+
+        result.put(AnalyzerConstants.Aggregates.max, (int) maxPods);
+        result.put(AnalyzerConstants.Aggregates.min, (int) minPods);
+        result.put(AnalyzerConstants.Aggregates.avg, (int) Math.round(totalPods / count));
+
+        return result;
+    }
+
+    private static Double extractPods(
+            Map<AnalyzerConstants.MetricName, MetricResults> metrics,
+            AnalyzerConstants.MetricName metricName) {
+
+        MetricResults metric = metrics.get(metricName);
+        if (metric == null)
+            return null;
+
+        MetricAggregationInfoResults agg = metric.getAggregationInfoResult();
+        if (agg == null)
+            return null;
+
+        Double sum = agg.getSum();
+        Double avg = agg.getAvg();
+
+        if (sum == null || avg == null || avg <= 0 || sum <= 0)
+            return null;
+
+        return (double) Math.round(sum / avg);
+    }
+
+
     /**
      * Populates the given map with Prometheus Query Language (PromQL) queries for various metrics.
      *
@@ -689,13 +753,24 @@ public class RecommendationEngine {
                         RecommendationConstants.RecommendationNotification.INFO_NOT_ENOUGH_DATA);
                 mappedRecommendationForTerm.addNotification(recommendationNotification);
             } else {
+                // Filter the map here to extract the results
+                Map<Timestamp, IntervalResults> filteredResultsMap = containerData.getResults().entrySet().stream()
+                        .filter((x -> (
+                                (x.getKey().compareTo(monitoringStartTime) >= 0)
+                                && (x.getKey().compareTo(monitoringEndTime) <= 0))
+                        )).collect((Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+
+                Map<AnalyzerConstants.Aggregates, Integer> podStats = getPodStats(filteredResultsMap);
+                if (null != podStats) {
+                    mappedRecommendationForTerm.setTermReplicas(podStats);
+                }
                 ArrayList<RecommendationNotification> termLevelNotifications = new ArrayList<>();
                 for (RecommendationModel model : getModels()) {
                     // Now generate a new recommendation for the new data corresponding to the monitoringEndTime
                     MappedRecommendationForModel mappedRecommendationForModel = generateRecommendationBasedOnModel(
                             monitoringStartTime,
                             model,
-                            containerData,
+                            filteredResultsMap,
                             monitoringEndTime,
                             kruizeObject,
                             currentConfig,
@@ -772,7 +847,9 @@ public class RecommendationEngine {
 
     }
 
-    private MappedRecommendationForModel generateRecommendationBasedOnModel(Timestamp monitoringStartTime, RecommendationModel model, ContainerData containerData,
+    private MappedRecommendationForModel generateRecommendationBasedOnModel(Timestamp monitoringStartTime,
+                                                                            RecommendationModel model,
+                                                                            Map<Timestamp, IntervalResults> filteredResultsMap,
                                                                             Timestamp monitoringEndTime,
                                                                             KruizeObject kruizeObject,
                                                                             HashMap<AnalyzerConstants.ResourceSetting,
@@ -828,10 +905,6 @@ public class RecommendationEngine {
         }
         if (null != monitoringStartTime) {
             Timestamp finalMonitoringStartTime = monitoringStartTime;
-            Map<Timestamp, IntervalResults> filteredResultsMap = containerData.getResults().entrySet().stream()
-                    .filter((x -> ((x.getKey().compareTo(finalMonitoringStartTime) >= 0)
-                            && (x.getKey().compareTo(monitoringEndTime) <= 0))))
-                    .collect((Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
 
             // Set number of pods
             int numPods = getNumPods(filteredResultsMap);

--- a/src/main/java/com/autotune/analyzer/recommendations/objects/TermRecommendations.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/objects/TermRecommendations.java
@@ -3,11 +3,13 @@ package com.autotune.analyzer.recommendations.objects;
 import com.autotune.analyzer.plots.PlotData;
 import com.autotune.analyzer.recommendations.RecommendationConstants;
 import com.autotune.analyzer.recommendations.RecommendationNotification;
+import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.utils.KruizeConstants;
 import com.google.gson.annotations.SerializedName;
 
 import java.sql.Timestamp;
 import java.util.HashMap;
+import java.util.Map;
 
 public class TermRecommendations implements MappedRecommendationForTerm {
 
@@ -21,6 +23,9 @@ public class TermRecommendations implements MappedRecommendationForTerm {
     private HashMap<Integer, RecommendationNotification> termLevelNotificationMap;
     @SerializedName(KruizeConstants.JSONKeys.MONITORING_START_TIME)
     private Timestamp monitoringStartTime;
+
+    @SerializedName(KruizeConstants.JSONKeys.TERM_REPLICAS)
+    private Map<AnalyzerConstants.Aggregates, Integer> termReplicas;
 
     @SerializedName(KruizeConstants.JSONKeys.RECOMMENDATION_ENGINES)
     private HashMap<String, MappedRecommendationForModel> recommendationForModelHashMap;
@@ -105,5 +110,13 @@ public class TermRecommendations implements MappedRecommendationForTerm {
 
     public void setPlots(PlotData.PlotsData plots) {
         this.plots = plots;
+    }
+
+    public Map<AnalyzerConstants.Aggregates, Integer> getTermReplicas() {
+        return termReplicas;
+    }
+
+    public void setTermReplicas(Map<AnalyzerConstants.Aggregates, Integer> termReplicas) {
+        this.termReplicas = termReplicas;
     }
 }

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -222,6 +222,12 @@ public class AnalyzerConstants {
         env
     }
 
+    public enum Aggregates {
+        max,
+        min,
+        avg
+    }
+
     public enum ConfigType {
         REQUESTS(ResourceSetting.requests),
         LIMITS(ResourceSetting.limits),

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -319,6 +319,9 @@ public class KruizeConstants {
         public static final String ACCELERATOR_PROFILE_NAME = "accelerator_profile_name";
         public static final String NODE = "node";
 
+        // Replicas related
+        public static final String TERM_REPLICAS = "term_replicas";
+
         private JSONKeys() {
         }
     }


### PR DESCRIPTION
## Description

This PR adds the replica information at term level

Fixes #1801 

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Add term-level replica statistics to recommendation outputs and reuse the time-window-filtered metrics map across recommendation generation.

New Features:
- Expose term-level replica counts (min, max, avg) in recommendation responses via a new term_replicas field.

Enhancements:
- Compute pod statistics from filtered interval metrics and pass the filtered results map into model-level recommendation generation instead of recomputing it.
- Introduce a shared Aggregates enum for max/min/avg and corresponding JSON key for term-level replica data.