### PR TITLE
Update computation logic for pod count

### DIFF
--- a/src/main/java/com/autotune/analyzer/adapters/MetricAggregationInfoResultsIntSerializer.java
+++ b/src/main/java/com/autotune/analyzer/adapters/MetricAggregationInfoResultsIntSerializer.java
@@ -1,0 +1,36 @@
+package com.autotune.analyzer.adapters;
+
+import com.autotune.common.data.metrics.MetricAggregationInfoResults;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import java.lang.reflect.Type;
+
+public class MetricAggregationInfoResultsIntSerializer implements JsonSerializer<MetricAggregationInfoResults> {
+
+    @Override
+    public JsonElement serialize(MetricAggregationInfoResults metricAggregationInfoResults, Type type, JsonSerializationContext jsonSerializationContext) {
+        JsonObject jsonObject = new JsonObject();
+        if(metricAggregationInfoResults.getAvg() != null)
+            jsonObject.addProperty("avg", metricAggregationInfoResults.getAvg().intValue());
+        if(metricAggregationInfoResults.getSum() != null)
+            jsonObject.addProperty("sum", metricAggregationInfoResults.getSum().intValue());
+        if(metricAggregationInfoResults.getMin() != null)
+            jsonObject.addProperty("min", metricAggregationInfoResults.getMin().intValue());
+        if(metricAggregationInfoResults.getMax() != null)
+            jsonObject.addProperty("max", metricAggregationInfoResults.getMax().intValue());
+        if(metricAggregationInfoResults.getCount() != null)
+            jsonObject.addProperty("count", metricAggregationInfoResults.getCount());
+        if(metricAggregationInfoResults.getMedian() != null)
+            jsonObject.addProperty("median", metricAggregationInfoResults.getMedian().intValue());
+        if(metricAggregationInfoResults.getMode() != null)
+            jsonObject.addProperty("mode", metricAggregationInfoResults.getMode().intValue());
+        if(metricAggregationInfoResults.getRange() != null)
+            jsonObject.addProperty("range", metricAggregationInfoResults.getRange().intValue());
+        if(metricAggregationInfoResults.getFormat() != null && !metricAggregationInfoResults.getFormat().isEmpty())
+            jsonObject.addProperty("format", metricAggregationInfoResults.getFormat());
+        return jsonObject;
+    }
+}

--- a/src/main/java/com/autotune/analyzer/kruizeObject/KruizeObject.java
+++ b/src/main/java/com/autotune/analyzer/kruizeObject/KruizeObject.java
@@ -443,13 +443,13 @@ public final class KruizeObject implements ExperimentTypeAware {
 
         switch (term) {
             case KruizeConstants.JSONKeys.SHORT_TERM:
-                minDataPoints = KruizeConstants.RecommendationEngineConstants.DurationBasedEngine.DurationAmount.SHORT_TERM_MIN_DATAPOINTS;
+                minDataPoints = KruizeConstants.RecommendationEngineConstants.DurationBasedEngine.DurationAmount.SHORT_TERM_MIN_DATAPOINTS; // 2
                 break;
             case KruizeConstants.JSONKeys.MEDIUM_TERM:
-                minDataPoints = KruizeConstants.RecommendationEngineConstants.DurationBasedEngine.DurationAmount.MEDIUM_TERM_MIN_DATAPOINTS;
+                minDataPoints = KruizeConstants.RecommendationEngineConstants.DurationBasedEngine.DurationAmount.MEDIUM_TERM_MIN_DATAPOINTS; // 192
                 break;
             case KruizeConstants.JSONKeys.LONG_TERM:
-                minDataPoints = KruizeConstants.RecommendationEngineConstants.DurationBasedEngine.DurationAmount.LONG_TERM_MIN_DATAPOINTS;
+                minDataPoints = KruizeConstants.RecommendationEngineConstants.DurationBasedEngine.DurationAmount.LONG_TERM_MIN_DATAPOINTS; // 768
                 break;
         }
 

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
@@ -182,6 +182,7 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
             } else {
                 // Determine min, max, avg pod count for a given term
                 MetricAggregationInfoResults podCountAggrInfo = getPodCountAggrInfo(filteredResultsMap);
+                LOGGER.info("[{}] pod count aggr results: {}", kruizeObject.getExperimentName(), podCountAggrInfo);
                 mappedRecommendationForTerm.addMetricsInfo(KruizeConstants.JSONKeys.POD_COUNT, podCountAggrInfo);
 
                 ArrayList<RecommendationNotification> termLevelNotifications = new ArrayList<>();
@@ -300,7 +301,7 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
     private static MetricAggregationInfoResults getPodCountAggrInfo(Map<Timestamp, IntervalResults> filteredResultsMap) {
         MetricAggregationInfoResults metricAggregationInfoResults = new MetricAggregationInfoResults();
         Double avg = 0.0, min = 0.0, max = 0.0;
-        LOGGER.debug("filteredResultsMap: size = {}", filteredResultsMap.size());
+        LOGGER.info("filteredResultsMap: size = {}", filteredResultsMap.size());
 
         // 1. Use 'podCount' metric data points
         List<MetricAggregationInfoResults> podCountMetrics = filteredResultsMap.values().stream()
@@ -310,7 +311,7 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
                 .map(metricEntry -> metricEntry.getValue().getAggregationInfoResult())
                 .filter(aggInfo -> aggInfo != null && aggInfo.getAvg() != null)
                 .toList();
-        LOGGER.debug("podCountMetrics : size = {}, content = {}", podCountMetrics.size(), podCountMetrics);
+        LOGGER.info("podCountMetrics : size = {}, content = {}", podCountMetrics.size(), podCountMetrics);
         if (!podCountMetrics.isEmpty()) {
             avg = podCountMetrics.stream()
                     .mapToDouble(MetricAggregationInfoResults::getAvg)
@@ -341,7 +342,7 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
                 .map(metricEntry -> metricEntry.getValue().getAggregationInfoResult())
                 .filter(aggInfo -> (aggInfo != null && aggInfo.getAvg() != null && aggInfo.getAvg() != 0.0 && aggInfo.getSum() != null))
                 .toList();
-        LOGGER.debug("cpuUsageMetrics : size = {}, content = {}", cpuUsageMetrics.size(), cpuUsageMetrics);
+        LOGGER.info("cpuUsageMetrics : size = {}, content = {}", cpuUsageMetrics.size(), cpuUsageMetrics);
         if (!cpuUsageMetrics.isEmpty()) {
             List<Double> calcPodCounts = cpuUsageMetrics.stream()
                     .mapToDouble(aggInfo -> aggInfo.getSum() / aggInfo.getAvg())
@@ -368,7 +369,7 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
                 .map(metricEntry -> metricEntry.getValue().getAggregationInfoResult())
                 .filter(aggInfo -> (aggInfo != null && aggInfo.getAvg() != null && aggInfo.getAvg() != 0.0 && aggInfo.getSum() != null))
                 .toList();
-        LOGGER.debug("memoryUsageMetrics : size = {}, content = {}", memoryUsageMetrics.size(), memoryUsageMetrics);
+        LOGGER.info("memoryUsageMetrics : size = {}, content = {}", memoryUsageMetrics.size(), memoryUsageMetrics);
         if (!memoryUsageMetrics.isEmpty()) {
             List<Double> calcPodCounts = memoryUsageMetrics.stream()
                     .mapToDouble(aggInfo -> aggInfo.getSum() / aggInfo.getAvg())

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
@@ -298,6 +298,18 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
         return mappedRecommendationForModel;
     }
 
+    /**
+     * getPodCountAggrInfo is utility function responsible to determine min, max and avg of pods based on following sequence
+     *
+     * 1. From 'podCount' metric data if exists.
+     * 2. From 'cpuUsage' metric data using formulae avg(sum/avg), min(sum/avg), max(sum/avg).
+     * 3. From 'memoryUsage' metric data using formulae avg(sum/avg), min(sum/avg), max(sum/avg).
+     *
+     * To avoid issues with formulae, results are filtered to chose datapoints whose sum, avg is not null and avg is not 0.0.
+     *
+     * @param filteredResultsMap
+     * @return aggregated results like min, max, avg of pods from the results supplied.
+     */
     private static MetricAggregationInfoResults getPodCountAggrInfo(Map<Timestamp, IntervalResults> filteredResultsMap) {
         MetricAggregationInfoResults metricAggregationInfoResults = new MetricAggregationInfoResults();
         Double avg = 0.0, min = 0.0, max = 0.0;

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
@@ -28,6 +28,7 @@ import com.autotune.analyzer.recommendations.term.Terms;
 import com.autotune.analyzer.recommendations.utils.RecommendationUtils;
 import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.analyzer.utils.AnalyzerErrorConstants;
+import com.autotune.common.data.metrics.MetricAggregationInfoResults;
 import com.autotune.common.data.metrics.MetricResults;
 import com.autotune.common.data.result.ContainerData;
 import com.autotune.common.data.result.IntervalResults;
@@ -167,18 +168,25 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
             Timestamp monitoringStartTime = Terms.getMonitoringStartTime(monitoringEndTime, duration);
             LOGGER.debug(String.format(KruizeConstants.APIMessages.MONITORING_START_TIME, monitoringStartTime));
 
+            // Extract the datapoints from monitoringStartTime to monitoringEndTime to be used for all recommendation models
+            Map<Timestamp, IntervalResults> filteredResultsMap = null;
+            if (containerData.getResults() != null) {
+                filteredResultsMap = containerData.getResults().entrySet().stream().filter(entry -> (entry.getKey().after(monitoringStartTime) && entry.getKey().before(monitoringEndTime))).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            }
+
             TermRecommendations mappedRecommendationForTerm = new TermRecommendations();
-            if (!Terms.checkIfMinDataAvailableForTerm(containerData, terms, monitoringEndTime, measurementDuration)) {
+            if (!Terms.checkIfMinDataAvailableForTerm(filteredResultsMap, terms, measurementDuration)) {
                 RecommendationNotification recommendationNotification = new RecommendationNotification(
                         RecommendationConstants.RecommendationNotification.INFO_NOT_ENOUGH_DATA);
                 mappedRecommendationForTerm.addNotification(recommendationNotification);
             } else {
+                // Determine min, max, avg pod count for a given term
+                MetricAggregationInfoResults podCountAggrInfo = getPodCountAggrInfo(filteredResultsMap);
+                mappedRecommendationForTerm.addMetricsInfo(KruizeConstants.JSONKeys.POD_COUNT, podCountAggrInfo);
+
                 ArrayList<RecommendationNotification> termLevelNotifications = new ArrayList<>();
                 for (RecommendationModel model : engineService.getModels()) {
-                    MappedRecommendationForModel mappedRecommendationForModel = generateRecommendationBasedOnModel(
-                            monitoringStartTime, model, containerData, monitoringEndTime, kruizeObject, currentConfig, termsEntry);
-
-                    if (null == mappedRecommendationForModel) continue;
+                    MappedRecommendationForModel mappedRecommendationForModel = generateRecommendationBasedOnModel(model, containerData, filteredResultsMap, kruizeObject, currentConfig, termsEntry);
 
                     RecommendationNotification rn = RecommendationNotification.getNotificationForTermAvailability(recommendationTerm);
                     if (null != rn) {
@@ -236,8 +244,9 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
         return recommendationAvailable;
     }
 
-    private MappedRecommendationForModel generateRecommendationBasedOnModel(Timestamp monitoringStartTime, RecommendationModel model, ContainerData containerData,
-                                                                            Timestamp monitoringEndTime, KruizeObject kruizeObject,
+    private MappedRecommendationForModel generateRecommendationBasedOnModel(RecommendationModel model, ContainerData containerData,
+                                                                            Map<Timestamp, IntervalResults> filteredResultsMap,
+                                                                            KruizeObject kruizeObject,
                                                                             HashMap<AnalyzerConstants.ResourceSetting,
                                                                                     HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> currentConfigMap,
                                                                             Map.Entry<String, Terms> termEntry) {
@@ -256,64 +265,129 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
         RecommendationConfigItem currentMemRequest = currentConfig.memoryRequest;
         RecommendationConfigItem currentMemLimit = currentConfig.memoryLimit;
 
-        if (null != monitoringStartTime) {
-            Timestamp finalMonitoringStartTime = monitoringStartTime;
-            Map<Timestamp, IntervalResults> filteredResultsMap = containerData.getResults().entrySet().stream()
-                    .filter((x -> ((x.getKey().compareTo(finalMonitoringStartTime) >= 0) && (x.getKey().compareTo(monitoringEndTime) <= 0))))
-                    .collect((Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+        ArrayList<RecommendationNotification> notifications = new ArrayList<>();
+        RecommendationConfigItem recommendationCpuRequest = model.getCPURequestRecommendation(filteredResultsMap, notifications);
+        RecommendationConfigItem recommendationMemRequest = model.getMemoryRequestRecommendation(filteredResultsMap, notifications);
+        Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> recommendationAcceleratorRequestMap = model.getAcceleratorRequestRecommendation(filteredResultsMap, notifications);
 
-            int numPods = getNumPods(filteredResultsMap);
-            mappedRecommendationForModel.setPodsCount(numPods);
+        RecommendationConfigItem recommendationCpuLimits = recommendationCpuRequest;
+        RecommendationConfigItem recommendationMemLimits = recommendationMemRequest;
 
-            ArrayList<RecommendationNotification> notifications = new ArrayList<>();
-            RecommendationConfigItem recommendationCpuRequest = model.getCPURequestRecommendation(filteredResultsMap, notifications);
-            RecommendationConfigItem recommendationMemRequest = model.getMemoryRequestRecommendation(filteredResultsMap, notifications);
-            Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> recommendationAcceleratorRequestMap = model.getAcceleratorRequestRecommendation(filteredResultsMap, notifications);
+        HashMap<String, RecommendationConfigItem> internalMapToPopulate = new HashMap<>();
+        internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.CURRENT_CPU_REQUEST, currentCPURequest);
+        internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.CURRENT_CPU_LIMIT, currentCPULimit);
+        internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.CURRENT_MEMORY_REQUEST, currentMemRequest);
+        internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.CURRENT_MEMORY_LIMIT, currentMemLimit);
+        internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.RECOMMENDED_CPU_REQUEST, recommendationCpuRequest);
+        internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.RECOMMENDED_CPU_LIMIT, recommendationCpuLimits);
+        internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.RECOMMENDED_MEMORY_REQUEST, recommendationMemRequest);
+        internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.RECOMMENDED_MEMORY_LIMIT, recommendationMemLimits);
+        List<RecommendationConfigEnv> runtimeRecommList = null;
 
-            RecommendationConfigItem recommendationCpuLimits = recommendationCpuRequest;
-            RecommendationConfigItem recommendationMemLimits = recommendationMemRequest;
-
-            HashMap<String, RecommendationConfigItem> internalMapToPopulate = new HashMap<>();
-            internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.CURRENT_CPU_REQUEST, currentCPURequest);
-            internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.CURRENT_CPU_LIMIT, currentCPULimit);
-            internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.CURRENT_MEMORY_REQUEST, currentMemRequest);
-            internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.CURRENT_MEMORY_LIMIT, currentMemLimit);
-            internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.RECOMMENDED_CPU_REQUEST, recommendationCpuRequest);
-            internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.RECOMMENDED_CPU_LIMIT, recommendationCpuLimits);
-            internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.RECOMMENDED_MEMORY_REQUEST, recommendationMemRequest);
-            internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.RECOMMENDED_MEMORY_LIMIT, recommendationMemLimits);
-            List<RecommendationConfigEnv> runtimeRecommList = null;
-
-            try {
-                if (RuntimeRecommendationProcessor.isRuntimeLayerPresent(containerData.getLayerMap())) {
-                    runtimeRecommList = RuntimeRecommendationProcessor.handleRuntimeRecommendations(kruizeObject, containerData, model, filteredResultsMap, notifications, recommendationCpuRequest, recommendationMemRequest, recommendationCpuLimits, recommendationMemLimits);
-                }
-            } catch (Exception e) {
-                LOGGER.error("Exception occurred while preparing runtime recommendations: {}", e.getMessage());
+        try {
+            if (RuntimeRecommendationProcessor.isRuntimeLayerPresent(containerData.getLayerMap())) {
+                runtimeRecommList = RuntimeRecommendationProcessor.handleRuntimeRecommendations(kruizeObject, containerData, model, filteredResultsMap, notifications, recommendationCpuRequest, recommendationMemRequest, recommendationCpuLimits, recommendationMemLimits);
             }
-
-            engineService.populateRecommendation(termEntry, mappedRecommendationForModel, notifications, internalMapToPopulate, numPods, cpuThreshold, memoryThreshold, recommendationAcceleratorRequestMap, runtimeRecommList);
-        } else {
-            RecommendationNotification notification = new RecommendationNotification(
-                    RecommendationConstants.RecommendationNotification.INFO_NOT_ENOUGH_DATA);
-            mappedRecommendationForModel.addNotification(notification);
+        } catch (Exception e) {
+            LOGGER.error("Exception occurred while preparing runtime recommendations: {}", e.getMessage());
         }
+
+        engineService.populateRecommendation(termEntry, mappedRecommendationForModel, notifications, internalMapToPopulate, cpuThreshold, memoryThreshold, recommendationAcceleratorRequestMap, runtimeRecommList);
+
         return mappedRecommendationForModel;
     }
 
-    private static int getNumPods(Map<Timestamp, IntervalResults> filteredResultsMap) {
-        Double max_pods_cpu = filteredResultsMap.values().stream()
-                .map(e -> {
-                    Optional<MetricResults> cpuUsageResults = Optional.ofNullable(e.getMetricResultsMap().get(AnalyzerConstants.MetricName.cpuUsage));
-                    double cpuUsageSum = cpuUsageResults.map(m -> m.getAggregationInfoResult().getSum()).orElse(0.0);
-                    double cpuUsageAvg = cpuUsageResults.map(m -> m.getAggregationInfoResult().getAvg()).orElse(0.0);
-                    double numPods = 0;
-                    if (0 != cpuUsageAvg) {
-                        numPods = (int) Math.ceil(cpuUsageSum / cpuUsageAvg);
-                    }
-                    return numPods;
-                })
-                .max(Double::compareTo).get();
-        return (int) Math.ceil(max_pods_cpu);
+    private static MetricAggregationInfoResults getPodCountAggrInfo(Map<Timestamp, IntervalResults> filteredResultsMap) {
+        MetricAggregationInfoResults metricAggregationInfoResults = new MetricAggregationInfoResults();
+        Double avg = 0.0, min = 0.0, max = 0.0;
+        LOGGER.debug("filteredResultsMap: size = {}", filteredResultsMap.size());
+
+        // 1. Use 'podCount' metric data points
+        List<MetricAggregationInfoResults> podCountMetrics = filteredResultsMap.values().stream()
+                .filter(results -> results.getMetricResultsMap() != null)
+                .flatMap(results -> results.getMetricResultsMap().entrySet().stream())
+                .filter(metricEntry -> metricEntry.getKey() == AnalyzerConstants.MetricName.podCount)
+                .map(metricEntry -> metricEntry.getValue().getAggregationInfoResult())
+                .filter(aggInfo -> aggInfo != null && aggInfo.getAvg() != null)
+                .toList();
+        LOGGER.debug("podCountMetrics : size = {}, content = {}", podCountMetrics.size(), podCountMetrics);
+        if (!podCountMetrics.isEmpty()) {
+            avg = podCountMetrics.stream()
+                    .mapToDouble(MetricAggregationInfoResults::getAvg)
+                    .average()
+                    .orElse(0.0);
+            if (avg > 0.0) {
+                min = podCountMetrics.stream()
+                        .mapToDouble(MetricAggregationInfoResults::getMin)
+                        .min()
+                        .orElse(0.0);
+                max = podCountMetrics.stream()
+                        .mapToDouble(MetricAggregationInfoResults::getMax)
+                        .max()
+                        .orElse(0.0);
+                metricAggregationInfoResults.setAvg(Math.ceil(avg));
+                metricAggregationInfoResults.setMin(Math.ceil(min));
+                metricAggregationInfoResults.setMax(Math.ceil(max));
+                LOGGER.info("Pod Count Aggregation Info: avg = {} min={}, max={}", avg, min, max);
+                return metricAggregationInfoResults;
+            }
+        }
+
+        // 2. Calculate from 'cpuUsage' datapoints using formulae avg of 'sum/avg', min of 'sum/avg', max of 'sum/avg'
+        List<MetricAggregationInfoResults> cpuUsageMetrics = filteredResultsMap.values().stream()
+                .filter(results -> results.getMetricResultsMap() != null)
+                .flatMap(results -> results.getMetricResultsMap().entrySet().stream())
+                .filter(metricEntry -> metricEntry.getKey() == AnalyzerConstants.MetricName.cpuUsage)
+                .map(metricEntry -> metricEntry.getValue().getAggregationInfoResult())
+                .filter(aggInfo -> (aggInfo != null && aggInfo.getAvg() != null && aggInfo.getSum() != null))
+                .toList();
+        LOGGER.debug("cpuUsageMetrics : size = {}, content = {}", cpuUsageMetrics.size(), cpuUsageMetrics);
+        if (!cpuUsageMetrics.isEmpty()) {
+            List<Double> calcPodCounts = cpuUsageMetrics.stream()
+                    .mapToDouble(aggInfo -> aggInfo.getSum() / aggInfo.getAvg())
+                    .boxed()
+                    .toList();
+
+            avg = calcPodCounts.stream().mapToDouble(Double::doubleValue).average().orElse(0.0);
+            min = calcPodCounts.stream().mapToDouble(Double::doubleValue).min().orElse(0.0);
+            max = calcPodCounts.stream().mapToDouble(Double::doubleValue).max().orElse(0.0);
+            if (avg > 0.0) {
+                metricAggregationInfoResults.setAvg(Math.ceil(avg));
+                metricAggregationInfoResults.setMin(Math.ceil(min));
+                metricAggregationInfoResults.setMax(Math.ceil(max));
+                LOGGER.info("Pod Count Aggregation Info calculated using cpuUsage metric : avg = {} min={}, max={}", avg, min, max);
+                return metricAggregationInfoResults;
+            }
+        }
+
+        // 3. Calculate from 'memoryUsage' datapoints using formulae avg of 'sum/avg', min of 'sum/avg', max of 'sum/avg'
+        List<MetricAggregationInfoResults> memoryUsageMetrics = filteredResultsMap.values().stream()
+                .filter(results -> results.getMetricResultsMap() != null)
+                .flatMap(results -> results.getMetricResultsMap().entrySet().stream())
+                .filter(metricEntry -> metricEntry.getKey() == AnalyzerConstants.MetricName.memoryUsage)
+                .map(metricEntry -> metricEntry.getValue().getAggregationInfoResult())
+                .filter(aggInfo -> (aggInfo != null && aggInfo.getAvg() != null && aggInfo.getSum() != null))
+                .toList();
+        LOGGER.debug("memoryUsageMetrics : size = {}, content = {}", memoryUsageMetrics.size(), memoryUsageMetrics);
+        if (!memoryUsageMetrics.isEmpty()) {
+            List<Double> calcPodCounts = memoryUsageMetrics.stream()
+                    .mapToDouble(aggInfo -> aggInfo.getSum() / aggInfo.getAvg())
+                    .boxed()
+                    .toList();
+
+            avg = calcPodCounts.stream().mapToDouble(Double::doubleValue).average().orElse(0.0);
+            min = calcPodCounts.stream().mapToDouble(Double::doubleValue).min().orElse(0.0);
+            max = calcPodCounts.stream().mapToDouble(Double::doubleValue).max().orElse(0.0);
+            if (avg > 0.0) {
+                metricAggregationInfoResults.setAvg(Math.ceil(avg));
+                metricAggregationInfoResults.setMin(Math.ceil(min));
+                metricAggregationInfoResults.setMax(Math.ceil(max));
+                LOGGER.info("Pod Count Aggregation Info calculated using memoryUsage metric : avg = {} min={}, max={}", avg, min, max);
+                return metricAggregationInfoResults;
+            }
+        }
+
+        LOGGER.error("Failed to calculate Pod Count Aggregation Info. Size of : podCountMetrics = {}, cpuUsageMetrics = {}, memoryUsageMetrics = {}", podCountMetrics.size(), cpuUsageMetrics.size(), memoryUsageMetrics.size());
+        return null;
     }
 }

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
@@ -339,7 +339,7 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
                 .flatMap(results -> results.getMetricResultsMap().entrySet().stream())
                 .filter(metricEntry -> metricEntry.getKey() == AnalyzerConstants.MetricName.cpuUsage)
                 .map(metricEntry -> metricEntry.getValue().getAggregationInfoResult())
-                .filter(aggInfo -> (aggInfo != null && aggInfo.getAvg() != null && aggInfo.getSum() != null))
+                .filter(aggInfo -> (aggInfo != null && aggInfo.getAvg() != null && aggInfo.getAvg() != 0.0 && aggInfo.getSum() != null))
                 .toList();
         LOGGER.debug("cpuUsageMetrics : size = {}, content = {}", cpuUsageMetrics.size(), cpuUsageMetrics);
         if (!cpuUsageMetrics.isEmpty()) {
@@ -366,7 +366,7 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
                 .flatMap(results -> results.getMetricResultsMap().entrySet().stream())
                 .filter(metricEntry -> metricEntry.getKey() == AnalyzerConstants.MetricName.memoryUsage)
                 .map(metricEntry -> metricEntry.getValue().getAggregationInfoResult())
-                .filter(aggInfo -> (aggInfo != null && aggInfo.getAvg() != null && aggInfo.getSum() != null))
+                .filter(aggInfo -> (aggInfo != null && aggInfo.getAvg() != null && aggInfo.getAvg() != 0.0 && aggInfo.getSum() != null))
                 .toList();
         LOGGER.debug("memoryUsageMetrics : size = {}, content = {}", memoryUsageMetrics.size(), memoryUsageMetrics);
         if (!memoryUsageMetrics.isEmpty()) {

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
@@ -171,7 +171,7 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
             // Extract the datapoints from monitoringStartTime to monitoringEndTime to be used for all recommendation models
             Map<Timestamp, IntervalResults> filteredResultsMap = null;
             if (containerData.getResults() != null) {
-                filteredResultsMap = containerData.getResults().entrySet().stream().filter(entry -> (entry.getKey().after(monitoringStartTime) && entry.getKey().before(monitoringEndTime))).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                filteredResultsMap = containerData.getResults().entrySet().stream().filter(entry -> (entry.getKey().compareTo(monitoringStartTime) >= 0 && entry.getKey().compareTo(monitoringEndTime) <= 0)).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
             }
 
             TermRecommendations mappedRecommendationForTerm = new TermRecommendations();

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/NamespaceRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/NamespaceRecommendationProcessor.java
@@ -178,7 +178,7 @@ public final class NamespaceRecommendationProcessor extends BaseRecommendationPr
             // Extract the datapoints from monitoringStartTime to monitoringEndTime to be used for all recommendation models
             Map<Timestamp, IntervalResults> filteredResultsMap = null;
             if (namespaceData.getResults() != null) {
-                filteredResultsMap = namespaceData.getResults().entrySet().stream().filter(entry -> (entry.getKey().after(monitoringStartTime) && entry.getKey().before(monitoringEndTime))).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                filteredResultsMap = namespaceData.getResults().entrySet().stream().filter(entry -> (entry.getKey().compareTo(monitoringStartTime) >= 0 && entry.getKey().compareTo(monitoringEndTime) <= 0)).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
             }
 
             TermRecommendations mappedRecommendationForTerm = new TermRecommendations();

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/NamespaceRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/NamespaceRecommendationProcessor.java
@@ -175,18 +175,22 @@ public final class NamespaceRecommendationProcessor extends BaseRecommendationPr
             int duration = termsEntry.getValue().getDays();
             Timestamp monitoringStartTime = Terms.getMonitoringStartTime(monitoringEndTime, duration);
 
+            // Extract the datapoints from monitoringStartTime to monitoringEndTime to be used for all recommendation models
+            Map<Timestamp, IntervalResults> filteredResultsMap = null;
+            if (namespaceData.getResults() != null) {
+                filteredResultsMap = namespaceData.getResults().entrySet().stream().filter(entry -> (entry.getKey().after(monitoringStartTime) && entry.getKey().before(monitoringEndTime))).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            }
+
             TermRecommendations mappedRecommendationForTerm = new TermRecommendations();
-            if (!Terms.checkIfMinDataAvailableForTermForNamespace(namespaceData, terms, monitoringEndTime, measurementDuration)) {
+            if (!Terms.checkIfMinDataAvailableForTermForNamespace(filteredResultsMap, terms, measurementDuration)) {
                 RecommendationNotification recommendationNotification = new RecommendationNotification(RecommendationConstants.RecommendationNotification.INFO_NOT_ENOUGH_DATA);
                 mappedRecommendationForTerm.addNotification(recommendationNotification);
             } else {
                 ArrayList<RecommendationNotification> termLevelNotifications = new ArrayList<>();
                 for (RecommendationModel model : engineService.getModels()) {
                     MappedRecommendationForModel mappedRecommendationForModel = generateNamespaceRecommendationBasedOnModel(
-                            monitoringStartTime, model, namespaceData, monitoringEndTime, kruizeObject.getRecommendation_settings(), currentConfig, termsEntry);
+                            model, filteredResultsMap, kruizeObject.getRecommendation_settings(), currentConfig, termsEntry);
 
-                    if (null == mappedRecommendationForModel)
-                        continue;
 
                     RecommendationNotification rn = RecommendationNotification.getNotificationForTermAvailability(recommendationTerm);
                     if (null != rn) {
@@ -245,10 +249,8 @@ public final class NamespaceRecommendationProcessor extends BaseRecommendationPr
         return namespaceRecommendationAvailable;
     }
 
-    private MappedRecommendationForModel generateNamespaceRecommendationBasedOnModel(Timestamp monitoringStartTime,
-                                                                                    RecommendationModel model,
-                                                                                    NamespaceData namespaceData,
-                                                                                    Timestamp monitoringEndTime,
+    private MappedRecommendationForModel generateNamespaceRecommendationBasedOnModel(RecommendationModel model,
+                                                                                    Map<Timestamp, IntervalResults> filteredResultsMap,
                                                                                     RecommendationSettings recommendationSettings,
                                                                                     HashMap<AnalyzerConstants.ResourceSetting,
                                                                                             HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> currentNamespaceConfigMap,
@@ -267,49 +269,24 @@ public final class NamespaceRecommendationProcessor extends BaseRecommendationPr
         RecommendationConfigItem currentNamespaceMemRequest = currentConfig.memoryRequest;
         RecommendationConfigItem currentNamespaceMemLimit = currentConfig.memoryLimit;
 
-        if (null != monitoringStartTime) {
-            Timestamp finalMonitoringStartTime = monitoringStartTime;
-            Map<Timestamp, IntervalResults> filteredResultsMap = namespaceData.getResults().entrySet().stream()
-                    .filter((x -> ((x.getKey().compareTo(finalMonitoringStartTime) >= 0) && (x.getKey().compareTo(monitoringEndTime) <= 0))))
-                    .collect((Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+        ArrayList<RecommendationNotification> notifications = new ArrayList<>();
+        RecommendationConfigItem namespaceRecommendationCpuRequest = model.getCPURequestRecommendationForNamespace(filteredResultsMap, notifications);
+        RecommendationConfigItem namespaceRecommendationMemRequest = model.getMemoryRequestRecommendationForNamespace(filteredResultsMap, notifications);
+        RecommendationConfigItem namespaceRecommendationCpuLimits = namespaceRecommendationCpuRequest;
+        RecommendationConfigItem namespaceRecommendationMemLimits = namespaceRecommendationMemRequest;
 
-            int numPodsInNamespace = getNumPodsForNamespace(filteredResultsMap);
-            mappedRecommendationForModel.setPodsCount(numPodsInNamespace);
+        HashMap<String, RecommendationConfigItem> internalMapToPopulate = new HashMap<>();
+        internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.CURRENT_CPU_REQUEST, currentNamespaceCPURequest);
+        internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.CURRENT_CPU_LIMIT, currentNamespaceCPULimit);
+        internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.CURRENT_MEMORY_REQUEST, currentNamespaceMemRequest);
+        internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.CURRENT_MEMORY_LIMIT, currentNamespaceMemLimit);
+        internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.RECOMMENDED_CPU_REQUEST, namespaceRecommendationCpuRequest);
+        internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.RECOMMENDED_CPU_LIMIT, namespaceRecommendationCpuLimits);
+        internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.RECOMMENDED_MEMORY_REQUEST, namespaceRecommendationMemRequest);
+        internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.RECOMMENDED_MEMORY_LIMIT, namespaceRecommendationMemLimits);
 
-            ArrayList<RecommendationNotification> notifications = new ArrayList<>();
-            RecommendationConfigItem namespaceRecommendationCpuRequest = model.getCPURequestRecommendationForNamespace(filteredResultsMap, notifications);
-            RecommendationConfigItem namespaceRecommendationMemRequest = model.getMemoryRequestRecommendationForNamespace(filteredResultsMap, notifications);
-            RecommendationConfigItem namespaceRecommendationCpuLimits = namespaceRecommendationCpuRequest;
-            RecommendationConfigItem namespaceRecommendationMemLimits = namespaceRecommendationMemRequest;
+        engineService.populateRecommendation(termEntry, mappedRecommendationForModel, notifications, internalMapToPopulate, namespaceCpuThreshold, namespaceMemoryThreshold, null, null);
 
-            HashMap<String, RecommendationConfigItem> internalMapToPopulate = new HashMap<>();
-            internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.CURRENT_CPU_REQUEST, currentNamespaceCPURequest);
-            internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.CURRENT_CPU_LIMIT, currentNamespaceCPULimit);
-            internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.CURRENT_MEMORY_REQUEST, currentNamespaceMemRequest);
-            internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.CURRENT_MEMORY_LIMIT, currentNamespaceMemLimit);
-            internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.RECOMMENDED_CPU_REQUEST, namespaceRecommendationCpuRequest);
-            internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.RECOMMENDED_CPU_LIMIT, namespaceRecommendationCpuLimits);
-            internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.RECOMMENDED_MEMORY_REQUEST, namespaceRecommendationMemRequest);
-            internalMapToPopulate.put(RecommendationConstants.RecommendationEngine.InternalConstants.RECOMMENDED_MEMORY_LIMIT, namespaceRecommendationMemLimits);
-
-            engineService.populateRecommendation(termEntry, mappedRecommendationForModel, notifications, internalMapToPopulate, numPodsInNamespace, namespaceCpuThreshold, namespaceMemoryThreshold, null, null);
-        } else {
-            RecommendationNotification notification = new RecommendationNotification(
-                    RecommendationConstants.RecommendationNotification.INFO_NOT_ENOUGH_DATA);
-            mappedRecommendationForModel.addNotification(notification);
-        }
         return mappedRecommendationForModel;
-    }
-
-    private static int getNumPodsForNamespace(Map<Timestamp, IntervalResults> filteredResultsMap) {
-        LOGGER.debug("Size of Filter Map: {}", filteredResultsMap.size());
-        Double max_pods_cpu = filteredResultsMap.values().stream()
-                .map(e -> {
-                    Optional<MetricResults> numPodsResults = Optional.ofNullable(e.getMetricResultsMap().get(AnalyzerConstants.MetricName.namespaceTotalPods));
-                    double numPods = numPodsResults.map(m -> m.getAggregationInfoResult().getAvg()).orElse(0.0);
-                    return numPods;
-                })
-                .max(Double::compareTo).get();
-        return (int) Math.ceil(max_pods_cpu);
     }
 }

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -463,7 +463,6 @@ public class RecommendationEngine implements RecommendationEngineService {
      * @param recommendationModel                 The model used to map recommendations.
      * @param notifications                       A list to which recommendation notifications will be added.
      * @param internalMapToPopulate               The internal map to populate with recommendation configuration items.
-     * @param numPods                             The number of pods to consider for the recommendation.
      * @param cpuThreshold                        The CPU usage threshold for the recommendation.
      * @param memoryThreshold                     The memory usage threshold for the recommendation.
      * @param recommendationAcceleratorRequestMap The Map which has Accelerator recommendations
@@ -474,7 +473,6 @@ public class RecommendationEngine implements RecommendationEngineService {
                                    MappedRecommendationForModel recommendationModel,
                                    ArrayList<RecommendationNotification> notifications,
                                    HashMap<String, RecommendationConfigItem> internalMapToPopulate,
-                                   int numPods,
                                    double cpuThreshold,
                                    double memoryThreshold,
                                    Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> recommendationAcceleratorRequestMap,
@@ -867,23 +865,6 @@ public class RecommendationEngine implements RecommendationEngineService {
 
         // build the engine level notifications here
         ArrayList<RecommendationNotification> engineNotifications = new ArrayList<>();
-        if (numPods == 0) {
-            RecommendationNotification recommendationNotification = new RecommendationNotification(RecommendationConstants.RecommendationNotification.ERROR_NUM_PODS_CANNOT_BE_ZERO);
-            engineNotifications.add(recommendationNotification);
-            LOGGER.error(RecommendationConstants.RecommendationNotificationMsgConstant.NUM_PODS_CANNOT_BE_ZERO
-                    .concat(String.format(AnalyzerErrorConstants.AutotuneObjectErrors.EXPERIMENT_AND_INTERVAL_END_TIME,
-                            experimentName, interval_end_time)));
-            isSuccess = false;
-        } else if (numPods < 0) {
-            RecommendationNotification recommendationNotification = new RecommendationNotification(RecommendationConstants.RecommendationNotification.ERROR_NUM_PODS_CANNOT_BE_NEGATIVE);
-            engineNotifications.add(recommendationNotification);
-            LOGGER.error(RecommendationConstants.RecommendationNotificationMsgConstant.NUM_PODS_CANNOT_BE_NEGATIVE
-                    .concat(String.format(AnalyzerErrorConstants.AutotuneObjectErrors.EXPERIMENT_AND_INTERVAL_END_TIME,
-                            experimentName, interval_end_time)));
-            isSuccess = false;
-        } else {
-            recommendationModel.setPodsCount(numPods);
-        }
 
         // Check for thresholds
         if (isRecommendedCPURequestAvailable) {

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngineService.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngineService.java
@@ -51,7 +51,6 @@ public interface RecommendationEngineService {
      * @param recommendationModel              The model to populate with recommendations
      * @param notifications                    List of notifications to be added
      * @param internalMapToPopulate           Map containing current and recommended values
-     * @param numPods                         Number of pods
      * @param cpuThreshold                    CPU threshold value
      * @param memoryThreshold                 Memory threshold value
      * @param recommendationAcceleratorRequestMap Map of accelerator recommendations (can be null)
@@ -62,7 +61,6 @@ public interface RecommendationEngineService {
                                    MappedRecommendationForModel recommendationModel,
                                    ArrayList<RecommendationNotification> notifications,
                                    HashMap<String, RecommendationConfigItem> internalMapToPopulate,
-                                   int numPods,
                                    double cpuThreshold,
                                    double memoryThreshold,
                                    Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> recommendationAcceleratorRequestMap,

--- a/src/main/java/com/autotune/analyzer/recommendations/objects/TermRecommendations.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/objects/TermRecommendations.java
@@ -3,6 +3,7 @@ package com.autotune.analyzer.recommendations.objects;
 import com.autotune.analyzer.plots.PlotData;
 import com.autotune.analyzer.recommendations.RecommendationConstants;
 import com.autotune.analyzer.recommendations.RecommendationNotification;
+import com.autotune.common.data.metrics.MetricAggregationInfoResults;
 import com.autotune.utils.KruizeConstants;
 import com.google.gson.annotations.SerializedName;
 
@@ -19,6 +20,10 @@ public class TermRecommendations implements MappedRecommendationForTerm {
 
     @SerializedName(KruizeConstants.JSONKeys.NOTIFICATIONS)
     private HashMap<Integer, RecommendationNotification> termLevelNotificationMap;
+
+    @SerializedName(KruizeConstants.JSONKeys.METRICS_INFO)
+    private HashMap<String, MetricAggregationInfoResults> metricsInfo;
+
     @SerializedName(KruizeConstants.JSONKeys.MONITORING_START_TIME)
     private Timestamp monitoringStartTime;
 
@@ -105,5 +110,13 @@ public class TermRecommendations implements MappedRecommendationForTerm {
 
     public void setPlots(PlotData.PlotsData plots) {
         this.plots = plots;
+    }
+
+    public void addMetricsInfo(String metricName, MetricAggregationInfoResults metricAggregationInfoResults) {
+        if (null != metricName && null != metricAggregationInfoResults) {
+            if (null == this.metricsInfo)
+                this.metricsInfo = new HashMap<>();
+            this.metricsInfo.put(metricName, metricAggregationInfoResults);
+        }
     }
 }

--- a/src/main/java/com/autotune/analyzer/recommendations/term/Terms.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/term/Terms.java
@@ -71,6 +71,15 @@ public class Terms {
         return maxTerms.map(term -> term.days).orElse(0); // Return the max days or 0 if terms is empty
     }
 
+    public static boolean checkIfMinDataAvailableForTerm(Map<Timestamp, IntervalResults> metricsData, Terms term, double measurementDuration) {
+        if (metricsData == null || metricsData.isEmpty()) {
+            return false;
+        }
+        int minDatapoints = 0;
+        minDatapoints = (int)((term.getThreshold_in_days() * KruizeConstants.TimeConv.NO_OF_HOURS_PER_DAY * KruizeConstants.TimeConv.NO_OF_MINUTES_PER_HOUR)  / measurementDuration);
+        return metricsData.size() >= minDatapoints;
+    }
+
     public static boolean checkIfMinDataAvailableForTerm(ContainerData containerData, Terms term, Timestamp monitoringEndTime,
                                                          double measurementDuration) {
         // Check if data is available
@@ -113,6 +122,15 @@ public class Terms {
             return true;
 
         return false;
+    }
+
+    public static boolean checkIfMinDataAvailableForTermForNamespace(Map<Timestamp, IntervalResults> metricsData, Terms term, double measurementDuration) {
+        if (metricsData == null || metricsData.isEmpty()) {
+            return false;
+        }
+        int minDatapoints = 0;
+        minDatapoints = (int)((term.getThreshold_in_days() * KruizeConstants.TimeConv.NO_OF_HOURS_PER_DAY * KruizeConstants.TimeConv.NO_OF_MINUTES_PER_HOUR)  / measurementDuration);
+        return metricsData.size() >= minDatapoints;
     }
 
     public static boolean checkIfMinDataAvailableForTermForNamespace(NamespaceData namespaceData,

--- a/src/main/java/com/autotune/analyzer/services/UpdateRecommendations.java
+++ b/src/main/java/com/autotune/analyzer/services/UpdateRecommendations.java
@@ -16,6 +16,7 @@
 package com.autotune.analyzer.services;
 
 import com.autotune.analyzer.adapters.DeviceDetailsAdapter;
+import com.autotune.analyzer.adapters.MetricAggregationInfoResultsIntSerializer;
 import com.autotune.analyzer.adapters.MetricMetadataAdapter;
 import com.autotune.analyzer.adapters.RecommendationItemAdapter;
 import com.autotune.analyzer.exceptions.FetchMetricsError;
@@ -27,6 +28,7 @@ import com.autotune.analyzer.serviceObjects.ListRecommendationsAPIObject;
 import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.analyzer.utils.AnalyzerErrorConstants;
 import com.autotune.analyzer.utils.GsonUTCDateAdapter;
+import com.autotune.common.data.metrics.MetricAggregationInfoResults;
 import com.autotune.common.data.metrics.MetricMetadata;
 import com.autotune.common.data.result.ContainerData;
 import com.autotune.common.data.system.info.device.DeviceDetails;
@@ -178,6 +180,7 @@ public class UpdateRecommendations extends HttpServlet {
                     .registerTypeAdapter(AnalyzerConstants.RecommendationItem.class, new RecommendationItemAdapter())
                     .registerTypeAdapter(DeviceDetails.class, new DeviceDetailsAdapter())
                     .registerTypeAdapter(MetricMetadata.class, new MetricMetadataAdapter())
+                    .registerTypeAdapter(MetricAggregationInfoResults.class, new MetricAggregationInfoResultsIntSerializer())
                     .setExclusionStrategies(strategy)
                     .create();
             gsonStr = gsonObj.toJson(recommendationList);

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -283,7 +283,8 @@ public class AnalyzerConstants {
         acceleratorMemoryUsage,
         acceleratorFrameBufferUsage,
         jvmInfo,
-        jvmInfoTotal
+        jvmInfoTotal,
+        podCount
     }
 
     public enum K8S_OBJECT_TYPES {

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -277,6 +277,8 @@ public class KruizeConstants {
         public static final String INTERVAL_END_TIME = "interval_end_time";
         public static final String DURATION_IN_MINUTES = "duration_in_minutes";
         public static final String DURATION_IN_HOURS = "duration_in_hours";
+        public static final String METRICS_INFO = "metrics_info";
+        public static final String POD_COUNT = "pod_count";
         public static final String MONITORING_START_TIME = "monitoring_start_time";
         public static final String MONITORING_END_TIME = "monitoring_end_time";
         public static final String PODS_COUNT = "pods_count";


### PR DESCRIPTION
## Description

This PR contains changes to include following section for each recommendation term.

```
"metrics_info": 
{
  "pod_count": 
  {
    "avg": 2,
    "min": 2,
    "max": 2
  }
}
```

At high level, following changes are made part of this PR

1. Added constants related json response in KruizeConstants.JSONKeys
2. Added new metric `podCount` to Enum MetricName
3. Created new method `checkIfMinDataAvailableForTerm` to check min data-points in efficient way. Our current implementation assumes 15 mins measurement duration would never change in ROS. So, new method also is inline with that assumption.
4. Added new instance variable in `com.autotune.analyzer.recommendations.objects.TermRecommendations` to support nee section `metrics_info`.
5. `com.autotune.analyzer.recommendations.engine.NamespaceRecommendationProcessor` is updated to remove computation of no.of pods as it is not applicable for namespace recommendations as confirmed in previous comments.
6. `com.autotune.analyzer.recommendations.engine.ContainerRecommendationProcessor` is updated to compute avg, min and max pod_count. 
7. I use existing model `MetricAggregationInfoResults` to hold the pod count. Note that this model define aggregations as Double. So, in response, we see “2.0” instead of “2”. If this has to be sent as “2”, we need to create new model object that holds aggregations as int instead of double. - Fixed by using custom serializer.
8. Optimized code to filter results at recommendation term instead of recommendation model. This helps in elimination of redundant code to filter results multiple times. As part of this `com.autotune.analyzer.recommendations.engine.ContainerRecommendationProcessor#generateRecommendationBasedOnModel` method signature is modified to remove unused parameters `monitoringStartTime` and `monitoringEndTime`

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [x] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: Kind
* Used remote monitoring scripts to deploy and test.

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Add per-term metrics metadata for pod count and refactor recommendation generation to use pre-filtered metric windows and metric-based data-availability checks.

New Features:
- Expose a metrics_info section on each recommendation term, including aggregated pod_count statistics (avg, min, max).
- Support a dedicated podCount metric and derive pod count aggregations from podCount, cpuUsage, or memoryUsage data as available.

Enhancements:
- Refactor container and namespace recommendation processing to compute and reuse a filtered metrics window per term instead of re-filtering in each model.
- Introduce generic, metrics-based minimum data checks for terms at container and namespace level, decoupling them from raw data objects.
- Simplify the recommendation engine populateRecommendation API by removing explicit numPods handling and related validations, aligning pod count handling with the new metrics_info aggregation.
- Update term threshold configuration comments to document the minimum datapoint expectations for each term type.

## Summary by Sourcery

Add per-term metrics metadata for pod count and refactor recommendation processing to use pre-filtered metric windows and metric-based data availability checks.

New Features:
- Expose a metrics_info section on each recommendation term including aggregated pod_count statistics.
- Introduce a dedicated podCount metric and compute pod count aggregations from available metrics data.

Enhancements:
- Refactor container and namespace recommendation processors to compute a filtered metrics window once per term and reuse it across models.
- Simplify the recommendation engine populateRecommendation API by removing explicit pod count handling and validations, aligning with metrics-based pod count aggregation.
- Add generic metrics-based minimum datapoint checks for container and namespace terms based on term thresholds.
- Register a custom MetricAggregationInfoResults serializer to emit integer-valued aggregations in recommendation responses and document expected term datapoint thresholds via inline comments.