### PR TITLE
include replicas in current config

### DIFF
--- a/src/main/java/com/autotune/analyzer/recommendations/Config.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/Config.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 public class Config {
+    private Integer replicas;
     private Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> requests;
     private Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> limits;
     private List<RecommendationConfigEnv> env;
@@ -48,5 +49,13 @@ public class Config {
 
     public void setEnv(List<RecommendationConfigEnv> env) {
         this.env = env;
+    }
+
+    public Integer getReplicas() {
+        return replicas;
+    }
+
+    public void setReplicas(Integer replicas) {
+        this.replicas = replicas;
     }
 }

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/BaseRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/BaseRecommendationProcessor.java
@@ -164,7 +164,7 @@ public abstract class BaseRecommendationProcessor {
     /**
      * Extracts current configuration items from requests and limits maps.
      *
-     * @param currentConfig object to reresent current configuration
+     * @param currentConfig object to represent current configuration
      * @return CurrentConfigValues object containing CPU and memory request/limit values
      */
     protected CurrentConfigValues extractCurrentConfig(Config currentConfig) {

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/BaseRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/BaseRecommendationProcessor.java
@@ -17,6 +17,7 @@
 package com.autotune.analyzer.recommendations.engine;
 
 import com.autotune.analyzer.kruizeObject.RecommendationSettings;
+import com.autotune.analyzer.recommendations.Config;
 import com.autotune.analyzer.recommendations.RecommendationConfigItem;
 import com.autotune.analyzer.recommendations.RecommendationConstants;
 import com.autotune.analyzer.utils.AnalyzerConstants;
@@ -26,7 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Map;
 
 import static com.autotune.analyzer.recommendations.RecommendationConstants.RecommendationValueConstants.DEFAULT_CPU_THRESHOLD;
 import static com.autotune.analyzer.recommendations.RecommendationConstants.RecommendationValueConstants.DEFAULT_MEMORY_THRESHOLD;
@@ -163,43 +164,26 @@ public abstract class BaseRecommendationProcessor {
     /**
      * Extracts current configuration items from requests and limits maps.
      *
-     * @param currentConfigMap Map containing current configuration
+     * @param currentConfig object to reresent current configuration
      * @return CurrentConfigValues object containing CPU and memory request/limit values
      */
-    protected CurrentConfigValues extractCurrentConfig(
-            HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> currentConfigMap) {
+    protected CurrentConfigValues extractCurrentConfig(Config currentConfig) {
 
         RecommendationConfigItem currentCPURequest = null;
         RecommendationConfigItem currentCPULimit = null;
         RecommendationConfigItem currentMemRequest = null;
         RecommendationConfigItem currentMemLimit = null;
 
-        if (currentConfigMap.containsKey(AnalyzerConstants.ResourceSetting.requests) &&
-                null != currentConfigMap.get(AnalyzerConstants.ResourceSetting.requests)) {
-            HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> requestsMap =
-                    currentConfigMap.get(AnalyzerConstants.ResourceSetting.requests);
-            if (requestsMap.containsKey(AnalyzerConstants.RecommendationItem.CPU) &&
-                    null != requestsMap.get(AnalyzerConstants.RecommendationItem.CPU)) {
-                currentCPURequest = requestsMap.get(AnalyzerConstants.RecommendationItem.CPU);
-            }
-            if (requestsMap.containsKey(AnalyzerConstants.RecommendationItem.MEMORY) &&
-                    null != requestsMap.get(AnalyzerConstants.RecommendationItem.MEMORY)) {
-                currentMemRequest = requestsMap.get(AnalyzerConstants.RecommendationItem.MEMORY);
-            }
-        }
+        Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> requests = currentConfig.getRequests();
+        Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> limits = currentConfig.getLimits();
 
-        if (currentConfigMap.containsKey(AnalyzerConstants.ResourceSetting.limits) &&
-                null != currentConfigMap.get(AnalyzerConstants.ResourceSetting.limits)) {
-            HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> limitsMap =
-                    currentConfigMap.get(AnalyzerConstants.ResourceSetting.limits);
-            if (limitsMap.containsKey(AnalyzerConstants.RecommendationItem.CPU) &&
-                    null != limitsMap.get(AnalyzerConstants.RecommendationItem.CPU)) {
-                currentCPULimit = limitsMap.get(AnalyzerConstants.RecommendationItem.CPU);
-            }
-            if (limitsMap.containsKey(AnalyzerConstants.RecommendationItem.MEMORY) &&
-                    null != limitsMap.get(AnalyzerConstants.RecommendationItem.MEMORY)) {
-                currentMemLimit = limitsMap.get(AnalyzerConstants.RecommendationItem.MEMORY);
-            }
+        if (null != requests) {
+            currentCPURequest = requests.get(AnalyzerConstants.RecommendationItem.CPU);
+            currentMemRequest = requests.get(AnalyzerConstants.RecommendationItem.MEMORY);
+        }
+        if (null != limits) {
+            currentCPULimit = limits.get(AnalyzerConstants.RecommendationItem.CPU);
+            currentMemLimit = limits.get(AnalyzerConstants.RecommendationItem.MEMORY);
         }
 
         return new CurrentConfigValues(currentCPURequest, currentCPULimit, currentMemRequest, currentMemLimit);

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
@@ -88,8 +88,7 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
 
         timestampRecommendation.setMonitoringEndTime(monitoringEndTime);
 
-        HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> currentConfig =
-                getCurrentConfigData(containerData, monitoringEndTime, timestampRecommendation);
+        Config currentConfig = getCurrentConfigData(containerData, monitoringEndTime, timestampRecommendation);
         timestampRecommendation.setCurrentConfig(currentConfig);
 
         boolean recommendationAvailable = generateRecommendationsBasedOnTerms(containerData, kruizeObject, monitoringEndTime, currentConfig, timestampRecommendation);
@@ -110,10 +109,9 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
         containerData.setContainerRecommendations(containerRecommendations);
     }
 
-    private HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> getCurrentConfigData(
-            ContainerData containerData, Timestamp monitoringEndTime, MappedRecommendationForTimestamp timestampRecommendation) {
+    private Config getCurrentConfigData(ContainerData containerData, Timestamp monitoringEndTime, MappedRecommendationForTimestamp timestampRecommendation) {
 
-        HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> currentConfig = new HashMap<>();
+        Config currentConfig = new Config();
         ArrayList<RecommendationConstants.RecommendationNotification> notifications = new ArrayList<>();
         HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> currentRequestsMap = new HashMap<>();
         HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> currentLimitsMap = new HashMap<>();
@@ -121,21 +119,42 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
         String experimentName = engineService.getExperimentName();
         Timestamp intervalEndTime = engineService.getInterval_end_time();
 
+        RecommendationConfigItem configItem = RecommendationUtils.getCurrentValue(AnalyzerConstants.MetricName.podCount, containerData.getResults(), monitoringEndTime, notifications);
+        if (configItem != null) {
+            int replicas = configItem.getAmount().intValue();
+            LOGGER.info("Current replicas for workload '{}' is {}", containerData.getContainer_name(), replicas);
+            currentConfig.setReplicas(replicas);
+        }
+
         for (AnalyzerConstants.ResourceSetting resourceSetting : AnalyzerConstants.ResourceSetting.values()) {
             for (AnalyzerConstants.RecommendationItem recommendationItem : AnalyzerConstants.RecommendationItem.values()) {
-                RecommendationConfigItem configItem = RecommendationUtils.getCurrentValue(containerData.getResults(),
-                        monitoringEndTime, resourceSetting, recommendationItem, notifications);
-
-                // Use base class validation method
-                if (!validateConfigItem(configItem, recommendationItem, notifications, LOGGER, experimentName, intervalEndTime)) {
-                    continue;
-                }
-
+                AnalyzerConstants.MetricName metricName = null;
                 if (resourceSetting == AnalyzerConstants.ResourceSetting.requests) {
-                    currentRequestsMap.put(recommendationItem, configItem);
+                    if (recommendationItem == AnalyzerConstants.RecommendationItem.CPU)
+                        metricName = AnalyzerConstants.MetricName.cpuRequest;
+                    else if (recommendationItem == AnalyzerConstants.RecommendationItem.MEMORY)
+                        metricName = AnalyzerConstants.MetricName.memoryRequest;
+                } else if (resourceSetting == AnalyzerConstants.ResourceSetting.limits) {
+                    if (recommendationItem == AnalyzerConstants.RecommendationItem.CPU)
+                        metricName = AnalyzerConstants.MetricName.cpuLimit;
+                    else if (recommendationItem == AnalyzerConstants.RecommendationItem.MEMORY)
+                        metricName = AnalyzerConstants.MetricName.memoryLimit;
                 }
-                if (resourceSetting == AnalyzerConstants.ResourceSetting.limits) {
-                    currentLimitsMap.put(recommendationItem, configItem);
+                // metricName is null for RecommendationItem other than MEMORY and CPU
+                if (metricName != null) {
+                    configItem = RecommendationUtils.getCurrentValue(metricName, containerData.getResults(), monitoringEndTime, notifications);
+                    // Use base class validation method
+                    // Handle case of missing (avg is null) or invalid data (avg is <= 0)
+                    if (!validateConfigItem(configItem, recommendationItem, notifications, LOGGER, experimentName, intervalEndTime)) {
+                        continue;
+                    }
+
+                    if (resourceSetting == AnalyzerConstants.ResourceSetting.requests) {
+                        currentRequestsMap.put(recommendationItem, configItem);
+                    }
+                    if (resourceSetting == AnalyzerConstants.ResourceSetting.limits) {
+                        currentLimitsMap.put(recommendationItem, configItem);
+                    }
                 }
             }
         }
@@ -143,19 +162,19 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
         for (RecommendationConstants.RecommendationNotification recommendationNotification : notifications) {
             timestampRecommendation.addNotification(new RecommendationNotification(recommendationNotification));
         }
+
         if (!currentRequestsMap.isEmpty()) {
-            currentConfig.put(AnalyzerConstants.ResourceSetting.requests, currentRequestsMap);
+            currentConfig.setRequests(currentRequestsMap);
         }
         if (!currentLimitsMap.isEmpty()) {
-            currentConfig.put(AnalyzerConstants.ResourceSetting.limits, currentLimitsMap);
+            currentConfig.setLimits(currentLimitsMap);
         }
         return currentConfig;
     }
 
     private boolean generateRecommendationsBasedOnTerms(ContainerData containerData, KruizeObject kruizeObject,
                                                        Timestamp monitoringEndTime,
-                                                       HashMap<AnalyzerConstants.ResourceSetting,
-                                                               HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> currentConfig,
+                                                       Config currentConfig,
                                                        MappedRecommendationForTimestamp timestampRecommendation) {
         boolean recommendationAvailable = false;
         double measurementDuration = kruizeObject.getTrial_settings().getMeasurement_durationMinutes_inDouble();
@@ -248,8 +267,7 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
     private MappedRecommendationForModel generateRecommendationBasedOnModel(RecommendationModel model, ContainerData containerData,
                                                                             Map<Timestamp, IntervalResults> filteredResultsMap,
                                                                             KruizeObject kruizeObject,
-                                                                            HashMap<AnalyzerConstants.ResourceSetting,
-                                                                                    HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> currentConfigMap,
+                                                                            Config currentConfig,
                                                                             Map.Entry<String, Terms> termEntry) {
 
         MappedRecommendationForModel mappedRecommendationForModel = new MappedRecommendationForModel();
@@ -260,11 +278,11 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
         double memoryThreshold = thresholds.memoryThreshold;
 
         // Extract current config using base class helper
-        CurrentConfigValues currentConfig = extractCurrentConfig(currentConfigMap);
-        RecommendationConfigItem currentCPURequest = currentConfig.cpuRequest;
-        RecommendationConfigItem currentCPULimit = currentConfig.cpuLimit;
-        RecommendationConfigItem currentMemRequest = currentConfig.memoryRequest;
-        RecommendationConfigItem currentMemLimit = currentConfig.memoryLimit;
+        CurrentConfigValues currentConfigValues = extractCurrentConfig(currentConfig);
+        RecommendationConfigItem currentCPURequest = currentConfigValues.cpuRequest;
+        RecommendationConfigItem currentCPULimit = currentConfigValues.cpuLimit;
+        RecommendationConfigItem currentMemRequest = currentConfigValues.memoryRequest;
+        RecommendationConfigItem currentMemLimit = currentConfigValues.memoryLimit;
 
         ArrayList<RecommendationNotification> notifications = new ArrayList<>();
         RecommendationConfigItem recommendationCpuRequest = model.getCPURequestRecommendation(filteredResultsMap, notifications);

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/NamespaceRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/NamespaceRecommendationProcessor.java
@@ -19,10 +19,7 @@ package com.autotune.analyzer.recommendations.engine;
 import com.autotune.analyzer.kruizeObject.KruizeObject;
 import com.autotune.analyzer.kruizeObject.RecommendationSettings;
 import com.autotune.analyzer.plots.PlotManager;
-import com.autotune.analyzer.recommendations.NamespaceRecommendations;
-import com.autotune.analyzer.recommendations.RecommendationConfigItem;
-import com.autotune.analyzer.recommendations.RecommendationConstants;
-import com.autotune.analyzer.recommendations.RecommendationNotification;
+import com.autotune.analyzer.recommendations.*;
 import com.autotune.analyzer.recommendations.model.RecommendationModel;
 import com.autotune.analyzer.recommendations.objects.MappedRecommendationForModel;
 import com.autotune.analyzer.recommendations.objects.MappedRecommendationForTimestamp;
@@ -94,8 +91,7 @@ public final class NamespaceRecommendationProcessor extends BaseRecommendationPr
 
             timestampRecommendation.setMonitoringEndTime(monitoringEndTime);
 
-            HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> currentConfig =
-                    getCurrentNamespaceConfigData(namespaceData, monitoringEndTime, timestampRecommendation);
+            Config currentConfig = getCurrentNamespaceConfigData(namespaceData, monitoringEndTime, timestampRecommendation);
             timestampRecommendation.setCurrentConfig(currentConfig);
 
             boolean recommendationAvailable = generateNamespaceRecommendationsBasedOnTerms(namespaceData, kruizeObject, monitoringEndTime, currentConfig, timestampRecommendation);
@@ -119,10 +115,9 @@ public final class NamespaceRecommendationProcessor extends BaseRecommendationPr
         }
     }
 
-    private HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> getCurrentNamespaceConfigData(
-            NamespaceData namespaceData, Timestamp monitoringEndTime, MappedRecommendationForTimestamp timestampRecommendation) {
+    private Config getCurrentNamespaceConfigData(NamespaceData namespaceData, Timestamp monitoringEndTime, MappedRecommendationForTimestamp timestampRecommendation) {
 
-        HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> currentNamespaceConfig = new HashMap<>();
+        Config currentConfig = new Config();
         ArrayList<RecommendationConstants.RecommendationNotification> notifications = new ArrayList<>();
         HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> currentNamespaceRequestsMap = new HashMap<>();
         HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> currentNamespaceLimitsMap = new HashMap<>();
@@ -130,20 +125,37 @@ public final class NamespaceRecommendationProcessor extends BaseRecommendationPr
         String experimentName = engineService.getExperimentName();
         Timestamp intervalEndTime = engineService.getInterval_end_time();
 
+
+
         for (AnalyzerConstants.ResourceSetting resourceSetting : AnalyzerConstants.ResourceSetting.values()) {
             for (AnalyzerConstants.RecommendationItem recommendationItem : AnalyzerConstants.RecommendationItem.values()) {
-                RecommendationConfigItem configItem = RecommendationUtils.getCurrentValueForNamespace(namespaceData.getResults(), monitoringEndTime, resourceSetting, recommendationItem, notifications);
-
-                // Use base class validation method
-                if (!validateConfigItem(configItem, recommendationItem, notifications, LOGGER, experimentName, intervalEndTime)) {
-                    continue;
-                }
-
+                AnalyzerConstants.MetricName metricName = null;
                 if (resourceSetting == AnalyzerConstants.ResourceSetting.requests) {
-                    currentNamespaceRequestsMap.put(recommendationItem, configItem);
+                    if (recommendationItem == AnalyzerConstants.RecommendationItem.CPU)
+                        metricName = AnalyzerConstants.MetricName.namespaceCpuRequest;
+                    else if (recommendationItem == AnalyzerConstants.RecommendationItem.MEMORY)
+                        metricName = AnalyzerConstants.MetricName.namespaceMemoryRequest;
+                } else if (resourceSetting == AnalyzerConstants.ResourceSetting.limits) {
+                    if (recommendationItem == AnalyzerConstants.RecommendationItem.CPU)
+                        metricName = AnalyzerConstants.MetricName.namespaceCpuLimit;
+                    else if (recommendationItem == AnalyzerConstants.RecommendationItem.MEMORY)
+                        metricName = AnalyzerConstants.MetricName.namespaceMemoryLimit;
                 }
-                if (resourceSetting == AnalyzerConstants.ResourceSetting.limits) {
-                    currentNamespaceLimitsMap.put(recommendationItem, configItem);
+
+                if (metricName != null) {
+                    RecommendationConfigItem configItem = RecommendationUtils.getCurrentValue(metricName, namespaceData.getResults(), monitoringEndTime, notifications);
+
+                    // Use base class validation method
+                    if (!validateConfigItem(configItem, recommendationItem, notifications, LOGGER, experimentName, intervalEndTime)) {
+                        continue;
+                    }
+
+                    if (resourceSetting == AnalyzerConstants.ResourceSetting.requests) {
+                        currentNamespaceRequestsMap.put(recommendationItem, configItem);
+                    }
+                    if (resourceSetting == AnalyzerConstants.ResourceSetting.limits) {
+                        currentNamespaceLimitsMap.put(recommendationItem, configItem);
+                    }
                 }
             }
         }
@@ -152,18 +164,17 @@ public final class NamespaceRecommendationProcessor extends BaseRecommendationPr
             timestampRecommendation.addNotification(new RecommendationNotification(recommendationNotification));
         }
         if (!currentNamespaceRequestsMap.isEmpty()) {
-            currentNamespaceConfig.put(AnalyzerConstants.ResourceSetting.requests, currentNamespaceRequestsMap);
+            currentConfig.setRequests(currentNamespaceRequestsMap);
         }
         if (!currentNamespaceLimitsMap.isEmpty()) {
-            currentNamespaceConfig.put(AnalyzerConstants.ResourceSetting.limits, currentNamespaceLimitsMap);
+            currentConfig.setLimits(currentNamespaceLimitsMap);
         }
-        return currentNamespaceConfig;
+        return currentConfig;
     }
 
     private boolean generateNamespaceRecommendationsBasedOnTerms(NamespaceData namespaceData, KruizeObject kruizeObject,
                                                                 Timestamp monitoringEndTime,
-                                                                HashMap<AnalyzerConstants.ResourceSetting,
-                                                                        HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> currentConfig,
+                                                                Config currentConfig,
                                                                 MappedRecommendationForTimestamp timestampRecommendation) {
         boolean namespaceRecommendationAvailable = false;
         double measurementDuration = kruizeObject.getTrial_settings().getMeasurement_durationMinutes_inDouble();
@@ -252,8 +263,7 @@ public final class NamespaceRecommendationProcessor extends BaseRecommendationPr
     private MappedRecommendationForModel generateNamespaceRecommendationBasedOnModel(RecommendationModel model,
                                                                                     Map<Timestamp, IntervalResults> filteredResultsMap,
                                                                                     RecommendationSettings recommendationSettings,
-                                                                                    HashMap<AnalyzerConstants.ResourceSetting,
-                                                                                            HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> currentNamespaceConfigMap,
+                                                                                    Config currentConfig,
                                                                                     Map.Entry<String, Terms> termEntry) {
         MappedRecommendationForModel mappedRecommendationForModel = new MappedRecommendationForModel();
         
@@ -263,11 +273,11 @@ public final class NamespaceRecommendationProcessor extends BaseRecommendationPr
         double namespaceMemoryThreshold = thresholds.memoryThreshold;
 
         // Extract current config using base class helper
-        CurrentConfigValues currentConfig = extractCurrentConfig(currentNamespaceConfigMap);
-        RecommendationConfigItem currentNamespaceCPURequest = currentConfig.cpuRequest;
-        RecommendationConfigItem currentNamespaceCPULimit = currentConfig.cpuLimit;
-        RecommendationConfigItem currentNamespaceMemRequest = currentConfig.memoryRequest;
-        RecommendationConfigItem currentNamespaceMemLimit = currentConfig.memoryLimit;
+        CurrentConfigValues currentConfigValues = extractCurrentConfig(currentConfig);
+        RecommendationConfigItem currentNamespaceCPURequest = currentConfigValues.cpuRequest;
+        RecommendationConfigItem currentNamespaceCPULimit = currentConfigValues.cpuLimit;
+        RecommendationConfigItem currentNamespaceMemRequest = currentConfigValues.memoryRequest;
+        RecommendationConfigItem currentNamespaceMemLimit = currentConfigValues.memoryLimit;
 
         ArrayList<RecommendationNotification> notifications = new ArrayList<>();
         RecommendationConfigItem namespaceRecommendationCpuRequest = model.getCPURequestRecommendationForNamespace(filteredResultsMap, notifications);

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/NamespaceRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/NamespaceRecommendationProcessor.java
@@ -143,7 +143,7 @@ public final class NamespaceRecommendationProcessor extends BaseRecommendationPr
                 }
 
                 if (metricName != null) {
-                    RecommendationConfigItem configItem = RecommendationUtils.getCurrentValue(metricName, namespaceData.getResults(), monitoringEndTime, notifications);
+                    RecommendationConfigItem configItem = RecommendationUtils.getCurrentValueForNamespace(metricName, namespaceData.getResults(), monitoringEndTime, notifications);
 
                     // Use base class validation method
                     if (!validateConfigItem(configItem, recommendationItem, notifications, LOGGER, experimentName, intervalEndTime)) {

--- a/src/main/java/com/autotune/analyzer/recommendations/objects/MappedRecommendationForTimestamp.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/objects/MappedRecommendationForTimestamp.java
@@ -1,5 +1,6 @@
 package com.autotune.analyzer.recommendations.objects;
 
+import com.autotune.analyzer.recommendations.Config;
 import com.autotune.analyzer.recommendations.RecommendationConfigItem;
 import com.autotune.analyzer.recommendations.RecommendationConstants;
 import com.autotune.analyzer.recommendations.RecommendationNotification;
@@ -23,7 +24,7 @@ public class MappedRecommendationForTimestamp {
     private Timestamp monitoringEndTime;
 
     @SerializedName(KruizeConstants.JSONKeys.CURRENT)
-    private HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> currentConfig;
+    private Config currentConfig;
 
     @SerializedName(KruizeConstants.JSONKeys.RECOMMENDATION_TERMS)
     private HashMap<String, TermRecommendations> recommendationForTermHashMap;
@@ -44,11 +45,11 @@ public class MappedRecommendationForTimestamp {
         this.monitoringEndTime = monitoringEndTime;
     }
 
-    public HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> getCurrentConfig() {
+    public Config getCurrentConfig() {
         return currentConfig;
     }
 
-    public void setCurrentConfig(HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> currentConfig) {
+    public void setCurrentConfig(Config currentConfig) {
         this.currentConfig = currentConfig;
     }
 

--- a/src/main/java/com/autotune/analyzer/recommendations/utils/RecommendationUtils.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/utils/RecommendationUtils.java
@@ -93,7 +93,7 @@ public class RecommendationUtils {
 
                 // if podCount is determined to be 0, return null.
                 if (currentValue != null && currentValue > 0.0) {
-                    return new RecommendationConfigItem(currentValue, format);
+                    return new RecommendationConfigItem(Math.ceil(currentValue), format);
                 }
             } else { // limits & requests
                 MetricResults metricResults = intervalResults.getMetricResultsMap().get(metricName);

--- a/src/main/java/com/autotune/analyzer/recommendations/utils/RecommendationUtils.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/utils/RecommendationUtils.java
@@ -38,6 +38,19 @@ import static com.autotune.analyzer.utils.AnalyzerConstants.ServiceConstants.CHA
 public class RecommendationUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(RecommendationUtils.class);
 
+    /**
+     * To populate current config of containers, we need to get request and limits of CPU and MEMORY of last datapoint.
+     * Currently, it supports
+     *   limits
+     *   requests
+     *   replicas
+     *
+     * @param metricName Name of the metric for which current value is to be determined
+     * @param filteredResultsMap List of datapoints of all metrics
+     * @param timestampToExtract Timestamp of datapoint to consider for current config
+     * @param notifications List of errors (if any).
+     * @return RecommendationConfigItem with value and format.
+     */
     public static RecommendationConfigItem getCurrentValue(AnalyzerConstants.MetricName metricName, Map<Timestamp, IntervalResults> filteredResultsMap, Timestamp timestampToExtract, ArrayList<RecommendationConstants.RecommendationNotification> notifications) {
         Double currentValue = null;
         String format = null;
@@ -96,14 +109,59 @@ public class RecommendationUtils {
         }
 
         // Shouldn't reach here in normal scenarios
-        if (metricName == AnalyzerConstants.MetricName.cpuRequest)
-            notifications.add(RecommendationConstants.RecommendationNotification.CRITICAL_CPU_REQUEST_NOT_SET);
-        else if (metricName == AnalyzerConstants.MetricName.memoryRequest)
-            notifications.add(RecommendationConstants.RecommendationNotification.CRITICAL_MEMORY_REQUEST_NOT_SET);
-        else if (metricName == AnalyzerConstants.MetricName.cpuLimit)
-            notifications.add(RecommendationConstants.RecommendationNotification.WARNING_CPU_LIMIT_NOT_SET);
-        else if (metricName == AnalyzerConstants.MetricName.memoryLimit)
-            notifications.add(RecommendationConstants.RecommendationNotification.CRITICAL_MEMORY_LIMIT_NOT_SET);
+        if (notifications != null) {
+            if (metricName == AnalyzerConstants.MetricName.cpuRequest)
+                notifications.add(RecommendationConstants.RecommendationNotification.CRITICAL_CPU_REQUEST_NOT_SET);
+            else if (metricName == AnalyzerConstants.MetricName.memoryRequest)
+                notifications.add(RecommendationConstants.RecommendationNotification.CRITICAL_MEMORY_REQUEST_NOT_SET);
+            else if (metricName == AnalyzerConstants.MetricName.cpuLimit)
+                notifications.add(RecommendationConstants.RecommendationNotification.WARNING_CPU_LIMIT_NOT_SET);
+            else if (metricName == AnalyzerConstants.MetricName.memoryLimit)
+                notifications.add(RecommendationConstants.RecommendationNotification.CRITICAL_MEMORY_LIMIT_NOT_SET);
+        }
+
+        return null;
+    }
+
+    /**
+     * To populate current config of namespace, we need to get request and limits of CPU and MEMORY of last datapoint.
+     * Currently, it supports
+     *   limits
+     *   requests
+     *
+     * @param metricName Name of the metric for which current value is to be determined
+     * @param filteredResultsMap List of datapoints of all metrics
+     * @param timestampToExtract Timestamp of datapoint to consider for current config
+     * @param notifications List of errors (if any).
+     * @return RecommendationConfigItem with value and format.
+     */
+    public static RecommendationConfigItem getCurrentValueForNamespace(AnalyzerConstants.MetricName metricName, Map<Timestamp, IntervalResults> filteredResultsMap, Timestamp timestampToExtract, ArrayList<RecommendationConstants.RecommendationNotification> notifications) {
+        Double currentValue = null;
+        String format = null;
+        IntervalResults intervalResults = filteredResultsMap.get(timestampToExtract);
+        if (null != intervalResults) {
+            MetricResults metricResults = intervalResults.getMetricResultsMap().get(metricName);
+            if (null != metricResults) {
+                MetricAggregationInfoResults metricAggregationInfoResults = metricResults.getAggregationInfoResult();
+                if (null != metricAggregationInfoResults) {
+                    currentValue = metricAggregationInfoResults.getSum();
+                    format = metricAggregationInfoResults.getFormat();
+                    return new RecommendationConfigItem(currentValue, format);
+                }
+            }
+        }
+
+        // Shouldn't reach here in normal scenarios
+        if (notifications != null) {
+            if (metricName == AnalyzerConstants.MetricName.namespaceCpuRequest)
+                notifications.add(RecommendationConstants.RecommendationNotification.CRITICAL_CPU_REQUEST_NOT_SET);
+            else if (metricName == AnalyzerConstants.MetricName.namespaceMemoryRequest)
+                notifications.add(RecommendationConstants.RecommendationNotification.CRITICAL_MEMORY_REQUEST_NOT_SET);
+            else if (metricName == AnalyzerConstants.MetricName.namespaceCpuLimit)
+                notifications.add(RecommendationConstants.RecommendationNotification.WARNING_CPU_LIMIT_NOT_SET);
+            else if (metricName == AnalyzerConstants.MetricName.namespaceMemoryLimit)
+                notifications.add(RecommendationConstants.RecommendationNotification.CRITICAL_MEMORY_LIMIT_NOT_SET);
+        }
 
         return null;
     }

--- a/src/main/java/com/autotune/analyzer/recommendations/utils/RecommendationUtils.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/utils/RecommendationUtils.java
@@ -6,6 +6,7 @@ import com.autotune.analyzer.recommendations.RecommendationConfigItem;
 import com.autotune.analyzer.recommendations.RecommendationConstants;
 import com.autotune.analyzer.recommendations.term.Terms;
 import com.autotune.analyzer.utils.AnalyzerConstants;
+import com.autotune.common.data.metrics.MetricAggregationInfoResults;
 import com.autotune.common.data.metrics.MetricMetadataResults;
 import com.autotune.common.data.metrics.MetricResults;
 import com.autotune.common.data.result.ContainerData;
@@ -37,123 +38,74 @@ import static com.autotune.analyzer.utils.AnalyzerConstants.ServiceConstants.CHA
 public class RecommendationUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(RecommendationUtils.class);
 
-    public static RecommendationConfigItem getCurrentValue(Map<Timestamp, IntervalResults> filteredResultsMap,
-                                                           Timestamp timestampToExtract,
-                                                           AnalyzerConstants.ResourceSetting resourceSetting,
-                                                           AnalyzerConstants.RecommendationItem recommendationItem,
-                                                           ArrayList<RecommendationConstants.RecommendationNotification> notifications) {
+    public static RecommendationConfigItem getCurrentValue(AnalyzerConstants.MetricName metricName, Map<Timestamp, IntervalResults> filteredResultsMap, Timestamp timestampToExtract, ArrayList<RecommendationConstants.RecommendationNotification> notifications) {
         Double currentValue = null;
         String format = null;
-        RecommendationConfigItem recommendationConfigItem = null;
-        AnalyzerConstants.MetricName metricName = null;
-        for (Timestamp timestamp : filteredResultsMap.keySet()) {
-            if (!timestamp.equals(timestampToExtract))
-                continue;
-            IntervalResults intervalResults = filteredResultsMap.get(timestamp);
-            if (resourceSetting == AnalyzerConstants.ResourceSetting.requests) {
-                if (recommendationItem == AnalyzerConstants.RecommendationItem.CPU)
-                    metricName = AnalyzerConstants.MetricName.cpuRequest;
-                if (recommendationItem == AnalyzerConstants.RecommendationItem.MEMORY)
-                    metricName = AnalyzerConstants.MetricName.memoryRequest;
-            }
-            if (resourceSetting == AnalyzerConstants.ResourceSetting.limits) {
-                if (recommendationItem == AnalyzerConstants.RecommendationItem.CPU)
-                    metricName = AnalyzerConstants.MetricName.cpuLimit;
-                if (recommendationItem == AnalyzerConstants.RecommendationItem.MEMORY)
-                    metricName = AnalyzerConstants.MetricName.memoryLimit;
-            }
-            if (null != metricName) {
-                if (intervalResults.getMetricResultsMap().containsKey(metricName)) {
-                    Optional<MetricResults> metricResults = Optional.ofNullable(intervalResults.getMetricResultsMap().get(metricName));
-                    currentValue = metricResults.map(m -> m.getAggregationInfoResult().getAvg()).orElse(null);
-                    format = metricResults.map(m -> m.getAggregationInfoResult().getFormat()).orElse(null);
+        IntervalResults intervalResults = filteredResultsMap.get(timestampToExtract);
+        if (null != intervalResults) {
+            if (metricName == AnalyzerConstants.MetricName.podCount) { // replicas
+                // Determine current replicas from metric 'podCount'
+                MetricResults metricResults = intervalResults.getMetricResultsMap().get(AnalyzerConstants.MetricName.podCount);
+                if (null != metricResults) {
+                    MetricAggregationInfoResults metricAggregationInfoResults = metricResults.getAggregationInfoResult();
+                    if (null != metricAggregationInfoResults) {
+                        currentValue = metricAggregationInfoResults.getSum();
+                    }
+                    LOGGER.debug("current replicas from metric 'podCount' is {}", currentValue);
                 }
-                if (null == currentValue) {
-                    setNotificationsFor(resourceSetting, recommendationItem, notifications);
-                }
-                return new RecommendationConfigItem(currentValue, format);
-            }
-        }
-        setNotificationsFor(resourceSetting, recommendationItem, notifications);
-        return null;
-    }
 
-    public static RecommendationConfigItem getCurrentValueForNamespace(Map<Timestamp, IntervalResults> filteredResultsMap,
-                                                                       Timestamp timestampToExtract,
-                                                                       AnalyzerConstants.ResourceSetting resourceSetting,
-                                                                       AnalyzerConstants.RecommendationItem recommendationItem,
-                                                                       ArrayList<RecommendationConstants.RecommendationNotification> notifications) {
-        Double currentNamespaceValue = null;
-        String format = null;
-        AnalyzerConstants.MetricName metricName = null;
-        for (Timestamp timestamp : filteredResultsMap.keySet()) {
-            if (!timestamp.equals(timestampToExtract))
-                continue;
-            IntervalResults intervalResults = filteredResultsMap.get(timestamp);
-            if (resourceSetting == AnalyzerConstants.ResourceSetting.requests) {
-                if (recommendationItem == AnalyzerConstants.RecommendationItem.CPU)
-                    metricName = AnalyzerConstants.MetricName.namespaceCpuRequest;
-                if (recommendationItem == AnalyzerConstants.RecommendationItem.MEMORY)
-                    metricName = AnalyzerConstants.MetricName.namespaceMemoryRequest;
-            }
-            if (resourceSetting == AnalyzerConstants.ResourceSetting.limits) {
-                if (recommendationItem == AnalyzerConstants.RecommendationItem.CPU)
-                    metricName = AnalyzerConstants.MetricName.namespaceCpuLimit;
-                if (recommendationItem == AnalyzerConstants.RecommendationItem.MEMORY)
-                    metricName = AnalyzerConstants.MetricName.namespaceMemoryLimit;
-            }
-            if (null != metricName) {
-                if (intervalResults.getMetricResultsMap().containsKey(metricName)) {
-                    Optional<MetricResults> metricResults = Optional.ofNullable(intervalResults.getMetricResultsMap().get(metricName));
-                    currentNamespaceValue = metricResults.map(m -> m.getAggregationInfoResult().getSum()).orElse(null);
-                    format = metricResults.map(m -> m.getAggregationInfoResult().getFormat()).orElse(null);
+                // Fallback logic - Determine current replicas from metric 'cpuUsage'
+                if (currentValue == null || currentValue == 0.0) {
+                    metricResults = intervalResults.getMetricResultsMap().get(AnalyzerConstants.MetricName.cpuUsage);
+                    if (null != metricResults) {
+                        MetricAggregationInfoResults metricAggregationInfoResults = metricResults.getAggregationInfoResult();
+                        if (null != metricAggregationInfoResults && metricAggregationInfoResults.getSum() != null && metricAggregationInfoResults.getAvg() != null && metricAggregationInfoResults.getAvg() != 0.0) {
+                            currentValue = metricAggregationInfoResults.getSum() / metricAggregationInfoResults.getAvg();
+                        }
+                        LOGGER.debug("current replicas from metric 'cpuUsage' is {}", currentValue);
+                    }
                 }
-                if (null == currentNamespaceValue) {
-                    setNotificationsFor(resourceSetting, recommendationItem, notifications);
-                }
-                return new RecommendationConfigItem(currentNamespaceValue, format);
-            }
-        }
-        setNotificationsFor(resourceSetting, recommendationItem, notifications);
-        return null;
-    }
 
-    private static void setNotificationsFor(AnalyzerConstants.ResourceSetting resourceSetting,
-                                            AnalyzerConstants.RecommendationItem recommendationItem,
-                                            ArrayList<RecommendationConstants.RecommendationNotification> notifications) {
-        // Check notifications is null, If it's null -> return.
-        if (null == notifications)
-            return;
-        // Check if the item is CPU
-        if (recommendationItem == AnalyzerConstants.RecommendationItem.CPU) {
-            // Check if the setting is REQUESTS
-            if (resourceSetting == AnalyzerConstants.ResourceSetting.requests) {
-                notifications.add(
-                        RecommendationConstants.RecommendationNotification.CRITICAL_CPU_REQUEST_NOT_SET
-                );
-            }
-            // Check if the setting is LIMITS
-            else if (resourceSetting == AnalyzerConstants.ResourceSetting.limits) {
-                notifications.add(
-                        RecommendationConstants.RecommendationNotification.WARNING_CPU_LIMIT_NOT_SET
-                );
-            }
-        }
-        // Check if the item is Memory
-        else if (recommendationItem == AnalyzerConstants.RecommendationItem.MEMORY) {
-            // Check if the setting is REQUESTS
-            if (resourceSetting == AnalyzerConstants.ResourceSetting.requests) {
-                notifications.add(
-                        RecommendationConstants.RecommendationNotification.CRITICAL_MEMORY_REQUEST_NOT_SET
-                );
-            }
-            // Check if the setting is LIMITS
-            else if (resourceSetting == AnalyzerConstants.ResourceSetting.limits) {
-                notifications.add(
-                        RecommendationConstants.RecommendationNotification.CRITICAL_MEMORY_LIMIT_NOT_SET
-                );
+                // Fallback logic - Determine current replicas from metric 'memoryUsage'
+                if (currentValue == null || currentValue == 0.0) {
+                    metricResults = intervalResults.getMetricResultsMap().get(AnalyzerConstants.MetricName.memoryUsage);
+                    if (null != metricResults) {
+                        MetricAggregationInfoResults metricAggregationInfoResults = metricResults.getAggregationInfoResult();
+                        if (null != metricAggregationInfoResults && metricAggregationInfoResults.getSum() != null && metricAggregationInfoResults.getAvg() != null && metricAggregationInfoResults.getAvg() != 0.0) {
+                            currentValue = metricAggregationInfoResults.getSum() / metricAggregationInfoResults.getAvg();
+                        }
+                        LOGGER.debug("current replicas from metric 'memoryUsage' is {}", currentValue);
+                    }
+                }
+
+                // if podCount is determined to be 0, return null.
+                if (currentValue != null && currentValue > 0.0) {
+                    return new RecommendationConfigItem(currentValue, format);
+                }
+            } else { // limits & requests
+                MetricResults metricResults = intervalResults.getMetricResultsMap().get(metricName);
+                if (null != metricResults) {
+                    MetricAggregationInfoResults metricAggregationInfoResults = metricResults.getAggregationInfoResult();
+                    if (null != metricAggregationInfoResults) {
+                        currentValue = metricAggregationInfoResults.getAvg();
+                        format = metricAggregationInfoResults.getFormat();
+                        return new RecommendationConfigItem(currentValue, format);
+                    }
+                }
             }
         }
+
+        // Shouldn't reach here in normal scenarios
+        if (metricName == AnalyzerConstants.MetricName.cpuRequest)
+            notifications.add(RecommendationConstants.RecommendationNotification.CRITICAL_CPU_REQUEST_NOT_SET);
+        else if (metricName == AnalyzerConstants.MetricName.memoryRequest)
+            notifications.add(RecommendationConstants.RecommendationNotification.CRITICAL_MEMORY_REQUEST_NOT_SET);
+        else if (metricName == AnalyzerConstants.MetricName.cpuLimit)
+            notifications.add(RecommendationConstants.RecommendationNotification.WARNING_CPU_LIMIT_NOT_SET);
+        else if (metricName == AnalyzerConstants.MetricName.memoryLimit)
+            notifications.add(RecommendationConstants.RecommendationNotification.CRITICAL_MEMORY_LIMIT_NOT_SET);
+
+        return null;
     }
 
     public static boolean markAcceleratorDeviceStatusToContainer(ContainerData containerData,


### PR DESCRIPTION
## Description

current config in recommendation currently has requests and limits of last datapoint. To this, we are adding `replicas` to current config now. This PR include
- code optimization
- add support for replicas in current config.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Include replica count in current configuration and refactor recommendation processors to use a unified Config object for current CPU/memory settings at container and namespace level.

New Features:
- Expose current replica count in recommendations by deriving it from podCount metrics with CPU and memory usage fallbacks.
- Support metric-based retrieval of current CPU and memory requests/limits for both containers and namespaces via updated utility methods.

Enhancements:
- Replace nested resource-setting maps with a dedicated Config object for representing current configuration in recommendation processors and timestamp mappings.
- Simplify extraction of current CPU and memory request/limit values using the new Config structure while preserving existing notification handling.