### PR TITLE
Add recomm-type feature to get specific recommendations

### DIFF
--- a/design/ADR-GranularRecommendationTypes.md
+++ b/design/ADR-GranularRecommendationTypes.md
@@ -1,0 +1,245 @@
+# ADR: Granular Recommendation Types Configuration
+
+## Status
+**PROPOSED** - Awaiting team review and approval
+
+## Context
+
+### Current State
+Currently, Kruize does **not** have a `recommendation_types` configuration field in `recommendation_settings`. The system generates all recommendation types by default without user control.
+
+**Current behavior:**
+- All resource recommendations (CPU and memory) are generated
+- All detected runtime layer recommendations (hotspot, quarkus, semeru) are generated
+- All accelerator recommendations are generated (if applicable)
+- No way for users to selectively enable/disable specific types
+
+**Limitations:**
+- **No user control**: Cannot disable unwanted recommendation types
+- **All-or-nothing**: Either get all recommendations or none
+- **No runtime granularity**: Cannot select specific runtime layers (e.g., only quarkus, not hotspot)
+- **No resource granularity**: Cannot select only CPU or only memory recommendations
+- **Performance impact**: Processing all types even when not needed
+- **User feedback**: Users want to select specific runtimes (e.g., only quarkus, not hotspot/java)
+
+### Problem Statement
+Users need granular control to:
+1. Select specific runtime layers independently (e.g., only quarkus recommendations, excluding hotspot)
+2. Choose specific resource types (CPU vs memory)
+3. Disable certain recommendation categories they don't need
+4. Support future runtime additions (nodejs, springboot, etc.)
+5. Reduce recommendation processing time by skipping unwanted types
+
+### User Story
+> "As a Quarkus application developer, I want to receive only Quarkus-specific runtime recommendations without Hotspot JVM recommendations, so that I get relevant tuning suggestions for my framework."
+
+## Decision
+
+### Proposed Solution
+Introduce a **new** nested object structure `recommendation_types_config` in `recommendation_settings`:
+
+```json
+{
+  "recommendation_types_config": {
+    "resources": ["cpu", "memory"],
+    "runtimes": ["hotspot", "quarkus", "semeru"],
+    "accelerators": ["gpu"]
+  }
+}
+```
+
+### Design Principles
+1. **Granularity**: Each category (resources, runtimes, accelerators) is independently configurable
+2. **Extensibility**: New runtime types can be added without API changes
+3. **Default Behavior**: Null/empty values enable all types (maintains current behavior)
+4. **Optional**: Field is completely optional - omitting it generates all recommendations (current behavior)
+5. **Future-Proof**: Structure supports unlimited expansion
+
+## Implementation Details
+
+### 1. New Data Structure
+
+**Class: `RecommendationTypesConfig`**
+```java
+public class RecommendationTypesConfig {
+    private List<String> resources;      // ["cpu", "memory"]
+    private List<String> runtimes;       // ["hotspot", "quarkus", "semeru", "nodejs", "springboot"]
+    private List<String> accelerators;   // ["gpu"]
+    
+    // Helper methods
+    public boolean isResourceEnabled(String resourceType);
+    public boolean isRuntimeEnabled(String runtimeLayer);
+    public boolean isAcceleratorEnabled(String acceleratorType);
+}
+```
+
+### 2. Constants Organization
+
+**New constant classes in `KruizeConstants`:**
+```java
+public static final class ResourceTypes {
+    public static final String CPU = "cpu";
+    public static final String MEMORY = "memory";
+}
+
+public static final class RuntimeLayers {
+    public static final String HOTSPOT = "hotspot";
+    public static final String QUARKUS = "quarkus";
+    public static final String SEMERU = "semeru";
+    public static final String NODEJS = "nodejs";
+    public static final String SPRINGBOOT = "springboot";
+}
+
+public static final class AcceleratorTypes {
+    public static final String GPU = "gpu";
+}
+```
+
+### 3. API Changes
+
+**This is a new feature addition:**
+- New optional field `recommendation_types_config` in `recommendation_settings`
+- When omitted, all recommendation types are generated (current default behavior)
+- No breaking changes to existing API
+- Fully backward compatible - existing experiments continue to work unchanged
+
+## Examples
+
+### Example 1: Only Quarkus Runtime (No Hotspot/Semeru)
+```json
+{
+  "recommendation_settings": {
+    "threshold": "0.1",
+    "recommendation_types_config": {
+      "runtimes": ["quarkus"]
+    }
+  }
+}
+```
+
+### Example 2: CPU + Memory with Hotspot Only
+```json
+{
+  "recommendation_settings": {
+    "threshold": "0.1",
+    "recommendation_types_config": {
+      "resources": ["cpu", "memory"],
+      "runtimes": ["hotspot"]
+    }
+  }
+}
+```
+
+### Example 3: CPU Only with Multiple Runtimes
+```json
+{
+  "recommendation_settings": {
+    "threshold": "0.1",
+    "recommendation_types_config": {
+      "resources": ["cpu"],
+      "runtimes": ["hotspot", "quarkus", "springboot"]
+    }
+  }
+}
+```
+
+## Consequences
+
+### Positive
+1. ✅ **User Empowerment**: Users get fine-grained control over recommendations
+2. ✅ **Flexibility**: Mix and match any combination of types
+3. ✅ **Extensibility**: Easy to add new runtime layers (nodejs, springboot, etc.)
+4. ✅ **Backward Compatible**: No breaking changes for existing users
+5. ✅ **Clear Structure**: Nested object is more intuitive than flat array
+6. ✅ **Performance**: Skip processing for disabled layers
+7. ✅ **Future-Proof**: Structure supports unlimited expansion
+
+### Negative
+1. ⚠️ **Testing**: More test cases needed for various combinations
+2. ⚠️ **Learning Curve**: Users need to learn new format (optional feature)
+3. ⚠️ **Validation**: Need to validate runtime layer names against supported types
+
+### Neutral
+1. 📝 **API Size**: Slightly larger JSON payload (negligible impact)
+2. 📝 **Code Size**: Additional class and methods (well-organized)
+
+## Alternatives Considered
+
+### Alternative 1: Extend Flat Array with Specific Types
+```json
+{
+  "recommendation_types": ["resource", "hotspot", "quarkus"]
+}
+```
+**Rejected because:**
+- Mixing category-level and item-level types is confusing
+- Unclear semantics: Does "resource" mean all resources or just a category?
+- Not extensible for future categories
+
+### Alternative 2: Separate Fields for Each Category
+```json
+{
+  "resource_types": ["cpu", "memory"],
+  "runtime_types": ["hotspot", "quarkus"],
+  "accelerator_types": ["gpu"]
+}
+```
+**Rejected because:**
+- Proliferates top-level fields
+- Less cohesive than nested structure
+- Harder to add new categories
+
+### Alternative 3: String-based Filtering
+```json
+{
+  "recommendation_filter": "resources.cpu,runtimes.hotspot,runtimes.quarkus"
+}
+```
+**Rejected because:**
+- String parsing is error-prone
+- Not type-safe
+- Poor developer experience
+
+
+## Open Questions for Team Discussion
+
+1. **Naming Convention**: Is `recommendation_types_config` the best name, or should it be `recommendation_types`, `recommendation_config`, or something else?
+
+2. **Default Behavior**: Should empty arrays mean "all enabled" or "none enabled"? Current implementation: empty = all enabled (maintains current behavior)
+
+3. **Validation**: Should we validate that specified runtime layers are actually supported/detected? Or allow any string for future extensibility?
+
+4. **Future Categories**: Are there other categories we should plan for? (e.g., `storage`, `network`, `security`?)
+
+5. **Extensibility**: Should we allow custom/plugin runtime types, or keep it to predefined constants only?
+
+6. **Runtime Layer Detection**: Should we skip recommendation generation if a specified runtime layer is not detected in the application? Or generate recommendations anyway?
+
+7. **Error Handling**: How should we handle invalid/unknown runtime layer names? Ignore them, log warnings, or return errors?
+
+8. **Documentation**: Should we provide migration guides even though this is a new feature? (To help users understand when to use it)
+
+## References
+
+- PR: https://github.com/kruize/autotune/pull/1851
+- User Story: "User should be given an option to select which runtime recommendation they would need"
+- Implementation Details: `RUNTIME_RECOMMENDATIONS_CHANGES_V2.md`
+- API Documentation: `design/KruizeLocalAPI.md`
+
+## Decision Makers
+
+- [ ] Architecture Team
+- [ ] API Team
+- [ ] Product Owner
+- [ ] Engineering Lead
+
+## Review Comments
+
+_Space for team members to add comments and feedback_
+
+---
+
+**Date**: 2026-04-06  
+**Author**: Development Team  
+**Reviewers**: _To be assigned_  
+**Status**: PROPOSED

--- a/design/CreateExperiment.md
+++ b/design/CreateExperiment.md
@@ -9,6 +9,8 @@ tuned.
   A unique string name is specified for identifying individual experiments.
 * experiment_type \
   An optional string used to indicate whether the experiment is of type `namespace` or `container`. If no experiment type is specified, it will default to `container`.
+* recommendation_types \
+  An optional array of strings within `recommendation_settings` that specifies which recommendation categories to generate. Supported values: `resource` (CPU/memory right-sizing), `runtime` (JVM options, GC policy, etc.), `accelerator` (GPU recommendations). When omitted or empty, all recommendation types are generated (default behavior).
 * deployment_name \
   Stay tuned
 * namespace \

--- a/design/KruizeLocalAPI.md
+++ b/design/KruizeLocalAPI.md
@@ -3207,50 +3207,6 @@ see [Create Experiment](/design/CreateExperiment.md)
 
 </details>
 
-**Request with `recommendation_types` field**
-
-The `recommendation_types` field within `recommendation_settings` is optional and allows users to specify which recommendation categories to generate. Supported values: `resource` (CPU/memory right-sizing), `runtime` (JVM options, GC policy, framework tuning), `accelerator` (GPU recommendations). When omitted or empty, all recommendation types are generated (default).
-
-<details>
-<summary><b>Example Request with recommendation_types - resource and runtime only</b></summary>
-
-```json
-[
-  {
-    "version": "v2.0",
-    "experiment_name": "default|default|deployment|tfb-qrh-deployment",
-    "cluster_name": "default",
-    "performance_profile": "resource-optimization-local-monitoring",
-    "metadata_profile": "cluster-metadata-local-monitoring",
-    "mode": "monitor",
-    "target_cluster": "local",
-    "kubernetes_objects": [
-      {
-        "type": "deployment",
-        "name": "tfb-qrh-deployment",
-        "namespace": "default",
-        "containers": [
-          {
-            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
-            "container_name": "tfb-server-1"
-          }
-        ]
-      }
-    ],
-    "trial_settings": {
-      "measurement_duration": "15min"
-    },
-    "recommendation_settings": {
-      "threshold": "0.1",
-      "recommendation_types": ["resource", "runtime"]
-    },
-    "datasource": "prometheus-1"
-  }
-]
-```
-
-</details>
-
 **Request with `experiment_type` field**
 
 The `experiment_type` field in the JSON is optional and can be used to

--- a/design/KruizeLocalAPI.md
+++ b/design/KruizeLocalAPI.md
@@ -3207,6 +3207,50 @@ see [Create Experiment](/design/CreateExperiment.md)
 
 </details>
 
+**Request with `recommendation_types` field**
+
+The `recommendation_types` field within `recommendation_settings` is optional and allows users to specify which recommendation categories to generate. Supported values: `resource` (CPU/memory right-sizing), `runtime` (JVM options, GC policy, framework tuning), `accelerator` (GPU recommendations). When omitted or empty, all recommendation types are generated (default).
+
+<details>
+<summary><b>Example Request with recommendation_types - resource and runtime only</b></summary>
+
+```json
+[
+  {
+    "version": "v2.0",
+    "experiment_name": "default|default|deployment|tfb-qrh-deployment",
+    "cluster_name": "default",
+    "performance_profile": "resource-optimization-local-monitoring",
+    "metadata_profile": "cluster-metadata-local-monitoring",
+    "mode": "monitor",
+    "target_cluster": "local",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment",
+        "namespace": "default",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1"
+          }
+        ]
+      }
+    ],
+    "trial_settings": {
+      "measurement_duration": "15min"
+    },
+    "recommendation_settings": {
+      "threshold": "0.1",
+      "recommendation_types": ["resource", "runtime"]
+    },
+    "datasource": "prometheus-1"
+  }
+]
+```
+
+</details>
+
 **Request with `experiment_type` field**
 
 The `experiment_type` field in the JSON is optional and can be used to

--- a/src/main/java/com/autotune/analyzer/kruizeObject/RecommendationSettings.java
+++ b/src/main/java/com/autotune/analyzer/kruizeObject/RecommendationSettings.java
@@ -28,6 +28,8 @@ public class RecommendationSettings {
     private TermSettings termSettings;
     @SerializedName(KruizeConstants.JSONKeys.RECOMMENDATION_TYPES)
     private List<String> recommendationTypes;
+    @SerializedName("recommendation_types_config")
+    private RecommendationTypesConfig recommendationTypesConfig;
 
     public RecommendationSettings(){}
 
@@ -63,9 +65,18 @@ public class RecommendationSettings {
         this.recommendationTypes = recommendationTypes;
     }
 
+    public RecommendationTypesConfig getRecommendationTypesConfig() {
+        return recommendationTypesConfig;
+    }
+
+    public void setRecommendationTypesConfig(RecommendationTypesConfig recommendationTypesConfig) {
+        this.recommendationTypesConfig = recommendationTypesConfig;
+    }
+
     /**
      * Returns true if the given recommendation type should be generated.
-     * When recommendationTypes is null or empty, all types are enabled (default behavior).
+     * Supports both legacy flat array format and new nested object format.
+     * When both are null/empty, all types are enabled (default behavior).
      *
      * @param type One of KruizeConstants.RecommendationTypes (RESOURCE, RUNTIME, ACCELERATOR)
      * @return true if the type should be generated
@@ -74,11 +85,98 @@ public class RecommendationSettings {
         if (type == null || type.isEmpty()) {
             return false;
         }
+        
+        // If new format is provided, use it
+        if (recommendationTypesConfig != null) {
+            if (KruizeConstants.RecommendationTypes.RESOURCE.equalsIgnoreCase(type)) {
+                return recommendationTypesConfig.hasResourcesEnabled();
+            } else if (KruizeConstants.RecommendationTypes.RUNTIME.equalsIgnoreCase(type)) {
+                return recommendationTypesConfig.hasRuntimesEnabled();
+            } else if (KruizeConstants.RecommendationTypes.ACCELERATOR.equalsIgnoreCase(type)) {
+                return recommendationTypesConfig.hasAcceleratorsEnabled();
+            }
+            return false;
+        }
+        
+        // Fall back to legacy format
         if (recommendationTypes == null || recommendationTypes.isEmpty()) {
             return true; // Default: all types enabled
         }
         return recommendationTypes.stream()
                 .anyMatch(t -> t != null && t.equalsIgnoreCase(type));
+    }
+
+    /**
+     * Returns true if a specific resource type should be generated.
+     *
+     * @param resourceType One of KruizeConstants.ResourceTypes (CPU, MEMORY)
+     * @return true if the resource type should be generated
+     */
+    public boolean isResourceTypeEnabled(String resourceType) {
+        if (resourceType == null || resourceType.isEmpty()) {
+            return false;
+        }
+        
+        // If new format is provided, use it
+        if (recommendationTypesConfig != null) {
+            return recommendationTypesConfig.isResourceEnabled(resourceType);
+        }
+        
+        // Fall back to legacy format - if "resource" is enabled, all resource types are enabled
+        return isRecommendationTypeEnabled(KruizeConstants.RecommendationTypes.RESOURCE);
+    }
+
+    /**
+     * Returns true if runtime recommendations for the specified layer should be generated.
+     * Supports both new nested format and legacy flat array format.
+     *
+     * @param layerName The specific runtime layer name (e.g., "hotspot", "quarkus", "semeru")
+     * @return true if recommendations for this layer should be generated
+     */
+    public boolean isRuntimeLayerEnabled(String layerName) {
+        if (layerName == null || layerName.isEmpty()) {
+            return false;
+        }
+        
+        // If new format is provided, use it
+        if (recommendationTypesConfig != null) {
+            return recommendationTypesConfig.isRuntimeEnabled(layerName);
+        }
+        
+        // Fall back to legacy format
+        if (recommendationTypes == null || recommendationTypes.isEmpty()) {
+            return true; // Default: all types enabled
+        }
+        
+        // Check if the specific layer is enabled
+        boolean specificLayerEnabled = recommendationTypes.stream()
+                .anyMatch(t -> t != null && t.equalsIgnoreCase(layerName));
+        
+        // Check if generic "runtime" is enabled (enables all runtime layers)
+        boolean genericRuntimeEnabled = recommendationTypes.stream()
+                .anyMatch(t -> t != null && t.equalsIgnoreCase(KruizeConstants.RecommendationTypes.RUNTIME));
+        
+        return specificLayerEnabled || genericRuntimeEnabled;
+    }
+
+    /**
+     * Returns true if a specific accelerator type should be generated.
+     *
+     * @param acceleratorType One of KruizeConstants.AcceleratorTypes (GPU)
+     * @return true if the accelerator type should be generated
+     */
+    public boolean isAcceleratorTypeEnabled(String acceleratorType) {
+        if (acceleratorType == null || acceleratorType.isEmpty()) {
+            return false;
+        }
+        
+        // If new format is provided, use it
+        if (recommendationTypesConfig != null) {
+            return recommendationTypesConfig.isAcceleratorEnabled(acceleratorType);
+        }
+        
+        // Fall back to legacy format - if "accelerator" is enabled, all accelerator types are enabled
+        return isRecommendationTypeEnabled(KruizeConstants.RecommendationTypes.ACCELERATOR);
     }
 
     @Override
@@ -88,6 +186,7 @@ public class RecommendationSettings {
                 ", modelSettings=" + modelSettings +
                 ", termSettings=" + termSettings +
                 ", recommendationTypes=" + recommendationTypes +
+                ", recommendationTypesConfig=" + recommendationTypesConfig +
                 '}';
     }
 }

--- a/src/main/java/com/autotune/analyzer/kruizeObject/RecommendationSettings.java
+++ b/src/main/java/com/autotune/analyzer/kruizeObject/RecommendationSettings.java
@@ -18,12 +18,16 @@ package com.autotune.analyzer.kruizeObject;
 import com.autotune.utils.KruizeConstants;
 import com.google.gson.annotations.SerializedName;
 
+import java.util.List;
+
 public class RecommendationSettings {
     private Double threshold;
     @SerializedName(KruizeConstants.JSONKeys.MODEL_SETTINGS)
     private ModelSettings modelSettings;
     @SerializedName(KruizeConstants.JSONKeys.TERM_SETTINGS)
     private TermSettings termSettings;
+    @SerializedName(KruizeConstants.JSONKeys.RECOMMENDATION_TYPES)
+    private List<String> recommendationTypes;
 
     public RecommendationSettings(){}
 
@@ -51,12 +55,39 @@ public class RecommendationSettings {
         this.termSettings = termSettings;
     }
 
+    public List<String> getRecommendationTypes() {
+        return recommendationTypes;
+    }
+
+    public void setRecommendationTypes(List<String> recommendationTypes) {
+        this.recommendationTypes = recommendationTypes;
+    }
+
+    /**
+     * Returns true if the given recommendation type should be generated.
+     * When recommendationTypes is null or empty, all types are enabled (default behavior).
+     *
+     * @param type One of KruizeConstants.RecommendationTypes (RESOURCE, RUNTIME, ACCELERATOR)
+     * @return true if the type should be generated
+     */
+    public boolean isRecommendationTypeEnabled(String type) {
+        if (type == null || type.isEmpty()) {
+            return false;
+        }
+        if (recommendationTypes == null || recommendationTypes.isEmpty()) {
+            return true; // Default: all types enabled
+        }
+        return recommendationTypes.stream()
+                .anyMatch(t -> t != null && t.equalsIgnoreCase(type));
+    }
+
     @Override
     public String toString() {
         return "RecommendationSettings{" +
                 "threshold=" + threshold +
                 ", modelSettings=" + modelSettings +
                 ", termSettings=" + termSettings +
+                ", recommendationTypes=" + recommendationTypes +
                 '}';
     }
 }

--- a/src/main/java/com/autotune/analyzer/kruizeObject/RecommendationTypesConfig.java
+++ b/src/main/java/com/autotune/analyzer/kruizeObject/RecommendationTypesConfig.java
@@ -1,0 +1,152 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.autotune.analyzer.kruizeObject;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+/**
+ * Represents the nested structure for recommendation_types configuration.
+ * Allows granular control over which specific resource types and runtime layers to enable.
+ * 
+ * Example JSON:
+ * {
+ *   "resources": ["cpu", "memory"],
+ *   "runtimes": ["hotspot", "quarkus"]
+ * }
+ */
+public class RecommendationTypesConfig {
+    
+    @SerializedName("resources")
+    private List<String> resources;
+    
+    @SerializedName("runtimes")
+    private List<String> runtimes;
+    
+    @SerializedName("accelerators")
+    private List<String> accelerators;
+
+    public RecommendationTypesConfig() {
+    }
+
+    public List<String> getResources() {
+        return resources;
+    }
+
+    public void setResources(List<String> resources) {
+        this.resources = resources;
+    }
+
+    public List<String> getRuntimes() {
+        return runtimes;
+    }
+
+    public void setRuntimes(List<String> runtimes) {
+        this.runtimes = runtimes;
+    }
+
+    public List<String> getAccelerators() {
+        return accelerators;
+    }
+
+    public void setAccelerators(List<String> accelerators) {
+        this.accelerators = accelerators;
+    }
+
+    /**
+     * Checks if a specific resource type is enabled.
+     * @param resourceType The resource type (e.g., "cpu", "memory")
+     * @return true if enabled or if resources list is null/empty (default: all enabled)
+     */
+    public boolean isResourceEnabled(String resourceType) {
+        if (resourceType == null || resourceType.isEmpty()) {
+            return false;
+        }
+        if (resources == null || resources.isEmpty()) {
+            return true; // Default: all resources enabled
+        }
+        return resources.stream()
+                .anyMatch(r -> r != null && r.equalsIgnoreCase(resourceType));
+    }
+
+    /**
+     * Checks if a specific runtime layer is enabled.
+     * @param runtimeLayer The runtime layer (e.g., "hotspot", "quarkus", "semeru")
+     * @return true if enabled or if runtimes list is null/empty (default: all enabled)
+     */
+    public boolean isRuntimeEnabled(String runtimeLayer) {
+        if (runtimeLayer == null || runtimeLayer.isEmpty()) {
+            return false;
+        }
+        if (runtimes == null || runtimes.isEmpty()) {
+            return true; // Default: all runtimes enabled
+        }
+        return runtimes.stream()
+                .anyMatch(r -> r != null && r.equalsIgnoreCase(runtimeLayer));
+    }
+
+    /**
+     * Checks if a specific accelerator type is enabled.
+     * @param acceleratorType The accelerator type (e.g., "gpu")
+     * @return true if enabled or if accelerators list is null/empty (default: all enabled)
+     */
+    public boolean isAcceleratorEnabled(String acceleratorType) {
+        if (acceleratorType == null || acceleratorType.isEmpty()) {
+            return false;
+        }
+        if (accelerators == null || accelerators.isEmpty()) {
+            return true; // Default: all accelerators enabled
+        }
+        return accelerators.stream()
+                .anyMatch(a -> a != null && a.equalsIgnoreCase(acceleratorType));
+    }
+
+    /**
+     * Checks if any resource recommendations are enabled.
+     * @return true if resources list is null, empty, or contains at least one resource type
+     */
+    public boolean hasResourcesEnabled() {
+        return resources == null || resources.isEmpty() || !resources.isEmpty();
+    }
+
+    /**
+     * Checks if any runtime recommendations are enabled.
+     * @return true if runtimes list is null, empty, or contains at least one runtime layer
+     */
+    public boolean hasRuntimesEnabled() {
+        return runtimes == null || runtimes.isEmpty() || !runtimes.isEmpty();
+    }
+
+    /**
+     * Checks if any accelerator recommendations are enabled.
+     * @return true if accelerators list is null, empty, or contains at least one accelerator type
+     */
+    public boolean hasAcceleratorsEnabled() {
+        return accelerators == null || accelerators.isEmpty() || !accelerators.isEmpty();
+    }
+
+    @Override
+    public String toString() {
+        return "RecommendationTypesConfig{" +
+                "resources=" + resources +
+                ", runtimes=" + runtimes +
+                ", accelerators=" + accelerators +
+                '}';
+    }
+}
+
+// Made with Bob

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
@@ -28,6 +28,7 @@ import com.autotune.analyzer.recommendations.term.Terms;
 import com.autotune.analyzer.recommendations.utils.RecommendationUtils;
 import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.analyzer.utils.AnalyzerErrorConstants;
+import com.autotune.utils.KruizeConstants;
 import com.autotune.common.data.metrics.MetricResults;
 import com.autotune.common.data.result.ContainerData;
 import com.autotune.common.data.result.IntervalResults;
@@ -268,7 +269,11 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
             ArrayList<RecommendationNotification> notifications = new ArrayList<>();
             RecommendationConfigItem recommendationCpuRequest = model.getCPURequestRecommendation(filteredResultsMap, notifications);
             RecommendationConfigItem recommendationMemRequest = model.getMemoryRequestRecommendation(filteredResultsMap, notifications);
-            Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> recommendationAcceleratorRequestMap = model.getAcceleratorRequestRecommendation(filteredResultsMap, notifications);
+            Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> recommendationAcceleratorRequestMap = null;
+            if (kruizeObject.getRecommendation_settings() == null
+                    || kruizeObject.getRecommendation_settings().isRecommendationTypeEnabled(KruizeConstants.RecommendationTypes.ACCELERATOR)) {
+                recommendationAcceleratorRequestMap = model.getAcceleratorRequestRecommendation(filteredResultsMap, notifications);
+            }
 
             RecommendationConfigItem recommendationCpuLimits = recommendationCpuRequest;
             RecommendationConfigItem recommendationMemLimits = recommendationMemRequest;
@@ -285,7 +290,9 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
             List<RecommendationConfigEnv> runtimeRecommList = null;
 
             try {
-                if (RuntimeRecommendationProcessor.isRuntimeLayerPresent(containerData.getLayerMap())) {
+                if (kruizeObject.getRecommendation_settings() != null
+                        && kruizeObject.getRecommendation_settings().isRecommendationTypeEnabled(KruizeConstants.RecommendationTypes.RUNTIME)
+                        && RuntimeRecommendationProcessor.isRuntimeLayerPresent(containerData.getLayerMap())) {
                     runtimeRecommList = RuntimeRecommendationProcessor.handleRuntimeRecommendations(kruizeObject, containerData, model, filteredResultsMap, notifications, recommendationCpuRequest, recommendationMemRequest, recommendationCpuLimits, recommendationMemLimits);
                 }
             } catch (Exception e) {

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -1570,6 +1570,12 @@ public class RecommendationEngine implements RecommendationEngineService {
                         if (isAcceleratorPartitionMetric && !fetchAcceleratorMetrics)
                             continue;
 
+                        // Skip fetching runtime metrics (jvm_info, etc.) if no runtime layer is detected or runtime recommendations are disabled
+                        boolean runtimeRecommendationsEnabled = kruizeObject.getRecommendation_settings() == null
+                                || kruizeObject.getRecommendation_settings().isRecommendationTypeEnabled(KruizeConstants.RecommendationTypes.RUNTIME);
+                        if (JVM_INFO_METRICS.contains(metricEntry.getName()) && (!runtimeLayerDetected || !runtimeRecommendationsEnabled))
+                            continue;
+
                         HashMap<String, AggregationFunctions> aggregationFunctions = metricEntry.getAggregationFunctionsMap();
                         for (Map.Entry<String, AggregationFunctions> aggregationFunctionsEntry : aggregationFunctions.entrySet()) {
                             // Determine promQL query on metric type

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RuntimeRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RuntimeRecommendationProcessor.java
@@ -105,6 +105,28 @@ public final class RuntimeRecommendationProcessor {
             return runtimeRecommList;
         }
 
+        // Filter layers based on recommendation_types settings
+        Map<String, KruizeLayer> filteredLayerMap = new HashMap<>();
+        for (Map.Entry<String, KruizeLayer> entry : layerMap.entrySet()) {
+            String layerName = entry.getKey();
+            // Skip container layer (not a runtime layer)
+            if (AnalyzerConstants.AutotuneConfigConstants.LAYER_CONTAINER.equalsIgnoreCase(layerName)) {
+                continue;
+            }
+            // Check if this runtime layer is enabled in recommendation settings
+            if (kruizeObject.getRecommendation_settings() != null
+                    && !kruizeObject.getRecommendation_settings().isRuntimeLayerEnabled(layerName)) {
+                LOGGER.debug("Skipping runtime layer '{}' as it's not enabled in recommendation_types", layerName);
+                continue;
+            }
+            filteredLayerMap.put(layerName, entry.getValue());
+        }
+
+        if (filteredLayerMap.isEmpty()) {
+            LOGGER.debug("No runtime layers enabled for recommendations");
+            return runtimeRecommList;
+        }
+
         // Pre-populate context with CPU/memory recommendations for tunable processing
         Map<TunableSpec, Object> tunableSpecObjectMap = new HashMap<>();
         String containerLayer = AnalyzerConstants.AutotuneConfigConstants.LAYER_CONTAINER;
@@ -117,7 +139,7 @@ public final class RuntimeRecommendationProcessor {
         tunableSpecObjectMap.put(new TunableSpec(containerLayer, AnalyzerConstants.MetricNameConstants.CPU_LIMIT),
                 recommendationCpuLimits != null ? recommendationCpuLimits.getAmount() : null);
 
-        List<KruizeLayer> kruizeLayers = layerMap.values().stream()
+        List<KruizeLayer> kruizeLayers = filteredLayerMap.values().stream()
                 .filter(layer -> layer.getTunables() != null)
                 .collect(Collectors.toList());
         List<TunableSpec> orderedTunables = TunableDependencyResolver.resolve(kruizeLayers);

--- a/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
@@ -96,6 +96,9 @@ public class Converters {
                     if (apiRecommendationSettings.getThreshold() != null) {
                         recommendationSettings.setThreshold(apiRecommendationSettings.getThreshold());
                     }
+                    if (apiRecommendationSettings.getRecommendationTypes() != null) {
+                        recommendationSettings.setRecommendationTypes(apiRecommendationSettings.getRecommendationTypes());
+                    }
                 }
                 kruizeObject.setRecommendation_settings(recommendationSettings);
                 kruizeObject.setExperiment_id(createExperimentAPIObject.getExperiment_id());

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -271,6 +271,7 @@ public class KruizeConstants {
         public static final String VERSION = "version";
         public static final String CONTAINER_IMAGE_NAME = "container_image_name";
         public static final String RECOMMENDATION_SETTINGS = "recommendation_settings";
+        public static final String RECOMMENDATION_TYPES = "recommendation_types";
         public static final String INTERVAL_START_TIME = "interval_start_time";
 
         public static final String CALCULATED_START_TIME = "calculated_start_time";
@@ -321,6 +322,22 @@ public class KruizeConstants {
         public static final String NODE = "node";
 
         private JSONKeys() {
+        }
+    }
+
+    /**
+     * Supported recommendation types for createExperiment API.
+     * When recommendation_types is null or empty, all types are generated (default).
+     */
+    public static final class RecommendationTypes {
+        /** CPU and memory right-sizing recommendations */
+        public static final String RESOURCE = "resource";
+        /** Runtime tuning recommendations (JVM options, GC policy, etc.) */
+        public static final String RUNTIME = "runtime";
+        /** Accelerator (GPU) recommendations */
+        public static final String ACCELERATOR = "accelerator";
+
+        private RecommendationTypes() {
         }
     }
 

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -332,12 +332,67 @@ public class KruizeConstants {
     public static final class RecommendationTypes {
         /** CPU and memory right-sizing recommendations */
         public static final String RESOURCE = "resource";
-        /** Runtime tuning recommendations (JVM options, GC policy, etc.) */
+        /** Runtime tuning recommendations (JVM options, GC policy, etc.) - enables all runtime layers */
         public static final String RUNTIME = "runtime";
         /** Accelerator (GPU) recommendations */
         public static final String ACCELERATOR = "accelerator";
+        
+        // Specific runtime layer types for granular control
+        /** Hotspot JVM runtime recommendations */
+        public static final String HOTSPOT = "hotspot";
+        /** Quarkus framework runtime recommendations */
+        public static final String QUARKUS = "quarkus";
+        /** Semeru JVM runtime recommendations */
+        public static final String SEMERU = "semeru";
+        /** Node.js runtime recommendations */
+        public static final String NODEJS = "nodejs";
+        /** Spring Boot framework recommendations */
+        public static final String SPRINGBOOT = "springboot";
 
         private RecommendationTypes() {
+        }
+    }
+
+    /**
+     * Supported resource types for granular resource recommendation control.
+     */
+    public static final class ResourceTypes {
+        /** CPU resource recommendations */
+        public static final String CPU = "cpu";
+        /** Memory resource recommendations */
+        public static final String MEMORY = "memory";
+
+        private ResourceTypes() {
+        }
+    }
+
+    /**
+     * Supported runtime layer names for granular runtime recommendation control.
+     */
+    public static final class RuntimeLayers {
+        /** Hotspot JVM layer */
+        public static final String HOTSPOT = "hotspot";
+        /** Quarkus framework layer */
+        public static final String QUARKUS = "quarkus";
+        /** Semeru JVM layer */
+        public static final String SEMERU = "semeru";
+        /** Node.js runtime layer */
+        public static final String NODEJS = "nodejs";
+        /** Spring Boot framework layer */
+        public static final String SPRINGBOOT = "springboot";
+
+        private RuntimeLayers() {
+        }
+    }
+
+    /**
+     * Supported accelerator types for granular accelerator recommendation control.
+     */
+    public static final class AcceleratorTypes {
+        /** GPU accelerator */
+        public static final String GPU = "gpu";
+
+        private AcceleratorTypes() {
         }
     }
 


### PR DESCRIPTION
## Description

Currently, the `createExperiment` API does not provide a mechanism for users to specify which types of recommendations should be generated and displayed for an experiment. As a result, all available recommendations may be generated by default, even if the user is only interested in a subset of them.

This PR contains following changes :

- The `createExperiment` API now supports an optional field called  `recommendation_types` to specify recommendation types.

- Only the specified recommendation categories are generated and displayed.

- Default behavior remains unchanged when the options are not provided (i.e., all recommendations are generated).

- API documentation is updated to include the new parameters and usage examples.

Fixes # (issue) : https://redhat.atlassian.net/browse/KRUIZE-1188

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Add support for selecting recommendation categories in experiments while preserving existing default behavior when not specified.

New Features:
- Allow the createExperiment API to accept an optional recommendation_types field under recommendation_settings to control which recommendation categories are generated (resource, runtime, accelerator).

Enhancements:
- Gate runtime and accelerator recommendations and related metric collection based on the configured recommendation_types to avoid unnecessary processing.
- Extend recommendation settings and constants to include typed recommendation categories for consistent usage across the analyzer and recommendation engine.

Documentation:
- Update CreateExperiment and local API design documentation with the new recommendation_types field description and example usage.