### PR TITLE
Update metric profile files with runtime queries

### DIFF
--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.yaml
@@ -470,3 +470,23 @@ slo:
       # Minimum Frame Buffer Usage per GPU
       - function: min
         query: 'min by (Hostname,device,GPU_I_PROFILE,modelName,UUID) (min_over_time(DCGM_FI_DEV_FB_USED{UUID="$UUID$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+
+    # JVM Info (runtime, vendor, version from jvm_info metric)
+  - name: jvmInfo
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "container"
+
+    aggregation_functions:
+      - function: sum
+        query: 'sum by(container, namespace, runtime, vendor, version)(jvm_info{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+
+    # JVM Info Total (runtime, vendor, version from jvm_info_total metric)
+  - name: jvmInfoTotal
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "container"
+
+    aggregation_functions:
+      - function: sum
+        query: 'sum by(container, namespace, runtime, vendor, version)(jvm_info_total{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.json
@@ -449,6 +449,30 @@
             "query": "min by (Hostname,device,GPU_I_PROFILE,modelName,UUID) (min_over_time(DCGM_FI_DEV_FB_USED{UUID=\"$UUID$\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
           }
         ]
+      },
+      {
+        "name": "jvmInfo",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "sum",
+            "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})"
+          }
+        ]
+      },
+      {
+        "name": "jvmInfoTotal",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "sum",
+            "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info_total{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})"
+          }
+        ]
       }
     ]
   }

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.yaml
@@ -434,3 +434,23 @@ slo:
       # Minimum Frame Buffer Usage per GPU
       - function: min
         query: 'min by (Hostname,device,GPU_I_PROFILE,modelName,UUID) (min_over_time(DCGM_FI_DEV_FB_USED{UUID="$UUID$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+
+  # JVM Info (runtime, vendor, version from jvm_info metric)
+  - name: jvmInfo
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "container"
+
+    aggregation_functions:
+      - function: sum
+        query: 'sum by(container, namespace, runtime, vendor, version)(jvm_info{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+
+  # JVM Info Total (runtime, vendor, version from jvm_info_total metric)
+  - name: jvmInfoTotal
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "container"
+
+    aggregation_functions:
+      - function: sum
+        query: 'sum by(container, namespace, runtime, vendor, version)(jvm_info_total{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'


### PR DESCRIPTION
## Description

This PR adds the runtime queries to the rest of the metric profile files which were missed earlier.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Add missing JVM runtime metrics to resource optimization local monitoring performance profiles.

New Features:
- Expose jvmInfo and jvmInfoTotal metrics in the resource optimization local monitoring performance profile.
- Expose jvmInfo and jvmInfoTotal metrics in the no-recording-rules variant of the resource optimization performance profile.

Enhancements:
- Align metric profile YAMLs and JSONs so JVM runtime information is consistently available across monitoring configurations.