### PR TITLE
Updated minikube & kubernetes version in github workflows

### DIFF
--- a/.github/workflows/rm-release-test.yaml
+++ b/.github/workflows/rm-release-test.yaml
@@ -15,8 +15,8 @@ jobs:
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.15.0
         with:
-          minikube version: 'v1.35.0'
-          kubernetes version: 'v1.33.0'
+          minikube version: 'v1.38.0'
+          kubernetes version: 'v1.34.4'
       - uses: actions/checkout@v4
         with:
           repository: kruize/autotune

--- a/.github/workflows/test-on-comment.yaml
+++ b/.github/workflows/test-on-comment.yaml
@@ -52,8 +52,8 @@ jobs:
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.15.0
         with:
-          minikube version: 'v1.35.0'
-          kubernetes version: 'v1.33.0'
+          minikube version: 'v1.38.0'
+          kubernetes version: 'v1.34.4'
 
       - name: Build crc
         run: |

--- a/.github/workflows/test-on-pr.yaml
+++ b/.github/workflows/test-on-pr.yaml
@@ -27,8 +27,8 @@ jobs:
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.15.0
         with:
-          minikube version: 'v1.35.0'
-          kubernetes version: 'v1.33.0'
+          minikube version: 'v1.38.0'
+          kubernetes version: 'v1.34.4'
       - name: Build crc
         run: |
           echo Build crc

--- a/.github/workflows/test-on-push.yaml
+++ b/.github/workflows/test-on-push.yaml
@@ -61,8 +61,8 @@ jobs:
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.15.0
         with:
-          minikube version: 'v1.35.0'
-          kubernetes version: 'v1.33.0'
+          minikube version: 'v1.38.0'
+          kubernetes version: 'v1.34.4'
       - name: Display cluster info
         run: |
           kubectl cluster-info


### PR DESCRIPTION
## Description

Updated minikube & kubernetes versions as per the versions supported by github action - manusa/actions-setup-minikube (2.15.0) in github workflows

https://github.com/manusa/actions-setup-minikube/pull/138/changes


### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

This will be tested through PR check

**Test Configuration**
* Kubernetes clusters tested on:  minikube

## Summary by Sourcery

CI:
- Bump Minikube to v1.38.0 and Kubernetes to v1.34.4 across all GitHub workflows that run tests and release checks.