### PR TITLE
Fix : Layers : Add a check to skip layer detection for namespace experiments

### DIFF
--- a/src/main/java/com/autotune/analyzer/services/CreateExperiment.java
+++ b/src/main/java/com/autotune/analyzer/services/CreateExperiment.java
@@ -121,8 +121,8 @@ public class CreateExperiment extends HttpServlet {
                     if (null != validAPIObj)
                         validAPIObj.setValidationData(ko.getValidation_data());
 
-                    // Detect layers only if it's not a remote monitoring experiment and not a namespace experiment
-                    if (null != validAPIObj && !ko.getTarget_cluster().equalsIgnoreCase(AnalyzerConstants.REMOTE) && !validAPIObj.isNamespaceExperiment()) {
+                    // Detect layers only if it's local monitoring container experiment.
+                    if (null != validAPIObj && ko.getTarget_cluster().equalsIgnoreCase(AnalyzerConstants.LOCAL) && validAPIObj.isContainerExperiment()) {
                         ServiceHelpers.detectLayers(validAPIObj);
                     }
                     addedToDB = new ExperimentDBService().addExperimentToDB(validAPIObj);


### PR DESCRIPTION
## Description

Tests were failing with namespace experiments at layer detection stage with 500 error code, added a check to prevent triggering layer detection for nsp experiment.
 
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Bug Fixes:
- Prevent layer detection from running on namespace-level experiments that lack container definitions, avoiding related server errors during analysis.