### PR TITLE
Fix: Handle null JSON values gracefully in createLayer API

### DIFF
--- a/src/main/java/com/autotune/analyzer/kruizeLayer/LayerValidation.java
+++ b/src/main/java/com/autotune/analyzer/kruizeLayer/LayerValidation.java
@@ -59,7 +59,7 @@ public class LayerValidation {
         }
 
         if (layer.getLayerPresence() == null) {
-            errors.add(AnalyzerErrorConstants.APIErrors.CreateLayerAPI.LAYER_PRESENCE_MISSING);
+            errors.add(AnalyzerErrorConstants.APIErrors.CreateLayerAPI.LAYER_PRESENCE_NULL);
         } else {
             // 2. Validate layer presence mutual exclusivity (only if not null)
             ValidationOutputData presenceValidation = validateLayerPresence(layer.getLayerPresence());


### PR DESCRIPTION
## Description

 When users send null values in createLayer API requests (e.g., `{"layer_name": null}`),
  the API returns ugly Java exception messages that expose implementation details.
  ### Before
  - `"Invalid Layer JSON: JSONObject["name"] is not a string (class org.json.JSONObject$Null : null)."`
  - `"Invalid Layer JSON: JSONObject["layer_presence"] is not a JSONObject (class org.json.JSONObject$Null : null)."`

  ### After
  - `"Validation failed: metadata.name cannot be null or empty"`
  - `"Validation failed: layer_presence configuration missing: must specify exactly one of: presence='always', queries, or label"`

  ### Changes
**Converters.java**: Use `opt*()` methods instead of `get*()` methods to handle null values

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Handle null and missing values in createLayer request parsing to avoid low-level JSON exceptions and produce clearer validation errors.

Bug Fixes:
- Allow null or missing metadata.name, layer_name, layer_presence, and tunables fields in createLayer requests without throwing JSON parsing exceptions.
- Return a specific validation error when layer_presence is missing instead of treating it as a generic null-layer presence error.