### PR TITLE
Layers : 12 Update & Delete api

### DIFF
--- a/src/main/java/com/autotune/analyzer/Analyzer.java
+++ b/src/main/java/com/autotune/analyzer/Analyzer.java
@@ -62,6 +62,8 @@ public class Analyzer {
         context.addServlet(MetadataProfileService.class, ServerContext.UPDATE_METADATA_PROFILE);
         context.addServlet(LayerService.class, ServerContext.CREATE_LAYER);
         context.addServlet(LayerService.class, ServerContext.LIST_LAYERS);
+        context.addServlet(LayerService.class, ServerContext.UPDATE_LAYER);
+        context.addServlet(LayerService.class, ServerContext.DELETE_LAYER);
 
         // Adding UI support API's
         context.addServlet(ListNamespaces.class, ServerContext.LIST_NAMESPACES);

--- a/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
@@ -577,6 +577,10 @@ public class Converters {
                         JSONArray queriesArray = layerPresenceObject.getJSONArray("queries");
                         queries = new ArrayList<>();
                         for (Object queryObj : queriesArray) {
+                            // Check for null elements in queries array
+                            if (queryObj == null || queryObj == JSONObject.NULL) {
+                                throw new IllegalArgumentException("Queries array contains null elements");
+                            }
                             JSONObject queryJsonObject = (JSONObject) queryObj;
                             String datasource = queryJsonObject.getString("datasource");
                             String query = queryJsonObject.getString("query");
@@ -590,7 +594,12 @@ public class Converters {
                     if (layerPresenceObject.has("label")) {
                         JSONArray labelArray = layerPresenceObject.getJSONArray("label");
                         if (labelArray.length() > 0) {
-                            JSONObject labelObject = labelArray.getJSONObject(0);
+                            Object labelObj = labelArray.get(0);
+                            // Check for null element in label array
+                            if (labelObj == null || labelObj == JSONObject.NULL) {
+                                throw new IllegalArgumentException("Label array contains null elements");
+                            }
+                            JSONObject labelObject = (JSONObject) labelObj;
                             labelName = labelObject.getString("name");
                             labelValue = labelObject.getString("value");
                         }
@@ -603,6 +612,10 @@ public class Converters {
                 if (tunablesArray != null) {
                     tunables = new ArrayList<>();
                     for (Object tunableObj : tunablesArray) {
+                        // Check for null elements in tunables array
+                        if (tunableObj == null || tunableObj == JSONObject.NULL) {
+                            throw new IllegalArgumentException("Tunables array contains null elements");
+                        }
                         JSONObject tunableJsonObject = (JSONObject) tunableObj;
                         Tunable tunable = new Gson().fromJson(tunableJsonObject.toString(), Tunable.class);
                         tunables.add(tunable);

--- a/src/main/java/com/autotune/analyzer/services/LayerService.java
+++ b/src/main/java/com/autotune/analyzer/services/LayerService.java
@@ -17,9 +17,11 @@
 package com.autotune.analyzer.services;
 
 import com.autotune.analyzer.exceptions.MonitoringAgentNotSupportedException;
+import com.autotune.analyzer.exceptions.PerformanceProfileResponse;
 import com.autotune.analyzer.kruizeLayer.KruizeLayer;
 import com.autotune.analyzer.kruizeLayer.LayerValidation;
 import com.autotune.analyzer.serviceObjects.Converters;
+import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.analyzer.utils.AnalyzerErrorConstants;
 import com.autotune.common.data.ValidationOutputData;
 import com.autotune.database.dao.ExperimentDAOImpl;
@@ -50,7 +52,7 @@ import static com.autotune.analyzer.utils.AnalyzerConstants.ServiceConstants.CHA
 import static com.autotune.analyzer.utils.AnalyzerConstants.ServiceConstants.JSON_CONTENT_TYPE;
 
 /**
- * REST API service for Layer management (create and list operations)
+ * REST API service for Layer management (create, list, update, and delete operations)
  */
 @WebServlet(asyncSupported = true)
 public class LayerService extends HttpServlet {
@@ -99,7 +101,7 @@ public class LayerService extends HttpServlet {
 
             if (addedToDB.isSuccess()) {
                 LOGGER.debug(KruizeConstants.LayerAPIMessages.ADD_LAYER_TO_DB, kruizeLayer.getLayerName());
-                sendSuccessResponse(response, String.format(KruizeConstants.LayerAPIMessages.CREATE_LAYER_SUCCESS_MSG, kruizeLayer.getLayerName()));
+                sendSuccessResponse(response, String.format(KruizeConstants.LayerAPIMessages.CREATE_LAYER_SUCCESS_MSG, kruizeLayer.getLayerName()), HttpServletResponse.SC_CREATED);
             } else {
                 sendErrorResponse(response, null, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
                         String.format(AnalyzerErrorConstants.APIErrors.CreateLayerAPI.ADD_LAYER_TO_DB_FAILURE, addedToDB.getMessage()));
@@ -212,6 +214,143 @@ public class LayerService extends HttpServlet {
     }
 
     /**
+     * Update an existing Layer
+     *
+     * @param request
+     * @param response
+     * @throws IOException
+     */
+    @Override
+    protected void doPut(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        try {
+            // Get layer name from query parameter
+            String layerName = request.getParameter(AnalyzerConstants.LAYER_NAME);
+            
+            if (layerName == null || layerName.trim().isEmpty()) {
+                sendErrorResponse(response, null, HttpServletResponse.SC_BAD_REQUEST,
+                        AnalyzerErrorConstants.APIErrors.UpdateLayerAPI.INVALID_LAYER_JSON);
+                return;
+            }
+
+            // Read input JSON
+            String inputData = request.getReader().lines().collect(Collectors.joining());
+            KruizeLayer kruizeLayer = Converters.KruizeObjectConverters.convertInputJSONToCreateLayer(inputData);
+
+            // Validate that layer name in URL matches layer name in payload
+            if (!layerName.equals(kruizeLayer.getLayerName())) {
+                sendErrorResponse(response, null, HttpServletResponse.SC_BAD_REQUEST,
+                        String.format(AnalyzerErrorConstants.APIErrors.UpdateLayerAPI.LAYER_NAME_MISMATCH,
+                                layerName, kruizeLayer.getLayerName()));
+                return;
+            }
+
+            // Validate layer using LayerValidation helper
+            LayerValidation validation = new LayerValidation();
+            ValidationOutputData validationResult = validation.validate(kruizeLayer);
+
+            if (!validationResult.isSuccess()) {
+                sendErrorResponse(response, null, HttpServletResponse.SC_BAD_REQUEST,
+                        String.format(AnalyzerErrorConstants.APIErrors.UpdateLayerAPI.VALIDATION_FAILED, validationResult.getMessage()));
+                return;
+            }
+
+            // Check if layer exists
+            ExperimentDAOImpl experimentDAO = new ExperimentDAOImpl();
+            List<KruizeLMLayerEntry> existingLayers = experimentDAO.loadLayerByName(kruizeLayer.getLayerName());
+
+            if (existingLayers == null || existingLayers.isEmpty()) {
+                sendErrorResponse(response, null, HttpServletResponse.SC_NOT_FOUND,
+                        String.format(AnalyzerErrorConstants.APIErrors.UpdateLayerAPI.LAYER_NOT_FOUND, kruizeLayer.getLayerName()));
+                return;
+            }
+
+            // Convert KruizeLayer to KruizeLMLayerEntry
+            KruizeLMLayerEntry layerEntry = convertToLayerEntry(kruizeLayer);
+
+            // Update in database
+            ValidationOutputData updatedInDB = experimentDAO.updateLayerToDB(layerEntry);
+
+            if (updatedInDB.isSuccess()) {
+                LOGGER.debug(KruizeConstants.LayerAPIMessages.UPDATE_LAYER_TO_DB, kruizeLayer.getLayerName());
+                sendSuccessResponse(response, String.format(KruizeConstants.LayerAPIMessages.UPDATE_LAYER_SUCCESS_MSG, kruizeLayer.getLayerName()),
+                        HttpServletResponse.SC_OK);
+            } else {
+                sendErrorResponse(response, null, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+                        String.format(AnalyzerErrorConstants.APIErrors.UpdateLayerAPI.UPDATE_LAYER_TO_DB_FAILURE, updatedInDB.getMessage()));
+            }
+        } catch (MonitoringAgentNotSupportedException e) {
+            LOGGER.error("Failed to update layer: {}", e.getMessage());
+            sendErrorResponse(response, new Exception(e), HttpServletResponse.SC_BAD_REQUEST,
+                    String.format(AnalyzerErrorConstants.APIErrors.UpdateLayerAPI.VALIDATION_FAILED, e.getMessage()));
+        } catch (org.json.JSONException e) {
+            LOGGER.error("Invalid JSON in layer update request: {}", e.getMessage());
+            // Extract field name from error like: JSONObject["apiVersion"] not found
+            String errorMsg = e.getMessage();
+            String userMsg = AnalyzerErrorConstants.APIErrors.UpdateLayerAPI.INVALID_LAYER_JSON;
+            if (errorMsg != null && errorMsg.contains("[\"") && errorMsg.contains("\"]")) {
+                int start = errorMsg.indexOf("[\"") + 2;
+                int end = errorMsg.indexOf("\"]", start);
+                if (start > 1 && end > start) {
+                    String fieldName = errorMsg.substring(start, end);
+                    userMsg = "Missing required field '" + fieldName + "'. Please ensure all required fields are present: apiVersion, kind, metadata, layer_name, layer_presence, tunables";
+                }
+            }
+            sendErrorResponse(response, e, HttpServletResponse.SC_BAD_REQUEST, userMsg);
+        } catch (Exception e) {
+            LOGGER.error("Unexpected error updating layer: {}", e.getMessage(), e);
+            sendErrorResponse(response, e, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+                    String.format(AnalyzerErrorConstants.APIErrors.UpdateLayerAPI.UNEXPECTED_ERROR, e.getMessage()));
+        }
+    }
+
+    /**
+     * Delete a Layer
+     *
+     * @param request
+     * @param response
+     * @throws IOException
+     */
+    @Override
+    protected void doDelete(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        try {
+            // Get layer name from query parameter
+            String layerName = request.getParameter(AnalyzerConstants.LAYER_NAME);
+            
+            if (layerName == null || layerName.trim().isEmpty()) {
+                sendErrorResponse(response, null, HttpServletResponse.SC_BAD_REQUEST,
+                        AnalyzerErrorConstants.APIErrors.DeleteLayerAPI.INVALID_LAYER_NAME);
+                return;
+            }
+
+            // Check if layer exists before deleting
+            ExperimentDAOImpl experimentDAO = new ExperimentDAOImpl();
+            List<KruizeLMLayerEntry> existingLayers = experimentDAO.loadLayerByName(layerName);
+
+            if (existingLayers == null || existingLayers.isEmpty()) {
+                sendErrorResponse(response, null, HttpServletResponse.SC_NOT_FOUND,
+                        String.format(AnalyzerErrorConstants.APIErrors.DeleteLayerAPI.DELETE_LAYER_ENTRY_NOT_FOUND_WITH_NAME, layerName));
+                return;
+            }
+
+            // Delete from database
+            ValidationOutputData deletedFromDB = experimentDAO.deleteLayerByName(layerName);
+
+            if (deletedFromDB.isSuccess()) {
+                LOGGER.debug(KruizeConstants.LayerAPIMessages.DELETE_LAYER_FROM_DB, layerName);
+                sendSuccessResponse(response, String.format(KruizeConstants.LayerAPIMessages.DELETE_LAYER_SUCCESS_MSG, layerName),
+                        HttpServletResponse.SC_OK);
+            } else {
+                sendErrorResponse(response, null, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+                        deletedFromDB.getMessage());
+            }
+        } catch (Exception e) {
+            LOGGER.error("Unexpected error deleting layer: {}", e.getMessage(), e);
+            sendErrorResponse(response, e, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+                    String.format(AnalyzerErrorConstants.APIErrors.DeleteLayerAPI.UNEXPECTED_ERROR, e.getMessage()));
+        }
+    }
+
+    /**
      * Convert KruizeLayer to KruizeLMLayerEntry for database storage
      *
      * @param kruizeLayer
@@ -258,22 +397,16 @@ public class LayerService extends HttpServlet {
      *
      * @param response
      * @param message
+     * @param httpStatusCode
      * @throws IOException
      */
-    private void sendSuccessResponse(HttpServletResponse response, String message) throws IOException {
-        response.setContentType(JSON_CONTENT_TYPE);
-        response.setCharacterEncoding(CHARACTER_ENCODING);
-        response.setStatus(HttpServletResponse.SC_CREATED);
-        PrintWriter out = response.getWriter();
-
-        Map<String, Object> responseMap = new HashMap<>();
-        responseMap.put("message", message + KruizeConstants.LayerAPIMessages.VIEW_LAYERS_MSG);
-        responseMap.put("httpcode", HttpServletResponse.SC_CREATED);
-        responseMap.put("documentationLink", "");
-        responseMap.put("status", "SUCCESS");
-
-        out.append(new Gson().toJson(responseMap));
-        out.flush();
+    private void sendSuccessResponse(HttpServletResponse response, String message, int httpStatusCode) throws IOException {
+        // Only add "View Layers" message for CREATE operations (201 status)
+        String finalMessage = message;
+        if (httpStatusCode == HttpServletResponse.SC_CREATED) {
+            finalMessage = message + KruizeConstants.LayerAPIMessages.VIEW_LAYERS_MSG;
+        }
+        sendJsonResponse(response, finalMessage, httpStatusCode, "SUCCESS");
     }
 
     /**
@@ -291,7 +424,7 @@ public class LayerService extends HttpServlet {
             if (null == errorMsg)
                 errorMsg = e.getMessage();
         }
-        response.sendError(httpStatusCode, errorMsg);
+        sendJsonResponse(response, errorMsg, httpStatusCode, "ERROR");
     }
 
     /**
@@ -304,5 +437,35 @@ public class LayerService extends HttpServlet {
                 .disableHtmlEscaping()
                 .setPrettyPrinting()
                 .create();
+    }
+
+    /**
+     * Sends a JSON response (for both success and error cases).
+     *
+     * @param response The servlet response
+     * @param message  Message to include in response
+     * @param statusCode HTTP status code (e.g., 200, 404, 500)
+     * @param status   "SUCCESS" or "ERROR"
+     * @throws IOException
+     */
+    public static void sendJsonResponse(HttpServletResponse response,
+                                        String message,
+                                        int statusCode,
+                                        String status) throws IOException {
+
+        response.setContentType(JSON_CONTENT_TYPE);
+        response.setCharacterEncoding(CHARACTER_ENCODING);
+        response.setStatus(statusCode);
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("message", message);
+        responseMap.put("httpcode", statusCode);
+        responseMap.put("documentationLink", "");
+        responseMap.put("status", status);
+
+        Gson gsonInstance = new Gson();
+        PrintWriter out = response.getWriter();
+        out.append(gsonInstance.toJson(responseMap));
+        out.flush();
     }
 }

--- a/src/main/java/com/autotune/analyzer/services/LayerService.java
+++ b/src/main/java/com/autotune/analyzer/services/LayerService.java
@@ -17,12 +17,12 @@
 package com.autotune.analyzer.services;
 
 import com.autotune.analyzer.exceptions.MonitoringAgentNotSupportedException;
-import com.autotune.analyzer.exceptions.PerformanceProfileResponse;
 import com.autotune.analyzer.kruizeLayer.KruizeLayer;
 import com.autotune.analyzer.kruizeLayer.LayerValidation;
 import com.autotune.analyzer.serviceObjects.Converters;
 import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.analyzer.utils.AnalyzerErrorConstants;
+import com.autotune.analyzer.utils.AnalyzerErrorConstants.APIErrors.ListLayerAPI;
 import com.autotune.common.data.ValidationOutputData;
 import com.autotune.database.dao.ExperimentDAOImpl;
 import com.autotune.database.helper.DBHelpers;
@@ -33,7 +33,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import org.json.JSONException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -177,17 +176,17 @@ public class LayerService extends HttpServlet {
                         error = true;
                         sendErrorResponse(
                                 response,
-                                new Exception(AnalyzerErrorConstants.APIErrors.ListLayerAPI.INVALID_LAYER_NAME_EXCPTN),
+                                new Exception(ListLayerAPI.INVALID_LAYER_NAME_EXCPTN),
                                 HttpServletResponse.SC_BAD_REQUEST,
-                                String.format(AnalyzerErrorConstants.APIErrors.ListLayerAPI.INVALID_LAYER_NAME_MSG, layerName)
+                                String.format(ListLayerAPI.INVALID_LAYER_NAME_MSG, layerName)
                         );
                     } else if (null == layerName && layerEntries.isEmpty()) {
                         error = true;
                         sendErrorResponse(
                                 response,
-                                new Exception(AnalyzerErrorConstants.APIErrors.ListLayerAPI.NO_LAYERS_EXCPTN),
+                                new Exception(ListLayerAPI.NO_LAYERS_EXCPTN),
                                 HttpServletResponse.SC_BAD_REQUEST,
-                                AnalyzerErrorConstants.APIErrors.ListLayerAPI.NO_LAYERS
+                                ListLayerAPI.NO_LAYERS
                         );
                     }
 
@@ -208,16 +207,15 @@ public class LayerService extends HttpServlet {
                     }
                 } catch (Exception e) {
                     LOGGER.error("Exception while loading layers: {}", e.getMessage());
-                    e.printStackTrace();
                     sendErrorResponse(response, e, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-                            String.format(AnalyzerErrorConstants.APIErrors.ListLayerAPI.LOAD_ALL_LAYERS_ERROR, e.getMessage()));
+                            String.format(ListLayerAPI.LOAD_ALL_LAYERS_ERROR, e.getMessage()));
                 }
             } else {
                 sendErrorResponse(
                         response,
-                        new Exception(AnalyzerErrorConstants.APIErrors.ListLayerAPI.INVALID_QUERY_PARAM),
+                        new Exception(ListLayerAPI.INVALID_QUERY_PARAM),
                         HttpServletResponse.SC_BAD_REQUEST,
-                        String.format(AnalyzerErrorConstants.APIErrors.ListLayerAPI.INVALID_QUERY_PARAM, invalidParams)
+                        String.format(ListLayerAPI.INVALID_QUERY_PARAM, invalidParams)
                 );
             }
         } catch (Exception e) {

--- a/src/main/java/com/autotune/analyzer/services/LayerService.java
+++ b/src/main/java/com/autotune/analyzer/services/LayerService.java
@@ -71,6 +71,14 @@ public class LayerService extends HttpServlet {
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
         try {
             String inputData = request.getReader().lines().collect(Collectors.joining());
+
+            // Validate that request body is not empty
+            if (inputData == null || inputData.trim().isEmpty()) {
+                sendErrorResponse(response, null, HttpServletResponse.SC_BAD_REQUEST,
+                        AnalyzerErrorConstants.APIErrors.CreateLayerAPI.INVALID_LAYER_JSON);
+                return;
+            }
+
             KruizeLayer kruizeLayer = Converters.KruizeObjectConverters.convertInputJSONToCreateLayer(inputData);
 
             // Validate layer using LayerValidation helper
@@ -106,6 +114,11 @@ public class LayerService extends HttpServlet {
                 sendErrorResponse(response, null, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
                         String.format(AnalyzerErrorConstants.APIErrors.CreateLayerAPI.ADD_LAYER_TO_DB_FAILURE, addedToDB.getMessage()));
             }
+        } catch (IllegalArgumentException e) {
+            // Handle validation errors from converter (e.g., null elements in arrays)
+            LOGGER.error("Invalid input in layer creation request: {}", e.getMessage());
+            sendErrorResponse(response, e, HttpServletResponse.SC_BAD_REQUEST,
+                    "Validation failed: " + e.getMessage());
         } catch (MonitoringAgentNotSupportedException e) {
             LOGGER.error("Failed to create layer: {}", e.getMessage());
             sendErrorResponse(response, new Exception(e), HttpServletResponse.SC_BAD_REQUEST, "Validation failed: " + e.getMessage());
@@ -225,15 +238,38 @@ public class LayerService extends HttpServlet {
         try {
             // Get layer name from query parameter
             String layerName = request.getParameter(AnalyzerConstants.LAYER_NAME);
-            
+
             if (layerName == null || layerName.trim().isEmpty()) {
                 sendErrorResponse(response, null, HttpServletResponse.SC_BAD_REQUEST,
-                        AnalyzerErrorConstants.APIErrors.UpdateLayerAPI.INVALID_LAYER_JSON);
+                        AnalyzerErrorConstants.APIErrors.UpdateLayerAPI.INVALID_LAYER_NAME);
+                return;
+            }
+
+            // Validate query params
+            Set<String> invalidParams = new HashSet<>();
+            for (String param : request.getParameterMap().keySet()) {
+                if (!KruizeSupportedTypes.UPDATE_LAYERS_QUERY_PARAMS_SUPPORTED.contains(param)) {
+                    invalidParams.add(param);
+                }
+            }
+
+            if (!invalidParams.isEmpty()) {
+                sendErrorResponse(response, null, HttpServletResponse.SC_BAD_REQUEST,
+                        String.format(AnalyzerErrorConstants.APIErrors.UpdateLayerAPI.INVALID_QUERY_PARAMS,
+                                invalidParams, KruizeSupportedTypes.UPDATE_LAYERS_QUERY_PARAMS_SUPPORTED));
                 return;
             }
 
             // Read input JSON
             String inputData = request.getReader().lines().collect(Collectors.joining());
+
+            // Validate that request body is not empty
+            if (inputData == null || inputData.trim().isEmpty()) {
+                sendErrorResponse(response, null, HttpServletResponse.SC_BAD_REQUEST,
+                        AnalyzerErrorConstants.APIErrors.UpdateLayerAPI.INVALID_LAYER_JSON);
+                return;
+            }
+
             KruizeLayer kruizeLayer = Converters.KruizeObjectConverters.convertInputJSONToCreateLayer(inputData);
 
             // Validate that layer name in URL matches layer name in payload
@@ -278,6 +314,11 @@ public class LayerService extends HttpServlet {
                 sendErrorResponse(response, null, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
                         String.format(AnalyzerErrorConstants.APIErrors.UpdateLayerAPI.UPDATE_LAYER_TO_DB_FAILURE, updatedInDB.getMessage()));
             }
+        } catch (IllegalArgumentException e) {
+            // Handle validation errors from converter (e.g., null elements in arrays)
+            LOGGER.error("Invalid input in layer update request: {}", e.getMessage());
+            sendErrorResponse(response, e, HttpServletResponse.SC_BAD_REQUEST,
+                    String.format(AnalyzerErrorConstants.APIErrors.UpdateLayerAPI.VALIDATION_FAILED, e.getMessage()));
         } catch (MonitoringAgentNotSupportedException e) {
             LOGGER.error("Failed to update layer: {}", e.getMessage());
             sendErrorResponse(response, new Exception(e), HttpServletResponse.SC_BAD_REQUEST,
@@ -292,7 +333,7 @@ public class LayerService extends HttpServlet {
                 int end = errorMsg.indexOf("\"]", start);
                 if (start > 1 && end > start) {
                     String fieldName = errorMsg.substring(start, end);
-                    userMsg = "Missing required field '" + fieldName + "'. Please ensure all required fields are present: apiVersion, kind, metadata, layer_name, layer_presence, tunables";
+                    userMsg = String.format(AnalyzerErrorConstants.APIErrors.UpdateLayerAPI.MISSING_REQUIRED_FIELD, fieldName);
                 }
             }
             sendErrorResponse(response, e, HttpServletResponse.SC_BAD_REQUEST, userMsg);
@@ -315,10 +356,25 @@ public class LayerService extends HttpServlet {
         try {
             // Get layer name from query parameter
             String layerName = request.getParameter(AnalyzerConstants.LAYER_NAME);
-            
+
             if (layerName == null || layerName.trim().isEmpty()) {
                 sendErrorResponse(response, null, HttpServletResponse.SC_BAD_REQUEST,
                         AnalyzerErrorConstants.APIErrors.DeleteLayerAPI.INVALID_LAYER_NAME);
+                return;
+            }
+
+            // Validate query params
+            Set<String> invalidParams = new HashSet<>();
+            for (String param : request.getParameterMap().keySet()) {
+                if (!KruizeSupportedTypes.DELETE_LAYERS_QUERY_PARAMS_SUPPORTED.contains(param)) {
+                    invalidParams.add(param);
+                }
+            }
+
+            if (!invalidParams.isEmpty()) {
+                sendErrorResponse(response, null, HttpServletResponse.SC_BAD_REQUEST,
+                        String.format(AnalyzerErrorConstants.APIErrors.DeleteLayerAPI.INVALID_QUERY_PARAMS,
+                                invalidParams, KruizeSupportedTypes.DELETE_LAYERS_QUERY_PARAMS_SUPPORTED));
                 return;
             }
 
@@ -448,10 +504,10 @@ public class LayerService extends HttpServlet {
      * @param status   "SUCCESS" or "ERROR"
      * @throws IOException
      */
-    public static void sendJsonResponse(HttpServletResponse response,
-                                        String message,
-                                        int statusCode,
-                                        String status) throws IOException {
+    private void sendJsonResponse(HttpServletResponse response,
+                                   String message,
+                                   int statusCode,
+                                   String status) throws IOException {
 
         response.setContentType(JSON_CONTENT_TYPE);
         response.setCharacterEncoding(CHARACTER_ENCODING);
@@ -463,7 +519,7 @@ public class LayerService extends HttpServlet {
         responseMap.put("documentationLink", "");
         responseMap.put("status", status);
 
-        Gson gsonInstance = new Gson();
+        Gson gsonInstance = createGsonObject();
         PrintWriter out = response.getWriter();
         out.append(gsonInstance.toJson(responseMap));
         out.flush();

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -116,6 +116,7 @@ public class AnalyzerConstants {
     public static final String LM = "lm";
     public static final String VENDOR = "vendor";
     public static final String RUNTIME = "runtime";
+    public static final String LAYER_NAME = "name";
 
     private AnalyzerConstants() {
     }

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
@@ -385,13 +385,13 @@ public class AnalyzerErrorConstants {
             public static final String TUNABLE_MISSING_CONFIG = "Tunable '%s' must have either categorical choices or numeric bounds/step configured.";
 
             // Bounds validation errors
-            public static final String TUNABLE_NULL_BOUNDS = "Tunable '%s': Both 'upper_bound' and 'lower_bound' are required for numeric tunables";
-            public static final String TUNABLE_NON_NUMERIC_BOUNDS = "Tunable '%s': Bounds must be numeric values. Found upper_bound=%s, lower_bound=%s";
-            public static final String TUNABLE_NULL_STEP = "Tunable '%s': 'step' is required for numeric tunables";
-            public static final String TUNABLE_INVALID_STEP = "Tunable '%s': 'step' must be greater than 0. Found: %s";
-            public static final String TUNABLE_NEGATIVE_BOUNDS = "Tunable '%s': Bounds cannot be negative. Found upper_bound=%s, lower_bound=%s";
-            public static final String TUNABLE_INVALID_BOUND_RANGE = "Tunable '%s': 'lower_bound' (%s) must be less than 'upper_bound' (%s)";
-            public static final String TUNABLE_STEP_TOO_LARGE = "Tunable '%s': 'step' (%s) cannot be larger than the range (upper_bound - lower_bound = %s)";
+            public static final String TUNABLE_NULL_BOUNDS = "Tunable '%s' has null bounds; both upper_bound and lower_bound must be set";
+            public static final String TUNABLE_NON_NUMERIC_BOUNDS = "Tunable '%s' has non-numeric bounds: upper=%s, lower=%s";
+            public static final String TUNABLE_NULL_STEP = "Tunable '%s' has null step; step must be set for bounded tunables";
+            public static final String TUNABLE_INVALID_STEP = "Tunable '%s' has invalid step; step must be > 0, got: %s";
+            public static final String TUNABLE_NEGATIVE_BOUNDS = "Tunable '%s' has negative bounds; upperBound: %s lowerBound: %s";
+            public static final String TUNABLE_INVALID_BOUND_RANGE = "Tunable '%s' has invalid bounds; lowerBound (%s) must be less than upperBound (%s)";
+            public static final String TUNABLE_STEP_TOO_LARGE = "Tunable '%s' has invalid step; step (%s) must be <= (upperBound - lowerBound) (%s)";
 
             // Categorical validation errors
             public static final String TUNABLE_EMPTY_CHOICES = "Tunable '%s' is categorical but has null or empty choices list";

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
@@ -385,16 +385,42 @@ public class AnalyzerErrorConstants {
             public static final String TUNABLE_MISSING_CONFIG = "Tunable '%s' must have either categorical choices or numeric bounds/step configured.";
 
             // Bounds validation errors
-            public static final String TUNABLE_NULL_BOUNDS = "Tunable '%s' has null bounds; both upper_bound and lower_bound must be set";
-            public static final String TUNABLE_NON_NUMERIC_BOUNDS = "Tunable '%s' has non-numeric bounds: upper=%s, lower=%s";
-            public static final String TUNABLE_NULL_STEP = "Tunable '%s' has null step; step must be set for bounded tunables";
-            public static final String TUNABLE_INVALID_STEP = "Tunable '%s' has invalid step; step must be > 0, got: %s";
-            public static final String TUNABLE_NEGATIVE_BOUNDS = "Tunable '%s' has negative bounds; upperBound: %s lowerBound: %s";
-            public static final String TUNABLE_INVALID_BOUND_RANGE = "Tunable '%s' has invalid bounds; lowerBound (%s) must be less than upperBound (%s)";
-            public static final String TUNABLE_STEP_TOO_LARGE = "Tunable '%s' has invalid step; step (%s) must be <= (upperBound - lowerBound) (%s)";
+            public static final String TUNABLE_NULL_BOUNDS = "Tunable '%s': Both 'upper_bound' and 'lower_bound' are required for numeric tunables";
+            public static final String TUNABLE_NON_NUMERIC_BOUNDS = "Tunable '%s': Bounds must be numeric values. Found upper_bound=%s, lower_bound=%s";
+            public static final String TUNABLE_NULL_STEP = "Tunable '%s': 'step' is required for numeric tunables";
+            public static final String TUNABLE_INVALID_STEP = "Tunable '%s': 'step' must be greater than 0. Found: %s";
+            public static final String TUNABLE_NEGATIVE_BOUNDS = "Tunable '%s': Bounds cannot be negative. Found upper_bound=%s, lower_bound=%s";
+            public static final String TUNABLE_INVALID_BOUND_RANGE = "Tunable '%s': 'lower_bound' (%s) must be less than 'upper_bound' (%s)";
+            public static final String TUNABLE_STEP_TOO_LARGE = "Tunable '%s': 'step' (%s) cannot be larger than the range (upper_bound - lower_bound = %s)";
 
             // Categorical validation errors
             public static final String TUNABLE_EMPTY_CHOICES = "Tunable '%s' is categorical but has null or empty choices list";
+        }
+
+        public static final class UpdateLayerAPI {
+            private UpdateLayerAPI() {
+            }
+
+            // Layer update errors
+            public static final String LAYER_NOT_FOUND = "Layer not found with name: %s";
+            public static final String INVALID_LAYER_JSON = "Invalid Layer JSON for update";
+            public static final String UPDATE_LAYER_TO_DB_FAILURE = "Failed to update layer in database: %s";
+            public static final String LAYER_NAME_MISMATCH = "Layer name in URL (%s) does not match layer name in payload (%s)";
+            public static final String VALIDATION_FAILED = "Validation failed: %s";
+            public static final String UPDATE_FAILED_PREFIX = "Failed to update layer: %s";
+            public static final String INVALID_JSON_PREFIX = "Invalid JSON in layer update request: %s";
+            public static final String UNEXPECTED_ERROR = "Failed to update layer due to an internal error: %s";
+        }
+
+        public static final class DeleteLayerAPI {
+            private DeleteLayerAPI() {
+            }
+
+            // Layer delete errors
+            public static final String DELETE_LAYER_ENTRY_NOT_FOUND_WITH_NAME = "Layer not found with name: %s";
+            public static final String DELETE_LAYER_ENTRY_ERROR_MSG = "Failed to delete layer %s due to: %s";
+            public static final String INVALID_LAYER_NAME = "Invalid layer name parameter";
+            public static final String UNEXPECTED_ERROR = "Failed to delete layer due to an internal error: %s";
         }
 
     public static final class ListLayerAPI {

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
@@ -426,7 +426,7 @@ public class AnalyzerErrorConstants {
         }
 
     public static final class ListLayerAPI {
-        public ListLayerAPI() {
+        private ListLayerAPI() {
         }
         public static final String INVALID_QUERY_PARAM = "The query param(s) - %s is/are invalid";
         public static final String INVALID_LAYER_NAME_EXCPTN = "Invalid Layer Name";

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
@@ -402,14 +402,15 @@ public class AnalyzerErrorConstants {
             }
 
             // Layer update errors
+            public static final String INVALID_LAYER_NAME = "Invalid layer name parameter";
             public static final String LAYER_NOT_FOUND = "Layer not found with name: %s";
             public static final String INVALID_LAYER_JSON = "Invalid Layer JSON for update";
             public static final String UPDATE_LAYER_TO_DB_FAILURE = "Failed to update layer in database: %s";
             public static final String LAYER_NAME_MISMATCH = "Layer name in URL (%s) does not match layer name in payload (%s)";
             public static final String VALIDATION_FAILED = "Validation failed: %s";
-            public static final String UPDATE_FAILED_PREFIX = "Failed to update layer: %s";
-            public static final String INVALID_JSON_PREFIX = "Invalid JSON in layer update request: %s";
             public static final String UNEXPECTED_ERROR = "Failed to update layer due to an internal error: %s";
+            public static final String INVALID_QUERY_PARAMS = "Invalid query parameter(s): %s. Supported parameters: %s";
+            public static final String MISSING_REQUIRED_FIELD = "Missing required field '%s'. Please ensure all required fields are present: apiVersion, kind, metadata, layer_name, layer_presence, tunables";
         }
 
         public static final class DeleteLayerAPI {
@@ -421,6 +422,7 @@ public class AnalyzerErrorConstants {
             public static final String DELETE_LAYER_ENTRY_ERROR_MSG = "Failed to delete layer %s due to: %s";
             public static final String INVALID_LAYER_NAME = "Invalid layer name parameter";
             public static final String UNEXPECTED_ERROR = "Failed to delete layer due to an internal error: %s";
+            public static final String INVALID_QUERY_PARAMS = "Invalid query parameter(s): %s. Supported parameters: %s";
         }
 
     public static final class ListLayerAPI {
@@ -431,7 +433,6 @@ public class AnalyzerErrorConstants {
         public static final String INVALID_LAYER_NAME_MSG = "Given layer name - %s either does not exist or is not valid";
         public static final String NO_LAYERS_EXCPTN = "No layers";
         public static final String NO_LAYERS = "No layers found!";
-        public static final String LOAD_LAYER_ERROR = "Failed to load layer data: %s";
         public static final String LOAD_ALL_LAYERS_ERROR = "Failed to load all layers: %s";
     }
     }

--- a/src/main/java/com/autotune/database/dao/ExperimentDAO.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAO.java
@@ -49,6 +49,12 @@ public interface ExperimentDAO {
     // Add Layer to DB
     public ValidationOutputData addLayerToDB(KruizeLMLayerEntry kruizeLayerEntry);
 
+    // Update Layer in DB
+    public ValidationOutputData updateLayerToDB(KruizeLMLayerEntry kruizeLayerEntry);
+
+    // Delete Layer from DB
+    public ValidationOutputData deleteLayerByName(String layerName);
+
     // If Kruize restarts load all layers
     List<KruizeLMLayerEntry> loadAllLayers() throws Exception;
 

--- a/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
@@ -722,6 +722,8 @@ public class ExperimentDAOImpl implements ExperimentDAO {
             validationOutputData.setMessage(e.getMessage());
         } catch (Exception e) {
             LOGGER.error("Not able to update layer due to: {}", e.getMessage(), e);
+            if (tx != null && tx.isActive()) tx.rollback();
+            validationOutputData.setSuccess(false);
             validationOutputData.setMessage(e.getMessage());
         } finally {
             if (null != timerUpdateLayerDB) {
@@ -752,7 +754,7 @@ public class ExperimentDAOImpl implements ExperimentDAO {
 
                 if (deletedCount == 0) {
                     validationOutputData.setSuccess(false);
-                    validationOutputData.setMessage(AnalyzerErrorConstants.APIErrors.DeleteLayerAPI.DELETE_LAYER_ENTRY_NOT_FOUND_WITH_NAME + layerName);
+                    validationOutputData.setMessage(String.format(AnalyzerErrorConstants.APIErrors.DeleteLayerAPI.DELETE_LAYER_ENTRY_NOT_FOUND_WITH_NAME, layerName));
                 } else {
                     validationOutputData.setSuccess(true);
                 }

--- a/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
@@ -697,6 +697,81 @@ public class ExperimentDAOImpl implements ExperimentDAO {
     }
 
     /**
+     * Update Layer in DB
+     *
+     * @param kruizeLayerEntry
+     * @return validationOutputData contains the status of the DB update operation
+     */
+    @Override
+    public ValidationOutputData updateLayerToDB(KruizeLMLayerEntry kruizeLayerEntry) {
+        ValidationOutputData validationOutputData = new ValidationOutputData(false, null, null);
+        String statusValue = "failure";
+        Timer.Sample timerUpdateLayerDB = Timer.start(MetricsConfig.meterRegistry());
+        Transaction tx = null;
+        try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
+            tx = session.beginTransaction();
+            session.merge(kruizeLayerEntry);
+            tx.commit();
+            validationOutputData.setSuccess(true);
+            statusValue = "success";
+        } catch (HibernateException e) {
+            LOGGER.error("Not able to update layer due to: {}", e.getMessage(), e);
+            if (tx != null && tx.isActive()) tx.rollback();
+            e.printStackTrace();
+            validationOutputData.setSuccess(false);
+            validationOutputData.setMessage(e.getMessage());
+        } catch (Exception e) {
+            LOGGER.error("Not able to update layer due to: {}", e.getMessage(), e);
+            validationOutputData.setMessage(e.getMessage());
+        } finally {
+            if (null != timerUpdateLayerDB) {
+                MetricsConfig.timerUpdateLayerDB = MetricsConfig.timerBUpdateLayerDB.tag("status", statusValue).register(MetricsConfig.meterRegistry());
+                timerUpdateLayerDB.stop(MetricsConfig.timerUpdateLayerDB);
+            }
+        }
+
+        return validationOutputData;
+    }
+
+    /**
+     * Delete Layer from DB by layer name
+     *
+     * @param layerName
+     * @return validationOutputData contains the status of the DB delete operation
+     */
+    @Override
+    public ValidationOutputData deleteLayerByName(String layerName) {
+        ValidationOutputData validationOutputData = new ValidationOutputData(false, null, null);
+        Transaction tx = null;
+        try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
+            try {
+                tx = session.beginTransaction();
+                Query query = session.createQuery(DBConstants.SQLQUERY.DELETE_FROM_LAYER_BY_NAME, null);
+                query.setParameter("layerName", layerName);
+                int deletedCount = query.executeUpdate();
+
+                if (deletedCount == 0) {
+                    validationOutputData.setSuccess(false);
+                    validationOutputData.setMessage(AnalyzerErrorConstants.APIErrors.DeleteLayerAPI.DELETE_LAYER_ENTRY_NOT_FOUND_WITH_NAME + layerName);
+                } else {
+                    validationOutputData.setSuccess(true);
+                }
+                tx.commit();
+            } catch (HibernateException e) {
+                LOGGER.error(AnalyzerErrorConstants.APIErrors.DeleteLayerAPI.DELETE_LAYER_ENTRY_ERROR_MSG, layerName, e.getMessage());
+                if (tx != null) tx.rollback();
+                e.printStackTrace();
+                validationOutputData.setSuccess(false);
+                validationOutputData.setMessage(e.getMessage());
+            }
+        } catch (Exception e) {
+            LOGGER.error(AnalyzerErrorConstants.APIErrors.DeleteLayerAPI.DELETE_LAYER_ENTRY_ERROR_MSG, layerName, e.getMessage());
+            validationOutputData.setMessage(e.getMessage());
+        }
+        return validationOutputData;
+    }
+
+    /**
      * @param kruizeDataSourceEntry
      * @param validationOutputData
      * @return validationOutputData contains the status of the DB insert operation

--- a/src/main/java/com/autotune/database/helper/DBConstants.java
+++ b/src/main/java/com/autotune/database/helper/DBConstants.java
@@ -87,6 +87,7 @@ public class DBConstants {
         public static final String SELECT_FROM_METADATA_PROFILE_BY_NAME = "from KruizeLMMetadataProfileEntry k WHERE k.name = :name";
         public static final String SELECT_FROM_LAYER = "from KruizeLMLayerEntry";
         public static final String SELECT_FROM_LAYER_BY_NAME = "from KruizeLMLayerEntry k WHERE k.layer_name = :layerName";
+        public static final String DELETE_FROM_LAYER_BY_NAME = "DELETE FROM KruizeLMLayerEntry k WHERE k.layer_name = :layerName";
         public static final String DELETE_FROM_EXPERIMENTS_BY_EXP_NAME = "DELETE FROM KruizeExperimentEntry k WHERE k.experiment_name = :experimentName";
         public static final String DELETE_FROM_LM_EXPERIMENTS_BY_EXP_NAME = "DELETE FROM KruizeLMExperimentEntry k WHERE k.experiment_name = :experimentName";
         public static final String DELETE_FROM_RESULTS_BY_EXP_NAME = "DELETE FROM KruizeResultsEntry k WHERE k.experiment_name = :experimentName";

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -1137,8 +1137,12 @@ public class KruizeConstants {
 
     public static final class LayerAPIMessages {
         public static final String CREATE_LAYER_SUCCESS_MSG = "Layer : %s created successfully.";
+        public static final String UPDATE_LAYER_SUCCESS_MSG = "Layer : %s updated successfully.";
+        public static final String DELETE_LAYER_SUCCESS_MSG = "Layer : %s deleted successfully.";
         public static final String VIEW_LAYERS_MSG = " View Layers at /listLayers";
         public static final String ADD_LAYER_TO_DB = "Added Layer : {} into the DB";
+        public static final String UPDATE_LAYER_TO_DB = "Updated Layer : {} in the DB";
+        public static final String DELETE_LAYER_FROM_DB = "Deleted Layer : {} from the DB";
         public static final String LOAD_LAYER_FAILURE = "Failed to load layer data: {}";
         public static final String LOAD_ALL_LAYERS_FAILURE = "Failed to load all layers: {}";
 

--- a/src/main/java/com/autotune/utils/KruizeSupportedTypes.java
+++ b/src/main/java/com/autotune/utils/KruizeSupportedTypes.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package com.autotune.utils;
 
+import com.autotune.analyzer.utils.AnalyzerConstants;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -75,19 +77,19 @@ public class KruizeSupportedTypes {
     ));
 
     public static final Set<String> UPDATE_METADATA_PROFILES_QUERY_PARAMS_SUPPORTED = new HashSet<>(Arrays.asList(
-            "name"
+            AnalyzerConstants.LAYER_NAME
     ));
 
     public static final Set<String> LIST_LAYERS_QUERY_PARAMS_SUPPORTED = new HashSet<>(Arrays.asList(
-            "name"
+            AnalyzerConstants.LAYER_NAME
     ));
 
     public static final Set<String> UPDATE_LAYERS_QUERY_PARAMS_SUPPORTED = new HashSet<>(Arrays.asList(
-            "name"
+            AnalyzerConstants.LAYER_NAME
     ));
 
     public static final Set<String> DELETE_LAYERS_QUERY_PARAMS_SUPPORTED = new HashSet<>(Arrays.asList(
-            "name"
+            AnalyzerConstants.LAYER_NAME
     ));
 
     public static final Set<String> RUNTIMES_SUPPORTED_DATASOURCES = new HashSet<>(Arrays.asList("thanos-querier"));

--- a/src/main/java/com/autotune/utils/KruizeSupportedTypes.java
+++ b/src/main/java/com/autotune/utils/KruizeSupportedTypes.java
@@ -82,6 +82,14 @@ public class KruizeSupportedTypes {
             "name"
     ));
 
+    public static final Set<String> UPDATE_LAYERS_QUERY_PARAMS_SUPPORTED = new HashSet<>(Arrays.asList(
+            "name"
+    ));
+
+    public static final Set<String> DELETE_LAYERS_QUERY_PARAMS_SUPPORTED = new HashSet<>(Arrays.asList(
+            "name"
+    ));
+
     public static final Set<String> RUNTIMES_SUPPORTED_DATASOURCES = new HashSet<>(Arrays.asList("thanos-querier"));
 
     private KruizeSupportedTypes() {

--- a/src/main/java/com/autotune/utils/MetricsConfig.java
+++ b/src/main/java/com/autotune/utils/MetricsConfig.java
@@ -22,7 +22,7 @@ public class MetricsConfig {
     public static Timer timerAddRecDB, timerAddResultsDB, timerAddExpDB, timerAddBulkResultsDB, timerSaveBulkJobDB, timerAddBulkJob;
     public static Timer timerAddPerfProfileDB, timerLoadPerfProfileName, timerLoadAllPerfProfiles;
     public static Timer timerAddMetadataProfileDB, timerLoadMetadataProfileName, timerLoadAllMetadataProfiles, timerUpdateMetadataProfileDB;
-    public static Timer timerAddLayerDB, timerLoadAllLayers, timerLoadLayerByName;
+    public static Timer timerAddLayerDB, timerLoadAllLayers, timerLoadLayerByName, timerUpdateLayerDB, timerDeleteLayerDB;
     public static Timer timerImportMetadata, timerGetMetadata;
     public static Timer timerJobStatus, timerCreateBulkJob, timerGetExpMap, timerCreateBulkExp, timerGenerateBulkRec, timerRunJob;
     public static Counter timerKruizeNotifications , timerBulkJobs;
@@ -42,7 +42,7 @@ public class MetricsConfig {
     public static Timer.Builder timerBUpdateMetadataProfile;
     public static Timer timerUpdatePerfProfile;
     public static Timer.Builder timerBUpdatePerfProfile;
-    public static Timer.Builder timerBAddLayerDB, timerBLoadAllLayers, timerBLoadLayerByName;
+    public static Timer.Builder timerBAddLayerDB, timerBLoadAllLayers, timerBLoadLayerByName, timerBUpdateLayerDB, timerBDeleteLayerDB;
 
     private static MetricsConfig INSTANCE;
     public String API_METRIC_DESC = "Time taken for Kruize APIs";
@@ -109,6 +109,8 @@ public class MetricsConfig {
         timerBAddLayerDB = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method", "addLayerToDB");
         timerBLoadAllLayers = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method", "loadAllLayers");
         timerBLoadLayerByName = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method", "loadLayerByName");
+        timerBUpdateLayerDB = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method", "updateLayerToDB");
+        timerBDeleteLayerDB = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method", "deleteLayerByName");
 
         new ClassLoaderMetrics().bindTo(meterRegistry);
         new ProcessorMetrics().bindTo(meterRegistry);

--- a/src/main/java/com/autotune/utils/ServerContext.java
+++ b/src/main/java/com/autotune/utils/ServerContext.java
@@ -47,6 +47,8 @@ public class ServerContext {
     public static final String UPDATE_METADATA_PROFILE = ROOT_CONTEXT + "updateMetadataProfile";
     public static final String CREATE_LAYER = ROOT_CONTEXT + "createLayer";
     public static final String LIST_LAYERS = ROOT_CONTEXT + "listLayers";
+    public static final String UPDATE_LAYER = ROOT_CONTEXT + "updateLayer";
+    public static final String DELETE_LAYER = ROOT_CONTEXT + "deleteLayer";
 
     public static final String KRUIZE_SERVER_URL = "http://localhost:" + KRUIZE_SERVER_PORT;
     public static final String LIST_EXPERIMENTS_END_POINT = KRUIZE_SERVER_URL + LIST_EXPERIMENTS;


### PR DESCRIPTION
## Description

Adds Update and delete layer apis

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Add full CRUD-style support for layer resources by introducing update and delete APIs and standardizing JSON responses for layer operations.

New Features:
- Expose updateLayer and deleteLayer REST endpoints backed by LayerService and ExperimentDAO operations to modify or remove layers.
- Provide JSON-formatted success and error responses for all layer management APIs with appropriate HTTP status codes.

Enhancements:
- Extend database access layer and metrics to support updating and deleting layer entries, including new timers and SQL queries.
- Improve validation and error messaging for layer tunable bounds and new update/delete layer flows to give clearer user-facing feedback.