### PR TITLE
Fix CVE-2026-27727 : Upgrade mchange to 0.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,6 +194,13 @@
             <artifactId>hibernate-c3p0</artifactId>
             <version>${hibernatecp30-version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.mchange</groupId>
+            <artifactId>mchange-commons-java</artifactId>
+            <version>0.4.0</version>
+        </dependency>
+
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>


### PR DESCRIPTION
## Description

This PR fixes the CVE-2026-27727 issue by explicitly upgrading the `mchange` version to `0.4.0`. 

In Kruize pom.xml, `mchange` is used as a transitive dependency internally by the hibernate-c3p0 connection pool. Since, the latest hibernate-c3p0 version doesn't upgrade the `mchange` internally, we need to explicitly update it.


Fixes # ([issue](https://issues.redhat.com/browse/KRUIZE-1168))

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here
