### PR TITLE
Configure kruize-operator branch in kruize demos test

### DIFF
--- a/tests/scripts/kruize_demos_test/kruize_demos_test.md
+++ b/tests/scripts/kruize_demos_test/kruize_demos_test.md
@@ -25,7 +25,7 @@ Kruize Demos test validates the behaviour of Kruize APIs by running the Kruize d
 Use the below command to test :
 
 ```
-<KRUIZE_REPO>/tests/scripts/kruize_demos_test/kruize_demos_test.sh -c [minikube|kind|openshift] [-i Kruize image] [-o Kruize operator image] [-r results directory path] [ -t <demo> ] [-a Kruize demos git repo URL] [-b Kruize demos branch] [-k] [-f] [-w wait time for metrics for bulk demo]
+<KRUIZE_REPO>/tests/scripts/kruize_demos_test/kruize_demos_test.sh -c [minikube|kind|openshift] [-i Kruize image] [-o Kruize operator image] [-s Kruize operator branch] [-r results directory path] [ -t <demo> ] [-a Kruize demos git repo URL] [-b Kruize demos branch] [-k] [-f] [-w wait time for metrics for bulk demo]
 ```
 
 Where values for kruize_demos_test.sh are:
@@ -34,6 +34,7 @@ Usage:
         [ -c ] : cluster_type. Supports minikube, kind and openshift cluster-type
         [ -i ] : kruize image. Default - quay.io/kruizehub/autotune-test-image:mvp_demo
         [ -o ] : Kruize operator image. Default - It will use the latest kruize operator image
+        [ -s ] = Kruize operator git repo branch. Default - mvp_demo"
         [ -a ] : Kruize demos git repo URL. Default - https://github.com/kruize/kruize-demos.git
         [ -b ] : Kruize demos git repo branch. Default - main
         [ -t ] : Kruize demo to run. Default - all (valid values - all/local_monitoring/remote_monitoring/bulk/vpa/runtimes)

--- a/tests/scripts/kruize_demos_test/kruize_demos_test.sh
+++ b/tests/scripts/kruize_demos_test/kruize_demos_test.sh
@@ -364,7 +364,7 @@ function run_demo() {
 		if [[ "${KRUIZE_OPERATOR}" -eq 1 ]]; then
 			if [ "${DEMO_NAME}" != "remote_monitoring" ]; then
 				pwd
-				git clone -b ${KRUIZE_OPERATOR_BRANCH} "kruize-operator"
+				git clone -b ${KRUIZE_OPERATOR_BRANCH} https://github.com/kruize/kruize-operator.git
 			fi
 		fi
 		pwd

--- a/tests/scripts/kruize_demos_test/kruize_demos_test.sh
+++ b/tests/scripts/kruize_demos_test/kruize_demos_test.sh
@@ -31,6 +31,7 @@ target="crc"
 KRUIZE_IMAGE="quay.io/kruizehub/autotune-test-image:mvp_demo"
 KRUIZE_OPERATOR_IMAGE=""
 KRUIZE_OPERATOR=1
+KRUIZE_OPERATOR_BRANCH="mvp_demo"
 failed=0
 
 KRUIZE_DEMOS_REPO="https://github.com/kruize/kruize-demos.git"
@@ -362,7 +363,7 @@ function run_demo() {
 		if [[ "${KRUIZE_OPERATOR}" -eq 1 ]]; then
 			if [ "${DEMO_NAME}" != "remote_monitoring" ]; then
 				pwd
-				clone_repos "kruize-operator"
+				git clone -b ${KRUIZE_OPERATOR_BRANCH} "kruize-operator"
 			fi
 		fi
 		pwd

--- a/tests/scripts/kruize_demos_test/kruize_demos_test.sh
+++ b/tests/scripts/kruize_demos_test/kruize_demos_test.sh
@@ -41,10 +41,11 @@ WAIT_TIME=20
 
 function usage() {
 	echo
-	echo "Usage: -c cluster_type[minikube|openshift] [-i Kruize image] [-o Kruize operator image] [ -t demo ] [-r <resultsdir path>] [-a Kruize demos git repo URL] [-b Kruize demos branch] [-k] [-f] [-w wait time for metrics for bulk demo]"
+	echo "Usage: -c cluster_type[minikube|openshift] [-i Kruize image] [-o Kruize operator image] [-s Kruize operator branch] [ -t demo ] [-r <resultsdir path>] [-a Kruize demos git repo URL] [-b Kruize demos branch] [-k] [-f] [-w wait time for metrics for bulk demo]"
 	echo "c = supports minikube, kind and openshift cluster-type"
 	echo "i = kruize image. Default - quay.io/kruizehub/autotune-test-image:mvp_demo"
 	echo "o = Kruize operator image. Default - It will use the latest kruize operator image"
+	echo "s = Kruize operator git repo branch. Default - mvp_demo"
 	echo "a = Kruize demos git repo URL. Default - https://github.com/kruize/kruize-demos.git"
 	echo "b = Kruize demos git repo branch. Default - main"
 	echo "t = Kruize demo to run. Default - all (valid values - all/local_monitoring/remote_monitoring/bulk/vpa)"
@@ -454,6 +455,9 @@ do
 		;;
 	o)
 		KRUIZE_OPERATOR_IMAGE="${OPTARG}"		
+		;;
+	s)
+		KRUIZE_OPERATOR_BRANCH="${OPTARG}"
 		;;
 	a)
 		KRUIZE_DEMOS_REPO="${OPTARG}"		


### PR DESCRIPTION
## Description

This PR adds a configurable option for kruize_operator branch mainly to help with operator release testing and kruize-demos verification.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: OpenShift

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [x] Dependent changes merged
- [x] Documentation updated
- [x] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Make the kruize-demos test script clone kruize-operator from a configurable branch for operator release and demo verification.

New Features:
- Introduce a configurable KRUIZE_OPERATOR_BRANCH variable for selecting the kruize-operator branch in kruize-demos tests.

Enhancements:
- Update the kruize-demos test script to use the configured kruize-operator branch when cloning the operator repository.