### PR TITLE
Bump kruize version to 0.9

### DIFF
--- a/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
@@ -92,7 +92,7 @@ spec:
               done
       containers:
         - name: kruize
-          image: quay.io/kruize/autotune_operator:0.8.1
+          image: quay.io/kruize/autotune_operator:0.9
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume

--- a/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
@@ -120,7 +120,7 @@ spec:
               done
       containers:
         - name: kruize
-          image: quay.io/kruize/autotune_operator:0.8.1
+          image: quay.io/kruize/autotune_operator:0.9
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume

--- a/manifests/crc/default-db-included-installation/aks/kruize-crc-aks.yaml
+++ b/manifests/crc/default-db-included-installation/aks/kruize-crc-aks.yaml
@@ -156,7 +156,7 @@ spec:
     spec:
       containers:
         - name: kruize
-          image: quay.io/kruize/autotune_operator:0.8.1
+          image: quay.io/kruize/autotune_operator:0.9
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume
@@ -221,7 +221,7 @@ spec:
         spec:
           containers:
             - name: kruizecronjob
-              image: quay.io/kruize/autotune_operator:0.8.1
+              image: quay.io/kruize/autotune_operator:0.9
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume
@@ -347,7 +347,7 @@ spec:
         spec:
           containers:
             - name: kruizedeletejob
-              image: quay.io/kruize/autotune_operator:0.8.1
+              image: quay.io/kruize/autotune_operator:0.9
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume

--- a/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
@@ -285,7 +285,7 @@ spec:
               done
       containers:
         - name: kruize
-          image: quay.io/kruize/autotune_operator:0.8.1
+          image: quay.io/kruize/autotune_operator:0.9
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume
@@ -358,7 +358,7 @@ spec:
         spec:
           containers:
             - name: kruizecronjob
-              image: quay.io/kruize/autotune_operator:0.8.1
+              image: quay.io/kruize/autotune_operator:0.9
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume
@@ -484,7 +484,7 @@ spec:
         spec:
           containers:
             - name: kruizedeletejob
-              image: quay.io/kruize/autotune_operator:0.8.1
+              image: quay.io/kruize/autotune_operator:0.9
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume

--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -363,7 +363,7 @@ spec:
               done
       containers:
         - name: kruize
-          image: quay.io/kruize/autotune_operator:0.8.1
+          image: quay.io/kruize/autotune_operator:0.9
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume
@@ -443,7 +443,7 @@ spec:
         spec:
           containers:
             - name: kruizecronjob
-              image: quay.io/kruize/autotune_operator:0.8.1
+              image: quay.io/kruize/autotune_operator:0.9
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume
@@ -484,7 +484,7 @@ spec:
         spec:
           containers:
             - name: kruizedeletejob
-              image: quay.io/kruize/autotune_operator:0.8.1
+              image: quay.io/kruize/autotune_operator:0.9
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.autotune</groupId>
     <artifactId>autotune</artifactId>
-    <version>0.8.1</version>
+    <version>0.9</version>
     <properties>
         <fabric8-version>7.5.2</fabric8-version>
         <org-json-version>20240303</org-json-version>


### PR DESCRIPTION
Bump kruize version to 0.9

## Summary by Sourcery

Bump the Kruize/autotune operator version across manifests and project metadata.

Build:
- Update all Kubernetes/OpenShift/minikube deployment manifests to use the quay.io/kruize/autotune_operator:0.9 image instead of 0.8.1.
- Update the project Maven artifact version in pom.xml from 0.8.1 to 0.9.