### PR TITLE
Add postgres datasource and corresponding code changes

### DIFF
--- a/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
@@ -200,6 +200,21 @@ data:
         "port": 5432,
         "sslMode": "require",
         "username": "admin"
+      },
+      "metricsDatabases": {
+        "db1": {
+          "hostname": "kruize01.fyre.ibm.com",
+          "port": 5433,
+          "name": "metrics_db",
+          "username": "kruize_user",
+          "password": "kruize123",
+          "sslMode": "disable",
+          "dbdriver": "jdbc:postgresql://",
+          "dialect": "org.hibernate.dialect.PostgreSQLDialect",
+          "driver": "org.postgresql.Driver",
+          "hbm2ddlauto": "none",
+          "showsql": "true"
+        }
       }
     }
   kruizeconfigjson: |
@@ -249,6 +264,11 @@ data:
           "serviceName": "prometheus-k8s",
           "namespace": "monitoring",
           "url": ""
+        },
+        {
+          "name": "db1",
+          "provider": "postgresql",
+          "metricsDbRef": "db1"
         }
       ]
     }
@@ -285,7 +305,7 @@ spec:
               done
       containers:
         - name: kruize
-          image: quay.io/kruize/autotune_operator:0.9
+          image: quay.io/khansaad/autotune_operator:byomdb-poc
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume
@@ -457,7 +477,7 @@ metadata:
 spec:
   containers:
     - name: kruize-ui-nginx-container
-      image: quay.io/kruize/kruize-ui:0.0.8
+      image: quay.io/kruize/kruize-ui:0.0.9
       imagePullPolicy: Always
       env:
         - name: KRUIZE_UI_ENV

--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -194,6 +194,21 @@ data:
         "port": 5432,
         "sslMode": "require",
         "username": "admin"
+      },
+      "metricsDatabases": {
+        "db1": {
+          "hostname": "kruize01.fyre.ibm.com",
+          "port": 5433,
+          "name": "metrics_db",
+          "username": "kruize_user",
+          "password": "kruize123",
+          "sslMode": "disable",
+          "dbdriver": "jdbc:postgresql://kruize01.fyre.ibm.com:5433/metrics_db",
+          "dialect": "org.hibernate.dialect.PostgreSQLDialect",
+          "driver": "org.postgresql.Driver",
+          "hbm2ddlauto": "none",
+          "showsql": "true"
+        }
       }
     }
   kruizeconfigjson: |
@@ -262,6 +277,11 @@ data:
                 "tokenFilePath": "/var/run/secrets/kubernetes.io/serviceaccount/token"
               }
           }
+        },
+        {
+          "name": "db1",
+          "provider": "postgresql",
+          "metricsDbRef": "db1"
         }
       ]
     }

--- a/src/main/java/com/autotune/Autotune.java
+++ b/src/main/java/com/autotune/Autotune.java
@@ -32,6 +32,7 @@ import com.autotune.common.exceptions.datasource.DataSourceNotServiceable;
 import com.autotune.common.exceptions.datasource.UnsupportedDataSourceProvider;
 import com.autotune.database.helper.DBConstants;
 import com.autotune.database.init.KruizeHibernateUtil;
+import com.autotune.database.init.MetricsDBConnectionManager;
 import com.autotune.experimentManager.core.ExperimentManager;
 import com.autotune.operator.InitializeDeployment;
 import com.autotune.operator.KruizeDeploymentInfo;
@@ -132,6 +133,9 @@ public class Autotune {
             if (KruizeDeploymentInfo.local) {
                 LOGGER.debug("Now running kruize local DDL's ");
                 executeDDLs(AnalyzerConstants.LM);
+                // Initialize metrics DB connections (db1) from KruizeConfig for Metric DB POC
+                MetricsDBConnectionManager.getInstance().initialize();
+                validateMetricsDBConnections();
                 // load available datasources from db
                 loadDataSourcesFromDB();
 
@@ -238,6 +242,18 @@ public class Autotune {
     }
 
     /**
+     * Validates metrics DB connections (Metric DB POC).
+     * Runs a SQL query on each configured metrics database and logs the query and output.
+     */
+    private static void validateMetricsDBConnections() {
+        MetricsDBConnectionManager manager = MetricsDBConnectionManager.getInstance();
+        for (String dbName : manager.getConfiguredDatabases()) {
+            String result = manager.executeQueryAndLog(dbName, "SELECT version()");
+            LOGGER.info("Metric DB POC - Connection validation for '{}' complete. Result: {}", dbName, result);
+        }
+    }
+
+    /**
      * loads datasources from database
      */
     private static void loadDataSourcesFromDB() {
@@ -258,8 +274,9 @@ public class Autotune {
             for (String name : dataSources.keySet()) {
                 DataSourceInfo dataSource = dataSources.get(name);
                 String dataSourceName = dataSource.getName();
-                String url = dataSource.getUrl().toString();
-                LOGGER.info(KruizeConstants.DataSourceConstants.DataSourceSuccessMsgs.DATASOURCE_FOUND + dataSourceName + ", " + url);
+                String urlOrRef = dataSource.getUrl() != null ? dataSource.getUrl().toString()
+                        : (dataSource.getMetricsDbRef() != null ? "metricsDb:" + dataSource.getMetricsDbRef() : "N/A");
+                LOGGER.info(KruizeConstants.DataSourceConstants.DataSourceSuccessMsgs.DATASOURCE_FOUND + dataSourceName + ", " + urlOrRef);
             }
         }
     }

--- a/src/main/java/com/autotune/common/datasource/DataSourceCollection.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceCollection.java
@@ -105,10 +105,25 @@ public class DataSourceCollection {
             throw new DataSourceAlreadyExist(DATASOURCE_ALREADY_EXIST);
         }
 
-        if (!provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.PROMETHEUS) && !provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.THANOS)) {
+        if (!provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.PROMETHEUS)
+                && !provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.THANOS)
+                && !provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.POSTGRESQL)) {
             throw new UnsupportedDataSourceProvider(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.UNSUPPORTED_DATASOURCE_PROVIDER);
         }
-//        Continue validations in case of supported providers
+
+        // PostgreSQL metrics DB: add to collection without Kruize DB persistence
+        if (provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.POSTGRESQL)) {
+            DataSourceOperatorImpl op = DataSourceOperatorImpl.getInstance().getOperator(KruizeConstants.SupportedDatasources.POSTGRESQL);
+            if (op != null && op.isServiceable(datasource) == CommonUtils.DatasourceReachabilityStatus.REACHABLE) {
+                dataSourceCollection.put(name, datasource);
+                LOGGER.info(DATASOURCE_ADDED + " (metrics DB: " + name + ")");
+                return;
+            } else {
+                throw new DataSourceNotServiceable(String.format(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.DATASOURCE_NOT_SERVICEABLE, name));
+            }
+        }
+
+        // Continue validations for Prometheus/Thanos
         LOGGER.info(KruizeConstants.DataSourceConstants.DataSourceInfoMsgs.VERIFYING_DATASOURCE_REACHABILITY, name);
         DataSourceOperatorImpl op = DataSourceOperatorImpl.getInstance().getOperator(KruizeConstants.SupportedDatasources.PROMETHEUS);
         if (op.isServiceable(datasource) == CommonUtils.DatasourceReachabilityStatus.REACHABLE) {
@@ -198,21 +213,27 @@ public class DataSourceCollection {
                 String namespace = dataSourceObject.optString(KruizeConstants.DataSourceConstants.DATASOURCE_SERVICE_NAMESPACE);
                 LOGGER.info(namespace);
                 String dataSourceURL = dataSourceObject.optString(KruizeConstants.DataSourceConstants.DATASOURCE_URL);
+                String metricsDbRef = dataSourceObject.optString(KruizeConstants.DataSourceConstants.DATASOURCE_METRICS_DB_REF);
                 LOGGER.info(dataSourceURL);
-                AuthenticationConfig authConfig = getAuthenticationDetails(dataSourceObject, name);
 
-                // Validate input
-                if (!validateInput(name, provider, serviceName, dataSourceURL, namespace)) { //TODO: add validations for auth
+                // Validate input (for postgresql, metricsDbRef is used)
+                if (!validateInputForProvider(name, provider, serviceName, dataSourceURL, namespace, metricsDbRef)) {
                     LOGGER.warn(DATASOURCE_VALIDATION_FAILURE, name);
                     failedDatasources.add(name + " (validation failed)");
                     continue;
                 }
                 try {
-                    URL url = null;
-                    if (!dataSourceURL.isBlank()) {
-                        url = new URI(dataSourceURL).toURL();
+                    if (provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.POSTGRESQL)) {
+                        dataSourceInfo = new DataSourceInfo(name, provider, null, null, null,
+                                AuthenticationConfig.noAuth(), metricsDbRef);
+                    } else {
+                        AuthenticationConfig authConfig = getAuthenticationDetails(dataSourceObject, name);
+                        URL url = null;
+                        if (dataSourceURL != null && !dataSourceURL.isBlank()) {
+                            url = new URI(dataSourceURL).toURL();
+                        }
+                        dataSourceInfo = new DataSourceInfo(name, provider, serviceName, namespace, url, authConfig);
                     }
-                    dataSourceInfo = new DataSourceInfo(name, provider, serviceName, namespace, url, authConfig);
 
                     // Attempt to add, addDataSource() returns corresponding exception if it fails. Increment the success count otherwise.
                     addDataSource(dataSourceInfo);
@@ -272,13 +293,29 @@ public class DataSourceCollection {
      * @return boolean returns true if validation is successful otherwise return false
      */
     public boolean validateInput(String name, String provider, String servicename, String url, String namespace) {
+        return validateInput(name, provider, servicename, url, namespace, null);
+    }
+
+    private boolean validateInputForProvider(String name, String provider, String servicename, String url, String namespace, String metricsDbRef) {
+        return validateInput(name, provider, servicename, url, namespace, metricsDbRef);
+    }
+
+    private boolean validateInput(String name, String provider, String servicename, String url, String namespace, String metricsDbRef) {
         try {
-            if (name.isEmpty()) {
+            if (name == null || name.isEmpty()) {
                 throw new DataSourceMissingRequiredFiled(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.MISSING_DATASOURCE_NAME);
             }
-            if (provider.isEmpty()) {
+            if (provider == null || provider.isEmpty()) {
                 throw new DataSourceMissingRequiredFiled(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.MISSING_DATASOURCE_PROVIDER);
             }
+            if (provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.POSTGRESQL)) {
+                if (metricsDbRef == null || metricsDbRef.isEmpty()) {
+                    throw new DataSourceMissingRequiredFiled("Metrics DB reference (metricsDbRef) is required for PostgreSQL datasource");
+                }
+                return true;
+            }
+            if (servicename == null) servicename = "";
+            if (url == null) url = "";
             if (servicename.isEmpty() && url.isEmpty()) {
                 throw new DataSourceMissingRequiredFiled(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.MISSING_DATASOURCE_SERVICENAME_AND_URL);
             }

--- a/src/main/java/com/autotune/common/datasource/DataSourceInfo.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceInfo.java
@@ -41,13 +41,23 @@ public class DataSourceInfo {
     private final String namespace;
     private final URL url;
     private AuthenticationConfig authenticationConfig;
+    private final String metricsDbRef;
 
     private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(DataSourceInfo.class);
 
     public DataSourceInfo(String name, String provider, String serviceName, String namespace, URL url, AuthenticationConfig authConfig) {
+        this(name, provider, serviceName, namespace, url, authConfig, null);
+    }
+
+    /**
+     * Constructor for metrics DB (PostgreSQL) datasources that reference a configured metrics database.
+     *
+     * @param metricsDbRef reference to metrics database config (e.g., "db1", "db2")
+     */
+    public DataSourceInfo(String name, String provider, String serviceName, String namespace, URL url, AuthenticationConfig authConfig, String metricsDbRef) {
         this.name = name;
         this.provider = provider;
-        if (null == url) {
+        if (null == url && metricsDbRef == null) {
             this.url = getDNSBasedUrlForService(serviceName, namespace, provider);
         } else {
             this.url = url;
@@ -55,6 +65,7 @@ public class DataSourceInfo {
         this.serviceName = serviceName;
         this.namespace = namespace;
         this.authenticationConfig = authConfig;
+        this.metricsDbRef = metricsDbRef;
     }
 
     /**
@@ -118,6 +129,15 @@ public class DataSourceInfo {
             LOGGER.error(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.INVALID_DATASOURCE_URL);
         }
         return dnsUrl;
+    }
+
+    /**
+     * Returns the metrics database reference for PostgreSQL datasources.
+     *
+     * @return metrics DB ref (e.g., "db1", "db2") or null for non-PostgreSQL datasources
+     */
+    public String getMetricsDbRef() {
+        return metricsDbRef;
     }
 
     public AuthenticationConfig getAuthenticationConfig() {

--- a/src/main/java/com/autotune/common/datasource/DataSourceOperatorImpl.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceOperatorImpl.java
@@ -3,6 +3,7 @@ package com.autotune.common.datasource;
 import com.autotune.analyzer.exceptions.MonitoringAgentNotFoundException;
 import com.autotune.analyzer.exceptions.TooManyRecursiveCallsException;
 import com.autotune.analyzer.utils.AnalyzerConstants;
+import com.autotune.common.datasource.postgresql.PostgresqlDataOperatorImpl;
 import com.autotune.common.datasource.prometheus.PrometheusDataOperatorImpl;
 import com.autotune.common.exceptions.datasource.ServiceNotFound;
 import com.autotune.common.target.kubernetes.service.KubernetesServices;
@@ -168,6 +169,9 @@ public class DataSourceOperatorImpl implements DataSourceOperator {
     public DataSourceOperatorImpl getOperator(String provider) {
         if (provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.PROMETHEUS)) {
             return PrometheusDataOperatorImpl.getInstance();
+        }
+        if (provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.POSTGRESQL)) {
+            return PostgresqlDataOperatorImpl.getInstance();
         }
         return null;
     }

--- a/src/main/java/com/autotune/common/datasource/postgresql/PostgresqlDataOperatorImpl.java
+++ b/src/main/java/com/autotune/common/datasource/postgresql/PostgresqlDataOperatorImpl.java
@@ -1,0 +1,150 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package com.autotune.common.datasource.postgresql;
+
+import com.autotune.common.datasource.DataSourceInfo;
+import com.autotune.common.datasource.DataSourceOperatorImpl;
+import com.autotune.common.utils.CommonUtils;
+import com.autotune.database.init.MetricsDBConnectionManager;
+import com.autotune.utils.KruizeConstants;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonPrimitive;
+import org.hibernate.Session;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+
+/**
+ * DataSource operator for PostgreSQL metrics databases.
+ * Executes SQL queries against configured metrics DBs (db1, db2).
+ */
+public class PostgresqlDataOperatorImpl extends DataSourceOperatorImpl {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PostgresqlDataOperatorImpl.class);
+    private static PostgresqlDataOperatorImpl instance;
+
+    private PostgresqlDataOperatorImpl() {
+        super();
+    }
+
+    public static PostgresqlDataOperatorImpl getInstance() {
+        if (instance == null) {
+            instance = new PostgresqlDataOperatorImpl();
+        }
+        return instance;
+    }
+
+    @Override
+    public String getDefaultServicePortForProvider() {
+        return "5432";
+    }
+
+    @Override
+    public CommonUtils.DatasourceReachabilityStatus isServiceable(DataSourceInfo dataSource) {
+        String metricsDbRef = dataSource.getMetricsDbRef();
+        if (metricsDbRef == null || metricsDbRef.isEmpty()) {
+            return CommonUtils.DatasourceReachabilityStatus.NOT_REACHABLE;
+        }
+        MetricsDBConnectionManager manager = MetricsDBConnectionManager.getInstance();
+        if (!manager.isConfigured(metricsDbRef)) {
+            return CommonUtils.DatasourceReachabilityStatus.NOT_REACHABLE;
+        }
+        try {
+            String result = manager.executeQueryAndLog(metricsDbRef, "SELECT version()");
+            return result != null && !result.contains("Error") && !result.contains("not configured")
+                    ? CommonUtils.DatasourceReachabilityStatus.REACHABLE
+                    : CommonUtils.DatasourceReachabilityStatus.NOT_REACHABLE;
+        } catch (Exception e) {
+            LOGGER.debug("Metrics DB {} reachability check failed: {}", metricsDbRef, e.getMessage());
+            return CommonUtils.DatasourceReachabilityStatus.NOT_REACHABLE;
+        }
+    }
+
+    @Override
+    public Object getValueForQuery(DataSourceInfo dataSource, String query) throws IOException {
+        String metricsDbRef = dataSource.getMetricsDbRef();
+        if (metricsDbRef == null) {
+            return null;
+        }
+        Session session = null;
+        try {
+            session = MetricsDBConnectionManager.getInstance().getSession(metricsDbRef);
+            if (session == null) {
+                return null;
+            }
+            return session.createNativeQuery(query).getSingleResult();
+        } catch (Exception e) {
+            LOGGER.error("SQL query failed on {}: {}", metricsDbRef, e.getMessage());
+            throw new IOException("Metrics DB query failed: " + e.getMessage());
+        } finally {
+            if (session != null) {
+                session.close();
+            }
+        }
+    }
+
+    @Override
+    public JSONObject getJsonObjectForQuery(DataSourceInfo dataSource, String query) throws IOException {
+        Object result = getValueForQuery(dataSource, query);
+        JSONObject json = new JSONObject();
+        json.put(KruizeConstants.JSONKeys.DATA, result != null ? result.toString() : "null");
+        return json;
+    }
+
+    @Override
+    public JsonArray getResultArrayForQuery(DataSourceInfo dataSource, String query) throws IOException {
+        String metricsDbRef = dataSource.getMetricsDbRef();
+        if (metricsDbRef == null) {
+            return new JsonArray();
+        }
+        Session session = null;
+        try {
+            session = MetricsDBConnectionManager.getInstance().getSession(metricsDbRef);
+            if (session == null) {
+                return new JsonArray();
+            }
+            List<?> results = session.createNativeQuery(query).list();
+            JsonArray arr = new JsonArray();
+            for (Object r : results) {
+                arr.add(new JsonPrimitive(r != null ? r.toString() : "null"));
+            }
+            return arr;
+        } catch (Exception e) {
+            LOGGER.error("SQL query failed on {}: {}", metricsDbRef, e.getMessage());
+            throw new IOException("Metrics DB query failed: " + e.getMessage());
+        } finally {
+            if (session != null) {
+                session.close();
+            }
+        }
+    }
+
+    @Override
+    public boolean validateResultArray(JsonArray resultArray) {
+        return resultArray != null && !resultArray.isJsonNull() && resultArray.size() > 0;
+    }
+
+    @Override
+    public String getQueryEndpoint() {
+        return "";
+    }
+}

--- a/src/main/java/com/autotune/database/init/MetricsDBConnectionManager.java
+++ b/src/main/java/com/autotune/database/init/MetricsDBConnectionManager.java
@@ -1,0 +1,238 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package com.autotune.database.init;
+
+import com.autotune.utils.KruizeConstants;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.cfg.Configuration;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Manages Hibernate sessions for metrics databases (db1, db2) configured in KruizeConfig.
+ * Used for Metric DB POC to connect to custom metrics databases and execute SQL queries.
+ */
+public class MetricsDBConnectionManager {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MetricsDBConnectionManager.class);
+    private static final String METRICS_DATABASES_KEY = "metricsDatabases";
+
+    private static MetricsDBConnectionManager instance;
+    private final Map<String, SessionFactory> sessionFactoryMap = new HashMap<>();
+
+    private MetricsDBConnectionManager() {
+    }
+
+    public static synchronized MetricsDBConnectionManager getInstance() {
+        if (instance == null) {
+            instance = new MetricsDBConnectionManager();
+        }
+        return instance;
+    }
+
+    /**
+     * Initializes metrics DB connections from the dbconfigjson file.
+     * Must be called after InitializeDeployment.setup_deployment_info().
+     */
+    public void initialize() {
+        String configFile = System.getenv(KruizeConstants.DBConstants.CONFIG_FILE);
+        if (configFile == null || configFile.isEmpty()) {
+            LOGGER.info("DB_CONFIG_FILE not set, skipping metrics databases initialization");
+            return;
+        }
+
+        try (InputStream is = new FileInputStream(configFile)) {
+            String jsonTxt = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            JSONObject configObject = new JSONObject(jsonTxt);
+
+            if (!configObject.has(METRICS_DATABASES_KEY)) {
+                LOGGER.info("No metricsDatabases configuration found in dbconfig");
+                return;
+            }
+
+            JSONObject metricsDatabases = configObject.getJSONObject(METRICS_DATABASES_KEY);
+            for (String dbName : metricsDatabases.keySet()) {
+                try {
+                    JSONObject dbConfig = metricsDatabases.getJSONObject(dbName);
+                    SessionFactory sf = createSessionFactory(dbName, dbConfig);
+                    if (sf != null) {
+                        sessionFactoryMap.put(dbName, sf);
+                        LOGGER.info("Metrics DB '{}' connection initialized successfully", dbName);
+                    }
+                } catch (Exception e) {
+                    LOGGER.error("Failed to initialize metrics DB '{}': {}", dbName, e.getMessage());
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Could not load metrics databases config from {}: {}", configFile, e.getMessage());
+        }
+    }
+
+    private SessionFactory createSessionFactory(String dbName, JSONObject dbConfig) {
+        try {
+            // All values must come from config - no hardcoded defaults
+            String hostname = getRequiredConfig(dbConfig, dbName, "hostname");
+            Integer port = getRequiredConfigInt(dbConfig, dbName, "port");
+            String dbNameConfig = getRequiredConfig(dbConfig, dbName, "name");
+            String username = getRequiredConfig(dbConfig, dbName, "username");
+            String password = getRequiredConfig(dbConfig, dbName, "password");
+            String sslMode = getRequiredConfig(dbConfig, dbName, "sslMode");
+            String dbdriver = getRequiredConfig(dbConfig, dbName, "dbdriver");
+            String dialect = getRequiredConfig(dbConfig, dbName, "dialect");
+            String driver = getRequiredConfig(dbConfig, dbName, "driver");
+            String hbm2ddlauto = getRequiredConfig(dbConfig, dbName, "hbm2ddlauto");
+            String showsql = getRequiredConfig(dbConfig, dbName, "showsql");
+
+            if (hostname == null || port == null || dbNameConfig == null || username == null
+                    || password == null || sslMode == null || dbdriver == null || dialect == null
+                    || driver == null || hbm2ddlauto == null || showsql == null) {
+                return null;
+            }
+
+            String connectionURL = dbdriver + hostname + ":" + port + "/" + dbNameConfig
+                    + "?sslmode=" + sslMode;
+
+            Configuration configuration = new Configuration();
+            configuration.setProperty("hibernate.connection.url", connectionURL);
+            configuration.setProperty("hibernate.connection.username", username);
+            configuration.setProperty("hibernate.connection.password", password);
+            configuration.setProperty("hibernate.dialect", dialect);
+            configuration.setProperty("hibernate.connection.driver_class", driver);
+            configuration.setProperty("hibernate.hbm2ddl.auto", hbm2ddlauto);
+            configuration.setProperty("hibernate.show_sql", showsql);
+
+            return configuration.buildSessionFactory();
+        } catch (Exception e) {
+            LOGGER.error("Failed to create SessionFactory for metrics DB '{}': {}", dbName, e.getMessage());
+            return null;
+        }
+    }
+
+    private String getRequiredConfig(JSONObject dbConfig, String dbName, String key) {
+        if (!dbConfig.has(key)) {
+            LOGGER.error("Metrics DB '{}' missing required config: '{}'", dbName, key);
+            return null;
+        }
+        String value = dbConfig.optString(key);
+        if (value == null || value.isEmpty()) {
+            LOGGER.error("Metrics DB '{}' has empty value for config: '{}'", dbName, key);
+            return null;
+        }
+        return value;
+    }
+
+    private Integer getRequiredConfigInt(JSONObject dbConfig, String dbName, String key) {
+        if (!dbConfig.has(key)) {
+            LOGGER.error("Metrics DB '{}' missing required config: '{}'", dbName, key);
+            return null;
+        }
+        try {
+            return dbConfig.getInt(key);
+        } catch (Exception e) {
+            LOGGER.error("Metrics DB '{}' invalid integer for config '{}': {}", dbName, key, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Gets a session for the specified metrics database.
+     *
+     * @param metricsDbRef the datasource reference (e.g., "db1", "db2")
+     * @return Session or null if not configured
+     */
+    public Session getSession(String metricsDbRef) {
+        SessionFactory sf = sessionFactoryMap.get(metricsDbRef);
+        if (sf == null) {
+            return null;
+        }
+        return sf.openSession();
+    }
+
+    /**
+     * Executes a SQL query on the specified metrics database and returns the result as string for logging.
+     * Logs the query and output to demonstrate successful connection and read for the Metric DB POC.
+     *
+     * @param metricsDbRef the datasource reference (e.g., "db1", "db2")
+     * @param sql          the SQL query to execute
+     * @return query result as string, or error message
+     */
+    public String executeQueryAndLog(String metricsDbRef, String sql) {
+        LOGGER.info("Metric DB POC: Executing query on '{}' - Query: {}", metricsDbRef, sql);
+        Session session = null;
+        try {
+            session = getSession(metricsDbRef);
+            if (session == null) {
+                String err = "Metrics DB '" + metricsDbRef + "' not configured";
+                LOGGER.error("Metric DB POC: Connection failed - {}", err);
+                return err;
+            }
+            Object result = session.createNativeQuery(sql).getSingleResult();
+            String resultStr = result != null ? result.toString() : "null";
+            LOGGER.info("Metric DB POC: Successfully connected and read from '{}'. Query: '{}' | Output: {}",
+                    metricsDbRef, sql, resultStr);
+            return resultStr;
+        } catch (Exception e) {
+            String errMsg = "Error executing query on " + metricsDbRef + ": " + e.getMessage();
+            LOGGER.error("Metric DB POC: Validation failed - {}", errMsg);
+            return errMsg;
+        } finally {
+            if (session != null) {
+                try {
+                    session.close();
+                } catch (Exception e) {
+                    LOGGER.debug("Error closing session: {}", e.getMessage());
+                }
+            }
+        }
+    }
+
+    /**
+     * Checks if a metrics database is configured.
+     */
+    public boolean isConfigured(String metricsDbRef) {
+        return sessionFactoryMap.containsKey(metricsDbRef);
+    }
+
+    /**
+     * Returns the set of configured metrics database names.
+     */
+    public java.util.Set<String> getConfiguredDatabases() {
+        return sessionFactoryMap.keySet();
+    }
+
+    /**
+     * Closes all metrics DB connections.
+     */
+    public void shutdown() {
+        for (Map.Entry<String, SessionFactory> entry : sessionFactoryMap.entrySet()) {
+            try {
+                entry.getValue().close();
+                LOGGER.info("Closed metrics DB connection: {}", entry.getKey());
+            } catch (Exception e) {
+                LOGGER.warn("Error closing metrics DB '{}': {}", entry.getKey(), e.getMessage());
+            }
+        }
+        sessionFactoryMap.clear();
+    }
+}

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -391,6 +391,7 @@ public class KruizeConstants {
     public static class SupportedDatasources {
         public static final String PROMETHEUS = "prometheus";
         public static final String THANOS = "thanos";
+        public static final String POSTGRESQL = "postgresql";
 
         private SupportedDatasources() {
         }
@@ -451,6 +452,7 @@ public class KruizeConstants {
         public static final String DATASOURCE_SERVICE_NAME = "serviceName";
         public static final String DATASOURCE_SERVICE_NAMESPACE = "namespace";
         public static final String DATASOURCE_URL = "url";
+        public static final String DATASOURCE_METRICS_DB_REF = "metricsDbRef";
         public static final String KRUIZE_DATASOURCE = "datasource";
         public static final String SERVICE_DNS = ".svc.cluster.local";
         public static final String PROMETHEUS_DEFAULT_SERVICE_PORT = "9090";

--- a/src/main/java/com/autotune/utils/KruizeSupportedTypes.java
+++ b/src/main/java/com/autotune/utils/KruizeSupportedTypes.java
@@ -26,7 +26,7 @@ public class KruizeSupportedTypes {
     public static final Set<String> DIRECTIONS_SUPPORTED =
             new HashSet<>(Arrays.asList("minimize", "maximize"));
     public static final Set<String> MONITORING_AGENTS_SUPPORTED =
-            new HashSet<>(Arrays.asList("prometheus"));
+            new HashSet<>(Arrays.asList("prometheus", "postgresql"));
     public static final Set<String> MODES_SUPPORTED =
             new HashSet<>(Arrays.asList("experiment", "monitor"));
     public static final Set<String> TARGET_CLUSTERS_SUPPORTED =


### PR DESCRIPTION
## Description

This PR contains changes to include new datasource(postgres) and corresponding code changes to connect multiple datasources simultaneously. 

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Add support for PostgreSQL-based metrics datasources and initialize Hibernate-backed connections to external metrics databases configured via Kruize config.

New Features:
- Introduce PostgreSQL as a supported monitoring datasource alongside Prometheus and Thanos, using a metrics database reference instead of a URL.
- Add a MetricsDBConnectionManager to initialize and manage Hibernate sessions for configured metrics databases and provide basic query execution utilities.
- Wire metrics database initialization and validation into the Autotune startup flow to verify connectivity by running a test SQL query against each configured metrics DB.

Enhancements:
- Extend datasource validation, configuration parsing, and logging to handle PostgreSQL-specific fields such as metricsDbRef and to support null-safe input handling.
- Update datasource operator selection and supported monitoring agents to include PostgreSQL and provide a dedicated PostgresqlDataOperatorImpl for executing SQL queries and returning results in existing formats.
- Adjust datasource discovery logging to surface either a URL or metrics DB reference depending on datasource type.

Build:
- Update CRC Minikube and OpenShift manifests to define metricsDatabases configurations, register a PostgreSQL datasource referencing them, and point to newer operator and UI images.