### PR TITLE
add required layer option to conditionally run runtimes queries

### DIFF
--- a/design/ConditionalRuntimeMetricQueries.md
+++ b/design/ConditionalRuntimeMetricQueries.md
@@ -1,0 +1,312 @@
+# ADR: Conditional Execution of Runtime Metric Queries Based on Layer Detection
+
+## Status
+Proposed
+
+## Context
+
+Currently, Kruize executes **all** metric queries defined in the performance profile, including runtime-related queries (e.g., `jvm_info`, `jvm_info_total`, and other JVM/runtime metrics), irrespective of whether a runtime layer has been detected in the container. This results in:
+
+1. **Unnecessary query executions** - Prometheus queries are executed even when no runtime layer exists
+2. **Performance overhead** - Additional load on Prometheus and the recommendation engine
+4. **Potential errors** - Queries may return empty results or errors when runtime metrics don't exist
+5. **Log noise** - Failed or empty query results clutter logs
+
+### Current Behavior
+
+The recommendation engine processes all metrics defined in the performance profile without any mechanism to conditionally execute queries based on detected layers. For example:
+
+```java
+// Current implementation - ALL queries executed unconditionally
+for (Map.Entry<String, AggregationFunctions> aggregationFunctionsEntry : aggregationFunctions.entrySet()) {
+    String promQL = aggregationFunctionsEntry.getValue().getQuery();
+    // Execute query regardless of whether the layer is present
+    executeQuery(promQL);
+}
+```
+
+
+### Problem Statement
+
+Even if a container has no JVM runtime, queries like `jvm_info` are still executed, wasting resources.
+
+
+**Expected Behavior:**
+- Detect whether a runtime layer (e.g., JVM or other supported runtime) is present
+- Execute runtime metric queries such as `jvm_info`, `heap_memory`, etc., only if the runtime layer detection flag is true
+- Skip runtime queries when no runtime layer is identified
+
+**Definition of Done:**
+- Runtime metric queries are triggered only when runtime layer detection succeeds
+- No runtime queries are executed when runtime layer detection is false
+- Existing functionality for runtime metric processing remains unaffected when a runtime layer is present
+
+## Decision
+
+We will introduce a **new optional field** `required_layer` in the aggregation function definition within performance profiles. This field will specify which layer(s) must be detected before executing the associated metric query.
+
+### Design Changes
+
+#### 1. Performance Profile Schema Enhancement
+
+**New Field Introduction:**
+
+We are adding an optional `required_layer` field to aggregation functions. This field accepts an array of layer names.
+
+**Before (No layer checking):**
+```json
+{
+  "name": "jvmInfo",
+  "aggregation_functions": [
+    {
+      "function": "sum",
+      "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})"
+      // No layer requirement - query always executed
+    }
+  ]
+}
+```
+
+**After (With layer requirement):**
+```json
+{
+  "name": "jvmInfo",
+  "aggregation_functions": [
+    {
+      "function": "sum",
+      "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})",
+      "required_layer": ["hotspot", "semeru"]
+      // Query executed only if hotspot OR semeru layer detected
+    }
+  ]
+}
+```
+
+**YAML Representation:**
+```yaml
+- name: jvmInfo
+  aggregation_functions:
+    - function: sum
+      query: 'sum by(container, namespace, runtime, vendor, version)(jvm_info{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+      required_layer:
+        - "hotspot"
+        - "semeru"
+```
+
+**Key Points:**
+- `required_layer` is **optional** - if not specified, query is always executed (backward compatible)
+- Accepts an **array of strings** representing layer names
+- Uses **OR logic** - query executes if ANY of the specified layers is detected
+- Empty array or null means no layer requirement (always execute)
+
+### Key Design Decisions
+
+1. **Optional Field** - Backward compatible; existing metrics without `required_layer` work unchanged
+2. **Array Format** - Using `List<String>` for type safety and clean representation
+3. **OR Logic** - Query executes if ANY specified layer is detected (flexible for multi-runtime support)
+4. **Early Exit** - Skip query execution immediately if layer not detected (performance optimization)
+5. **Debug Logging** - Log skipped queries for troubleshooting and monitoring
+
+## Consequences
+
+### Positive
+
+1. **Performance Optimization**
+   - Reduces unnecessary Prometheus queries
+
+2. **Resource Efficiency**
+   - Minimizes memory usage for storing empty results
+
+3. **Better User Experience**
+   - Faster recommendation generation
+   - Reduced noise in logs (no failed queries for non-existent metrics)
+
+4. **Maintainability**
+   - Cleaner data structure
+   - Easier to add new runtime layers
+   - Type-safe implementation
+
+5. **Extensibility**
+   - Pattern can be applied to other layer-specific metrics
+   - Supports multi-layer requirements (OR logic)
+
+### Negative
+
+1. **Schema Change**
+   - Performance profile schema is extended with new optional field
+   - Requires documentation updates
+
+2. **Testing Requirements**
+   - Need to test with various layer combinations
+   - Verify backward compatibility (metrics without `required_layer`)
+   - Validate query skipping logic
+   - Test OR logic with multiple layers
+
+3. **Potential for Misconfiguration**
+   - Incorrect layer names in `required_layer` will cause queries to be skipped
+   - Need validation to ensure specified layers are valid/supported
+
+### Neutral
+
+1. **Documentation Updates**
+   - Performance profile documentation needs updates
+   - API examples need to reflect new format
+   - Migration guide for existing users
+
+## Implementation Plan
+
+### Phase 1: Core Changes (Completed)
+- [x] Add `requiredLayer` field to `AggregationFunctions.java` as `List<String>`
+- [x] Implement layer checking logic in `RecommendationEngine.java`
+- [x] Update performance profile JSON files with `required_layer` for runtime metrics
+- [x] Update performance profile YAML files with `required_layer` for runtime metrics
+
+### Phase 2: Testing
+- [ ] Unit tests for layer detection logic
+- [ ] Integration tests with various layer combinations
+- [ ] Performance benchmarking (query reduction metrics)
+- [ ] Validation with real workloads
+
+### Phase 3: Documentation
+- [ ] Update Performance Profile API documentation
+- [ ] Create migration guide for existing users
+- [ ] Update design documentation
+- [ ] Add examples to API samples
+
+### Phase 4: Deployment
+- [ ] Release notes highlighting new feature
+- [ ] Monitoring for query reduction metrics
+- [ ] User communication about new capability
+
+## Alternatives Considered
+
+### Alternative 1: Use Single String Instead of Array
+**Approach:** Use a single string field for one layer only
+
+**Pros:**
+- Simpler implementation
+- Easier to parse
+
+**Cons:**
+- Cannot handle metrics applicable to multiple runtimes
+- Would require duplicate metric definitions for multi-runtime support
+- Less flexible for future extensions
+
+**Decision:** Rejected - Array format provides necessary flexibility
+
+### Alternative 2: Use Comma-Separated String
+**Approach:** Store multiple layers as comma-separated string (e.g., "hotspot,semeru")
+
+**Pros:**
+- Single field
+- Compact representation
+
+**Cons:**
+- Requires string parsing (`.split(",")`)
+- Less type-safe
+- Needs trimming
+- Not idiomatic for modern JSON/YAML APIs
+- More error-prone
+
+**Decision:** Rejected - Array format is cleaner and more maintainable
+
+### Alternative 3: Single Layer Only (Strict Matching)
+**Approach:** Allow only one layer per metric query
+
+**Pros:**
+- Simpler implementation
+- No OR logic needed
+
+**Cons:**
+- Less flexible
+- Cannot handle metrics applicable to multiple runtimes
+- Would require duplicate metric definitions
+
+**Decision:** Rejected - Multiple layers support is essential for metrics like `jvm_info` that apply to both Hotspot and Semeru
+
+### Alternative 4: Layer Detection at Profile Load Time
+**Approach:** Filter metrics when loading performance profile
+
+**Pros:**
+- One-time check
+- Potentially faster at query time
+
+**Cons:**
+- Less dynamic
+- Cannot adapt to runtime changes
+- More complex profile loading logic
+
+**Decision:** Rejected - Runtime checking is more flexible and accurate
+
+## Related Work
+
+- **Layer Detection System:** [KruizeLayers.md](./KruizeLayers.md)
+- **Performance Profiles:** [PerformanceProfile.md](./PerformanceProfile.md)
+- **Recommendation Engine:** Core recommendation logic in `RecommendationEngine.java`
+
+## References
+
+- JIRA Ticket: [KRUIZE-1187](https://redhat.atlassian.net/browse/KRUIZE-1187) Conditionally Execute Runtime Metric Queries Only When Runtime Layer Is Detected
+- PR: https://github.com/kruize/autotune/pull/1866
+- Layer Detection Documentation: [KruizeLayers.md](./KruizeLayers.md)
+
+## Notes
+
+### Supported Runtime Layers
+Currently supported runtime layers that can be specified in `required_layer`:
+- `hotspot` - OpenJDK Hotspot JVM
+- `semeru` - IBM Semeru JVM
+- `quarkus` - Quarkus framework (future runtime metrics)
+
+### Example Usage
+
+**Container-level metrics (no layer requirement - backward compatible):**
+```json
+{
+  "name": "cpuUsage",
+  "datasource": "prometheus",
+  "value_type": "double",
+  "kubernetes_object": "container",
+  "aggregation_functions": [
+    {
+      "function": "avg",
+      "query": "avg by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{...}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+      // No required_layer field - query always executed (backward compatible)
+    }
+  ]
+}
+```
+
+**Runtime-specific metrics (new feature):**
+```json
+{
+  "name": "jvmInfo",
+  "datasource": "prometheus",
+  "value_type": "double",
+  "kubernetes_object": "container",
+  "aggregation_functions": [
+    {
+      "function": "sum",
+      "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})",
+      "required_layer": ["hotspot", "semeru"]
+      // NEW: Only executed if hotspot OR semeru layer detected
+    }
+  ]
+}
+```
+
+**Behavior:**
+- If container has Hotspot JVM → `jvmInfo` query is executed
+- If container has Semeru JVM → `jvmInfo` query is executed
+- If container has no JVM runtime → `jvmInfo` query is **skipped**
+- `cpuUsage` query is **always** executed (no layer requirement)
+
+## Decision Date
+2026-04-10
+
+## Decision Makers
+- Kruize Development Team
+
+## Review Status
+- [ ] Technical Review
+- [ ] Architecture Review

--- a/design/ConditionalRuntimeMetricQueries.md
+++ b/design/ConditionalRuntimeMetricQueries.md
@@ -25,11 +25,12 @@ for (Map.Entry<String, AggregationFunctions> aggregationFunctionsEntry : aggrega
 }
 ```
 
+**Problem:** Even if a container has no JVM runtime, queries like `jvm_info` are still executed, wasting resources.
 
 ### Problem Statement
 
-Even if a container has no JVM runtime, queries like `jvm_info` are still executed, wasting resources.
-
+**JIRA Requirement:**
+> Modify the logic so that runtime-specific queries are executed only when a runtime layer is detected during layer analysis.
 
 **Expected Behavior:**
 - Detect whether a runtime layer (e.g., JVM or other supported runtime) is present
@@ -43,7 +44,7 @@ Even if a container has no JVM runtime, queries like `jvm_info` are still execut
 
 ## Decision
 
-We will introduce a **new optional field** `required_layer` in the aggregation function definition within performance profiles. This field will specify which layer(s) must be detected before executing the associated metric query.
+We will introduce a **new optional field** `layers_required` at the **metric level** within performance profiles. This field will specify which layer(s) must be detected before executing any queries for that metric.
 
 ### Design Changes
 
@@ -51,17 +52,19 @@ We will introduce a **new optional field** `required_layer` in the aggregation f
 
 **New Field Introduction:**
 
-We are adding an optional `required_layer` field to aggregation functions. This field accepts an array of layer names.
+We are adding an optional `layers_required` field at the metric level (not inside aggregation_functions). This field accepts an array of layer names and applies to all aggregation functions for that metric.
 
 **Before (No layer checking):**
 ```json
 {
   "name": "jvmInfo",
+  "datasource": "prometheus",
+  "value_type": "double",
+  "kubernetes_object": "container",
   "aggregation_functions": [
     {
       "function": "sum",
       "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})"
-      // No layer requirement - query always executed
     }
   ]
 }
@@ -71,12 +74,14 @@ We are adding an optional `required_layer` field to aggregation functions. This 
 ```json
 {
   "name": "jvmInfo",
+  "datasource": "prometheus",
+  "value_type": "double",
+  "kubernetes_object": "container",
+  "layers_required": ["hotspot", "semeru"],
   "aggregation_functions": [
     {
       "function": "sum",
-      "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})",
-      "required_layer": ["hotspot", "semeru"]
-      // Query executed only if hotspot OR semeru layer detected
+      "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})"
     }
   ]
 }
@@ -85,27 +90,121 @@ We are adding an optional `required_layer` field to aggregation functions. This 
 **YAML Representation:**
 ```yaml
 - name: jvmInfo
+  datasource: prometheus
+  value_type: "double"
+  kubernetes_object: "container"
+  layers_required:
+    - "hotspot"
+    - "semeru"
   aggregation_functions:
     - function: sum
       query: 'sum by(container, namespace, runtime, vendor, version)(jvm_info{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
-      required_layer:
-        - "hotspot"
-        - "semeru"
 ```
 
 **Key Points:**
-- `required_layer` is **optional** - if not specified, query is always executed (backward compatible)
+- `layers_required` is **optional** - if not specified, all queries for the metric are always executed (backward compatible)
+- Placed at **metric level**, not inside aggregation_functions - applies to ALL aggregation functions for that metric
 - Accepts an **array of strings** representing layer names
-- Uses **OR logic** - query executes if ANY of the specified layers is detected
+- Uses **OR logic** - metric queries execute if ANY of the specified layers is detected
 - Empty array or null means no layer requirement (always execute)
+- **Field name:** `layers_required` (not `required_layer`) for better clarity
+
+#### 2. Data Model Update
+
+**File:** `src/main/java/com/autotune/common/data/metrics/Metric.java`
+
+**New Field Addition:**
+```java
+import java.util.List;
+import com.fasterxml.jackson.annotation.SerializedName;
+
+public final class Metric {
+    private String name;
+    private String query;
+    private String datasource;
+    @SerializedName("value_type")
+    private String valueType;
+    @SerializedName("kubernetes_object")
+    private String kubernetesObject;
+    @SerializedName("layers_required")
+    private List<String> layersRequired;  // NEW FIELD
+    @SerializedName("aggregation_functions")
+    private HashMap<String, AggregationFunctions> aggregationFunctionsMap;
+
+    // Existing getters/setters...
+
+    // NEW: Getter for layers required
+    public List<String> getLayersRequired() {
+        return layersRequired;
+    }
+
+    // NEW: Setter for layers required
+    public void setLayersRequired(List<String> layersRequired) {
+        this.layersRequired = layersRequired;
+    }
+}
+```
+
+**Design Choice:** 
+- Field placed at **Metric level** (not AggregationFunctions level)
+- Using `List<String>` provides type safety, no parsing overhead, natural JSON/YAML representation
+- `@SerializedName("layers_required")` maps to JSON field name
+- Applies to entire metric, not individual aggregation functions
+
+#### 3. Recommendation Engine Logic Update
+
+**File:** `src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java`
+
+**New Logic Addition:**
+
+Check is performed at metric level before processing any aggregation functions:
+
+```java
+// NEW: Check if this metric requires specific layers (at metric level)
+List<String> layersRequired = metricEntry.getLayersRequired();
+if (layersRequired != null && !layersRequired.isEmpty()) {
+    // Check if any of the required layers are detected
+    boolean layerDetected = false;
+    for (String layer : layersRequired) {
+        if (containerData.getLayerMap() != null &&
+                containerData.getLayerMap().containsKey(layer)) {
+            layerDetected = true;
+            break;
+        }
+    }
+    // Skip this metric entirely if required layer is not detected
+    if (!layerDetected) {
+        LOGGER.debug("Skipping metric {} - required layer(s) {} not detected for container {}",
+                metricEntry.getName(), layersRequired, containerName);
+        continue;  // Skip entire metric (all aggregation functions)
+    }
+}
+
+// Proceed with aggregation functions only if layer check passed
+HashMap<String, AggregationFunctions> aggregationFunctions = metricEntry.getAggregationFunctionsMap();
+for (Map.Entry<String, AggregationFunctions> aggregationFunctionsEntry : aggregationFunctions.entrySet()) {
+    String promQL = aggregationFunctionsEntry.getValue().getQuery();
+    executeQuery(promQL);
+}
+```
+
+**Logic Flow:**
+1. Check if `layers_required` is specified at the metric level
+2. If specified, verify at least one required layer is detected in the container
+3. If no required layer is detected, skip the **entire metric** (all its aggregation functions) and log the decision
+4. If layer is detected (or no requirement specified), proceed with all aggregation functions for that metric
+
+**Key Advantage:** Single check per metric instead of per aggregation function - more efficient
 
 ### Key Design Decisions
 
-1. **Optional Field** - Backward compatible; existing metrics without `required_layer` work unchanged
-2. **Array Format** - Using `List<String>` for type safety and clean representation
-3. **OR Logic** - Query executes if ANY specified layer is detected (flexible for multi-runtime support)
-4. **Early Exit** - Skip query execution immediately if layer not detected (performance optimization)
-5. **Debug Logging** - Log skipped queries for troubleshooting and monitoring
+1. **Optional Field** - Backward compatible; existing metrics without `layers_required` work unchanged
+2. **Metric Level Placement** - Field at metric level (not aggregation function level) for simplicity and efficiency
+3. **Array Format** - Using `List<String>` for type safety and clean representation
+4. **OR Logic** - Metric queries execute if ANY specified layer is detected (flexible for multi-runtime support)
+5. **Early Exit** - Skip entire metric if layer not detected (performance optimization)
+6. **Debug Logging** - Log skipped metrics for troubleshooting and monitoring
+7. **Field Naming** - `layers_required` (plural) is more descriptive than `required_layer`
 
 ## Consequences
 
@@ -122,9 +221,10 @@ We are adding an optional `required_layer` field to aggregation functions. This 
    - Reduced noise in logs (no failed queries for non-existent metrics)
 
 4. **Maintainability**
-   - Cleaner data structure
+   - Cleaner data structure (array at metric level)
    - Easier to add new runtime layers
    - Type-safe implementation
+   - Single check per metric (not per aggregation function)
 
 5. **Extensibility**
    - Pattern can be applied to other layer-specific metrics
@@ -133,17 +233,17 @@ We are adding an optional `required_layer` field to aggregation functions. This 
 ### Negative
 
 1. **Schema Change**
-   - Performance profile schema is extended with new optional field
    - Requires documentation updates
+   - No change with respect to schema since it's part of SLO JsonNode column
 
 2. **Testing Requirements**
    - Need to test with various layer combinations
-   - Verify backward compatibility (metrics without `required_layer`)
+   - Verify backward compatibility (metrics without `layers_required`)
    - Validate query skipping logic
    - Test OR logic with multiple layers
 
 3. **Potential for Misconfiguration**
-   - Incorrect layer names in `required_layer` will cause queries to be skipped
+   - Incorrect layer names in `layers_required` will cause queries to be skipped
    - Need validation to ensure specified layers are valid/supported
 
 ### Neutral
@@ -151,15 +251,15 @@ We are adding an optional `required_layer` field to aggregation functions. This 
 1. **Documentation Updates**
    - Performance profile documentation needs updates
    - API examples need to reflect new format
-   - Migration guide for existing users
+   - Design documentation updates
 
 ## Implementation Plan
 
 ### Phase 1: Core Changes (Completed)
-- [x] Add `requiredLayer` field to `AggregationFunctions.java` as `List<String>`
-- [x] Implement layer checking logic in `RecommendationEngine.java`
-- [x] Update performance profile JSON files with `required_layer` for runtime metrics
-- [x] Update performance profile YAML files with `required_layer` for runtime metrics
+- [x] Add `layersRequired` field to `Metric.java` as `List<String>`
+- [x] Implement layer checking logic in `RecommendationEngine.java` at metric level
+- [x] Update performance profile JSON files with `layers_required` for runtime metrics
+- [x] Update performance profile YAML files with `layers_required` for runtime metrics
 
 ### Phase 2: Testing
 - [ ] Unit tests for layer detection logic
@@ -169,7 +269,6 @@ We are adding an optional `required_layer` field to aggregation functions. This 
 
 ### Phase 3: Documentation
 - [ ] Update Performance Profile API documentation
-- [ ] Create migration guide for existing users
 - [ ] Update design documentation
 - [ ] Add examples to API samples
 
@@ -253,7 +352,7 @@ We are adding an optional `required_layer` field to aggregation functions. This 
 ## Notes
 
 ### Supported Runtime Layers
-Currently supported runtime layers that can be specified in `required_layer`:
+Currently supported runtime layers that can be specified in `layers_required`:
 - `hotspot` - OpenJDK Hotspot JVM
 - `semeru` - IBM Semeru JVM
 - `quarkus` - Quarkus framework (future runtime metrics)
@@ -271,7 +370,6 @@ Currently supported runtime layers that can be specified in `required_layer`:
     {
       "function": "avg",
       "query": "avg by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{...}[$MEASUREMENT_DURATION_IN_MIN$m]))"
-      // No required_layer field - query always executed (backward compatible)
     }
   ]
 }
@@ -284,25 +382,28 @@ Currently supported runtime layers that can be specified in `required_layer`:
   "datasource": "prometheus",
   "value_type": "double",
   "kubernetes_object": "container",
+  "layers_required": ["hotspot", "semeru"],
   "aggregation_functions": [
     {
       "function": "sum",
-      "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})",
-      "required_layer": ["hotspot", "semeru"]
-      // NEW: Only executed if hotspot OR semeru layer detected
+      "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})"
     }
   ]
 }
 ```
 
 **Behavior:**
-- If container has Hotspot JVM → `jvmInfo` query is executed
-- If container has Semeru JVM → `jvmInfo` query is executed
-- If container has no JVM runtime → `jvmInfo` query is **skipped**
-- `cpuUsage` query is **always** executed (no layer requirement)
+- If container has Hotspot JVM → All `jvmInfo` queries are executed
+- If container has Semeru JVM → All `jvmInfo` queries are executed  
+- If container has no JVM runtime → All `jvmInfo` queries are **skipped**
+- `cpuUsage` queries are **always** executed (no layer requirement)
+
+**Efficiency Benefit:**
+- Single layer check per metric (not per aggregation function)
+- If metric has 5 aggregation functions, only 1 check is performed instead of 5
 
 ## Decision Date
-2026-04-10
+2026-04-16
 
 ## Decision Makers
 - Kruize Development Team

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.json
@@ -4,7 +4,7 @@
   "metadata": {
     "name": "resource-optimization-local-monitoring"
   },
-  "profile_version": 1,
+  "profile_version": 2,
   "k8s_type": "openshift",
   "slo": {
     "slo_class": "resource_usage",

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.json
@@ -482,7 +482,7 @@
           {
             "function": "sum",
             "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})",
-            "required_layer": "hotspot,semeru"
+            "required_layer": ["hotspot", "semeru"]
           }
         ]
       },
@@ -495,7 +495,7 @@
           {
             "function": "sum",
             "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info_total{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})",
-            "required_layer": "hotspot,semeru"
+            "required_layer": ["hotspot", "semeru"]
           }
         ]
       }

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.json
@@ -478,11 +478,11 @@
         "datasource": "prometheus",
         "value_type": "double",
         "kubernetes_object": "container",
+        "layers_required": ["hotspot", "semeru"],
         "aggregation_functions": [
           {
             "function": "sum",
-            "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})",
-            "required_layer": ["hotspot", "semeru"]
+            "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})"
           }
         ]
       },
@@ -491,11 +491,11 @@
         "datasource": "prometheus",
         "value_type": "double",
         "kubernetes_object": "container",
+        "layers_required": ["hotspot", "semeru"],
         "aggregation_functions": [
           {
             "function": "sum",
-            "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info_total{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})",
-            "required_layer": ["hotspot", "semeru"]
+            "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info_total{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})"
           }
         ]
       }

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.json
@@ -481,7 +481,8 @@
         "aggregation_functions": [
           {
             "function": "sum",
-            "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})"
+            "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})",
+            "required_layer": "hotspot,semeru"
           }
         ]
       },
@@ -493,7 +494,8 @@
         "aggregation_functions": [
           {
             "function": "sum",
-            "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info_total{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})"
+            "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info_total{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})",
+            "required_layer": "hotspot,semeru"
           }
         ]
       }

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.yaml
@@ -480,6 +480,7 @@ slo:
     aggregation_functions:
       - function: sum
         query: 'sum by(container, namespace, runtime, vendor, version)(jvm_info{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+        required_layer: "hotspot,semeru"
 
     # JVM Info Total (runtime, vendor, version from jvm_info_total metric)
   - name: jvmInfoTotal
@@ -490,3 +491,4 @@ slo:
     aggregation_functions:
       - function: sum
         query: 'sum by(container, namespace, runtime, vendor, version)(jvm_info_total{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+        required_layer: "hotspot,semeru"

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.yaml
@@ -2,7 +2,7 @@ apiVersion: "recommender.com/v1"
 kind: "KruizePerformanceProfile"
 metadata:
   name: "resource-optimization-local-monitoring"
-profile_version: 1.0
+profile_version: 2.0
 k8s_type: openshift
 
 slo:

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.yaml
@@ -476,23 +476,23 @@ slo:
     datasource: prometheus
     value_type: "double"
     kubernetes_object: "container"
+    layers_required:
+      - "hotspot"
+      - "semeru"
 
     aggregation_functions:
       - function: sum
         query: 'sum by(container, namespace, runtime, vendor, version)(jvm_info{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
-        required_layer:
-          - "hotspot"
-          - "semeru"
 
     # JVM Info Total (runtime, vendor, version from jvm_info_total metric)
   - name: jvmInfoTotal
     datasource: prometheus
     value_type: "double"
     kubernetes_object: "container"
+    layers_required:
+      - "hotspot"
+      - "semeru"
 
     aggregation_functions:
       - function: sum
         query: 'sum by(container, namespace, runtime, vendor, version)(jvm_info_total{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
-        required_layer:
-          - "hotspot"
-          - "semeru"

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.yaml
@@ -480,7 +480,9 @@ slo:
     aggregation_functions:
       - function: sum
         query: 'sum by(container, namespace, runtime, vendor, version)(jvm_info{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
-        required_layer: "hotspot,semeru"
+        required_layer:
+          - "hotspot"
+          - "semeru"
 
     # JVM Info Total (runtime, vendor, version from jvm_info_total metric)
   - name: jvmInfoTotal
@@ -491,4 +493,6 @@ slo:
     aggregation_functions:
       - function: sum
         query: 'sum by(container, namespace, runtime, vendor, version)(jvm_info_total{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
-        required_layer: "hotspot,semeru"
+        required_layer:
+          - "hotspot"
+          - "semeru"

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.json
@@ -4,7 +4,7 @@
   "metadata": {
     "name": "resource-optimization-local-monitoring"
   },
-  "profile_version": 1,
+  "profile_version": 2,
   "k8s_type": "openshift",
   "slo": {
     "slo_class": "resource_usage",

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.json
@@ -458,7 +458,8 @@
         "aggregation_functions": [
           {
             "function": "sum",
-            "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})"
+            "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})",
+            "required_layer": ["hotspot", "semeru"]
           }
         ]
       },
@@ -470,7 +471,8 @@
         "aggregation_functions": [
           {
             "function": "sum",
-            "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info_total{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})"
+            "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info_total{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})",
+            "required_layer": ["hotspot", "semeru"]
           }
         ]
       }

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.json
@@ -455,11 +455,11 @@
         "datasource": "prometheus",
         "value_type": "double",
         "kubernetes_object": "container",
+        "layers_required": ["hotspot", "semeru"],
         "aggregation_functions": [
           {
             "function": "sum",
-            "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})",
-            "required_layer": ["hotspot", "semeru"]
+            "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})"
           }
         ]
       },
@@ -468,11 +468,11 @@
         "datasource": "prometheus",
         "value_type": "double",
         "kubernetes_object": "container",
+        "layers_required": ["hotspot", "semeru"],
         "aggregation_functions": [
           {
             "function": "sum",
-            "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info_total{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})",
-            "required_layer": ["hotspot", "semeru"]
+            "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info_total{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})"
           }
         ]
       }

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.yaml
@@ -440,23 +440,23 @@ slo:
     datasource: prometheus
     value_type: "double"
     kubernetes_object: "container"
+    layers_required:
+      - "hotspot"
+      - "semeru"
 
     aggregation_functions:
       - function: sum
         query: 'sum by(container, namespace, runtime, vendor, version)(jvm_info{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
-        required_layer:
-          - "hotspot"
-          - "semeru"
 
   # JVM Info Total (runtime, vendor, version from jvm_info_total metric)
   - name: jvmInfoTotal
     datasource: prometheus
     value_type: "double"
     kubernetes_object: "container"
+    layers_required:
+      - "hotspot"
+      - "semeru"
 
     aggregation_functions:
       - function: sum
         query: 'sum by(container, namespace, runtime, vendor, version)(jvm_info_total{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
-        required_layer:
-          - "hotspot"
-          - "semeru"

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.yaml
@@ -2,7 +2,7 @@ apiVersion: "recommender.com/v1"
 kind: "KruizePerformanceProfile"
 metadata:
   name: "resource-optimization-local-monitoring"
-profile_version: 1.0
+profile_version: 2.0
 k8s_type: openshift
 
 slo:

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.yaml
@@ -444,7 +444,9 @@ slo:
     aggregation_functions:
       - function: sum
         query: 'sum by(container, namespace, runtime, vendor, version)(jvm_info{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
-        required_layer: "hotspot,semeru"
+        required_layer:
+          - "hotspot"
+          - "semeru"
 
   # JVM Info Total (runtime, vendor, version from jvm_info_total metric)
   - name: jvmInfoTotal
@@ -455,4 +457,6 @@ slo:
     aggregation_functions:
       - function: sum
         query: 'sum by(container, namespace, runtime, vendor, version)(jvm_info_total{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
-        required_layer: "hotspot,semeru"
+        required_layer:
+          - "hotspot"
+          - "semeru"

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.yaml
@@ -444,6 +444,7 @@ slo:
     aggregation_functions:
       - function: sum
         query: 'sum by(container, namespace, runtime, vendor, version)(jvm_info{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+        required_layer: "hotspot,semeru"
 
   # JVM Info Total (runtime, vendor, version from jvm_info_total metric)
   - name: jvmInfoTotal
@@ -454,3 +455,4 @@ slo:
     aggregation_functions:
       - function: sum
         query: 'sum by(container, namespace, runtime, vendor, version)(jvm_info_total{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+        required_layer: "hotspot,semeru"

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -1570,28 +1570,28 @@ public class RecommendationEngine implements RecommendationEngineService {
                         if (isAcceleratorPartitionMetric && !fetchAcceleratorMetrics)
                             continue;
 
-                        HashMap<String, AggregationFunctions> aggregationFunctions = metricEntry.getAggregationFunctionsMap();
-                        for (Map.Entry<String, AggregationFunctions> aggregationFunctionsEntry : aggregationFunctions.entrySet()) {
-                            // Check if this metric requires a specific layer
-                            List<String> requiredLayers = aggregationFunctionsEntry.getValue().getRequiredLayer();
-                            if (requiredLayers != null && !requiredLayers.isEmpty()) {
-                                // Check if any of the required layers are detected
-                                boolean layerDetected = false;
-                                for (String layer : requiredLayers) {
-                                    if (containerData.getLayerMap() != null &&
-                                            containerData.getLayerMap().containsKey(layer)) {
-                                        layerDetected = true;
-                                        break;
-                                    }
-                                }
-                                // Skip this metric if required layer is not detected
-                                if (!layerDetected) {
-                                    LOGGER.debug("Skipping metric {} - required layer(s) {} not detected for container {}",
-                                            metricEntry.getName(), requiredLayers, containerName);
-                                    continue;
+                        // Check if this metric requires specific layers
+                        List<String> layersRequired = metricEntry.getLayersRequired();
+                        if (layersRequired != null && !layersRequired.isEmpty()) {
+                            // Check if any of the required layers are detected
+                            boolean layerDetected = false;
+                            for (String layer : layersRequired) {
+                                if (containerData.getLayerMap() != null &&
+                                        containerData.getLayerMap().containsKey(layer)) {
+                                    layerDetected = true;
+                                    break;
                                 }
                             }
+                            // Skip this metric entirely if required layer is not detected
+                            if (!layerDetected) {
+                                LOGGER.debug("Skipping metric {} - required layer(s) {} not detected for container {}",
+                                        metricEntry.getName(), layersRequired, containerName);
+                                continue;
+                            }
+                        }
 
+                        HashMap<String, AggregationFunctions> aggregationFunctions = metricEntry.getAggregationFunctionsMap();
+                        for (Map.Entry<String, AggregationFunctions> aggregationFunctionsEntry : aggregationFunctions.entrySet()) {
                             // Determine promQL query on metric type
                             String promQL = aggregationFunctionsEntry.getValue().getQuery();
 

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -1572,6 +1572,27 @@ public class RecommendationEngine implements RecommendationEngineService {
 
                         HashMap<String, AggregationFunctions> aggregationFunctions = metricEntry.getAggregationFunctionsMap();
                         for (Map.Entry<String, AggregationFunctions> aggregationFunctionsEntry : aggregationFunctions.entrySet()) {
+                            // Check if this metric requires a specific layer
+                            String requiredLayer = aggregationFunctionsEntry.getValue().getRequiredLayer();
+                            if (requiredLayer != null && !requiredLayer.isEmpty()) {
+                                // Check if any of the required layers are detected
+                                String[] requiredLayers = requiredLayer.split(",");
+                                boolean layerDetected = false;
+                                for (String layer : requiredLayers) {
+                                    if (containerData.getLayerMap() != null &&
+                                            containerData.getLayerMap().containsKey(layer.trim())) {
+                                        layerDetected = true;
+                                        break;
+                                    }
+                                }
+                                // Skip this metric if required layer is not detected
+                                if (!layerDetected) {
+                                    LOGGER.debug("Skipping metric {} - required layer(s) {} not detected for container {}",
+                                            metricEntry.getName(), requiredLayer, containerName);
+                                    continue;
+                                }
+                            }
+
                             // Determine promQL query on metric type
                             String promQL = aggregationFunctionsEntry.getValue().getQuery();
 

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -1523,9 +1523,6 @@ public class RecommendationEngine implements RecommendationEngineService {
                     MetricResults metricResults = null;
                     MetricAggregationInfoResults metricAggregationInfoResults = null;
 
-                    List<Metric> metricList = filterMetricsBasedOnExpTypeAndK8sObject(metricProfile,
-                            AnalyzerConstants.MetricName.maxDate.name(), kruizeObject.getExperimentType());
-
                     List<String> acceleratorFunctions = Arrays.asList(
                             AnalyzerConstants.MetricName.acceleratorCoreUsage.toString(),
                             AnalyzerConstants.MetricName.acceleratorMemoryUsage.toString()
@@ -1534,61 +1531,31 @@ public class RecommendationEngine implements RecommendationEngineService {
                     List<String> acceleratorPartitionFunctions = Arrays.asList(
                             AnalyzerConstants.MetricName.acceleratorFrameBufferUsage.toString()
                     );
-                    // Iterate over metrics and aggregation functions
+
+                    // Determine if accelerator metrics should be fetched
+                    boolean fetchAcceleratorMetrics = false;
+                    if (!isROS && null != containerData.getContainerDeviceList()) {
+                        fetchAcceleratorMetrics = containerData.getContainerDeviceList().isAcceleratorDeviceDetected() ||
+                                containerData.getContainerDeviceList().isAcceleratorPartitionDetected();
+                    }
+
+                    // Use the new filtering method to pre-filter metrics based on all criteria
+                    List<Metric> metricList = filterMetricsBasedOnExpTypeAndK8sObjectAndLayers(
+                            metricProfile,
+                            AnalyzerConstants.MetricName.maxDate.name(),
+                            kruizeObject.getExperimentType(),
+                            containerData,
+                            isROS,
+                            fetchAcceleratorMetrics,
+                            acceleratorFunctions,
+                            acceleratorPartitionFunctions
+                    );
+
+                    // Iterate over pre-filtered metrics and aggregation functions
                     for (Metric metricEntry : metricList) {
-
-                        boolean isAcceleratorMetric = false;
-                        boolean fetchAcceleratorMetrics = false;
-                        boolean isAcceleratorPartitionMetric = false;
-
-                        if (acceleratorFunctions.contains(metricEntry.getName())) {
-                            isAcceleratorMetric = true;
-                        }
-
-                        // Proceed to set fetchAcceleratorMetrics only if it's not ROS
-                        if (isAcceleratorMetric && !isROS
-                                && null != containerData.getContainerDeviceList()
-                                && containerData.getContainerDeviceList().isAcceleratorDeviceDetected()) {
-                            fetchAcceleratorMetrics = true;
-                        }
-
-                        if (acceleratorPartitionFunctions.contains(metricEntry.getName())) {
-                            isAcceleratorPartitionMetric = true;
-                        }
-
-                        // Proceed to set fetchAcceleratorMetrics only if it's not ROS
-                        if (isAcceleratorPartitionMetric && !isROS
-                                && null != containerData.getContainerDeviceList()
-                                && containerData.getContainerDeviceList().isAcceleratorPartitionDetected()) {
-                            fetchAcceleratorMetrics = true;
-                        }
-
-                        // Skip fetching Accelerator metrics if the workload doesn't use Accelerator
-                        if (isAcceleratorMetric && !fetchAcceleratorMetrics)
-                            continue;
-
-                        if (isAcceleratorPartitionMetric && !fetchAcceleratorMetrics)
-                            continue;
-
-                        // Check if this metric requires specific layers
-                        List<String> layersRequired = metricEntry.getLayersRequired();
-                        if (layersRequired != null && !layersRequired.isEmpty()) {
-                            // Check if any of the required layers are detected
-                            boolean layerDetected = false;
-                            for (String layer : layersRequired) {
-                                if (containerData.getLayerMap() != null &&
-                                        containerData.getLayerMap().containsKey(layer)) {
-                                    layerDetected = true;
-                                    break;
-                                }
-                            }
-                            // Skip this metric entirely if required layer is not detected
-                            if (!layerDetected) {
-                                LOGGER.debug("Skipping metric {} - required layer(s) {} not detected for container {}",
-                                        metricEntry.getName(), layersRequired, containerName);
-                                continue;
-                            }
-                        }
+                        // Determine metric type for this specific metric
+                        boolean isAcceleratorMetric = acceleratorFunctions.contains(metricEntry.getName());
+                        boolean isAcceleratorPartitionMetric = acceleratorPartitionFunctions.contains(metricEntry.getName());
 
                         HashMap<String, AggregationFunctions> aggregationFunctions = metricEntry.getAggregationFunctionsMap();
                         for (Map.Entry<String, AggregationFunctions> aggregationFunctionsEntry : aggregationFunctions.entrySet()) {
@@ -1936,6 +1903,88 @@ public class RecommendationEngine implements RecommendationEngineService {
                             (experimentType.name().equalsIgnoreCase(AnalyzerConstants.ExperimentTypes.NAMESPACE_EXPERIMENT) && kubernetes_object.equals(namespace)) ||
                                     (experimentType.name().equalsIgnoreCase(AnalyzerConstants.ExperimentTypes.CONTAINER_EXPERIMENT) && kubernetes_object.equals(container))
                     );
+                })
+                .toList();
+    }
+
+    /**
+     * Filters metrics based on experiment type, kubernetes_object, detected layers, and accelerator support.
+     * This method pre-filters metrics to improve performance by avoiding iteration over irrelevant metrics.
+     *
+     * @param metricProfile                  Metric profile to be used
+     * @param maxDateQuery                   maxDateQuery metric to be filtered out
+     * @param experimentType                 experiment type
+     * @param containerData                  container data containing layer information
+     * @param isROS                          whether ROS is enabled
+     * @param fetchAcceleratorMetrics        whether accelerator metrics should be fetched
+     * @param acceleratorFunctions           list of accelerator metric names
+     * @param acceleratorPartitionFunctions  list of accelerator partition metric names
+     * @return filtered list of metrics
+     */
+    public List<Metric> filterMetricsBasedOnExpTypeAndK8sObjectAndLayers(
+            PerformanceProfile metricProfile,
+            String maxDateQuery,
+            AnalyzerConstants.ExperimentType experimentType,
+            ContainerData containerData,
+            boolean isROS,
+            boolean fetchAcceleratorMetrics,
+            List<String> acceleratorFunctions,
+            List<String> acceleratorPartitionFunctions) {
+
+        String namespace = KruizeConstants.JSONKeys.NAMESPACE;
+        String container = KruizeConstants.JSONKeys.CONTAINER;
+
+        return metricProfile.getSloInfo().getFunctionVariables().stream()
+                .filter(metric -> {
+                    String name = metric.getName();
+                    String kubernetes_object = metric.getKubernetesObject();
+
+                    // Filter out maxDate metric
+                    if (name.equals(maxDateQuery)) {
+                        return false;
+                    }
+
+                    // Filter based on experiment type and kubernetes object
+                    boolean matchesExpType = (experimentType.name().equalsIgnoreCase(AnalyzerConstants.ExperimentTypes.NAMESPACE_EXPERIMENT) && kubernetes_object.equals(namespace)) ||
+                            (experimentType.name().equalsIgnoreCase(AnalyzerConstants.ExperimentTypes.CONTAINER_EXPERIMENT) && kubernetes_object.equals(container));
+
+                    if (!matchesExpType) {
+                        return false;
+                    }
+
+                    // Filter accelerator metrics
+                    boolean isAcceleratorMetric = acceleratorFunctions.contains(name);
+                    boolean isAcceleratorPartitionMetric = acceleratorPartitionFunctions.contains(name);
+
+                    if (isAcceleratorMetric && !fetchAcceleratorMetrics) {
+                        return false;
+                    }
+
+                    if (isAcceleratorPartitionMetric && !fetchAcceleratorMetrics) {
+                        return false;
+                    }
+
+                    // Filter based on required layers
+                    List<String> layersRequired = metric.getLayersRequired();
+                    if (layersRequired != null && !layersRequired.isEmpty()) {
+                        // Check if any of the required layers are detected
+                        boolean layerDetected = false;
+                        for (String layer : layersRequired) {
+                            if (containerData.getLayerMap() != null &&
+                                    containerData.getLayerMap().containsKey(layer)) {
+                                layerDetected = true;
+                                break;
+                            }
+                        }
+                        // Skip this metric if required layer is not detected
+                        if (!layerDetected) {
+                            LOGGER.debug("Skipping metric {} - required layer(s) {} not detected for container {}",
+                                    name, layersRequired, containerData.getContainer_name());
+                            return false;
+                        }
+                    }
+
+                    return true;
                 })
                 .toList();
     }

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -1573,14 +1573,13 @@ public class RecommendationEngine implements RecommendationEngineService {
                         HashMap<String, AggregationFunctions> aggregationFunctions = metricEntry.getAggregationFunctionsMap();
                         for (Map.Entry<String, AggregationFunctions> aggregationFunctionsEntry : aggregationFunctions.entrySet()) {
                             // Check if this metric requires a specific layer
-                            String requiredLayer = aggregationFunctionsEntry.getValue().getRequiredLayer();
-                            if (requiredLayer != null && !requiredLayer.isEmpty()) {
+                            List<String> requiredLayers = aggregationFunctionsEntry.getValue().getRequiredLayer();
+                            if (requiredLayers != null && !requiredLayers.isEmpty()) {
                                 // Check if any of the required layers are detected
-                                String[] requiredLayers = requiredLayer.split(",");
                                 boolean layerDetected = false;
                                 for (String layer : requiredLayers) {
                                     if (containerData.getLayerMap() != null &&
-                                            containerData.getLayerMap().containsKey(layer.trim())) {
+                                            containerData.getLayerMap().containsKey(layer)) {
                                         layerDetected = true;
                                         break;
                                     }
@@ -1588,7 +1587,7 @@ public class RecommendationEngine implements RecommendationEngineService {
                                 // Skip this metric if required layer is not detected
                                 if (!layerDetected) {
                                     LOGGER.debug("Skipping metric {} - required layer(s) {} not detected for container {}",
-                                            metricEntry.getName(), requiredLayer, containerName);
+                                            metricEntry.getName(), requiredLayers, containerName);
                                     continue;
                                 }
                             }

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -1545,7 +1545,6 @@ public class RecommendationEngine implements RecommendationEngineService {
                             AnalyzerConstants.MetricName.maxDate.name(),
                             kruizeObject.getExperimentType(),
                             containerData,
-                            isROS,
                             fetchAcceleratorMetrics,
                             acceleratorFunctions,
                             acceleratorPartitionFunctions
@@ -1915,7 +1914,6 @@ public class RecommendationEngine implements RecommendationEngineService {
      * @param maxDateQuery                   maxDateQuery metric to be filtered out
      * @param experimentType                 experiment type
      * @param containerData                  container data containing layer information
-     * @param isROS                          whether ROS is enabled
      * @param fetchAcceleratorMetrics        whether accelerator metrics should be fetched
      * @param acceleratorFunctions           list of accelerator metric names
      * @param acceleratorPartitionFunctions  list of accelerator partition metric names
@@ -1926,7 +1924,6 @@ public class RecommendationEngine implements RecommendationEngineService {
             String maxDateQuery,
             AnalyzerConstants.ExperimentType experimentType,
             ContainerData containerData,
-            boolean isROS,
             boolean fetchAcceleratorMetrics,
             List<String> acceleratorFunctions,
             List<String> acceleratorPartitionFunctions) {
@@ -1970,7 +1967,8 @@ public class RecommendationEngine implements RecommendationEngineService {
                         // Check if any of the required layers are detected
                         boolean layerDetected = false;
                         for (String layer : layersRequired) {
-                            if (containerData.getLayerMap() != null &&
+                            if (containerData != null &&
+                                    containerData.getLayerMap() != null &&
                                     containerData.getLayerMap().containsKey(layer)) {
                                 layerDetected = true;
                                 break;
@@ -1979,7 +1977,7 @@ public class RecommendationEngine implements RecommendationEngineService {
                         // Skip this metric if required layer is not detected
                         if (!layerDetected) {
                             LOGGER.debug("Skipping metric {} - required layer(s) {} not detected for container {}",
-                                    name, layersRequired, containerData.getContainer_name());
+                                    name, layersRequired, containerData != null ? containerData.getContainer_name() : "unknown");
                             return false;
                         }
                     }

--- a/src/main/java/com/autotune/common/data/metrics/AggregationFunctions.java
+++ b/src/main/java/com/autotune/common/data/metrics/AggregationFunctions.java
@@ -15,14 +15,11 @@
  *******************************************************************************/
 package com.autotune.common.data.metrics;
 
-import java.util.List;
-
 public class AggregationFunctions {
 
     private String function;
     private String query;
     private String version;
-    private List<String> requiredLayer;
 
     public AggregationFunctions(String function, String query, String version) {
         this.function = function;
@@ -54,21 +51,12 @@ public class AggregationFunctions {
         this.version = version;
     }
 
-    public List<String> getRequiredLayer() {
-        return requiredLayer;
-    }
-
-    public void setRequiredLayer(List<String> requiredLayer) {
-        this.requiredLayer = requiredLayer;
-    }
-
     @Override
     public String toString() {
         return "AggregationFunctions{" +
                 "function='" + function + '\'' +
                 ", query='" + query + '\'' +
                 ", version='" + version + '\'' +
-                ", requiredLayer='" + requiredLayer + '\'' +
                 '}';
     }
 }

--- a/src/main/java/com/autotune/common/data/metrics/AggregationFunctions.java
+++ b/src/main/java/com/autotune/common/data/metrics/AggregationFunctions.java
@@ -20,6 +20,7 @@ public class AggregationFunctions {
     private String function;
     private String query;
     private String version;
+    private String requiredLayer;
 
     public AggregationFunctions(String function, String query, String version) {
         this.function = function;
@@ -51,12 +52,21 @@ public class AggregationFunctions {
         this.version = version;
     }
 
+    public String getRequiredLayer() {
+        return requiredLayer;
+    }
+
+    public void setRequiredLayer(String requiredLayer) {
+        this.requiredLayer = requiredLayer;
+    }
+
     @Override
     public String toString() {
         return "AggregationFunctions{" +
                 "function='" + function + '\'' +
                 ", query='" + query + '\'' +
                 ", version='" + version + '\'' +
+                ", requiredLayer='" + requiredLayer + '\'' +
                 '}';
     }
 }

--- a/src/main/java/com/autotune/common/data/metrics/AggregationFunctions.java
+++ b/src/main/java/com/autotune/common/data/metrics/AggregationFunctions.java
@@ -15,12 +15,14 @@
  *******************************************************************************/
 package com.autotune.common.data.metrics;
 
+import java.util.List;
+
 public class AggregationFunctions {
 
     private String function;
     private String query;
     private String version;
-    private String requiredLayer;
+    private List<String> requiredLayer;
 
     public AggregationFunctions(String function, String query, String version) {
         this.function = function;
@@ -52,11 +54,11 @@ public class AggregationFunctions {
         this.version = version;
     }
 
-    public String getRequiredLayer() {
+    public List<String> getRequiredLayer() {
         return requiredLayer;
     }
 
-    public void setRequiredLayer(String requiredLayer) {
+    public void setRequiredLayer(List<String> requiredLayer) {
         this.requiredLayer = requiredLayer;
     }
 

--- a/src/main/java/com/autotune/common/data/metrics/Metric.java
+++ b/src/main/java/com/autotune/common/data/metrics/Metric.java
@@ -41,6 +41,8 @@ public final class Metric {
     private String valueType;
     @SerializedName("kubernetes_object")
     private String kubernetesObject;
+    @SerializedName("layers_required")
+    private List<String> layersRequired;
     private final LinkedHashMap<String, MetricResults> trialSummaryResult = new LinkedHashMap<>();
     @SerializedName("results")
     private MetricResults metricResults;
@@ -111,6 +113,14 @@ public final class Metric {
         this.aggregationFunctionsMap = aggregationFunctionsMap;
     }
 
+    public List<String> getLayersRequired() {
+        return layersRequired;
+    }
+
+    public void setLayersRequired(List<String> layersRequired) {
+        this.layersRequired = layersRequired;
+    }
+
     @Override
     public String toString() {
         return "Metric{" +
@@ -119,6 +129,7 @@ public final class Metric {
                 ", datasource='" + datasource + '\'' +
                 ", valueType='" + valueType + '\'' +
                 ", kubernetesObject='" + kubernetesObject + '\'' +
+                ", layersRequired=" + layersRequired +
                 ", aggregationFunctionsMap=" + aggregationFunctionsMap +
                 '}';
     }


### PR DESCRIPTION
## Description

This PR adds a new `required_layer` attribute in the `aggregation_functions` alongside the `query` to conditionally run the runtime queries based on the corresponding layer detection.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Introduce conditional execution of runtime metrics based on detected layers to reduce unnecessary queries and improve efficiency.

New Features:
- Add optional layers_required attribute to metrics to gate runtime Prometheus queries on detected runtime layers.
- Extend metric filtering in the recommendation engine to consider experiment type, Kubernetes object, detected layers, and accelerator support before executing queries.

Enhancements:
- Refactor recommendation engine metric filtering to pre-filter metrics for accelerators and layers, reducing redundant checks and query executions.
- Update performance profile manifests and version to annotate JVM-related metrics with required runtime layers.

Documentation:
- Add an ADR documenting the design and behavior of conditional runtime metric queries based on layer detection.