### PR TITLE
Add new metric 'podCount' to profiles

### DIFF
--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.json
@@ -505,19 +505,19 @@
         "aggregation_functions": [
           {
             "function": "sum",
-            "query": "sum(kube_pod_container_status_ready{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})"
+            "query": "sum(kube_pod_container_status_ready{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})"
           },
           {
             "function": "avg",
-            "query": "avg_over_time(sum(kube_pod_container_status_ready{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})[15m:])"
+            "query": "avg_over_time(sum(kube_pod_container_status_ready{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
           },
           {
             "function": "max",
-            "query": "max_over_time(sum(kube_pod_container_status_ready{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})[15m:])"
+            "query": "max_over_time(sum(kube_pod_container_status_ready{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
           },
           {
             "function": "min",
-            "query": "min_over_time(sum(kube_pod_container_status_ready{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})[15m:])"
+            "query": "min_over_time(sum(kube_pod_container_status_ready{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
           }
         ]
       }

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.json
@@ -496,6 +496,30 @@
             "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info_total{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})"
           }
         ]
+      },
+      {
+        "name": "podCount",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "sum",
+            "query": "sum(kube_pod_container_status_ready{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})"
+          },
+          {
+            "function": "avg",
+            "query": "avg_over_time(sum(kube_pod_container_status_ready{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})[15m:])"
+          },
+          {
+            "function": "max",
+            "query": "max_over_time(sum(kube_pod_container_status_ready{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})[15m:])"
+          },
+          {
+            "function": "min",
+            "query": "min_over_time(sum(kube_pod_container_status_ready{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})[15m:])"
+          }
+        ]
       }
     ]
   }

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.yaml
@@ -236,7 +236,28 @@ slo:
     - function: sum
       query: 'sum by(container, namespace) (avg_over_time(container_memory_rss{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
+    # Pod Count (based on READY containers, not total pods)
+  - name: podCount
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "container"
 
+    aggregation_functions:
+      # Current ready pods
+      - function: sum
+        query: 'sum(kube_pod_container_status_ready{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+
+      # Avg ready pods over time
+      - function: avg
+        query: 'avg_over_time(sum(kube_pod_container_status_ready{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+      # Max ready pods over time
+      - function: max
+        query: 'max_over_time(sum(kube_pod_container_status_ready{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+      # Min ready pods over time
+      - function: min
+        query: 'min_over_time(sum(kube_pod_container_status_ready{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})[$MEASUREMENT_DURATION_IN_MIN$m:])'
   # Container Last Active Timestamp
   - name: maxDate
     datasource: prometheus

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.yaml
@@ -236,7 +236,7 @@ slo:
     - function: sum
       query: 'sum by(container, namespace) (avg_over_time(container_memory_rss{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
-    # Pod Count (based on READY containers, not total pods)
+  # Pod Count (based on READY containers, not total pods)
   - name: podCount
     datasource: prometheus
     value_type: "double"

--- a/manifests/autotune/performance-profiles/resource_optimization_openshift.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_openshift.json
@@ -429,19 +429,19 @@
         "aggregation_functions": [
           {
             "function": "sum",
-            "query": "sum(kube_pod_container_status_ready{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})"
+            "query": "sum(kube_pod_container_status_ready{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})"
           },
           {
             "function": "avg",
-            "query": "avg_over_time(sum(kube_pod_container_status_ready{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})[15m:])"
+            "query": "avg_over_time(sum(kube_pod_container_status_ready{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
           },
           {
             "function": "max",
-            "query": "max_over_time(sum(kube_pod_container_status_ready{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})[15m:])"
+            "query": "max_over_time(sum(kube_pod_container_status_ready{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
           },
           {
             "function": "min",
-            "query": "min_over_time(sum(kube_pod_container_status_ready{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})[15m:])"
+            "query": "min_over_time(sum(kube_pod_container_status_ready{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
           }
         ]
       }

--- a/manifests/autotune/performance-profiles/resource_optimization_openshift.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_openshift.json
@@ -420,6 +420,30 @@
             "query": "avg(avg_over_time(DCGM_FI_DEV_FB_USED{exported_namespace != \"\", exported_container != \"\", exported_pod != \"\"}[15m])) by (modelName, GPU_I_PROFILE, exported_container, exported_namespace, exported_pod, Hostname)"
           }
         ]
+      },
+      {
+        "name": "podCount",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "sum",
+            "query": "sum(kube_pod_container_status_ready{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})"
+          },
+          {
+            "function": "avg",
+            "query": "avg_over_time(sum(kube_pod_container_status_ready{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})[15m:])"
+          },
+          {
+            "function": "max",
+            "query": "max_over_time(sum(kube_pod_container_status_ready{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})[15m:])"
+          },
+          {
+            "function": "min",
+            "query": "min_over_time(sum(kube_pod_container_status_ready{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})[15m:])"
+          }
+        ]
       }
     ]
   }

--- a/manifests/autotune/performance-profiles/resource_optimization_openshift.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_openshift.yaml
@@ -217,17 +217,21 @@ slo:
     kubernetes_object: "container"
 
     aggregation_functions:
+      # Current ready pods
       - function: sum
-        query: 'sum(kube_pod_container_status_ready{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+        query: 'sum(kube_pod_container_status_ready{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
 
+      # Avg ready pods over time
       - function: avg
-        query: 'avg_over_time(sum(kube_pod_container_status_ready{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})[15m:])'
+        query: 'avg_over_time(sum(kube_pod_container_status_ready{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})[$MEASUREMENT_DURATION_IN_MIN$m:])'
 
+      # Max ready pods over time
       - function: max
-        query: 'max_over_time(sum(kube_pod_container_status_ready{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})[15m:])'
+        query: 'max_over_time(sum(kube_pod_container_status_ready{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})[$MEASUREMENT_DURATION_IN_MIN$m:])'
 
+      # Min ready pods over time
       - function: min
-        query: 'min_over_time(sum(kube_pod_container_status_ready{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})[15m:])'
+        query: 'min_over_time(sum(kube_pod_container_status_ready{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})[$MEASUREMENT_DURATION_IN_MIN$m:])'
     ## namespace related queries
 
     # Namespace quota for CPU requests

--- a/manifests/autotune/performance-profiles/resource_optimization_openshift.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_openshift.yaml
@@ -210,6 +210,24 @@ slo:
     - function: sum
       query: 'sum by(container, namespace)(avg_over_time(container_memory_rss{container!="", container!="POD", pod!="", namespace=$NAMESPACE$, container=”$CONTAINER_NAME$”}[15m]))'
 
+  # Pod Count (based on READY containers)
+  - name: podCount
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "container"
+
+    aggregation_functions:
+      - function: sum
+        query: 'sum(kube_pod_container_status_ready{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+
+      - function: avg
+        query: 'avg_over_time(sum(kube_pod_container_status_ready{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})[15m:])'
+
+      - function: max
+        query: 'max_over_time(sum(kube_pod_container_status_ready{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})[15m:])'
+
+      - function: min
+        query: 'min_over_time(sum(kube_pod_container_status_ready{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})[15m:])'
     ## namespace related queries
 
     # Namespace quota for CPU requests


### PR DESCRIPTION
## Description

Please describe the issue or feature and the summary of changes made to fix this. 

This PR introduces support for a new metric podCount, which will be ingested from ROS via the updateResults API endpoint.
The changes include updates to the performance profile and metric profile manifests (JSON/YAML) to incorporate:
- Definition of the new podCount metric
- Associated PromQL queries as specified in the ADR
These updates align with the design outlined in the ADR for pod count metrics:
https://github.com/kruize/kruize-docs/blob/main/design/pod-count/pod-count-adr.md#cost-management-queries

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

The basic JSON validation is done and functional tests have dependency on other changes , hence delaying it further.

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Add support for a podCount metric based on ready containers across Kubernetes and OpenShift performance profiles.

New Features:
- Introduce a podCount metric derived from kube_pod_container_status_ready for local monitoring and OpenShift resource optimization profiles.

Enhancements:
- Extend performance profile manifests to include aggregation functions (sum, avg, max, min) for podCount over the measurement window.