### PR TITLE
Fix Quarkus ENV

### DIFF
--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RuntimeRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RuntimeRecommendationProcessor.java
@@ -206,7 +206,7 @@ public final class RuntimeRecommendationProcessor {
 
         addIfNotEmpty(runtimeRecommList, KruizeConstants.JSONKeys.JDK_JAVA_OPTIONS, jvmOptsBuilder);
         addIfNotEmpty(runtimeRecommList, KruizeConstants.JSONKeys.JAVA_OPTIONS, jvmOptsBuilder);
-        addIfNotEmpty(runtimeRecommList, RecommendationConstants.RecommendationEngine.TunablesConstants.QUARKUS_THREAD_POOL_CORE_THREADS, quarkusBuilder);
+        addIfNotEmpty(runtimeRecommList, KruizeConstants.JSONKeys.QUARKUS_THREAD_POOL_CORE_THREADS, quarkusBuilder);
 
         return runtimeRecommList;
     }

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -214,6 +214,7 @@ public class KruizeConstants {
         public static final String TEMPLATE = "template";
         public static final String JAVA_OPTIONS = "JAVA_OPTIONS";
         public static final String JDK_JAVA_OPTIONS = "JDK_JAVA_OPTIONS";
+        public static final String QUARKUS_THREAD_POOL_CORE_THREADS = "QUARKUS_THREAD_POOL_CORE_THREADS";
         public static final String ENV = "ENV";
         public static final String TRIAL_RUNNING = "--Trial Running--";
         public static final String RESULT_VALUE = "result_value";


### PR DESCRIPTION
## Description

This PR fixes the quarkus ENV name in the recommendation response as per the quarkus docs.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Correct Quarkus runtime recommendation environment key usage in recommendation processing.

Bug Fixes:
- Use the standardized JSON key for QUARKUS_THREAD_POOL_CORE_THREADS when generating runtime recommendations to align with expected environment variable naming.

Enhancements:
- Introduce a dedicated JSON key constant for QUARKUS_THREAD_POOL_CORE_THREADS in shared constants for consistent reuse.