### PR TITLE
Added a experimentCache to be used in createExperiment to check for existing experiments

### DIFF
--- a/src/main/java/com/autotune/analyzer/services/CreateExperiment.java
+++ b/src/main/java/com/autotune/analyzer/services/CreateExperiment.java
@@ -28,7 +28,10 @@ import com.autotune.analyzer.serviceObjects.Converters;
 import com.autotune.analyzer.serviceObjects.CreateExperimentAPIObject;
 import com.autotune.analyzer.serviceObjects.KubernetesAPIObject;
 import com.autotune.analyzer.utils.AnalyzerConstants;
+import static com.autotune.analyzer.utils.AnalyzerConstants.ServiceConstants.CHARACTER_ENCODING;
+import static com.autotune.analyzer.utils.AnalyzerConstants.ServiceConstants.JSON_CONTENT_TYPE;
 import com.autotune.analyzer.utils.AnalyzerErrorConstants;
+import com.autotune.analyzer.utils.ExperimentCache;
 import com.autotune.analyzer.utils.ServiceHelpers;
 import com.autotune.common.data.ValidationOutputData;
 import com.autotune.database.dao.ExperimentDAO;
@@ -58,9 +61,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
-import static com.autotune.analyzer.utils.AnalyzerConstants.ServiceConstants.CHARACTER_ENCODING;
-import static com.autotune.analyzer.utils.AnalyzerConstants.ServiceConstants.JSON_CONTENT_TYPE;
-
 /**
  * REST API to create experiments to Analyser for monitoring metrics.
  */
@@ -68,6 +68,9 @@ import static com.autotune.analyzer.utils.AnalyzerConstants.ServiceConstants.JSO
 public class CreateExperiment extends HttpServlet {
     private static final long serialVersionUID = 1L;
     private static final Logger LOGGER = LoggerFactory.getLogger(CreateExperiment.class);
+    
+    private static final ExperimentCache experimentCache = new ExperimentCache();
+    private static final Gson gson = new Gson();
 
     @Override
     public void init(ServletConfig config) throws ServletException {
@@ -97,12 +100,20 @@ public class CreateExperiment extends HttpServlet {
             // Set the character encoding of the request to UTF-8
             request.setCharacterEncoding(CHARACTER_ENCODING);
             inputData = request.getReader().lines().collect(Collectors.joining());
-            List<CreateExperimentAPIObject> createExperimentAPIObjects = Arrays.asList(
-                    new Gson().fromJson(inputData, CreateExperimentAPIObject[].class)
-            );
-
+            List<CreateExperimentAPIObject> createExperimentAPIObjects = Arrays.asList(gson.fromJson(inputData, CreateExperimentAPIObject[].class));
+            
             // check for bulk entries and respond accordingly
             ServiceHelpers.checkForBulk(createExperimentAPIObjects);
+
+            // Check if experiment already exists before processing
+            for (CreateExperimentAPIObject createExperimentAPIObject : createExperimentAPIObjects) {
+                String experimentName = createExperimentAPIObject.getExperimentName();
+                if (experimentCache.isExists(experimentName)) {
+                    LOGGER.debug("Experiment {} already exists, returning 409", experimentName);
+                    sendErrorResponse(inputData, response, null, HttpServletResponse.SC_CONFLICT, "Experiment name already exists");
+                    return;
+                }
+            }
 
             List<KruizeObject> kruizeExpList = ServiceHelpers.normalizeAndValidateExperimentTypes(
                     createExperimentAPIObjects
@@ -112,7 +123,7 @@ public class CreateExperiment extends HttpServlet {
             //TODO: UX needs to be modified - Handle response for the multiple objects
             KruizeObject invalidKruizeObject = kruizeExpList.stream().filter((ko) -> (!ko.getValidation_data().isSuccess())).findAny().orElse(null);
             if (null == invalidKruizeObject) {
-                ValidationOutputData addedToDB = null;  // TODO savetoDB should move to queue and bulk upload not considered here
+                ValidationOutputData addedToDB = null;
                 for (KruizeObject ko : kruizeExpList) {
                     CreateExperimentAPIObject validAPIObj = createExperimentAPIObjects.stream()
                             .filter(createObj -> ko.getExperimentName().equals(createObj.getExperimentName()))
@@ -126,6 +137,18 @@ public class CreateExperiment extends HttpServlet {
                         ServiceHelpers.detectLayers(validAPIObj);
                     }
                     addedToDB = new ExperimentDBService().addExperimentToDB(validAPIObj);
+                    
+                    if (addedToDB.isSuccess()) {
+                        experimentCache.add(ko.getExperimentName());
+                    } else {
+                        // Check if experiment already exists
+                        if (addedToDB.getMessage() != null && addedToDB.getMessage().contains("already exists")) {
+                            LOGGER.debug("Experiment {} already exists, returning 409", ko.getExperimentName());
+                            experimentCache.add(ko.getExperimentName());
+                            sendErrorResponse(inputData, response, null, HttpServletResponse.SC_CONFLICT, "Experiment name already exists");
+                            return;
+                        }
+                    }
                 }
                 if (addedToDB.isSuccess()) {
                     sendSuccessResponse(response, "Experiment registered successfully with Kruize.");
@@ -219,7 +242,7 @@ public class CreateExperiment extends HttpServlet {
         response.setStatus(HttpServletResponse.SC_CREATED);
         PrintWriter out = response.getWriter();
         out.append(
-                new Gson().toJson(
+                gson.toJson(
                         new KruizeResponse(message + " View registered experiments at /listExperiments", HttpServletResponse.SC_CREATED, "", "SUCCESS")
                 )
         );

--- a/src/main/java/com/autotune/analyzer/utils/ExperimentCache.java
+++ b/src/main/java/com/autotune/analyzer/utils/ExperimentCache.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package com.autotune.analyzer.utils;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.autotune.analyzer.kruizeObject.KruizeObject;
+import com.autotune.database.service.ExperimentDBService;
+import com.autotune.operator.KruizeDeploymentInfo;
+
+/**
+ * Cache implementation for experiment names to avoid frequent database lookups.
+ * Handles cache miss by loading from appropriate database table based on 
+ * KruizeDeploymentInfo.is_ros_enabled configuration.
+ */
+public class ExperimentCache {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExperimentCache.class);
+    
+    private final Set<String> experimentNamesCache = ConcurrentHashMap.newKeySet();
+    
+    /**
+     * Check if an experiment exists in cache or database.
+     *
+     * Fast path:
+     *   - Null check
+     *   - Concurrent cache lookup
+     * Slow path:
+     *   - DB lookup (potentially blocking)
+     *   - On positive hit, cache the experiment name
+     *
+     * This avoids serializing callers on a single monitor while still keeping the cache consistent.
+     * 
+     * @param experiment_name the experiment name to check
+     * @return true if experiment exists, false otherwise
+     */
+    public boolean isExists(String experiment_name) {
+        if (experiment_name == null) {
+            return false;
+        }
+        if (experimentNamesCache.contains(experiment_name)) {
+            LOGGER.debug("Experiment {} found in cache", experiment_name);
+            return true;
+        }
+
+        // Slow-path DB lookup outside any lock to avoid serializing callers
+        boolean existsInDb = checkExperimentInDatabase(experiment_name);
+
+        // If found in DB, cache it for future calls
+        if (existsInDb) {
+            experimentNamesCache.add(experiment_name);
+            LOGGER.debug("Experiment {} found in database, added to cache", experiment_name);
+            return true;
+        }
+
+        return false;
+    }
+    
+    /**
+     * Helper method to check if experiment exists in database using existing ExperimentDBService API.
+     * 
+     * @param experiment_name the experiment name to check
+     * @return true if experiment exists in database, false otherwise
+     */
+    private boolean checkExperimentInDatabase(String experiment_name) {
+        Map<String, KruizeObject> experimentMap = new ConcurrentHashMap<>();
+        try {
+            ExperimentDBService experimentDBService = new ExperimentDBService();
+            if (KruizeDeploymentInfo.is_ros_enabled) {
+                // load from kruize_experiments table
+                experimentDBService.loadExperimentFromDBByName(experimentMap, experiment_name);
+            } else {
+                // load from kruize_lm_experiments table
+                experimentDBService.loadLMExperimentFromDBByName(experimentMap, experiment_name);
+            }
+            
+            return experimentMap.containsKey(experiment_name);
+        } catch (Exception e) {
+            LOGGER.debug("Database check for experiment {} failed: {}", experiment_name, e.getMessage());
+            return false;
+        }
+    }
+    
+    /**
+     * Add an experiment name to the cache.
+     * 
+     * @param experiment_name the experiment name to add
+     */
+    public void add(String experiment_name) {
+        if (experiment_name != null) {
+            experimentNamesCache.add(experiment_name);
+            LOGGER.debug("Added experiment {} to cache", experiment_name);
+        }
+    }
+    
+    /**
+     * Remove an experiment name from the cache.
+     * 
+     * @param experiment_name the experiment name to remove
+     */
+    public void remove(String experiment_name) {
+        if (experiment_name != null) {
+            boolean removed = experimentNamesCache.remove(experiment_name);
+            if (removed) {
+                LOGGER.debug("Removed experiment {} from cache", experiment_name);
+            }
+        }
+    }
+}

--- a/src/main/java/com/autotune/analyzer/utils/ExperimentCache.java
+++ b/src/main/java/com/autotune/analyzer/utils/ExperimentCache.java
@@ -16,6 +16,7 @@
 
 package com.autotune.analyzer.utils;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -82,7 +83,7 @@ public class ExperimentCache {
      * @return true if experiment exists in database, false otherwise
      */
     private boolean checkExperimentInDatabase(String experiment_name) {
-        Map<String, KruizeObject> experimentMap = new ConcurrentHashMap<>();
+        Map<String, KruizeObject> experimentMap = new HashMap<>();
         try {
             if (KruizeDeploymentInfo.is_ros_enabled) {
                 // load from kruize_experiments table

--- a/src/main/java/com/autotune/analyzer/utils/ExperimentCache.java
+++ b/src/main/java/com/autotune/analyzer/utils/ExperimentCache.java
@@ -36,6 +36,7 @@ public class ExperimentCache {
     private static final Logger LOGGER = LoggerFactory.getLogger(ExperimentCache.class);
     
     private final Set<String> experimentNamesCache = ConcurrentHashMap.newKeySet();
+    private final ExperimentDBService experimentDBService = new ExperimentDBService();
     
     /**
      * Check if an experiment exists in cache or database.
@@ -83,7 +84,6 @@ public class ExperimentCache {
     private boolean checkExperimentInDatabase(String experiment_name) {
         Map<String, KruizeObject> experimentMap = new ConcurrentHashMap<>();
         try {
-            ExperimentDBService experimentDBService = new ExperimentDBService();
             if (KruizeDeploymentInfo.is_ros_enabled) {
                 // load from kruize_experiments table
                 experimentDBService.loadExperimentFromDBByName(experimentMap, experiment_name);

--- a/src/main/java/com/autotune/analyzer/utils/ExperimentCache.java
+++ b/src/main/java/com/autotune/analyzer/utils/ExperimentCache.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Red Hat, IBM Corporation and others.
+ * Copyright (c) 2026 Red Hat, IBM Corporation and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Original PR had to recreate due to wrong branch: https://github.com/kruize/autotune/pull/1782

## Description

Added a experimentCache to be used in createExperiment to check for existing experiments.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [x] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Introduce an in-memory experiment cache to avoid redundant database lookups when creating and deleting experiments.

New Features:
- Add an ExperimentCache utility to track existing experiment names using an in-memory set backed by on-demand database lookups.
- Enforce conflict responses when attempting to create an experiment with a name that already exists.

Enhancements:
- Reuse singleton Gson and ExperimentDBService instances within CreateExperiment to avoid repeated object creation.
- Simplify experiment deletion by relying on the new cache instead of preloading experiments into an in-memory map.

## Summary by Sourcery

Introduce an in-memory experiment cache to optimize experiment creation and enforce unique experiment names.

New Features:
- Add an ExperimentCache utility to track and cache experiment names using database lookups on cache misses.
- Validate experiment creation requests against the cache and return HTTP 409 when an experiment name already exists.

Enhancements:
- Reuse a shared Gson instance in CreateExperiment instead of creating new instances for each request.
- Cache experiment names after successful database writes and handle duplicate-name errors consistently in API responses.

## Summary by Sourcery

Introduce an in-memory experiment cache to optimize experiment creation and enforce unique experiment names.

New Features:
- Add an ExperimentCache utility to track experiment names backed by on-demand database lookups.
- Use the experiment cache in the CreateExperiment servlet to prevent creation of experiments with duplicate names and return HTTP 409 conflicts.

Enhancements:
- Reuse a shared Gson instance in the CreateExperiment servlet instead of creating a new instance per request.