### PR TITLE
Add missing -s operator branch option in getopts

### DIFF
--- a/tests/scripts/kruize_demos_test/kruize_demos_test.sh
+++ b/tests/scripts/kruize_demos_test/kruize_demos_test.sh
@@ -438,7 +438,7 @@ function run_demo() {
 	} | tee -a ${LOG}
 }
 
-while getopts c:w:r:i:o:a:b:t:fkh gopts
+while getopts c:w:r:i:o:s:a:b:t:fkh gopts
 do
 	case ${gopts} in
 	c)


### PR DESCRIPTION
## Description

Updates the `kruize_demos_test` script's while getopts loop to add the missing `-s` flag i.e operator branch flag 

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Bug Fixes:
- Ensure the kruize_demos_test script correctly recognizes and handles the -s operator branch option in its getopts parsing.