### PR TITLE
Detect Quarkus layer through query

### DIFF
--- a/manifests/autotune/layers/quarkus-micrometer-config.json
+++ b/manifests/autotune/layers/quarkus-micrometer-config.json
@@ -10,7 +10,7 @@
     "queries": [
       {
         "datasource": "prometheus",
-        "query": "container_cpu_usage_seconds_total{} * on(namespace, pod) group_left(label_app_kubernetes_io_layer) kube_pod_labels{label_app_kubernetes_io_layer=\"quarkus\"}",
+        "query": "container_cpu_usage_seconds_total{} * on(namespace, pod) group_left(com.redhat.component-name) kube_pod_labels{com.redhat.component-name: \"Quarkus\"}",
         "key": "pod"
       }
     ]

--- a/manifests/autotune/layers/quarkus-micrometer-config.yaml
+++ b/manifests/autotune/layers/quarkus-micrometer-config.yaml
@@ -7,7 +7,7 @@ details: quarkus tunables
 layer_presence:
   queries:
   - datasource: 'prometheus'
-    query: 'container_cpu_usage_seconds_total{} * on(namespace, pod) group_left(label_app_kubernetes_io_layer) kube_pod_labels{label_app_kubernetes_io_layer="quarkus"}'
+    query: 'container_cpu_usage_seconds_total{} * on(namespace, pod) group_left(com.redhat.component-name) kube_pod_labels{com.redhat.component-name: "Quarkus"}'
     key: pod
 tunables:
 # upper_bound is set to 8 times of cpu.


### PR DESCRIPTION
## Description

Currently, Quarkus layer definition to detect the layer is through label. As label support is not implemented yet, converting the detection to query instead of label for now.