### PR TITLE
read metrics data from configured SQL datasource based on profile

### DIFF
--- a/manifests/autotune/performance-profiles/byomdb-poc.json
+++ b/manifests/autotune/performance-profiles/byomdb-poc.json
@@ -1,0 +1,430 @@
+{
+  "name": "byomdb-poc",
+  "profile_version": 2.0,
+  "k8s_type": "openshift",
+  "slo": {
+    "slo_class": "resource_usage",
+    "direction": "minimize",
+    "objective_function": {
+      "function_type": "source"
+    },
+    "function_variables": [
+      {
+        "name": "cpuRequest",
+        "datasource": "db1",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "select interval_start as interval_start_time, interval_end as interval_end_time, usage_metrics -> 'cpuRequest' -> 'aggregation_info' ->> 'avg' as value from workload_metrics wm, workloads w where w.id = wm.workload_id and w.experiment_name = :experiment_name and wm.container_name = :container_name and usage_metrics -> 'cpuRequest' -> 'aggregation_info' ->> 'avg' is not null and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+            "query_params": ["experiment_name", "container_name", "start_time", "end_time"]
+          },
+          {
+            "function": "sum",
+            "query": "select interval_start as interval_start_time, interval_end as interval_end_time, usage_metrics -> 'cpuRequest' -> 'aggregation_info' ->> 'sum' as value from workload_metrics wm, workloads w where w.id = wm.workload_id and w.experiment_name = :experiment_name and wm.container_name = :container_name and usage_metrics -> 'cpuRequest' -> 'aggregation_info' ->> 'sum' is not null and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+            "query_params": ["experiment_name", "container_name", "start_time", "end_time"]
+          }
+        ]
+      },
+      {
+        "name": "cpuLimit",
+        "datasource": "db1",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "select interval_start as interval_start_time, interval_end as interval_end_time, usage_metrics -> 'cpuLimit' -> 'aggregation_info' ->> 'avg' as value from workload_metrics wm, workloads w where w.id = wm.workload_id and w.experiment_name = :experiment_name and wm.container_name = :container_name and usage_metrics -> 'cpuLimit' -> 'aggregation_info' ->> 'avg' is not null and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+            "query_params": ["experiment_name", "container_name", "start_time", "end_time"]
+          },
+          {
+            "function": "sum",
+            "query": "select interval_start as interval_start_time, interval_end as interval_end_time, usage_metrics -> 'cpuLimit' -> 'aggregation_info' ->> 'sum' as value from workload_metrics wm, workloads w where w.id = wm.workload_id and w.experiment_name = :experiment_name and wm.container_name = :container_name and usage_metrics -> 'cpuLimit' -> 'aggregation_info' ->> 'sum' is not null and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+            "query_params": ["experiment_name", "container_name", "start_time", "end_time"]
+          }
+        ]
+      },
+      {
+        "name": "cpuUsage",
+        "datasource": "db1",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "select interval_start as interval_start_time, interval_end as interval_end_time, usage_metrics -> 'cpuUsage' -> 'aggregation_info' ->> 'avg' as value from workload_metrics wm, workloads w where w.id = wm.workload_id and w.experiment_name = :experiment_name and wm.container_name = :container_name and usage_metrics -> 'cpuUsage' -> 'aggregation_info' ->> 'avg' is not null and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+            "query_params": ["experiment_name", "container_name", "start_time", "end_time"]
+          },
+          {
+            "function": "sum",
+            "query": "select interval_start as interval_start_time, interval_end as interval_end_time, usage_metrics -> 'cpuUsage' -> 'aggregation_info' ->> 'sum' as value from workload_metrics wm, workloads w where w.id = wm.workload_id and w.experiment_name = :experiment_name and wm.container_name = :container_name and usage_metrics -> 'cpuUsage' -> 'aggregation_info' ->> 'sum' is not null and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+            "query_params": ["experiment_name", "container_name", "start_time", "end_time"]
+          },
+          {
+            "function": "min",
+            "query": "select interval_start as interval_start_time, interval_end as interval_end_time, usage_metrics -> 'cpuUsage' -> 'aggregation_info' ->> 'min' as value from workload_metrics wm, workloads w where w.id = wm.workload_id and w.experiment_name = :experiment_name and wm.container_name = :container_name and usage_metrics -> 'cpuUsage' -> 'aggregation_info' ->> 'min' is not null and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+            "query_params": ["experiment_name", "container_name", "start_time", "end_time"]
+          },
+          {
+            "function": "max",
+            "query": "select interval_start as interval_start_time, interval_end as interval_end_time, usage_metrics -> 'cpuUsage' -> 'aggregation_info' ->> 'max' as value from workload_metrics wm, workloads w where w.id = wm.workload_id and w.experiment_name = :experiment_name and wm.container_name = :container_name and usage_metrics -> 'cpuUsage' -> 'aggregation_info' ->> 'max' is not null and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+            "query_params": ["experiment_name", "container_name", "start_time", "end_time"]
+          }
+        ]
+      },
+      {
+        "name": "cpuThrottle",
+        "datasource": "db1",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "select interval_start as interval_start_time, interval_end as interval_end_time, usage_metrics -> 'cpuThrottle' -> 'aggregation_info' ->> 'avg' as value from workload_metrics wm, workloads w where w.id = wm.workload_id and w.experiment_name = :experiment_name and wm.container_name = :container_name and usage_metrics -> 'cpuThrottle' -> 'aggregation_info' ->> 'avg' is not null and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+            "query_params": ["experiment_name", "container_name", "start_time", "end_time"]
+          },
+          {
+            "function": "sum",
+            "query": "select interval_start as interval_start_time, interval_end as interval_end_time, usage_metrics -> 'cpuThrottle' -> 'aggregation_info' ->> 'sum' as value from workload_metrics wm, workloads w where w.id = wm.workload_id and w.experiment_name = :experiment_name and wm.container_name = :container_name and usage_metrics -> 'cpuThrottle' -> 'aggregation_info' ->> 'sum' is not null and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+            "query_params": ["experiment_name", "container_name", "start_time", "end_time"]
+          },
+          {
+            "function": "min",
+            "query": "select interval_start as interval_start_time, interval_end as interval_end_time, usage_metrics -> 'cpuThrottle' -> 'aggregation_info' ->> 'min' as value from workload_metrics wm, workloads w where w.id = wm.workload_id and w.experiment_name = :experiment_name and wm.container_name = :container_name and usage_metrics -> 'cpuThrottle' -> 'aggregation_info' ->> 'min' is not null and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+            "query_params": ["experiment_name", "container_name", "start_time", "end_time"]
+          },
+          {
+            "function": "max",
+            "query": "select interval_start as interval_start_time, interval_end as interval_end_time, usage_metrics -> 'cpuThrottle' -> 'aggregation_info' ->> 'max' as value from workload_metrics wm, workloads w where w.id = wm.workload_id and w.experiment_name = :experiment_name and wm.container_name = :container_name and usage_metrics -> 'cpuThrottle' -> 'aggregation_info' ->> 'max' is not null and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+            "query_params": ["experiment_name", "container_name", "start_time", "end_time"]
+          }
+        ]
+      },
+      {
+        "name": "memoryRequest",
+        "datasource": "db1",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "select interval_start as interval_start_time, interval_end as interval_end_time, usage_metrics -> 'memoryRequest' -> 'aggregation_info' ->> 'avg' as value from workload_metrics wm, workloads w where w.id = wm.workload_id and w.experiment_name = :experiment_name and wm.container_name = :container_name and usage_metrics -> 'memoryRequest' -> 'aggregation_info' ->> 'avg' is not null and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+            "query_params": ["experiment_name", "container_name", "start_time", "end_time"]
+          },
+          {
+            "function": "sum",
+            "query": "select interval_start as interval_start_time, interval_end as interval_end_time, usage_metrics -> 'memoryRequest' -> 'aggregation_info' ->> 'sum' as value from workload_metrics wm, workloads w where w.id = wm.workload_id and w.experiment_name = :experiment_name and wm.container_name = :container_name and usage_metrics -> 'memoryRequest' -> 'aggregation_info' ->> 'sum' is not null and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+            "query_params": ["experiment_name", "container_name", "start_time", "end_time"]
+          }
+        ]
+      },
+      {
+        "name": "memoryLimit",
+        "datasource": "db1",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "select interval_start as interval_start_time, interval_end as interval_end_time, usage_metrics -> 'memoryLimit' -> 'aggregation_info' ->> 'avg' as value from workload_metrics wm, workloads w where w.id = wm.workload_id and w.experiment_name = :experiment_name and wm.container_name = :container_name and usage_metrics -> 'memoryLimit' -> 'aggregation_info' ->> 'avg' is not null and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+            "query_params": ["experiment_name", "container_name", "start_time", "end_time"]
+          },
+          {
+            "function": "sum",
+            "query": "select interval_start as interval_start_time, interval_end as interval_end_time, usage_metrics -> 'memoryLimit' -> 'aggregation_info' ->> 'sum' as value from workload_metrics wm, workloads w where w.id = wm.workload_id and w.experiment_name = :experiment_name and wm.container_name = :container_name and usage_metrics -> 'memoryLimit' -> 'aggregation_info' ->> 'sum' is not null and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+            "query_params": ["experiment_name", "container_name", "start_time", "end_time"]
+          }
+        ]
+      },
+      {
+        "name": "memoryUsage",
+        "datasource": "db1",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "select interval_start as interval_start_time, interval_end as interval_end_time, usage_metrics -> 'memoryUsage' -> 'aggregation_info' ->> 'avg' as value from workload_metrics wm, workloads w where w.id = wm.workload_id and w.experiment_name = :experiment_name and wm.container_name = :container_name and usage_metrics -> 'memoryUsage' -> 'aggregation_info' ->> 'avg' is not null and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+            "query_params": ["experiment_name", "container_name", "start_time", "end_time"]
+          },
+          {
+            "function": "sum",
+            "query": "select interval_start as interval_start_time, interval_end as interval_end_time, usage_metrics -> 'memoryUsage' -> 'aggregation_info' ->> 'sum' as value from workload_metrics wm, workloads w where w.id = wm.workload_id and w.experiment_name = :experiment_name and wm.container_name = :container_name and usage_metrics -> 'memoryUsage' -> 'aggregation_info' ->> 'sum' is not null and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+            "query_params": ["experiment_name", "container_name", "start_time", "end_time"]
+          },
+          {
+            "function": "min",
+            "query": "select interval_start as interval_start_time, interval_end as interval_end_time, usage_metrics -> 'memoryUsage' -> 'aggregation_info' ->> 'min' as value from workload_metrics wm, workloads w where w.id = wm.workload_id and w.experiment_name = :experiment_name and wm.container_name = :container_name and usage_metrics -> 'memoryUsage' -> 'aggregation_info' ->> 'min' is not null and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+            "query_params": ["experiment_name", "container_name", "start_time", "end_time"]
+          },
+          {
+            "function": "max",
+            "query": "select interval_start as interval_start_time, interval_end as interval_end_time, usage_metrics -> 'memoryUsage' -> 'aggregation_info' ->> 'max' as value from workload_metrics wm, workloads w where w.id = wm.workload_id and w.experiment_name = :experiment_name and wm.container_name = :container_name and usage_metrics -> 'memoryUsage' -> 'aggregation_info' ->> 'max' is not null and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+            "query_params": ["experiment_name", "container_name", "start_time", "end_time"]
+          }
+        ]
+      },
+      {
+        "name": "memoryRSS",
+        "datasource": "db1",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "select interval_start as interval_start_time, interval_end as interval_end_time, usage_metrics -> 'memoryRSS' -> 'aggregation_info' ->> 'avg' as value from workload_metrics wm, workloads w where w.id = wm.workload_id and w.experiment_name = :experiment_name and wm.container_name = :container_name and usage_metrics -> 'memoryRSS' -> 'aggregation_info' ->> 'avg' is not null and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+            "query_params": ["experiment_name", "container_name", "start_time", "end_time"]
+          },
+          {
+            "function": "sum",
+            "query": "select interval_start as interval_start_time, interval_end as interval_end_time, usage_metrics -> 'memoryRSS' -> 'aggregation_info' ->> 'sum' as value from workload_metrics wm, workloads w where w.id = wm.workload_id and w.experiment_name = :experiment_name and wm.container_name = :container_name and usage_metrics -> 'memoryRSS' -> 'aggregation_info' ->> 'sum' is not null and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+            "query_params": ["experiment_name", "container_name", "start_time", "end_time"]
+          },
+          {
+            "function": "min",
+            "query": "select interval_start as interval_start_time, interval_end as interval_end_time, usage_metrics -> 'memoryRSS' -> 'aggregation_info' ->> 'min' as value from workload_metrics wm, workloads w where w.id = wm.workload_id and w.experiment_name = :experiment_name and wm.container_name = :container_name and usage_metrics -> 'memoryRSS' -> 'aggregation_info' ->> 'min' is not null and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+            "query_params": ["experiment_name", "container_name", "start_time", "end_time"]
+          },
+          {
+            "function": "max",
+            "query": "select interval_start as interval_start_time, interval_end as interval_end_time, usage_metrics -> 'memoryRSS' -> 'aggregation_info' ->> 'max' as value from workload_metrics wm, workloads w where w.id = wm.workload_id and w.experiment_name = :experiment_name and wm.container_name = :container_name and usage_metrics -> 'memoryRSS' -> 'aggregation_info' ->> 'max' is not null and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+            "query_params": ["experiment_name", "container_name", "start_time", "end_time"]
+          }
+        ]
+      },
+      {
+        "name": "namespaceCpuRequest",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "sum",
+            "query": "sum by (namespace) (kube_resourcequota{namespace=\"$NAMESPACE$\", resource=\"requests.cpu\", type=\"hard\"})"
+          }
+        ]
+      },
+      {
+        "name": "namespaceCpuLimit",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "sum",
+            "query": "sum by (namespace) (kube_resourcequota{namespace=\"$NAMESPACE$\", resource=\"limits.cpu\", type=\"hard\"})"
+          }
+        ]
+      },
+      {
+        "name": "namespaceMemoryRequest",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "sum",
+            "query": "sum by (namespace) (kube_resourcequota{namespace=\"$NAMESPACE$\", resource=\"requests.memory\", type=\"hard\"})"
+          }
+        ]
+      },
+      {
+        "name": "namespaceMemoryLimit",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "sum",
+            "query": "sum by (namespace) (kube_resourcequota{namespace=\"$NAMESPACE$\", resource=\"limits.memory\", type=\"hard\"})"
+          }
+        ]
+      },
+      {
+        "name": "namespaceCpuUsage",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg_over_time(sum by(namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[15m:])"
+          },
+          {
+            "function": "max",
+            "query": "max_over_time(sum by(namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[15m:])"
+          },
+          {
+            "function": "min",
+            "query": "min_over_time(sum by(namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[15m:])"
+          }
+        ]
+      },
+      {
+        "name": "namespaceCpuThrottle",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"}[5m]))[15m:])"
+          },
+          {
+            "function": "max",
+            "query": "max_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"}[5m]))[15m:])"
+          },
+          {
+            "function": "min",
+            "query": "min_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"}[5m]))[15m:])"
+          }
+        ]
+      },
+      {
+        "name": "namespaceMemoryUsage",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[15m:])"
+          },
+          {
+            "function": "max",
+            "query": "max_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[15m:])"
+          },
+          {
+            "function": "min",
+            "query": "min_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[15m:])"
+          }
+        ]
+      },
+      {
+        "name": "namespaceMemoryRSS",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg_over_time(sum by(namespace) (container_memory_rss{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[15m:])"
+          },
+          {
+            "function": "max",
+            "query": "max_over_time(sum by(namespace) (container_memory_rss{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[15m:])"
+          },
+          {
+            "function": "min",
+            "query": "min_over_time(sum by(namespace) (container_memory_rss{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[15m:])"
+          }
+        ]
+      },
+      {
+        "name": "namespaceTotalPods",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "max",
+            "query": "max_over_time(sum by(namespace) ((kube_pod_info{namespace=\"$NAMESPACE$\"}))[15m:])"
+          },
+          {
+            "function": "avg",
+            "query": "avg_over_time(sum by(namespace) ((kube_pod_info{namespace=\"$NAMESPACE$\"}))[15m:])"
+          }
+        ]
+      },
+      {
+        "name": "namespaceRunningPods",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "max",
+            "query": "max_over_time(sum by(namespace) ((kube_pod_status_phase{phase=\"Running\"}))[15m:])"
+          },
+          {
+            "function": "avg",
+            "query": "avg_over_time(sum by(namespace) ((kube_pod_status_phase{phase=\"Running\"}))[15m:])"
+          }
+        ]
+      },
+      {
+        "name": "namespaceMaxDate",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "max",
+            "query": "max(last_over_time(timestamp((sum by (namespace) (container_cpu_usage_seconds_total{namespace=\"$NAMESPACE$\"})) > 0 )[15d:]))"
+          }
+        ]
+      },
+      {
+        "name": "acceleratorCoreUsage",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "min",
+            "query": "min(min_over_time(DCGM_FI_DEV_GPU_UTIL{exported_namespace != \"\", exported_container != \"\", exported_pod != \"\"}[15m])) by (modelName, exported_container, exported_namespace, exported_pod, Hostname)"
+          },
+          {
+            "function": "max",
+            "query": "max(max_over_time(DCGM_FI_DEV_GPU_UTIL{exported_namespace != \"\", exported_container != \"\", exported_pod != \"\"}[15m])) by (modelName, exported_container, exported_namespace, exported_pod, Hostname)"
+          },
+          {
+            "function": "avg",
+            "query": "avg(avg_over_time(DCGM_FI_DEV_GPU_UTIL{exported_namespace != \"\", exported_container != \"\", exported_pod != \"\"}[15m])) by (modelName, exported_container, exported_namespace, exported_pod, Hostname)"
+          }
+        ]
+      },
+      {
+        "name": "acceleratorMemoryUsage",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "min",
+            "query": "min(min_over_time(DCGM_FI_DEV_MEM_COPY_UTIL{exported_namespace != \"\", exported_container != \"\", exported_pod != \"\"}[15m])) by (modelName, exported_container, exported_namespace, exported_pod, Hostname)"
+          },
+          {
+            "function": "max",
+            "query": "max(max_over_time(DCGM_FI_DEV_MEM_COPY_UTIL{exported_namespace != \"\", exported_container != \"\", exported_pod != \"\"}[15m])) by (modelName, exported_container, exported_namespace, exported_pod, Hostname)"
+          },
+          {
+            "function": "avg",
+            "query": "avg(avg_over_time(DCGM_FI_DEV_MEM_COPY_UTIL{exported_namespace != \"\", exported_container != \"\", exported_pod != \"\"}[15m])) by (modelName, exported_container, exported_namespace, exported_pod, Hostname)"
+          }
+        ]
+      },
+      {
+        "name": "acceleratorFrameBufferUsage",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "min",
+            "query": "min(min_over_time(DCGM_FI_DEV_FB_USED{exported_namespace != \"\", exported_container != \"\", exported_pod != \"\"}[15m])) by (modelName, GPU_I_PROFILE, exported_container, exported_namespace, exported_pod, Hostname)"
+          },
+          {
+            "function": "max",
+            "query": "max(max_over_time(DCGM_FI_DEV_FB_USED{exported_namespace != \"\", exported_container != \"\", exported_pod != \"\"}[15m])) by (modelName, GPU_I_PROFILE, exported_container, exported_namespace, exported_pod, Hostname)"
+          },
+          {
+            "function": "avg",
+            "query": "avg(avg_over_time(DCGM_FI_DEV_FB_USED{exported_namespace != \"\", exported_container != \"\", exported_pod != \"\"}[15m])) by (modelName, GPU_I_PROFILE, exported_container, exported_namespace, exported_pod, Hostname)"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/main/java/com/autotune/analyzer/performanceProfiles/PerformanceProfile.java
+++ b/src/main/java/com/autotune/analyzer/performanceProfiles/PerformanceProfile.java
@@ -17,9 +17,13 @@ package com.autotune.analyzer.performanceProfiles;
 
 import com.autotune.analyzer.kruizeObject.SloInfo;
 import com.autotune.analyzer.recommendations.term.Terms;
+import com.autotune.analyzer.utils.AnalyzerConstants;
+import com.autotune.common.data.metrics.Metric;
+import com.autotune.utils.KruizeConstants;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.gson.annotations.SerializedName;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -147,5 +151,23 @@ public class PerformanceProfile {
                 ", k8s_type='" + k8s_type + '\'' +
                 ", sloInfo=" + sloInfo +
                 '}';
+    }
+
+    public List<Metric> getContainerMetrics() {
+        return sloInfo.getFunctionVariables().stream()
+            .filter(metric -> {
+                String name = metric.getName();
+                return KruizeConstants.JSONKeys.CONTAINER.equalsIgnoreCase(metric.getKubernetesObject());
+            })
+            .toList();
+    }
+
+    public List<Metric> getNamespaceMetrics() {
+        return sloInfo.getFunctionVariables().stream()
+                .filter(metric -> {
+                    String name = metric.getName();
+                    return !name.equals(AnalyzerConstants.MetricName.namespaceMaxDate.name()) && KruizeConstants.JSONKeys.NAMESPACE.equalsIgnoreCase(metric.getKubernetesObject());
+                })
+                .toList();
     }
 }

--- a/src/main/java/com/autotune/analyzer/performanceProfiles/PerformanceProfileValidation.java
+++ b/src/main/java/com/autotune/analyzer/performanceProfiles/PerformanceProfileValidation.java
@@ -603,11 +603,11 @@ public class PerformanceProfileValidation {
         String expression = null;
         for (Metric functionVariable : sloInfo.getFunctionVariables()) {
             // Check if datasource is supported
-            if (!KruizeSupportedTypes.MONITORING_AGENTS_SUPPORTED.contains(functionVariable.getDatasource().toLowerCase())) {
+            /*if (!KruizeSupportedTypes.MONITORING_AGENTS_SUPPORTED.contains(functionVariable.getDatasource().toLowerCase())) {
                 errorString.append(AnalyzerConstants.AutotuneObjectConstants.FUNCTION_VARIABLE)
                         .append(functionVariable.getName())
                         .append(AnalyzerErrorConstants.AutotuneObjectErrors.DATASOURCE_NOT_SUPPORTED);
-            }
+            }*/
 
             // Check if value_type is supported
             if (!KruizeSupportedTypes.VALUE_TYPES_SUPPORTED.contains(functionVariable.getValueType().toLowerCase())) {

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -23,14 +23,17 @@ import com.autotune.common.data.result.IntervalResults;
 import com.autotune.common.data.result.NamespaceData;
 import com.autotune.common.data.system.info.device.DeviceDetails;
 import com.autotune.common.data.system.info.device.accelerator.NvidiaAcceleratorDeviceData;
+import com.autotune.common.datasource.DataSourceCollection;
 import com.autotune.common.datasource.DataSourceInfo;
 import com.autotune.common.exceptions.DataSourceNotExist;
 import com.autotune.common.k8sObjects.K8sObject;
 import com.autotune.common.utils.CommonUtils;
+import com.autotune.database.init.MetricsDBConnectionManager;
 import com.autotune.database.service.ExperimentDBService;
 import com.autotune.metrics.KruizeNotificationCollectionRegistry;
 import com.autotune.operator.KruizeDeploymentInfo;
 import com.autotune.utils.*;
+import com.autotune.utils.cache.PerformanceProfileCache;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -40,10 +43,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServletResponse;
+import javax.xml.crypto.Data;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URLEncoder;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -1139,17 +1146,21 @@ public class RecommendationEngine implements RecommendationEngineService {
         mainKruizeExperimentMAP.put(experimentName, kruizeObject);
         // get data from the DB in case of remote monitoring
         if (kruizeObject.getExperiment_usecase_type().isRemote_monitoring()) {
-            try {
-                boolean resultsAvailable = new ExperimentDBService().loadResultsFromDBByName(mainKruizeExperimentMAP, experimentName, intervalStartTime, interval_end_time);
-                if (!resultsAvailable) {
-                    SimpleDateFormat dateFormat = new SimpleDateFormat(KruizeConstants.DateFormats.STANDARD_JSON_DATE_FORMAT);
-                    errorMsg = String.format(AnalyzerErrorConstants.AutotuneObjectErrors.NO_METRICS_AVAILABLE,
-                            dateFormat.format(intervalStartTime), dateFormat.format(interval_end_time));
-                    LOGGER.error(errorMsg);
-                    return errorMsg;
+            if ("resource-optimization-openshift".equalsIgnoreCase(kruizeObject.getPerformanceProfile())) {
+                try {
+                    boolean resultsAvailable = new ExperimentDBService().loadResultsFromDBByName(mainKruizeExperimentMAP, experimentName, intervalStartTime, interval_end_time);
+                    if (!resultsAvailable) {
+                        SimpleDateFormat dateFormat = new SimpleDateFormat(KruizeConstants.DateFormats.STANDARD_JSON_DATE_FORMAT);
+                        errorMsg = String.format(AnalyzerErrorConstants.AutotuneObjectErrors.NO_METRICS_AVAILABLE,
+                                dateFormat.format(intervalStartTime), dateFormat.format(interval_end_time));
+                        LOGGER.error(errorMsg);
+                        return errorMsg;
+                    }
+                } catch (Exception e) {
+                    LOGGER.error(String.format(AnalyzerErrorConstants.APIErrors.UpdateRecommendationsAPI.FETCHING_RESULTS_FAILED, e.getMessage()));
                 }
-            } catch (Exception e) {
-                LOGGER.error(String.format(AnalyzerErrorConstants.APIErrors.UpdateRecommendationsAPI.FETCHING_RESULTS_FAILED, e.getMessage()));
+            } else {
+                fetchMetricsBasedOnProfile(kruizeObject, intervalStartTime, interval_end_time, PerformanceProfileCache.get(kruizeObject.getPerformanceProfile()));
             }
         } else if (kruizeObject.getExperiment_usecase_type().isLocal_monitoring()) {
             // get data from the provided datasource in case of local monitoring
@@ -1165,6 +1176,13 @@ public class RecommendationEngine implements RecommendationEngineService {
         return errorMsg;
     }
 
+    public void fetchMetricsBasedOnProfile(KruizeObject kruizeObject, Timestamp startTime, Timestamp endTime, PerformanceProfile profile) throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+        if (kruizeObject.isContainerExperiment()) {
+            fetchContainerMetricsBasedOnProfile(kruizeObject, startTime, endTime, profile);
+        } else if (kruizeObject.isNamespaceExperiment()) {
+            fetchNamespaceMetricsBasedOnProfile(kruizeObject, startTime, endTime, profile);
+        }
+    }
 
     /**
      * Fetches metrics based on the specified datasource using queries from the metricProfile for the given time interval.
@@ -1368,6 +1386,115 @@ public class RecommendationEngine implements RecommendationEngineService {
         }
     }
 
+    private void fetchNamespaceMetricsBasedOnProfile(KruizeObject kruizeObject, Timestamp startTime, Timestamp endTime, PerformanceProfile profile) throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+        String experiment_name = kruizeObject.getExperimentName();
+        HashMap<String, String> queryParams = new HashMap<>();
+        queryParams.put("experiment_name", experiment_name);
+        for (K8sObject k8sObject : kruizeObject.getKubernetes_objects()) {
+            String namespace = k8sObject.getNamespace();
+            for (ContainerData container : k8sObject.getContainerDataMap().values()) {
+                String container_name = container.getContainer_name();
+                queryParams.put("container_name", container_name);
+                HashMap<Timestamp, IntervalResults> results = container.getResults();
+                if (null == results) {
+                    results = new HashMap<>();
+                    container.setResults(results);
+                }
+                List<Metric> metrics = profile.getNamespaceMetrics();
+                for (Metric metric : metrics) {
+                    String metricName  = metric.getName();
+                    HashMap<Metric, MetricResults>  metricResults = new HashMap<>();
+                    String datasourceName = metric.getDatasource();
+                    MetricsDBConnectionManager metricsDBConnectionManager = MetricsDBConnectionManager.getInstance();
+                    Set<String> aggrFunctions = metric.getAggregationFunctions();
+                    for (String function : aggrFunctions) {
+                        String query = metric.getQuery(function).toLowerCase();
+                        List<String> queryParamsFromProfile = metric.getQueryParams(function);
+                        for (String param : queryParamsFromProfile) {
+                            if ("container_name".equalsIgnoreCase(param))
+                                queryParams.put("container_name", container_name);
+                            else if ("namepsace".equalsIgnoreCase(param))
+                                queryParams.put("namepsace", namespace);
+                            else if ("experiment_name".equalsIgnoreCase(param))
+                                queryParams.put("experiment_name", experiment_name);
+                            else if ("start_time".equalsIgnoreCase(param))
+                                queryParams.put("start_time", experiment_name);
+
+                        }
+
+                        List<Object[]> dbResult = metricsDBConnectionManager.getMetricsData(datasourceName, query, queryParams);
+                        for (Object[] dbRow : dbResult) {
+                            Timestamp interval_start_time = (Timestamp) dbRow[0];
+                            Timestamp interval_end_time = (Timestamp) dbRow[1];
+                            Double value =  Double.valueOf((String) dbRow[2]);
+                            IntervalResults intervalResults = results.computeIfAbsent(interval_end_time, k -> new IntervalResults());
+                            intervalResults.addMetricResult(metricName, function, value);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private void fetchContainerMetricsBasedOnProfile(KruizeObject kruizeObject, Timestamp startTime, Timestamp endTime, PerformanceProfile profile) throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+        String experiment_name = kruizeObject.getExperimentName();
+        HashMap<String, String> queryParams = new HashMap<>();
+        LocalDateTime startTimeLocalDateTime = startTime.toLocalDateTime();
+        LocalDateTime endTimeLocalDateTime = endTime.toLocalDateTime();
+        //LOGGER.error("experiment_name = {}, interval_start_time = {}, interval_end_time = {}", experiment_name, startTimeLocalDateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME), endTimeLocalDateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+        for (K8sObject k8sObject : kruizeObject.getKubernetes_objects()) {
+            String namespace = k8sObject.getNamespace();
+            for (ContainerData container : k8sObject.getContainerDataMap().values()) {
+                String container_name = container.getContainer_name();
+                HashMap<Timestamp, IntervalResults> results = container.getResults();
+                if (null == results) {
+                    results = new HashMap<>();
+                    container.setResults(results);
+                }
+                List<Metric> metrics = profile.getContainerMetrics();
+                for (Metric metric : metrics) {
+                    String metricName  = metric.getName();
+                    LOGGER.error("metricName = {}", metricName);
+                    HashMap<Metric, MetricResults>  metricResults = new HashMap<>();
+                    String datasourceName = metric.getDatasource();
+                    MetricsDBConnectionManager metricsDBConnectionManager = MetricsDBConnectionManager.getInstance();
+                    Set<String> aggrFunctions = metric.getAggregationFunctions();
+                    for (String function : aggrFunctions) {
+                        String query = metric.getQuery(function);
+                        // Populate query params as defined in profile from standard list
+                        List<String> queryParamsFromProfile = metric.getQueryParams(function);
+                        for (String param : queryParamsFromProfile) {
+                            if ("container_name".equalsIgnoreCase(param))
+                                queryParams.put("container_name", container_name);
+                            else if ("namepsace".equalsIgnoreCase(param))
+                                queryParams.put("namepsace", namespace);
+                            else if ("experiment_name".equalsIgnoreCase(param))
+                                queryParams.put("experiment_name", experiment_name);
+                            else if ("start_time".equalsIgnoreCase(param))
+                                queryParams.put("start_time", startTimeLocalDateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+                            else if ("end_time".equalsIgnoreCase(param))
+                                queryParams.put("end_time", endTimeLocalDateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+                        }
+                        //LOGGER.error("query = {}", query);
+                        List<Object[]> dbResult = metricsDBConnectionManager.getMetricsData(datasourceName, query, queryParams);
+                        if (dbResult == null) {
+                            return;
+                        }
+                        for (Object[] dbRow : dbResult) {
+                            Timestamp interval_start_time = (Timestamp) dbRow[0];
+                            Timestamp interval_end_time = (Timestamp) dbRow[1];
+                            Double value =  Double.valueOf((String) dbRow[2]);
+                            IntervalResults intervalResults = results.computeIfAbsent(interval_end_time, k -> new IntervalResults(interval_start_time, interval_end_time));
+                            intervalResults.setIntervalStartTime(interval_start_time);
+                            intervalResults.setIntervalEndTime(interval_end_time);
+                            intervalResults.addMetricResult(metricName, function, value);
+                            //LOGGER.error("interval_start_time = {}, interval_end_time = {}, metricName = {}, function = {}, value = {}", interval_start_time, interval_end_time, metricName, function, value);
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     /**
      * Fetches Container metrics based on the specified datasource using queries from the metricProfile for the given time interval.

--- a/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
@@ -428,7 +428,14 @@ public class Converters {
                                         String function = aggrFuncJsonObject.optString(AnalyzerConstants.FUNCTION, null);
                                         String aggrFuncQuery = aggrFuncJsonObject.optString(KruizeConstants.JSONKeys.QUERY, null);
                                         String version = aggrFuncJsonObject.optString(KruizeConstants.JSONKeys.VERSION, null);
-                                        AggregationFunctions aggregationFunctions = new AggregationFunctions(function, aggrFuncQuery, version);
+                                        JSONArray queryParamsArray = aggrFuncJsonObject.optJSONArray(KruizeConstants.JSONKeys.QUERY_PARAMS, null);
+                                        List<String> queryParams = new ArrayList<>();
+                                        if (queryParamsArray != null) {
+                                            for (Object param : queryParamsArray) {
+                                                queryParams.add((String) param);
+                                            }
+                                        }
+                                        AggregationFunctions aggregationFunctions = new AggregationFunctions(function, aggrFuncQuery, version, queryParams);
                                         aggregationFunctionsMap.put(function, aggregationFunctions);
                                     } catch (Exception e) {
                                         LOGGER.info(e.getMessage());
@@ -483,7 +490,14 @@ public class Converters {
                         String function = aggrFuncJsonObject.getString(AnalyzerConstants.FUNCTION);
                         String aggrFuncQuery = aggrFuncJsonObject.getString(KruizeConstants.JSONKeys.QUERY);
                         String version = aggrFuncJsonObject.has(KruizeConstants.JSONKeys.VERSION) ? aggrFuncJsonObject.getString(KruizeConstants.JSONKeys.VERSION) : null;
-                        AggregationFunctions aggregationFunctions = new AggregationFunctions(function, aggrFuncQuery, version);
+                        JSONArray queryParamsArray = aggrFuncJsonObject.optJSONArray(KruizeConstants.JSONKeys.QUERY_PARAMS, null);
+                        List<String> queryParams = new ArrayList<>();
+                        if (queryParamsArray != null) {
+                            for (Object param : queryParamsArray) {
+                                queryParams.add((String) param);
+                            }
+                        }
+                        AggregationFunctions aggregationFunctions = new AggregationFunctions(function, aggrFuncQuery, version, queryParams);
                         aggregationFunctionsMap.put(function, aggregationFunctions);
                     }
                     metric.setAggregationFunctionsMap(aggregationFunctionsMap);
@@ -531,7 +545,14 @@ public class Converters {
                         String function = aggrFuncJsonObject.getString(AnalyzerConstants.FUNCTION);
                         String aggrFuncQuery = aggrFuncJsonObject.getString(KruizeConstants.JSONKeys.QUERY);
                         String version = aggrFuncJsonObject.has(KruizeConstants.JSONKeys.VERSION) ? aggrFuncJsonObject.getString(KruizeConstants.JSONKeys.VERSION) : null;
-                        AggregationFunctions aggregationFunctions = new AggregationFunctions(function, aggrFuncQuery, version);
+                        JSONArray queryParamsArray = aggrFuncJsonObject.optJSONArray(KruizeConstants.JSONKeys.QUERY_PARAMS, null);
+                        List<String> queryParams = new ArrayList<>();
+                        if (queryParamsArray != null) {
+                            for (Object param : queryParamsArray) {
+                                queryParams.add((String) param);
+                            }
+                        }
+                        AggregationFunctions aggregationFunctions = new AggregationFunctions(function, aggrFuncQuery, version, queryParams);
                         aggregationFunctionsMap.put(function, aggregationFunctions);
                     }
                     metric.setAggregationFunctionsMap(aggregationFunctionsMap);

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -71,6 +71,7 @@ public class AnalyzerConstants {
     public static final String MEASUREMENT_DURATION_IN_MIN_VARAIBLE = "$MEASUREMENT_DURATION_IN_MIN$";
     public static final String WORKLOAD_VARIABLE = "$WORKLOAD$";
     public static final String WORKLOAD_TYPE_VARIABLE = "$WORKLOAD_TYPE$";
+    public static final String EXPERIMENT_NAME_VARIABLE = "$EXPERIMENT_NAME$";
     public static final String API_VERSION = "apiVersion";
     public static final String KIND = "kind";
     public static final String RESOURCE_VERSION = "resourceVersion";

--- a/src/main/java/com/autotune/common/data/metrics/AggregationFunctions.java
+++ b/src/main/java/com/autotune/common/data/metrics/AggregationFunctions.java
@@ -15,16 +15,28 @@
  *******************************************************************************/
 package com.autotune.common.data.metrics;
 
+import java.util.List;
+
 public class AggregationFunctions {
 
     private String function;
     private String query;
+    private List<String> queryParams;
     private String version;
 
-    public AggregationFunctions(String function, String query, String version) {
+    public AggregationFunctions(String function, String query, String version, List<String> query_params) {
         this.function = function;
         this.query = query;
         this.version = version;
+        this.queryParams = query_params;
+    }
+
+    public List<String> getQueryParams() {
+        return queryParams;
+    }
+
+    public void setQueryParams(List<String> queryParams) {
+        this.queryParams = queryParams;
     }
 
     public String getFunction() {

--- a/src/main/java/com/autotune/common/data/metrics/Metric.java
+++ b/src/main/java/com/autotune/common/data/metrics/Metric.java
@@ -18,9 +18,7 @@ import com.autotune.utils.KruizeConstants;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.SerializedName;
 
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
+import java.util.*;
 
 /**
  * Holds the variables used in the objective_function for the autotune object
@@ -121,5 +119,28 @@ public final class Metric {
                 ", kubernetesObject='" + kubernetesObject + '\'' +
                 ", aggregationFunctionsMap=" + aggregationFunctionsMap +
                 '}';
+    }
+
+    public String getQuery(String function) {
+        if (aggregationFunctionsMap == null) {
+            return null;
+        }
+        AggregationFunctions aggregationFunctions = aggregationFunctionsMap.get(function);
+        return aggregationFunctions != null ? aggregationFunctions.getQuery() : null;
+    }
+
+    public List<String> getQueryParams(String function) {
+        if (aggregationFunctionsMap == null) {
+            return null;
+        }
+        AggregationFunctions aggregationFunctions = aggregationFunctionsMap.get(function);
+        return aggregationFunctions != null ? aggregationFunctions.getQueryParams() : null;
+    }
+
+    public Set<String> getAggregationFunctions() {
+        if (aggregationFunctionsMap == null) {
+            return Collections.emptySet();
+        }
+        return aggregationFunctionsMap.keySet();
     }
 }

--- a/src/main/java/com/autotune/common/data/metrics/MetricDataPoint.java
+++ b/src/main/java/com/autotune/common/data/metrics/MetricDataPoint.java
@@ -1,0 +1,61 @@
+package com.autotune.common.data.metrics;
+
+import com.autotune.utils.KruizeConstants;
+import software.amazon.awssdk.utils.StringUtils;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.sql.Timestamp;
+
+public class MetricDataPoint {
+    private String metricName;
+    private Timestamp startTime;
+    private  Timestamp endTime;
+    private  MetricAggregationInfoResults aggregationInfo = new MetricAggregationInfoResults();
+
+    public MetricDataPoint(String metricName) {
+        this.metricName = metricName;
+    }
+
+    public String getMetricName() {
+        return metricName;
+    }
+
+    public void setMetricName(String metricName) {
+        this.metricName = metricName;
+    }
+
+    public Timestamp getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(Timestamp startTime) {
+        this.startTime = startTime;
+    }
+
+    public Timestamp getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(Timestamp endTime) {
+        this.endTime = endTime;
+    }
+
+    public MetricAggregationInfoResults getAggregationInfo() {
+        return aggregationInfo;
+    }
+
+    public void setMetricAggregationInfo(String function, Double value) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+
+        Method method = MetricAggregationInfoResults.class.getDeclaredMethod(KruizeConstants.APIMessages.SET + StringUtils.capitalize(function), Double.class);
+        method.setAccessible(true);
+        method.invoke(aggregationInfo, value);
+    }
+
+    public void setMetricAggregationInfo(String function, Integer value) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+
+        Method method = MetricAggregationInfoResults.class.getDeclaredMethod(KruizeConstants.APIMessages.SET + StringUtils.capitalize(function), Integer.class);
+        method.setAccessible(true);
+        method.invoke(aggregationInfo, value);
+    }
+}

--- a/src/main/java/com/autotune/common/data/metrics/MetricResults.java
+++ b/src/main/java/com/autotune/common/data/metrics/MetricResults.java
@@ -21,6 +21,10 @@ import com.autotune.utils.KruizeConstants;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.SerializedName;
 import org.json.JSONObject;
+import software.amazon.awssdk.utils.StringUtils;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 public class MetricResults {
     private String name;
@@ -99,6 +103,7 @@ public class MetricResults {
 
     public void setFormat(String format) {
         this.format = format;
+        metricAggregationInfoResults.setFormat(format);
     }
     public String getName() {
         return name;
@@ -126,5 +131,19 @@ public class MetricResults {
                 ", format='" + format + '\'' +
                 ", isPercentileResultsAvailable=" + percentile_results_available +
                 '}';
+    }
+
+    public void setMetricValueByFunction(String function, Double value) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+
+        Method method = MetricAggregationInfoResults.class.getDeclaredMethod(KruizeConstants.APIMessages.SET + StringUtils.capitalize(function), Double.class);
+        method.setAccessible(true);
+        method.invoke(metricAggregationInfoResults, value);
+    }
+
+    public void setMetricValueByFunction(String function, Integer value) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+
+        Method method = MetricAggregationInfoResults.class.getDeclaredMethod(KruizeConstants.APIMessages.SET + StringUtils.capitalize(function), Integer.class);
+        method.setAccessible(true);
+        method.invoke(metricAggregationInfoResults, value);
     }
 }

--- a/src/main/java/com/autotune/common/data/result/IntervalResults.java
+++ b/src/main/java/com/autotune/common/data/result/IntervalResults.java
@@ -18,8 +18,10 @@ package com.autotune.common.data.result;
 import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.common.data.metrics.AcceleratorMetricResult;
 import com.autotune.common.data.metrics.MetricResults;
+import com.autotune.utils.KruizeConstants;
 import com.google.gson.annotations.SerializedName;
 
+import java.lang.reflect.InvocationTargetException;
 import java.sql.Timestamp;
 import java.util.HashMap;
 
@@ -32,7 +34,7 @@ import static com.autotune.utils.KruizeConstants.TimeConv.NO_OF_SECONDS_PER_MINU
  */
 public class IntervalResults {
     @SerializedName(METRICS)
-    HashMap<AnalyzerConstants.MetricName, MetricResults> metricResultsMap;
+    HashMap<AnalyzerConstants.MetricName, MetricResults> metricResultsMap = new HashMap<>();
     HashMap<AnalyzerConstants.MetricName, AcceleratorMetricResult> acceleratorMetricResultHashMap;
     @SerializedName(INTERVAL_START_TIME)
     private Timestamp intervalStartTime;
@@ -45,6 +47,7 @@ public class IntervalResults {
     public IntervalResults(Timestamp intervalStartTime, Timestamp intervalEndTime) {
         this.intervalStartTime = intervalStartTime;
         this.intervalEndTime = intervalEndTime;
+
         this.duration_in_seconds = Double.valueOf((intervalEndTime.getTime() - intervalStartTime.getTime()) / NO_OF_MSECS_IN_SEC);
         this.durationInMinutes = Double.valueOf(intervalEndTime.getTime() - intervalStartTime.getTime()) / (NO_OF_MSECS_IN_SEC * NO_OF_SECONDS_PER_MINUTE);
     }
@@ -104,5 +107,17 @@ public class IntervalResults {
                 ", durationInMinutes=" + durationInMinutes +
                 ", durationInSeconds=" + duration_in_seconds +
                 '}';
+    }
+
+    public void addMetricResult(String metricName, String function, Double value) throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+        MetricResults metricResults = metricResultsMap.computeIfAbsent(AnalyzerConstants.MetricName.valueOf(metricName),k->new MetricResults());
+        metricResults.setMetricValueByFunction(function, value);
+        if (metricResults.getFormat() == null) {
+            if (metricName.toLowerCase().contains("cpu")) {
+                metricResults.setFormat(CORES);
+            } else if (metricName.toLowerCase().contains("memory")) {
+                metricResults.setFormat(BYTES);
+            }
+        }
     }
 }

--- a/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
@@ -337,6 +337,42 @@ public class ExperimentDAOImpl implements ExperimentDAO {
         return failedResultsEntries;
     }
 
+    private void createPartitions(KruizeRecommendationEntry entry) {
+        try {
+            LocalDateTime localDateTime = entry.getInterval_end_time().toLocalDateTime();
+            LocalDateTime newDateTime;
+            int dayOfTheMonth = localDateTime.getDayOfMonth();
+            // Subtract 15 days from the current date
+            newDateTime = localDateTime.minus(DBConstants.PARTITION_TYPES.LAST_N_DAYS, ChronoUnit.DAYS);
+            // Check if the start date is not within the same month and adjust the date accordingly
+            if (newDateTime.getMonth() != localDateTime.getMonth()) {
+                newDateTime = localDateTime.minusDays(DBConstants.PARTITION_TYPES.LAST_N_DAYS);
+                LOGGER.debug("newDateTime: {}", newDateTime);
+            }
+            // create partition for the previous 15 days
+            //addPartitions(DBConstants.TABLE_NAMES.KRUIZE_RESULTS, String.format("%02d", newDateTime.getMonthValue()), String.valueOf(newDateTime.getYear()), newDateTime.getDayOfMonth(), DBConstants.PARTITION_TYPES.BY_MONTH);
+            addPartitions(DBConstants.TABLE_NAMES.KRUIZE_RECOMMENDATIONS, String.format("%02d", newDateTime.getMonthValue()), String.valueOf(newDateTime.getYear()), newDateTime.getDayOfMonth(), DBConstants.PARTITION_TYPES.BY_MONTH);
+
+            // check the dayOfTheMonth and create partitions accordingly
+            if (dayOfTheMonth < DBConstants.PARTITION_TYPES.PARTITION_DAY) {
+                //addPartitions(DBConstants.TABLE_NAMES.KRUIZE_RESULTS, String.format("%02d", localDateTime.getMonthValue()), String.valueOf(localDateTime.getYear()), 1, DBConstants.PARTITION_TYPES.BY_MONTH);
+                addPartitions(DBConstants.TABLE_NAMES.KRUIZE_RECOMMENDATIONS, String.format("%02d", localDateTime.getMonthValue()), String.valueOf(localDateTime.getYear()), 1, DBConstants.PARTITION_TYPES.BY_MONTH);
+            } else {
+                // create the partitions for the rest of the days for the current month
+                // Fixing the partition type to 'by_month'
+                //addPartitions(DBConstants.TABLE_NAMES.KRUIZE_RESULTS, String.format("%02d", localDateTime.getMonthValue()), String.valueOf(localDateTime.getYear()), dayOfTheMonth, DBConstants.PARTITION_TYPES.BY_MONTH);
+                addPartitions(DBConstants.TABLE_NAMES.KRUIZE_RECOMMENDATIONS, String.format("%02d", localDateTime.getMonthValue()), String.valueOf(localDateTime.getYear()), dayOfTheMonth, DBConstants.PARTITION_TYPES.BY_MONTH);
+
+                // create the partitions for the next month
+                YearMonth yearMonth = buildDateForNextMonth(YearMonth.of(localDateTime.getYear(), localDateTime.getMonthValue()));
+                //addPartitions(DBConstants.TABLE_NAMES.KRUIZE_RESULTS, String.format("%02d", yearMonth.getMonthValue()), String.valueOf(yearMonth.getYear()), 1, DBConstants.PARTITION_TYPES.BY_MONTH);
+                addPartitions(DBConstants.TABLE_NAMES.KRUIZE_RECOMMENDATIONS, String.format("%02d", yearMonth.getMonthValue()), String.valueOf(yearMonth.getYear()), 1, DBConstants.PARTITION_TYPES.BY_MONTH);
+            }
+        } catch (Exception e) {
+            LOGGER.error("Error occurred while creating partitions for kruize_recommendations.", e);
+        }
+    }
+
     private void createPartitions(KruizeResultsEntry entry) {
         try {
             LocalDateTime localDateTime = entry.getInterval_end_time().toLocalDateTime();
@@ -386,16 +422,45 @@ public class ExperimentDAOImpl implements ExperimentDAO {
                 if (null == existingRecommendationEntry) {
                     tx = session.beginTransaction();
                     session.persist(recommendationEntry);
-                    tx.commit();
+                    session.flush();
                     validationOutputData.setSuccess(true);
                     statusValue = "success";
                 } else {
                     tx = session.beginTransaction();
                     existingRecommendationEntry.setExtended_data(recommendationEntry.getExtended_data());
                     session.merge(existingRecommendationEntry);
-                    tx.commit();
+                    session.flush();
                     validationOutputData.setSuccess(true);
                     statusValue = "success";
+                }
+            } catch (PersistenceException e) {
+                ConstraintViolationException constraintViolationException = null;
+                String message = "";
+                if (null != e.getCause()) {
+                    constraintViolationException = (ConstraintViolationException) e.getCause();
+                    message = constraintViolationException.getCause().getMessage();
+                } else {
+                    message = e.getMessage();
+                }
+                LOGGER.debug(message);
+                if (message.contains(DBConstants.DB_MESSAGES.NO_PARTITION_RELATION)) {
+                    try {
+                        LOGGER.debug(DBConstants.DB_MESSAGES.CREATE_PARTITION_RETRY);
+                        tx.commit();
+                        tx = session.beginTransaction();
+                        // create partitions based on entry object
+                        synchronized (new Object()) {
+                            createPartitions(recommendationEntry);
+                        }
+                        session.persist(recommendationEntry);
+                        session.flush();
+                        validationOutputData.setSuccess(true);
+                        statusValue = "success";
+                    } catch (Exception partitionException) {
+                        LOGGER.error("Error occurred while creating partitions.", partitionException);
+                    }
+                } else {
+                    LOGGER.error(message);
                 }
             } catch (Exception e) {
                 LOGGER.error("Not able to save recommendation due to {}", e.getMessage());
@@ -404,9 +469,11 @@ public class ExperimentDAOImpl implements ExperimentDAO {
                 validationOutputData.setSuccess(false);
                 validationOutputData.setMessage(e.getMessage());
                 //todo save error to API_ERROR_LOG
+            } finally {
+                tx.commit();
             }
         } catch (Exception e) {
-            LOGGER.error("Not able to save recommendation due to {}", e.getMessage());
+            LOGGER.error("Not able to save recommendation due to ", e);
         } finally {
             if (null != timerAddRecDB) {
                 MetricsConfig.timerAddRecDB = MetricsConfig.timerBAddRecDB.tag("status", statusValue).register(MetricsConfig.meterRegistry());

--- a/src/main/java/com/autotune/database/init/MetricsDBConnectionManager.java
+++ b/src/main/java/com/autotune/database/init/MetricsDBConnectionManager.java
@@ -16,10 +16,14 @@
 
 package com.autotune.database.init;
 
+import com.autotune.common.data.metrics.MetricDataPoint;
 import com.autotune.utils.KruizeConstants;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.cfg.Configuration;
+import org.hibernate.query.MutationQuery;
+import org.hibernate.query.NativeQuery;
+import org.hibernate.query.Query;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,6 +32,7 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -202,6 +207,44 @@ public class MetricsDBConnectionManager {
                     session.close();
                 } catch (Exception e) {
                     LOGGER.debug("Error closing session: {}", e.getMessage());
+                }
+            }
+        }
+    }
+
+    public List<Object[]> getMetricsData(String metricsDbRef, String sql, Map<String, String> params) {
+        Session session = null;
+        try {
+            session = getSession(metricsDbRef);
+            if (session == null) {
+                String err = "Metrics DB '" + metricsDbRef + "' not configured";
+                LOGGER.error("Metric DB POC: Connection failed - {}", err);
+                return null;
+            }
+            Query query = session.createNativeQuery(sql)
+                    .addScalar("interval_start_time", java.sql.Timestamp.class)
+                    .addScalar("interval_end_time", java.sql.Timestamp.class)
+                    .addScalar("value", String.class);
+            LOGGER.error("final query = {}", query.toString());
+            if (params != null) {
+                for (String key : params.keySet()) {
+                    query.setParameter(key, params.get(key));
+                }
+            }
+
+
+            List<Object[]> resultList = query.getResultList();
+            return resultList;
+
+        }  catch (Exception e) {
+            LOGGER.error("Metric DB POC: Validation failed - {}", e);
+            return null;
+        } finally {
+            if (session != null) {
+                try {
+                    session.close();
+                }  catch (Exception e) {
+                    LOGGER.error("Error closing session: {}", e.getMessage());
                 }
             }
         }

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -204,6 +204,7 @@ public class KruizeConstants {
         public static final String CURRENT = "current";
         public static final String NAME = "name";
         public static final String QUERY = "query";
+        public static final String QUERY_PARAMS = "query_params";
         public static final String DATASOURCE = "datasource";
         public static final String CPU = "cpu";
         public static final String MEMORY = "memory";

--- a/src/main/java/com/autotune/utils/KruizeSupportedTypes.java
+++ b/src/main/java/com/autotune/utils/KruizeSupportedTypes.java
@@ -23,6 +23,8 @@ import java.util.Set;
  * Supported types to both Autotune and KruizeLayer objects
  */
 public class KruizeSupportedTypes {
+    public static final Set<String> METRICS_QUERY_PARAMS_SUPPORTED =
+            new HashSet<>(Arrays.asList("container_name", "experiment_name", "namespace", "start_time", "end_time"));
     public static final Set<String> DIRECTIONS_SUPPORTED =
             new HashSet<>(Arrays.asList("minimize", "maximize"));
     public static final Set<String> MONITORING_AGENTS_SUPPORTED =


### PR DESCRIPTION
## Description

POC changes to support read of metrics data from SQL database using queries configured in performance profile for remote monitoring.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes
- [ ] POC

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
Setup postgresql DB with datamodel to store workloads and their metrics data.
Create experiment and generate experiments.

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Enable fetching metrics for remote monitoring experiments from SQL datasources using performance profile–defined queries and improve DB handling for recommendations and metrics aggregation.

New Features:
- Support reading container and namespace metrics from configured SQL metrics datasources based on queries and parameters defined in performance profiles.
- Add query parameter metadata to aggregation functions in performance, metric, and metadata profiles, and expose helpers on Metric to access queries and aggregation functions.
- Introduce a MetricDataPoint model and a performance profile manifest for BYO metrics database experiments.

Enhancements:
- Route remote monitoring experiments using non-OpenShift profiles through a new profile-based metrics fetch path instead of the existing OpenShift-specific DB loader.
- Provide helpers on PerformanceProfile to retrieve container- and namespace-scoped metrics and automatically infer metric formats when adding interval results.
- Extend MetricsDBConnectionManager to execute parameterized native SQL queries and return typed metric rows.
- Improve recommendation persistence by handling missing partition errors, auto-creating required partitions for recommendations, and adjusting transaction/flush behavior.
- Allow metric datasources beyond the previously enforced monitoring agents set by relaxing validation of supported datasources.