### PR TITLE
Updated RH UBI minimal 10.1 image to latest available

### DIFF
--- a/Dockerfile.autotune
+++ b/Dockerfile.autotune
@@ -16,7 +16,7 @@
 ##########################################################
 #            Build Docker Image
 ##########################################################
-FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1772441549 as mvnbuild-jdk25
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1774545417 as mvnbuild-jdk25
 ARG USER=autotune
 ARG AUTOTUNE_HOME=/home/$USER
 
@@ -49,7 +49,7 @@ RUN jlink --strip-debug --compress 2 --no-header-files --no-man-pages --module-p
 #            Runtime Docker Image
 ##########################################################
 # Use ubi-minimal as the base image
-FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1772441549
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1774545417
 
 ARG AUTOTUNE_VERSION
 ARG USER=autotune


### PR DESCRIPTION
## Description

Updated RH UBI minimal 10.1 image to latest available to address CVE


### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Tested using PR check & quay scan report


**Test Configuration**
* Kubernetes clusters tested on: minikube

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Build:
- Refresh Dockerfile.autotune to build from the latest available RH UBI minimal 10.1 image for improved security posture.