### PR TITLE
Fix Local map issue in Performance Profile

### DIFF
--- a/design/PerformanceProfile.md
+++ b/design/PerformanceProfile.md
@@ -101,7 +101,7 @@ Same as in the createPerformanceProfile. You can refer [here](/design/Performanc
     ```
     {
         "message": "Performance Profile <name> updated successfully to version %s. View Performance Profiles at /listPerformanceProfiles",
-        "httpcode": 201,
+        "httpcode": 200,
         "documentationLink": "",
         "status": "SUCCESS"
     }

--- a/design/PerformanceProfileAPI.md
+++ b/design/PerformanceProfileAPI.md
@@ -754,7 +754,7 @@ This is quick guide instructions to update performance profile using input JSON 
 ```
 {
     "message": "Performance Profile : <name> updated successfully to version <new-version>. View all performance profiles at /listPerformanceProfiles",
-    "httpcode": 201,
+    "httpcode": 200,
     "documentationLink": "",
     "status": "SUCCESS"
 }
@@ -777,7 +777,7 @@ This is quick guide instructions to delete performance profile using input param
 
 `DELETE /deletePerformanceProfile`
 
-`curl -H 'Accept: application/json' -X DELETE http://<URL>:<PORT>/deletePerformanceProfile?name=resource-optimization-openshift`
+`curl -H 'Accept: application/json' -X DELETE http://<URL>:<PORT>/deletePerformanceProfile?name=<name>`
 
 Deletes the specified performance profile, provided it is already created
 
@@ -787,8 +787,8 @@ Deletes the specified performance profile, provided it is already created
 
 ```json
 {
-  "message": "Performance profile resource-optimization-openshift deleted successfully. View Performance Profiles at /listPerformanceProfiles",
-  "httpcode": 201,
+  "message": "Performance profile <name> deleted successfully. View Performance Profiles at /listPerformanceProfiles",
+  "httpcode": 200,
   "documentationLink": "",
   "status": "SUCCESS"
 }

--- a/src/main/java/com/autotune/analyzer/serviceObjects/verification/validators/PerformanceProfileValidator.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/verification/validators/PerformanceProfileValidator.java
@@ -28,8 +28,9 @@ import org.slf4j.LoggerFactory;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.HashMap;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Map;
 
 import static com.autotune.analyzer.utils.AnalyzerErrorConstants.AutotuneObjectErrors.MISSING_PERF_PROFILE;
 
@@ -49,7 +50,7 @@ public class PerformanceProfileValidator implements ConstraintValidator<Performa
          and then validate the Performance Profile data
         */
         try {
-            ConcurrentHashMap<String, PerformanceProfile> performanceProfilesMap = new ConcurrentHashMap<>();
+            Map<String, PerformanceProfile> performanceProfilesMap = new HashMap<>();
             KruizeObject kruizeObject = updateResultsAPIObject.getKruizeObject();
             String performanceProfileName = kruizeObject.getPerformanceProfile();
             try {

--- a/src/main/java/com/autotune/analyzer/serviceObjects/verification/validators/PerformanceProfileValidator.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/verification/validators/PerformanceProfileValidator.java
@@ -29,8 +29,8 @@ import org.slf4j.LoggerFactory;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 
-import static com.autotune.analyzer.services.UpdateResults.performanceProfilesMap;
 import static com.autotune.analyzer.utils.AnalyzerErrorConstants.AutotuneObjectErrors.MISSING_PERF_PROFILE;
 
 public class PerformanceProfileValidator implements ConstraintValidator<PerformanceProfileCheck, UpdateResultsAPIObject> {
@@ -49,6 +49,7 @@ public class PerformanceProfileValidator implements ConstraintValidator<Performa
          and then validate the Performance Profile data
         */
         try {
+            ConcurrentHashMap<String, PerformanceProfile> performanceProfilesMap = new ConcurrentHashMap<>();
             KruizeObject kruizeObject = updateResultsAPIObject.getKruizeObject();
             String performanceProfileName = kruizeObject.getPerformanceProfile();
             try {

--- a/src/main/java/com/autotune/analyzer/serviceObjects/verification/validators/PerformanceProfileValidator.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/verification/validators/PerformanceProfileValidator.java
@@ -20,7 +20,6 @@ import com.autotune.analyzer.performanceProfiles.PerformanceProfile;
 import com.autotune.analyzer.performanceProfiles.utils.PerformanceProfileUtil;
 import com.autotune.analyzer.serviceObjects.UpdateResultsAPIObject;
 import com.autotune.analyzer.serviceObjects.verification.annotators.PerformanceProfileCheck;
-import com.autotune.analyzer.services.UpdateResults;
 import com.autotune.database.service.ExperimentDBService;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
@@ -30,8 +29,8 @@ import org.slf4j.LoggerFactory;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 
+import static com.autotune.analyzer.services.UpdateResults.performanceProfilesMap;
 import static com.autotune.analyzer.utils.AnalyzerErrorConstants.AutotuneObjectErrors.MISSING_PERF_PROFILE;
 
 public class PerformanceProfileValidator implements ConstraintValidator<PerformanceProfileCheck, UpdateResultsAPIObject> {
@@ -51,16 +50,17 @@ public class PerformanceProfileValidator implements ConstraintValidator<Performa
         */
         try {
             KruizeObject kruizeObject = updateResultsAPIObject.getKruizeObject();
-            if (UpdateResults.performanceProfilesMap.isEmpty() || !UpdateResults.performanceProfilesMap.containsKey(kruizeObject.getPerformanceProfile())) {
-                ConcurrentHashMap<String, PerformanceProfile> tempPerformanceProfilesMap = new ConcurrentHashMap<>();
-                new ExperimentDBService().loadAllPerformanceProfiles(tempPerformanceProfilesMap);
-                UpdateResults.performanceProfilesMap.putAll(tempPerformanceProfilesMap);
+            String performanceProfileName = kruizeObject.getPerformanceProfile();
+            try {
+                new ExperimentDBService().loadPerformanceProfileFromDBByName(performanceProfilesMap, performanceProfileName);
+            } catch (Exception e) {
+                LOGGER.error("Loading saved performance profiles failed: {}", e.getMessage());
+                throw e;
             }
-            PerformanceProfile performanceProfile = null;
-            if (UpdateResults.performanceProfilesMap.containsKey(kruizeObject.getPerformanceProfile())) {
-                performanceProfile = UpdateResults.performanceProfilesMap.get(kruizeObject.getPerformanceProfile());
-            } else {
-                throw new Exception(String.format("%s%s", MISSING_PERF_PROFILE, kruizeObject.getPerformanceProfile()));
+
+            PerformanceProfile performanceProfile = performanceProfilesMap.get(performanceProfileName);
+            if (performanceProfile == null) {
+                throw new Exception(String.format("%s%s", MISSING_PERF_PROFILE, performanceProfileName));
             }
 
             // validate the results value present in the updateResultsAPIObject

--- a/src/main/java/com/autotune/analyzer/services/PerformanceProfileService.java
+++ b/src/main/java/com/autotune/analyzer/services/PerformanceProfileService.java
@@ -176,7 +176,6 @@ public class PerformanceProfileService extends HttpServlet {
     @Override
     protected void doPut(HttpServletRequest request, HttpServletResponse response) throws IOException {
         try {
-            Map<String, PerformanceProfile> performanceProfilesMap = new ConcurrentHashMap<>();
             // Parse incoming JSON
             String inputData = request.getReader().lines().collect(Collectors.joining());
             PerformanceProfile incomingPerfProfile = Converters.KruizeObjectConverters.convertInputJSONToCreatePerfProfile(inputData);

--- a/src/main/java/com/autotune/analyzer/services/PerformanceProfileService.java
+++ b/src/main/java/com/autotune/analyzer/services/PerformanceProfileService.java
@@ -76,7 +76,7 @@ public class PerformanceProfileService extends HttpServlet {
     }
 
     /**
-     * Validate and create new Performance Profile.
+     * Validate and create a new Performance Profile.
      *
      * @param request
      * @param response
@@ -92,8 +92,6 @@ public class PerformanceProfileService extends HttpServlet {
             if (validationOutputData.isSuccess()) {
                 ValidationOutputData addedToDB = new ExperimentDBService().addPerformanceProfileToDB(performanceProfile);
                 if (addedToDB.isSuccess()) {
-                    performanceProfilesMap.put(performanceProfile.getName(), performanceProfile);
-                    getServletContext().setAttribute(AnalyzerConstants.PerformanceProfileConstants.PERF_PROFILE_MAP, performanceProfilesMap);
                     LOGGER.debug("Added Performance Profile : {} into the DB with version: {}",
                             performanceProfile.getName(), performanceProfile.getProfile_version());
                     sendSuccessResponse(response, "Performance Profile : " + performanceProfile.getName() + " created successfully.");
@@ -187,8 +185,6 @@ public class PerformanceProfileService extends HttpServlet {
                 if (updatedInDB.isSuccess()) {
                     LOGGER.info("{}", String.format(KruizeConstants.APIMessages.PERFORMANCE_PROFILE_UPDATE_SUCCESS,
                             profileName, incomingPerfProfile.getProfile_version()));
-                    performanceProfilesMap.put(incomingPerfProfile.getName(), incomingPerfProfile);
-                    getServletContext().setAttribute(AnalyzerConstants.PerformanceProfileConstants.PERF_PROFILE_MAP, performanceProfilesMap);
                     sendSuccessResponse(
                             response,
                             String.format(KruizeConstants.APIMessages.PERFORMANCE_PROFILE_UPDATE_SUCCESS,
@@ -248,7 +244,6 @@ public class PerformanceProfileService extends HttpServlet {
                 return;
             }
             // remove the profile from the local storage as well
-            performanceProfilesMap.remove(perfProfileName);
             PerformanceProfileCache.remove(perfProfileName);
             sendSuccessResponse(resp, String.format(KruizeConstants.APIMessages.PERF_PROFILE_DELETION_SUCCESS, perfProfileName));
         } catch (Exception e) {

--- a/src/main/java/com/autotune/analyzer/services/PerformanceProfileService.java
+++ b/src/main/java/com/autotune/analyzer/services/PerformanceProfileService.java
@@ -176,6 +176,7 @@ public class PerformanceProfileService extends HttpServlet {
     @Override
     protected void doPut(HttpServletRequest request, HttpServletResponse response) throws IOException {
         try {
+            Map<String, PerformanceProfile> performanceProfilesMap = new ConcurrentHashMap<>();
             // Parse incoming JSON
             String inputData = request.getReader().lines().collect(Collectors.joining());
             PerformanceProfile incomingPerfProfile = Converters.KruizeObjectConverters.convertInputJSONToCreatePerfProfile(inputData);

--- a/src/main/java/com/autotune/analyzer/services/PerformanceProfileService.java
+++ b/src/main/java/com/autotune/analyzer/services/PerformanceProfileService.java
@@ -185,11 +185,10 @@ public class PerformanceProfileService extends HttpServlet {
                 if (updatedInDB.isSuccess()) {
                     LOGGER.info("{}", String.format(KruizeConstants.APIMessages.PERFORMANCE_PROFILE_UPDATE_SUCCESS,
                             profileName, incomingPerfProfile.getProfile_version()));
-                    sendSuccessResponse(
-                            response,
-                            String.format(KruizeConstants.APIMessages.PERFORMANCE_PROFILE_UPDATE_SUCCESS,
-                                    profileName, incomingPerfProfile.getProfile_version())
-                    );
+                    String message = String.format(KruizeConstants.APIMessages.PERFORMANCE_PROFILE_UPDATE_SUCCESS,
+                                    profileName, incomingPerfProfile.getProfile_version());
+                    message += " View Performance Profiles at /listPerformanceProfiles";
+                    sendJsonResponse(response, message, HttpServletResponse.SC_OK, "SUCCESS");
                 } else {
                     sendErrorResponse(response, null, HttpServletResponse.SC_BAD_REQUEST, updatedInDB.getMessage());
                 }
@@ -245,7 +244,9 @@ public class PerformanceProfileService extends HttpServlet {
             }
             // remove the profile from the local storage as well
             PerformanceProfileCache.remove(perfProfileName);
-            sendSuccessResponse(resp, String.format(KruizeConstants.APIMessages.PERF_PROFILE_DELETION_SUCCESS, perfProfileName));
+            String message = String.format(KruizeConstants.APIMessages.PERF_PROFILE_DELETION_SUCCESS, perfProfileName);
+            message += " View Performance Profiles at /listPerformanceProfiles";
+            sendJsonResponse(resp, message, HttpServletResponse.SC_OK, "SUCCESS");
         } catch (Exception e) {
             LOGGER.error("{}",String.format(AnalyzerErrorConstants.AutotuneObjectErrors.PERF_PROFILE_DELETION_EXCEPTION, perfProfileName, e.getMessage()));
             sendErrorResponse(resp, null, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());

--- a/src/main/java/com/autotune/analyzer/services/PerformanceProfileService.java
+++ b/src/main/java/com/autotune/analyzer/services/PerformanceProfileService.java
@@ -49,7 +49,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Serial;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import com.autotune.database.dao.ExperimentDAOImpl;
@@ -85,7 +84,7 @@ public class PerformanceProfileService extends HttpServlet {
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
         try {
-            Map<String, PerformanceProfile> performanceProfilesMap = new ConcurrentHashMap<>();
+            Map<String, PerformanceProfile> performanceProfilesMap = new HashMap<>();
             String inputData = request.getReader().lines().collect(Collectors.joining());
             PerformanceProfile performanceProfile = Converters.KruizeObjectConverters.convertInputJSONToCreatePerfProfile(inputData);
             ValidationOutputData validationOutputData = PerformanceProfileUtil.validateAndAddProfile(performanceProfilesMap, performanceProfile, AnalyzerConstants.OperationType.CREATE);
@@ -94,7 +93,8 @@ public class PerformanceProfileService extends HttpServlet {
                 if (addedToDB.isSuccess()) {
                     LOGGER.debug("Added Performance Profile : {} into the DB with version: {}",
                             performanceProfile.getName(), performanceProfile.getProfile_version());
-                    sendSuccessResponse(response, "Performance Profile : " + performanceProfile.getName() + " created successfully.");
+                    sendSuccessResponse(response, String.format(KruizeConstants.APIMessages.PERFORMANCE_PROFILE_CREATE_SUCCESS,
+                            performanceProfile.getName()), HttpServletResponse.SC_CREATED);
                 } else {
                     sendErrorResponse(response, null, HttpServletResponse.SC_BAD_REQUEST, addedToDB.getMessage());
                 }
@@ -122,7 +122,7 @@ public class PerformanceProfileService extends HttpServlet {
         response.setStatus(HttpServletResponse.SC_OK);
         String gsonStr = "[]";
         // Fetch all profiles from the DB
-        Map<String, PerformanceProfile> performanceProfilesMap = new ConcurrentHashMap<>();
+        Map<String, PerformanceProfile> performanceProfilesMap = new HashMap<>();
         try {
             new ExperimentDBService().loadAllPerformanceProfiles(performanceProfilesMap);
         } catch (Exception e) {
@@ -171,7 +171,7 @@ public class PerformanceProfileService extends HttpServlet {
     @Override
     protected void doPut(HttpServletRequest request, HttpServletResponse response) throws IOException {
         try {
-            Map<String, PerformanceProfile> performanceProfilesMap = new ConcurrentHashMap<>();
+            Map<String, PerformanceProfile> performanceProfilesMap = new HashMap<>();
             // Parse incoming JSON
             String inputData = request.getReader().lines().collect(Collectors.joining());
             PerformanceProfile incomingPerfProfile = Converters.KruizeObjectConverters.convertInputJSONToCreatePerfProfile(inputData);
@@ -185,10 +185,8 @@ public class PerformanceProfileService extends HttpServlet {
                 if (updatedInDB.isSuccess()) {
                     LOGGER.info("{}", String.format(KruizeConstants.APIMessages.PERFORMANCE_PROFILE_UPDATE_SUCCESS,
                             profileName, incomingPerfProfile.getProfile_version()));
-                    String message = String.format(KruizeConstants.APIMessages.PERFORMANCE_PROFILE_UPDATE_SUCCESS,
-                                    profileName, incomingPerfProfile.getProfile_version());
-                    message += " View Performance Profiles at /listPerformanceProfiles";
-                    sendJsonResponse(response, message, HttpServletResponse.SC_OK, "SUCCESS");
+                    sendSuccessResponse(response, String.format(KruizeConstants.APIMessages.PERFORMANCE_PROFILE_UPDATE_SUCCESS,
+                            profileName, incomingPerfProfile.getProfile_version()), HttpServletResponse.SC_OK);
                 } else {
                     sendErrorResponse(response, null, HttpServletResponse.SC_BAD_REQUEST, updatedInDB.getMessage());
                 }
@@ -213,7 +211,7 @@ public class PerformanceProfileService extends HttpServlet {
      */
     @Override
     protected void doDelete(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        Map<String, PerformanceProfile> performanceProfilesMap = new ConcurrentHashMap<>();
+        Map<String, PerformanceProfile> performanceProfilesMap = new HashMap<>();
         String perfProfileName = req.getParameter(AnalyzerConstants.ServiceConstants.PERF_PROFILE_NAME);
         if (perfProfileName == null || perfProfileName.isBlank()) {
             sendErrorResponse(resp, null, HttpServletResponse.SC_BAD_REQUEST, AnalyzerErrorConstants.AutotuneObjectErrors.MISSING_PERF_PROFILE_NAME);
@@ -244,9 +242,8 @@ public class PerformanceProfileService extends HttpServlet {
             }
             // remove the profile from the local storage as well
             PerformanceProfileCache.remove(perfProfileName);
-            String message = String.format(KruizeConstants.APIMessages.PERF_PROFILE_DELETION_SUCCESS, perfProfileName);
-            message += " View Performance Profiles at /listPerformanceProfiles";
-            sendJsonResponse(resp, message, HttpServletResponse.SC_OK, "SUCCESS");
+            sendSuccessResponse(resp, String.format(KruizeConstants.APIMessages.PERF_PROFILE_DELETION_SUCCESS, perfProfileName),
+                    HttpServletResponse.SC_OK);
         } catch (Exception e) {
             LOGGER.error("{}",String.format(AnalyzerErrorConstants.AutotuneObjectErrors.PERF_PROFILE_DELETION_EXCEPTION, perfProfileName, e.getMessage()));
             sendErrorResponse(resp, null, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
@@ -284,11 +281,11 @@ public class PerformanceProfileService extends HttpServlet {
      * success response
      * @param response
      * @param message
+     * @param responseCode
      * @throws IOException
      */
-    public static void sendSuccessResponse(HttpServletResponse response, String message) throws IOException {
-        message += " View Performance Profiles at /listPerformanceProfiles";
-        sendJsonResponse(response, message, HttpServletResponse.SC_CREATED, "SUCCESS");
+    public static void sendSuccessResponse(HttpServletResponse response, String message, int responseCode) throws IOException {
+        sendJsonResponse(response, message, responseCode, "SUCCESS");
     }
 
     /***

--- a/src/main/java/com/autotune/analyzer/services/PerformanceProfileService.java
+++ b/src/main/java/com/autotune/analyzer/services/PerformanceProfileService.java
@@ -65,7 +65,6 @@ public class PerformanceProfileService extends HttpServlet {
     @Serial
     private static final long serialVersionUID = 1L;
     private static final Logger LOGGER = LoggerFactory.getLogger(PerformanceProfileService.class);
-    private ConcurrentHashMap<String, PerformanceProfile> performanceProfilesMap;
     private static final Gson gson = new GsonBuilder()
             .disableHtmlEscaping()  // Prevents escaping of quotes
             .setPrettyPrinting()
@@ -74,8 +73,6 @@ public class PerformanceProfileService extends HttpServlet {
     @Override
     public void init(ServletConfig config) throws ServletException {
         super.init(config);
-        performanceProfilesMap = (ConcurrentHashMap<String, PerformanceProfile>) getServletContext()
-                .getAttribute(AnalyzerConstants.PerformanceProfileConstants.PERF_PROFILE_MAP);
     }
 
     /**
@@ -221,6 +218,7 @@ public class PerformanceProfileService extends HttpServlet {
      */
     @Override
     protected void doDelete(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        Map<String, PerformanceProfile> performanceProfilesMap = new ConcurrentHashMap<>();
         String perfProfileName = req.getParameter(AnalyzerConstants.ServiceConstants.PERF_PROFILE_NAME);
         if (perfProfileName == null || perfProfileName.isBlank()) {
             sendErrorResponse(resp, null, HttpServletResponse.SC_BAD_REQUEST, AnalyzerErrorConstants.AutotuneObjectErrors.MISSING_PERF_PROFILE_NAME);

--- a/src/main/java/com/autotune/analyzer/services/UpdateResults.java
+++ b/src/main/java/com/autotune/analyzer/services/UpdateResults.java
@@ -21,7 +21,6 @@ import com.autotune.analyzer.adapters.MetricMetadataAdapter;
 import com.autotune.analyzer.adapters.RecommendationItemAdapter;
 import com.autotune.analyzer.exceptions.KruizeResponse;
 import com.autotune.analyzer.experiment.ExperimentInitiator;
-import com.autotune.analyzer.performanceProfiles.PerformanceProfile;
 import com.autotune.analyzer.serviceObjects.FailedUpdateResultsAPIObject;
 import com.autotune.analyzer.serviceObjects.UpdateResultsAPIObject;
 import com.autotune.analyzer.utils.AnalyzerConstants;
@@ -47,7 +46,6 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import static com.autotune.analyzer.utils.AnalyzerConstants.ServiceConstants.CHARACTER_ENCODING;
@@ -60,7 +58,6 @@ import static com.autotune.analyzer.utils.AnalyzerConstants.ServiceConstants.JSO
 public class UpdateResults extends HttpServlet {
     private static final long serialVersionUID = 1L;
     private static final Logger LOGGER = LoggerFactory.getLogger(UpdateResults.class);
-    public static ConcurrentHashMap<String, PerformanceProfile> performanceProfilesMap = new ConcurrentHashMap<>();
     private static int requestCount = 0;
 
     @Override

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -72,8 +72,9 @@ public class KruizeConstants {
         public static final String UPDATE_RECOMMENDATIONS_FAILURE = "UpdateRecommendations API failure response, experiment_name: %s and intervalEndTimeStr : %s";
         public static final String UPDATE_RECOMMENDATIONS_RESPONSE = "Update Recommendation API response: %s";
         public static final String UPDATE_RECOMMENDATIONS_FAILURE_MSG = "UpdateRecommendations API failed for experiment_name: %s and intervalEndTimeStr : %s due to %s";
-        public static final String PERFORMANCE_PROFILE_UPDATE_SUCCESS = "Performance Profile '%s' updated successfully to version %.1f.";
-        public static final String PERF_PROFILE_DELETION_SUCCESS = "Performance profile %s deleted successfully.";
+        public static final String PERFORMANCE_PROFILE_CREATE_SUCCESS = "Performance Profile : %s created successfully.";
+        public static final String PERFORMANCE_PROFILE_UPDATE_SUCCESS = "Performance Profile '%s' updated successfully to version %.1f. View Performance Profiles at /listPerformanceProfiles";
+        public static final String PERF_PROFILE_DELETION_SUCCESS = "Performance profile %s deleted successfully. View Performance Profiles at /listPerformanceProfiles";
     }
 
     public static class MetricProfileAPIMessages {

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -72,7 +72,7 @@ public class KruizeConstants {
         public static final String UPDATE_RECOMMENDATIONS_FAILURE = "UpdateRecommendations API failure response, experiment_name: %s and intervalEndTimeStr : %s";
         public static final String UPDATE_RECOMMENDATIONS_RESPONSE = "Update Recommendation API response: %s";
         public static final String UPDATE_RECOMMENDATIONS_FAILURE_MSG = "UpdateRecommendations API failed for experiment_name: %s and intervalEndTimeStr : %s due to %s";
-        public static final String PERFORMANCE_PROFILE_CREATE_SUCCESS = "Performance Profile : %s created successfully.";
+        public static final String PERFORMANCE_PROFILE_CREATE_SUCCESS = "Performance Profile : %s created successfully. View Performance Profiles at /listPerformanceProfiles";
         public static final String PERFORMANCE_PROFILE_UPDATE_SUCCESS = "Performance Profile '%s' updated successfully to version %.1f. View Performance Profiles at /listPerformanceProfiles";
         public static final String PERF_PROFILE_DELETION_SUCCESS = "Performance profile %s deleted successfully. View Performance Profiles at /listPerformanceProfiles";
     }


### PR DESCRIPTION
## Description

**Context**
ROS is encountering a validation error in the Update Results API call during testing of namespace recommendations. This happens because when the performance profile is updated in the database, the local cache/map is not refreshed. As a result, the Update Results API’s validation step still refers to an outdated version of the performance profile, causing the validation to fail.

**Solution**
This PR removes the local map from the updatePerformanceProfile API so that the global map is refrenced everywhere.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: Openshift

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Bug Fixes:
- Remove the unused local performance profile map in the update handler so validations operate on the up-to-date shared profile data.