### PR TITLE
Fix Runtimes test issues

### DIFF
--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -156,7 +156,7 @@ metadata:
 spec:
   storageClassName: manual
   capacity:
-    storage: 1Gi # Sets PV Volume
+    storage: 500Mi # Sets PV Volume
   accessModes:
     - ReadWriteMany
   hostPath:
@@ -175,7 +175,7 @@ spec:
     - ReadWriteMany  # Sets read and write access
   resources:
     requests:
-      storage: 1Gi  # Sets volume size
+      storage: 500Mi  # Sets volume size
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -207,7 +207,7 @@ data:
       "savetodb": "true",
       "dbdriver": "jdbc:postgresql://",
       "plots": "true",
-      "isROSEnabled": "true",
+      "isROSEnabled": "false",
       "local": "true",
       "logAllHttpReqAndResp": "true",
       "recommendationsURL" : "http://kruize.openshift-tuning.svc.cluster.local:8080/generateRecommendations?experiment_name=%s",
@@ -215,8 +215,6 @@ data:
       "experimentNameFormat" : "%datasource%|%clustername%|%namespace%|%workloadname%(%workloadtype%)|%containername%",
       "bulkapilimit" : 1000,
       "isKafkaEnabled" : "false",
-      "metricProfileFilePath": "/home/autotune/app/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.json",
-      "metadataProfileFilePath": "/home/autotune/app/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.json",
       "hibernate": {
         "dialect": "org.hibernate.dialect.PostgreSQLDialect",
         "driver": "org.postgresql.Driver",
@@ -301,11 +299,11 @@ spec:
               value: /var/lib/pg_data
           resources:
             requests:
-              memory: "2Gi"
-              cpu: "2"
+              memory: "100Mi"
+              cpu: "0.5"
             limits:
-              memory: "2Gi"
-              cpu: "2"
+              memory: "100Mi"
+              cpu: "0.5"
           ports:
             - containerPort: 5432
           volumeMounts:
@@ -391,11 +389,11 @@ spec:
               value: ""
           resources:
             requests:
-              memory: "2Gi"
-              cpu: "2"
+              memory: "768Mi"
+              cpu: "0.7"
             limits:
-              memory: "2Gi"
-              cpu: "2"
+              memory: "768Mi"
+              cpu: "0.7"
           ports:
             - name: kruize-port
               containerPort: 8080

--- a/tests/scripts/helpers/utils.py
+++ b/tests/scripts/helpers/utils.py
@@ -275,6 +275,7 @@ PERF_PROFILE_NAME = "resource-optimization-openshift"
 # Expected env names for JVM runtime recommendations
 JDK_JAVA_OPTIONS = "JDK_JAVA_OPTIONS"
 JAVA_OPTIONS = "JAVA_OPTIONS"
+QUARKUS_CORE_THREADS = "quarkus.thread-pool.core-threads"
 
 # GC flag patterns (Hotspot)
 HOTSPOT_GC_PATTERNS = (
@@ -2405,8 +2406,8 @@ def validate_runtime_recommendations_if_present(recommendations_json):
                         for env_item in env_list:
                             name = env_item.get("name")
                             value = env_item.get("value")
-                            assert name in (JDK_JAVA_OPTIONS, JAVA_OPTIONS), (
-                                    f"Runtime env {name} should be among {JDK_JAVA_OPTIONS}, {JAVA_OPTIONS}"
+                            assert name in (JDK_JAVA_OPTIONS, JAVA_OPTIONS, QUARKUS_CORE_THREADS), (
+                                    f"Runtime env {name} should be among {JDK_JAVA_OPTIONS}, {JAVA_OPTIONS}, {QUARKUS_CORE_THREADS}"
                                 )
                             assert _has_runtime_env_value(value), f"Runtime values are incorrect"
                             assert value, f"Runtime env {name} has empty value"


### PR DESCRIPTION
## Description

This PR fixes the datasource name issue while running the runtime tests on non-openshift environmnet.
Also, revert the changes made in the openshift crc file which got pushed and merged by mistake in the PR #1798 

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [x] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Adjust OpenShift CRC manifests and runtime recommendation tests for correct local monitoring behavior and datasources.

Bug Fixes:
- Ensure runtime recommendation tests correctly update the datasource only for the relevant metric profile and clean up temporary experiment JSON files safely.
- Allow runtime recommendation validation to accept Quarkus thread pool environment variables in addition to existing JVM options.

Enhancements:
- Tune CRC OpenShift manifest defaults by reducing database PVC size, disabling ROS, and lowering resource requests/limits for PostgreSQL and Kruize components.

Tests:
- Update local monitoring generate_recommendation test to use a fixed input experiment file path, conditionally rewrite the datasource, and perform targeted temp file cleanup.