### PR TITLE
Fixed netty cve and upgraded to RH UBI minimal 10.1 latest available

### DIFF
--- a/Dockerfile.autotune
+++ b/Dockerfile.autotune
@@ -16,7 +16,7 @@
 ##########################################################
 #            Build Docker Image
 ##########################################################
-FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1772441549 as mvnbuild-jdk25
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1774545417 as mvnbuild-jdk25
 ARG USER=autotune
 ARG AUTOTUNE_HOME=/home/$USER
 
@@ -49,7 +49,7 @@ RUN jlink --strip-debug --compress 2 --no-header-files --no-man-pages --module-p
 #            Runtime Docker Image
 ##########################################################
 # Use ubi-minimal as the base image
-FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1772441549
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1774545417
 
 ARG AUTOTUNE_VERSION
 ARG USER=autotune

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <hibernatecp30-version>6.1.7.Final</hibernatecp30-version>
         <hibernate-Validator>8.0.1.Final</hibernate-Validator>
         <micrometer-version>1.9.9</micrometer-version>
-        <awssdk-version>2.42.6</awssdk-version>
+        <awssdk-version>2.42.28</awssdk-version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
## Description

Fixed netty cve and upgraded to RH UBI minimal 10.1 latest available

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Quay scan report on the image & PR check

**Test Configuration**
* Kubernetes clusters tested on: minikube

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Update dependencies to address security vulnerabilities and align with the latest supported runtime image.

Bug Fixes:
- Upgrade AWS SDK dependency to a newer patch version to remediate known vulnerabilities.

Enhancements:
- Refresh container build to use the latest Red Hat UBI minimal 10.1 base image for the autotune component.