### PR TITLE
Updated RH UBI minimal version 10.1 to latest available

### DIFF
--- a/Dockerfile.autotune
+++ b/Dockerfile.autotune
@@ -16,7 +16,7 @@
 ##########################################################
 #            Build Docker Image
 ##########################################################
-FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1770180557 as mvnbuild-jdk25
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1772441549 as mvnbuild-jdk25
 ARG USER=autotune
 ARG AUTOTUNE_HOME=/home/$USER
 
@@ -49,7 +49,7 @@ RUN jlink --strip-debug --compress 2 --no-header-files --no-man-pages --module-p
 #            Runtime Docker Image
 ##########################################################
 # Use ubi-minimal as the base image
-FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1770180557
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1772441549
 
 ARG AUTOTUNE_VERSION
 ARG USER=autotune


### PR DESCRIPTION
## Description

Updated RH UBI minimal version 10.1 to latest available

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Will be tested as part of PR check

**Test Configuration**
* Kubernetes clusters tested on: minikube

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Build:
- Bump the Red Hat UBI 10.1 minimal base image version in Dockerfile.autotune to the latest available release.