### PR TITLE
bulk api filter label fix with testing logs

### DIFF
--- a/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
+++ b/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
@@ -511,6 +511,12 @@ public class BulkJobManager implements Runnable {
         try {
             Map<String, CreateExperimentAPIObject> createExperimentAPIObjectMap = new HashMap<>();
             Collection<DataSource> dataSourceCollection = metadataInfo.getDatasources().values();
+            LOGGER.info("[BULK API LABEL FILTER] Starting to process metadata and create experiments");
+            LOGGER.info("[BULK API LABEL FILTER] Label string used for experiment naming: {}", labelString != null ? labelString : "NONE");
+            
+            int totalWorkloadsProcessed = 0;
+            int totalExperimentsCreated = 0;
+            
             for (DataSource ds : dataSourceCollection) {
                 HashMap<String, DataSourceCluster> clusterHashMap = ds.getClusters();
                 for (DataSourceCluster dsc : clusterHashMap.values()) {
@@ -519,6 +525,7 @@ public class BulkJobManager implements Runnable {
                         HashMap<String, DataSourceWorkload> dataSourceWorkloadHashMap = namespace.getWorkloads();
                         if (dataSourceWorkloadHashMap != null) {
                             for (DataSourceWorkload dsw : dataSourceWorkloadHashMap.values()) {
+                                totalWorkloadsProcessed++;
                                 HashMap<String, DataSourceContainer> dataSourceContainerHashMap = dsw.getContainers();
                                 if (dataSourceContainerHashMap != null) {
                                     for (DataSourceContainer dc : dataSourceContainerHashMap.values()) {
@@ -529,6 +536,9 @@ public class BulkJobManager implements Runnable {
                                         CreateExperimentAPIObject apiObject = prepareCreateExperimentJSONInput(dc, dsc, dsw, namespace,
                                                 experiment_name, createExperimentAPIObjectList);
                                         createExperimentAPIObjectMap.put(experiment_name, apiObject);
+                                        totalExperimentsCreated++;
+                                        LOGGER.info("[BULK API LABEL FILTER] Created experiment for: cluster={}, namespace={}, workload={}, container={}, experiment_name={}",
+                                                dsc.getDataSourceClusterName(), namespace.getNamespace(), dsw.getWorkloadName(), dc.getContainerName(), experiment_name);
                                     }
                                 }
                             }
@@ -536,6 +546,8 @@ public class BulkJobManager implements Runnable {
                     }
                 }
             }
+            LOGGER.info("[BULK API LABEL FILTER] Summary: Processed {} workloads, created {} experiments", totalWorkloadsProcessed, totalExperimentsCreated);
+            LOGGER.info("[BULK API LABEL FILTER] If label filter was applied correctly, only workloads matching the label should appear above");
             return createExperimentAPIObjectMap;
         } finally {
             if (null != timerGetExpMap) {
@@ -581,7 +593,19 @@ public class BulkJobManager implements Runnable {
                     filter.getWorkload().stream().map(String::trim).collect(Collectors.joining("|")) : "");
             resourceFilters.put("containerRegex", filter.getContainers() != null ?
                     filter.getContainers().stream().map(String::trim).collect(Collectors.joining("|")) : "");
+            // Add label filters to the resource filters map
+            if (filter.getLabels() != null && !filter.getLabels().isEmpty()) {
+                String labelFilterString = getLabels(new BulkInput.FilterWrapper() {{
+                    setInclude(filter);
+                }});
+                resourceFilters.put("labels", labelFilterString);
+                LOGGER.info("[BULK API LABEL FILTER] Label filters extracted from request: {}", labelFilterString);
+                LOGGER.info("[BULK API LABEL FILTER] Label filter map: {}", filter.getLabels());
+            } else {
+                LOGGER.info("[BULK API LABEL FILTER] No label filters found in request");
+            }
         }
+        LOGGER.info("[BULK API LABEL FILTER] Complete resource filters map: {}", resourceFilters);
         return resourceFilters;
     }
 

--- a/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
@@ -193,6 +193,19 @@ public class DataSourceMetadataOperator {
 
         MetadataProfile metadataProfile = MetadataProfileCollection.getInstance().getMetadataProfileCollection().get(metadataProfileName);
 
+        // Extract label filters from includeResources if present
+        String labelFilter = includeResources.getOrDefault("labels", "");
+        if (labelFilter.isEmpty()) {
+            labelFilter = excludeResources.getOrDefault("labels", "");
+        }
+        // Use labelFilter if provided, otherwise use uniqueKey
+        String effectiveLabelFilter = !labelFilter.isEmpty() ? labelFilter : uniqueKey;
+
+        LOGGER.info("[BULK API LABEL FILTER] Label filter from includeResources: {}", includeResources.getOrDefault("labels", "NOT_FOUND"));
+        LOGGER.info("[BULK API LABEL FILTER] Label filter from excludeResources: {}", excludeResources.getOrDefault("labels", "NOT_FOUND"));
+        LOGGER.info("[BULK API LABEL FILTER] uniqueKey parameter: {}", uniqueKey);
+        LOGGER.info("[BULK API LABEL FILTER] Effective label filter to be applied: {}", effectiveLabelFilter);
+
         // Populate filters for each field
         fields.forEach(field -> {
             String includeRegex = includeResources.getOrDefault(field + "Regex", "");
@@ -208,12 +221,14 @@ public class DataSourceMetadataOperator {
         String containerQuery = queries.get("container");
 
         String dataSourceName = dataSourceInfo.getName();
-        if (null != uniqueKey && !uniqueKey.isEmpty()) {
-            LOGGER.debug("uniquekey: {}", uniqueKey);
-            namespaceQuery = namespaceQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "," + uniqueKey);
-            workloadQuery = workloadQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "," + uniqueKey);
-            containerQuery = containerQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "," + uniqueKey);
+        if (null != effectiveLabelFilter && !effectiveLabelFilter.isEmpty()) {
+            LOGGER.info("[BULK API LABEL FILTER] Applying label filter to queries: {}", effectiveLabelFilter);
+            namespaceQuery = namespaceQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "," + effectiveLabelFilter);
+            workloadQuery = workloadQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "," + effectiveLabelFilter);
+            containerQuery = containerQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "," + effectiveLabelFilter);
+            LOGGER.info("[BULK API LABEL FILTER] Label filter applied successfully to all queries");
         } else {
+            LOGGER.info("[BULK API LABEL FILTER] No label filter to apply - queries will fetch all resources");
             namespaceQuery = namespaceQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "");
             workloadQuery = workloadQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "");
             containerQuery = containerQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "");
@@ -223,9 +238,9 @@ public class DataSourceMetadataOperator {
         workloadQuery = workloadQuery.replace(AnalyzerConstants.MEASUREMENT_DURATION_IN_MIN_VARAIBLE, Integer.toString(measurementDuration));
         containerQuery = containerQuery.replace(AnalyzerConstants.MEASUREMENT_DURATION_IN_MIN_VARAIBLE, Integer.toString(measurementDuration));
 
-        LOGGER.info("namespaceQuery: {}", namespaceQuery);
-        LOGGER.info("workloadQuery: {}", workloadQuery);
-        LOGGER.info("containerQuery: {}", containerQuery);
+        LOGGER.info("[BULK API LABEL FILTER] Final namespaceQuery: {}", namespaceQuery);
+        LOGGER.info("[BULK API LABEL FILTER] Final workloadQuery: {}", workloadQuery);
+        LOGGER.info("[BULK API LABEL FILTER] Final containerQuery: {}", containerQuery);
 
         JsonArray namespacesDataResultArray = fetchQueryResults(dataSourceInfo, namespaceQuery, startTime, endTime, steps);
         LOGGER.debug("namespacesDataResultArray: {}", namespacesDataResultArray);


### PR DESCRIPTION
## Description

Please describe the issue or feature and the summary of changes made to fix this. 

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Handle bulk API label filters when constructing queries and add detailed logging around label-based filtering and experiment creation.

New Features:
- Support passing label filters from bulk API requests into datasource query construction so they can override the unique key when present.

Enhancements:
- Apply a unified effective label filter to namespace, workload, and container queries, falling back to the existing uniqueKey parameter when no labels are specified.
- Improve logging around bulk label filtering, including input filters, constructed queries, and experiment creation metrics for easier debugging.