### PR TITLE
update the conf to avoid perm issues in openshift

### DIFF
--- a/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
@@ -209,7 +209,14 @@ metadata:
 data:
   nginx.conf: |
     events {}
+    pid /tmp/nginx.pid;
     http {
+      client_body_temp_path /tmp/client_temp;
+      proxy_temp_path /tmp/proxy_temp;
+      fastcgi_temp_path /tmp/fastcgi_temp;
+      uwsgi_temp_path /tmp/uwsgi_temp;
+      scgi_temp_path /tmp/scgi_temp;
+    
       upstream kruize-api {
         server kruize:8080;
       }

--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -538,7 +538,14 @@ metadata:
 data:
   nginx.conf: |
     events {}
+    pid /tmp/nginx.pid;
     http {
+      client_body_temp_path /tmp/client_temp;
+      proxy_temp_path /tmp/proxy_temp;
+      fastcgi_temp_path /tmp/fastcgi_temp;
+      uwsgi_temp_path /tmp/uwsgi_temp;
+      scgi_temp_path /tmp/scgi_temp;
+    
       upstream kruize-api {
         server kruize:8080;
       }


### PR DESCRIPTION
## Description

This change updates the NGINX configuration to ensure compatibility with OpenShift’s restricted security model. In OpenShift, containers do not run as a fixed user like `nginx` but instead use a randomly assigned non-root UID. As a result, default NGINX paths such as `/var/cache/nginx` and `/run/nginx.pid`, which are typically owned by root, are not writable at runtime. This leads to permission denied errors and causes the container to crash during startup.

To address this, the NGINX PID file location has been explicitly moved from its default path (`/run/nginx.pid`) to `/tmp/nginx.pid`. The `/tmp` directory is universally writable inside containers, regardless of the runtime UID assigned by OpenShift, making it a safe location for runtime-generated files like PID files.

In addition, all temporary file paths used by NGINX (such as `client_body_temp_path`, `proxy_temp_path`, and others) have been redirected from `/var/cache/nginx` to subdirectories under `/tmp`. This ensures that NGINX can successfully create and manage temporary files required for request processing without encountering filesystem permission issues.

These changes do not alter application functionality but instead adapt the runtime behavior of NGINX to align with OpenShift’s security constraints. By avoiding reliance on root-owned filesystem paths, the container can run successfully under the default restricted security context without requiring elevated privileges or custom security policies.

Overall, this update improves portability and robustness of the deployment, ensuring that the UI service runs reliably in OpenShift environments while adhering to container security best practices.


Fixes #1859 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Update NGINX configuration to use writable temporary directories for runtime files to ensure compatibility with OpenShift security constraints.

Bug Fixes:
- Redirect NGINX PID file to /tmp to prevent permission errors when running under OpenShift-assigned non-root UIDs.
- Move NGINX temporary file paths from root-owned cache locations to /tmp subdirectories to avoid filesystem permission issues in OpenShift environments.