### PR TITLE
remove pods_count attribute from recommendation response

### DIFF
--- a/src/main/java/com/autotune/analyzer/recommendations/objects/MappedRecommendationForModel.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/objects/MappedRecommendationForModel.java
@@ -13,15 +13,12 @@ import java.util.HashMap;
 public class MappedRecommendationForModel {
 
     public MappedRecommendationForModel() {
-        this.podsCount = 0;
         this.confidence_level = 0.0;
         this.config = new Config();
         this.variation = new Variation();
         this.notificationHashMap = new HashMap<>();
     }
 
-    @SerializedName(KruizeConstants.JSONKeys.PODS_COUNT)
-    private int podsCount;
     @SerializedName(KruizeConstants.JSONKeys.CONFIDENCE_LEVEL)
     private double confidence_level;
     @SerializedName(KruizeConstants.JSONKeys.CONFIG)
@@ -31,14 +28,6 @@ public class MappedRecommendationForModel {
 
     @SerializedName(KruizeConstants.JSONKeys.NOTIFICATIONS)
     private HashMap<Integer, RecommendationNotification> notificationHashMap;
-
-    public int getPodsCount() {
-        return podsCount;
-    }
-
-    public void setPodsCount(int podsCount) {
-        this.podsCount = podsCount;
-    }
 
     public double getConfidence_level() {
         return confidence_level;


### PR DESCRIPTION
## Description

This PR removes attribute `pods_count` from recommendation response.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite
- [X] Tested locally using e2e test.

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Enhancements:
- Simplify the recommendation model by dropping the unused pods_count attribute and its accessors.