### PR TITLE
Support custom operator image for bulk demo test

### DIFF
--- a/tests/scripts/kruize_demos_test/kruize_demos_test.sh
+++ b/tests/scripts/kruize_demos_test/kruize_demos_test.sh
@@ -312,7 +312,7 @@ function run_demo() {
 
 	if [ "${KRUIZE_OPERATOR}" == 1 ]; then
 		if [ "${KRUIZE_OPERATOR_IMAGE}" != "" ]; then
-			if [[ "${DEMO_NAME}" != "remote_monitoring" && "${DEMO_NAME}" != "bulk" ]]; then
+			if [ "${DEMO_NAME}" != "remote_monitoring" ]; then
 				CMD+=( -o ${KRUIZE_OPERATOR_IMAGE})
 			fi
 		fi


### PR DESCRIPTION
## Description

This PR updates `kruize_demos_test` script, enabling custom operator image for bulk demo 

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Allow specifying a custom Kruize operator image when running the bulk demo in kruize_demos_test.

Bug Fixes:
- Fix omission where the bulk demo could not use a custom Kruize operator image in the demo test script.

Tests:
- Adjust demo test script behavior so bulk demo runs respect the configured operator image.