### PR TITLE
Adding changes to accomodate unified aggregrate query at metric level

### DIFF
--- a/manifests/autotune/performance-profiles/ros-metrics-db.json
+++ b/manifests/autotune/performance-profiles/ros-metrics-db.json
@@ -14,6 +14,7 @@
         "datasource": "db1",
         "value_type": "double",
         "kubernetes_object": "container",
+        "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'avg' as avg_value, metrics -> 'results' -> 'aggregation_info' ->> 'sum' as sum_value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'cpuRequest' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
         "aggregation_functions": [
           {
             "function": "avg",
@@ -32,6 +33,7 @@
         "datasource": "db1",
         "value_type": "double",
         "kubernetes_object": "container",
+        "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'avg' as avg_value, metrics -> 'results' -> 'aggregation_info' ->> 'sum' as sum_value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'cpuLimit' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
         "aggregation_functions": [
           {
             "function": "avg",
@@ -50,6 +52,7 @@
         "datasource": "db1",
         "value_type": "double",
         "kubernetes_object": "container",
+        "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'avg' as avg_value, metrics -> 'results' -> 'aggregation_info' ->> 'sum' as sum_value, metrics -> 'results' -> 'aggregation_info' ->> 'min' as min_value, metrics -> 'results' -> 'aggregation_info' ->> 'max' as max_value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'cpuUsage' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
         "aggregation_functions": [
           {
             "function": "avg",
@@ -78,6 +81,7 @@
         "datasource": "db1",
         "value_type": "double",
         "kubernetes_object": "container",
+        "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'avg' as avg_value, metrics -> 'results' -> 'aggregation_info' ->> 'sum' as sum_value, metrics -> 'results' -> 'aggregation_info' ->> 'min' as min_value, metrics -> 'results' -> 'aggregation_info' ->> 'max' as max_value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'cpuThrottle' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
         "aggregation_functions": [
           {
             "function": "avg",
@@ -106,6 +110,7 @@
         "datasource": "db1",
         "value_type": "double",
         "kubernetes_object": "container",
+        "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'avg' as avg_value, metrics -> 'results' -> 'aggregation_info' ->> 'sum' as sum_value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'memoryRequest' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
         "aggregation_functions": [
           {
             "function": "avg",
@@ -124,6 +129,7 @@
         "datasource": "db1",
         "value_type": "double",
         "kubernetes_object": "container",
+        "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'avg' as avg_value, metrics -> 'results' -> 'aggregation_info' ->> 'sum' as sum_value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'memoryLimit' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
         "aggregation_functions": [
           {
             "function": "avg",
@@ -142,6 +148,7 @@
         "datasource": "db1",
         "value_type": "double",
         "kubernetes_object": "container",
+        "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'avg' as avg_value, metrics -> 'results' -> 'aggregation_info' ->> 'sum' as sum_value, metrics -> 'results' -> 'aggregation_info' ->> 'min' as min_value, metrics -> 'results' -> 'aggregation_info' ->> 'max' as max_value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'memoryUsage' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
         "aggregation_functions": [
           {
             "function": "avg",
@@ -170,6 +177,7 @@
         "datasource": "db1",
         "value_type": "double",
         "kubernetes_object": "container",
+        "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'avg' as avg_value, metrics -> 'results' -> 'aggregation_info' ->> 'sum' as sum_value, metrics -> 'results' -> 'aggregation_info' ->> 'min' as min_value, metrics -> 'results' -> 'aggregation_info' ->> 'max' as max_value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'memoryRSS' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
         "aggregation_functions": [
           {
             "function": "avg",

--- a/manifests/autotune/performance-profiles/ros-metrics-db.json
+++ b/manifests/autotune/performance-profiles/ros-metrics-db.json
@@ -15,16 +15,20 @@
         "value_type": "double",
         "kubernetes_object": "container",
         "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'avg' as avg_value, metrics -> 'results' -> 'aggregation_info' ->> 'sum' as sum_value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'cpuRequest' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+        "query_params": ["experiment_name", "start_time", "end_time"],
+        "result_columns": ["interval_start_time", "interval_end_time", "avg_value", "sum_value"],
         "aggregation_functions": [
           {
             "function": "avg",
             "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'avg' as value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'cpuRequest' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
-            "query_params": ["experiment_name", "start_time", "end_time"]
+            "query_params": ["experiment_name", "start_time", "end_time"],
+            "result_columns": ["interval_start_time", "interval_end_time", "value"]
           },
           {
             "function": "sum",
             "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'sum' as value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'cpuRequest' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
-            "query_params": ["experiment_name", "start_time", "end_time"]
+            "query_params": ["experiment_name", "start_time", "end_time"],
+            "result_columns": ["interval_start_time", "interval_end_time", "value"]
           }
         ]
       },
@@ -34,16 +38,20 @@
         "value_type": "double",
         "kubernetes_object": "container",
         "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'avg' as avg_value, metrics -> 'results' -> 'aggregation_info' ->> 'sum' as sum_value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'cpuLimit' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+        "query_params": ["experiment_name", "start_time", "end_time"],
+        "result_columns": ["interval_start_time", "interval_end_time", "avg_value", "sum_value"],
         "aggregation_functions": [
           {
             "function": "avg",
             "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'avg' as value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'cpuLimit' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
-            "query_params": ["experiment_name", "start_time", "end_time"]
+            "query_params": ["experiment_name", "start_time", "end_time"],
+            "result_columns": ["interval_start_time", "interval_end_time", "value"]
           },
           {
             "function": "sum",
             "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'sum' as value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'cpuLimit' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
-            "query_params": ["experiment_name", "start_time", "end_time"]
+            "query_params": ["experiment_name", "start_time", "end_time"],
+            "result_columns": ["interval_start_time", "interval_end_time", "value"]
           }
         ]
       },
@@ -53,26 +61,32 @@
         "value_type": "double",
         "kubernetes_object": "container",
         "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'avg' as avg_value, metrics -> 'results' -> 'aggregation_info' ->> 'sum' as sum_value, metrics -> 'results' -> 'aggregation_info' ->> 'min' as min_value, metrics -> 'results' -> 'aggregation_info' ->> 'max' as max_value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'cpuUsage' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+        "query_params": ["experiment_name", "start_time", "end_time"],
+        "result_columns": ["interval_start_time", "interval_end_time", "avg_value", "sum_value","min_value","max_value"],
         "aggregation_functions": [
           {
             "function": "avg",
             "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'avg' as value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'cpuUsage' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
-            "query_params": ["experiment_name", "start_time", "end_time"]
+            "query_params": ["experiment_name", "start_time", "end_time"],
+            "result_columns": ["interval_start_time", "interval_end_time", "value"]
           },
           {
             "function": "sum",
             "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'sum' as value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'cpuUsage' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
-            "query_params": ["experiment_name", "start_time", "end_time"]
+            "query_params": ["experiment_name", "start_time", "end_time"],
+            "result_columns": ["interval_start_time", "interval_end_time", "value"]
           },
           {
             "function": "min",
             "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'min' as value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'cpuUsage' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
-            "query_params": ["experiment_name", "start_time", "end_time"]
+            "query_params": ["experiment_name", "start_time", "end_time"],
+            "result_columns": ["interval_start_time", "interval_end_time", "value"]
           },
           {
             "function": "max",
             "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'max' as value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'cpuUsage' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
-            "query_params": ["experiment_name", "start_time", "end_time"]
+            "query_params": ["experiment_name", "start_time", "end_time"],
+            "result_columns": ["interval_start_time", "interval_end_time", "value"]
           }
         ]
       },
@@ -82,26 +96,32 @@
         "value_type": "double",
         "kubernetes_object": "container",
         "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'avg' as avg_value, metrics -> 'results' -> 'aggregation_info' ->> 'sum' as sum_value, metrics -> 'results' -> 'aggregation_info' ->> 'min' as min_value, metrics -> 'results' -> 'aggregation_info' ->> 'max' as max_value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'cpuThrottle' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+        "query_params": ["experiment_name", "start_time", "end_time"],
+        "result_columns": ["interval_start_time", "interval_end_time", "avg_value", "sum_value","min_value","max_value"],
         "aggregation_functions": [
           {
             "function": "avg",
             "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'avg' as value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'cpuThrottle' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
-            "query_params": ["experiment_name", "start_time", "end_time"]
+            "query_params": ["experiment_name", "start_time", "end_time"],
+            "result_columns": ["interval_start_time", "interval_end_time", "value"]
           },
           {
             "function": "sum",
             "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'sum' as value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'cpuThrottle' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
-            "query_params": ["experiment_name", "start_time", "end_time"]
+            "query_params": ["experiment_name", "start_time", "end_time"],
+            "result_columns": ["interval_start_time", "interval_end_time", "value"]
           },
           {
             "function": "min",
             "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'min' as value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'cpuThrottle' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
-            "query_params": ["experiment_name", "start_time", "end_time"]
+            "query_params": ["experiment_name", "start_time", "end_time"],
+            "result_columns": ["interval_start_time", "interval_end_time", "value"]
           },
           {
             "function": "max",
             "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'max' as value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'cpuThrottle' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
-            "query_params": ["experiment_name", "start_time", "end_time"]
+            "query_params": ["experiment_name", "start_time", "end_time"],
+            "result_columns": ["interval_start_time", "interval_end_time", "value"]
           }
         ]
       },
@@ -111,16 +131,20 @@
         "value_type": "double",
         "kubernetes_object": "container",
         "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'avg' as avg_value, metrics -> 'results' -> 'aggregation_info' ->> 'sum' as sum_value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'memoryRequest' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+        "query_params": ["experiment_name", "start_time", "end_time"],
+        "result_columns": ["interval_start_time", "interval_end_time", "avg_value", "sum_value"],
         "aggregation_functions": [
           {
             "function": "avg",
             "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'avg' as value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'memoryRequest' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
-            "query_params": ["experiment_name", "start_time", "end_time"]
+            "query_params": ["experiment_name", "start_time", "end_time"],
+            "result_columns": ["interval_start_time", "interval_end_time", "value"]
           },
           {
             "function": "sum",
             "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'sum' as value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'memoryRequest' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
-            "query_params": ["experiment_name", "start_time", "end_time"]
+            "query_params": ["experiment_name", "start_time", "end_time"],
+            "result_columns": ["interval_start_time", "interval_end_time", "value"]
           }
         ]
       },
@@ -130,16 +154,20 @@
         "value_type": "double",
         "kubernetes_object": "container",
         "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'avg' as avg_value, metrics -> 'results' -> 'aggregation_info' ->> 'sum' as sum_value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'memoryLimit' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+        "query_params": ["experiment_name", "start_time", "end_time"],
+        "result_columns": ["interval_start_time", "interval_end_time", "avg_value", "sum_value"],
         "aggregation_functions": [
           {
             "function": "avg",
             "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'avg' as value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'memoryLimit' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
-            "query_params": ["experiment_name", "start_time", "end_time"]
+            "query_params": ["experiment_name", "start_time", "end_time"],
+            "result_columns": ["interval_start_time", "interval_end_time", "value"]
           },
           {
             "function": "sum",
             "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'sum' as value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'memoryLimit' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
-            "query_params": ["experiment_name", "start_time", "end_time"]
+            "query_params": ["experiment_name", "start_time", "end_time"],
+            "result_columns": ["interval_start_time", "interval_end_time", "value"]
           }
         ]
       },
@@ -149,26 +177,33 @@
         "value_type": "double",
         "kubernetes_object": "container",
         "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'avg' as avg_value, metrics -> 'results' -> 'aggregation_info' ->> 'sum' as sum_value, metrics -> 'results' -> 'aggregation_info' ->> 'min' as min_value, metrics -> 'results' -> 'aggregation_info' ->> 'max' as max_value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'memoryUsage' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+        "query_params": ["experiment_name", "start_time", "end_time"],
+        "result_columns": ["interval_start_time", "interval_end_time", "avg_value", "sum_value","min_value","max_value"],
         "aggregation_functions": [
           {
             "function": "avg",
             "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'avg' as value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'memoryUsage' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
-            "query_params": ["experiment_name", "start_time", "end_time"]
+            "query_params": ["experiment_name", "start_time", "end_time"],
+            "result_columns": ["interval_start_time", "interval_end_time", "value"]
+
           },
           {
             "function": "sum",
             "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'sum' as value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'memoryUsage' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
-            "query_params": ["experiment_name", "start_time", "end_time"]
+            "query_params": ["experiment_name", "start_time", "end_time"],
+            "result_columns": ["interval_start_time", "interval_end_time", "value"]
           },
           {
             "function": "min",
             "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'min' as value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'memoryUsage' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
-            "query_params": ["experiment_name", "start_time", "end_time"]
+            "query_params": ["experiment_name", "start_time", "end_time"],
+            "result_columns": ["interval_start_time", "interval_end_time", "value"]
           },
           {
             "function": "max",
             "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'max' as value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'memoryUsage' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
-            "query_params": ["experiment_name", "start_time", "end_time"]
+            "query_params": ["experiment_name", "start_time", "end_time"],
+            "result_columns": ["interval_start_time", "interval_end_time", "value"]
           }
         ]
       },
@@ -178,26 +213,32 @@
         "value_type": "double",
         "kubernetes_object": "container",
         "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'avg' as avg_value, metrics -> 'results' -> 'aggregation_info' ->> 'sum' as sum_value, metrics -> 'results' -> 'aggregation_info' ->> 'min' as min_value, metrics -> 'results' -> 'aggregation_info' ->> 'max' as max_value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'memoryRSS' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
+        "query_params": ["experiment_name", "start_time", "end_time"],
+        "result_columns": ["interval_start_time", "interval_end_time", "avg_value", "sum_value","min_value","max_value"],
         "aggregation_functions": [
           {
             "function": "avg",
             "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'avg' as value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'memoryRSS' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
-            "query_params": ["experiment_name", "start_time", "end_time"]
+            "query_params": ["experiment_name", "start_time", "end_time"],
+            "result_columns": ["interval_start_time", "interval_end_time", "value"]
           },
           {
             "function": "sum",
             "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'sum' as value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'memoryRSS' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
-            "query_params": ["experiment_name", "start_time", "end_time"]
+            "query_params": ["experiment_name", "start_time", "end_time"],
+            "result_columns": ["interval_start_time", "interval_end_time", "value"]
           },
           {
             "function": "min",
             "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'min' as value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'memoryRSS' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
-            "query_params": ["experiment_name", "start_time", "end_time"]
+            "query_params": ["experiment_name", "start_time", "end_time"],
+            "result_columns": ["interval_start_time", "interval_end_time", "value"]
           },
           {
             "function": "max",
             "query": "select interval_start as interval_start_time, interval_end as interval_end_time, metrics -> 'results' -> 'aggregation_info' ->> 'max' as value from workload_metrics wm, workloads w, LATERAL jsonb_array_elements(wm.usage_metrics) as metrics where w.id = wm.workload_id and w.experiment_name = :experiment_name and metrics ->> 'name' = 'memoryRSS' and interval_start >= cast(:start_time as timestamp) and interval_end <= cast(:end_time as timestamp) order by interval_end desc;",
-            "query_params": ["experiment_name", "start_time", "end_time"]
+            "query_params": ["experiment_name", "start_time", "end_time"],
+            "result_columns": ["interval_start_time", "interval_end_time", "value"]
           }
         ]
       }

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -1423,8 +1423,12 @@ public class RecommendationEngine implements RecommendationEngineService {
                                 queryParams.put("namespace", namespace);
                             else if ("experiment_name".equalsIgnoreCase(param))
                                 queryParams.put("experiment_name", experiment_name);
-                            else if ("start_time".equalsIgnoreCase(param))
-                                queryParams.put("start_time", experiment_name);
+                            else if ("start_time".equalsIgnoreCase(param)) {
+                            queryParams.put(
+                                "start_time",
+                                startTimeLocalDateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+                            );
+                            }
                         }
                         
                         // Execute unified query
@@ -1460,8 +1464,8 @@ public class RecommendationEngine implements RecommendationEngineService {
                             for (String param : queryParamsFromProfile) {
                                 if ("container_name".equalsIgnoreCase(param))
                                     queryParams.put("container_name", container_name);
-                                else if ("namepsace".equalsIgnoreCase(param))
-                                    queryParams.put("namepsace", namespace);
+                                else if ("namespace".equalsIgnoreCase(param))
+                                    queryParams.put("namespace", namespace);
                                 else if ("experiment_name".equalsIgnoreCase(param))
                                     queryParams.put("experiment_name", experiment_name);
                                 else if ("start_time".equalsIgnoreCase(param))
@@ -1561,14 +1565,15 @@ public class RecommendationEngine implements RecommendationEngineService {
                         // Fallback to individual aggregation function queries (backward compatibility)
                         Set<String> aggrFunctions = metric.getAggregationFunctions();
                         for (String function : aggrFunctions) {
+                            queryParams.clear(); 
                             String query = metric.getQuery(function);
                             // Populate query params as defined in profile from standard list
                             List<String> queryParamsFromProfile = metric.getQueryParams(function);
                             for (String param : queryParamsFromProfile) {
                                 if ("container_name".equalsIgnoreCase(param))
                                     queryParams.put("container_name", container_name);
-                                else if ("namepsace".equalsIgnoreCase(param))
-                                    queryParams.put("namepsace", namespace);
+                                else if ("namespace".equalsIgnoreCase(param))
+                                    queryParams.put("namespace", namespace);
                                 else if ("experiment_name".equalsIgnoreCase(param))
                                     queryParams.put("experiment_name", experiment_name);
                                 else if ("start_time".equalsIgnoreCase(param))
@@ -1590,9 +1595,6 @@ public class RecommendationEngine implements RecommendationEngineService {
                                 intervalResults.setIntervalEndTime(interval_end_time);
                                 intervalResults.addMetricResult(metricName, function, value);
                             }
-                        }
-                    }
-                            //LOGGER.error("interval_start_time = {}, interval_end_time = {}, metricName = {}, function = {}, value = {}", interval_start_time, interval_end_time, metricName, function, value);
                         }
                     }
                 }

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -1406,29 +1406,77 @@ public class RecommendationEngine implements RecommendationEngineService {
                     HashMap<Metric, MetricResults>  metricResults = new HashMap<>();
                     String datasourceName = metric.getDatasource();
                     MetricsDBConnectionManager metricsDBConnectionManager = MetricsDBConnectionManager.getInstance();
-                    Set<String> aggrFunctions = metric.getAggregationFunctions();
-                    for (String function : aggrFunctions) {
-                        String query = metric.getQuery(function).toLowerCase();
-                        List<String> queryParamsFromProfile = metric.getQueryParams(function);
+                    
+                    // Check if metric has unified query at metric level
+                    if (metric.hasUnifiedQuery()) {
+                        // Use unified query path - single query returns all aggregate values
+                        String unifiedQuery = metric.getQuery();
+                        List<String> queryParamsFromProfile = metric.getUnifiedQueryParams();
+                        List<String> expectedFunctions = metric.getExpectedResultColumns();
+                        
+                        // Populate query parameters
+                        queryParams.clear();
                         for (String param : queryParamsFromProfile) {
                             if ("container_name".equalsIgnoreCase(param))
                                 queryParams.put("container_name", container_name);
-                            else if ("namepsace".equalsIgnoreCase(param))
-                                queryParams.put("namepsace", namespace);
+                            else if ("namespace".equalsIgnoreCase(param))
+                                queryParams.put("namespace", namespace);
                             else if ("experiment_name".equalsIgnoreCase(param))
                                 queryParams.put("experiment_name", experiment_name);
                             else if ("start_time".equalsIgnoreCase(param))
                                 queryParams.put("start_time", experiment_name);
-
                         }
+                        
+                        // Execute unified query
+                        List<Object[]> unifiedResults = metricsDBConnectionManager.getUnifiedMetricsData(
+                            datasourceName, unifiedQuery, queryParams, expectedFunctions);
+                        
+                        if (unifiedResults != null && !unifiedResults.isEmpty()) {
+                            // Process unified results - each row contains all aggregate values
+                            for (Object[] row : unifiedResults) {
+                                Timestamp interval_start_time = (Timestamp) row[0];
+                                Timestamp interval_end_time = (Timestamp) row[1];
+                                
+                                IntervalResults intervalResults = results.computeIfAbsent(
+                                    interval_end_time, k -> new IntervalResults());
+                                
+                                // Process each aggregate function value
+                                for (int i = 0; i < expectedFunctions.size(); i++) {
+                                    String function = expectedFunctions.get(i);
+                                    String valueStr = (String) row[2 + i];
+                                    if (valueStr != null) {
+                                        Double value = Double.valueOf(valueStr);
+                                        intervalResults.addMetricResult(metricName, function, value);
+                                    }
+                                }
+                            }
+                        }
+                    } else {
+                        // Fallback to individual aggregation function queries (backward compatibility)
+                        Set<String> aggrFunctions = metric.getAggregationFunctions();
+                        for (String function : aggrFunctions) {
+                            String query = metric.getQuery(function).toLowerCase();
+                            List<String> queryParamsFromProfile = metric.getQueryParams(function);
+                            for (String param : queryParamsFromProfile) {
+                                if ("container_name".equalsIgnoreCase(param))
+                                    queryParams.put("container_name", container_name);
+                                else if ("namepsace".equalsIgnoreCase(param))
+                                    queryParams.put("namepsace", namespace);
+                                else if ("experiment_name".equalsIgnoreCase(param))
+                                    queryParams.put("experiment_name", experiment_name);
+                                else if ("start_time".equalsIgnoreCase(param))
+                                    queryParams.put("start_time", experiment_name);
 
-                        List<Object[]> dbResult = metricsDBConnectionManager.getMetricsData(datasourceName, query, queryParams);
-                        for (Object[] dbRow : dbResult) {
-                            Timestamp interval_start_time = (Timestamp) dbRow[0];
-                            Timestamp interval_end_time = (Timestamp) dbRow[1];
-                            Double value =  Double.valueOf((String) dbRow[2]);
-                            IntervalResults intervalResults = results.computeIfAbsent(interval_end_time, k -> new IntervalResults());
-                            intervalResults.addMetricResult(metricName, function, value);
+                            }
+
+                            List<Object[]> dbResult = metricsDBConnectionManager.getMetricsData(datasourceName, query, queryParams);
+                            for (Object[] dbRow : dbResult) {
+                                Timestamp interval_start_time = (Timestamp) dbRow[0];
+                                Timestamp interval_end_time = (Timestamp) dbRow[1];
+                                Double value =  Double.valueOf((String) dbRow[2]);
+                                IntervalResults intervalResults = results.computeIfAbsent(interval_end_time, k -> new IntervalResults());
+                                intervalResults.addMetricResult(metricName, function, value);
+                            }
                         }
                     }
                 }
@@ -1458,16 +1506,21 @@ public class RecommendationEngine implements RecommendationEngineService {
                     HashMap<Metric, MetricResults>  metricResults = new HashMap<>();
                     String datasourceName = metric.getDatasource();
                     MetricsDBConnectionManager metricsDBConnectionManager = MetricsDBConnectionManager.getInstance();
-                    Set<String> aggrFunctions = metric.getAggregationFunctions();
-                    for (String function : aggrFunctions) {
-                        String query = metric.getQuery(function);
-                        // Populate query params as defined in profile from standard list
-                        List<String> queryParamsFromProfile = metric.getQueryParams(function);
+                    
+                    // Check if metric has unified query at metric level
+                    if (metric.hasUnifiedQuery()) {
+                        // Use unified query path - single query returns all aggregate values
+                        String unifiedQuery = metric.getQuery();
+                        List<String> queryParamsFromProfile = metric.getUnifiedQueryParams();
+                        List<String> expectedFunctions = metric.getExpectedResultColumns();
+                        
+                        // Populate query parameters
+                        queryParams.clear();
                         for (String param : queryParamsFromProfile) {
                             if ("container_name".equalsIgnoreCase(param))
                                 queryParams.put("container_name", container_name);
-                            else if ("namepsace".equalsIgnoreCase(param))
-                                queryParams.put("namepsace", namespace);
+                            else if ("namespace".equalsIgnoreCase(param))
+                                queryParams.put("namespace", namespace);
                             else if ("experiment_name".equalsIgnoreCase(param))
                                 queryParams.put("experiment_name", experiment_name);
                             else if ("start_time".equalsIgnoreCase(param))
@@ -1475,19 +1528,70 @@ public class RecommendationEngine implements RecommendationEngineService {
                             else if ("end_time".equalsIgnoreCase(param))
                                 queryParams.put("end_time", endTimeLocalDateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
                         }
-                        //LOGGER.error("query = {}", query);
-                        List<Object[]> dbResult = metricsDBConnectionManager.getMetricsData(datasourceName, query, queryParams);
-                        if (dbResult == null) {
-                            return;
+                        
+                        // Execute unified query
+                        List<Object[]> unifiedResults = metricsDBConnectionManager.getUnifiedMetricsData(
+                            datasourceName, unifiedQuery, queryParams, expectedFunctions);
+                        
+                        if (unifiedResults == null || unifiedResults.isEmpty()) {
+                            continue;
                         }
-                        for (Object[] dbRow : dbResult) {
-                            Timestamp interval_start_time = (Timestamp) dbRow[0];
-                            Timestamp interval_end_time = (Timestamp) dbRow[1];
-                            Double value =  Double.valueOf((String) dbRow[2]);
-                            IntervalResults intervalResults = results.computeIfAbsent(interval_end_time, k -> new IntervalResults(interval_start_time, interval_end_time));
+                        
+                        // Process unified results - each row contains all aggregate values
+                        for (Object[] row : unifiedResults) {
+                            Timestamp interval_start_time = (Timestamp) row[0];
+                            Timestamp interval_end_time = (Timestamp) row[1];
+                            
+                            IntervalResults intervalResults = results.computeIfAbsent(
+                                interval_end_time, k -> new IntervalResults(interval_start_time, interval_end_time));
                             intervalResults.setIntervalStartTime(interval_start_time);
                             intervalResults.setIntervalEndTime(interval_end_time);
-                            intervalResults.addMetricResult(metricName, function, value);
+                            
+                            // Process each aggregate function value
+                            for (int i = 0; i < expectedFunctions.size(); i++) {
+                                String function = expectedFunctions.get(i);
+                                String valueStr = (String) row[2 + i];
+                                if (valueStr != null) {
+                                    Double value = Double.valueOf(valueStr);
+                                    intervalResults.addMetricResult(metricName, function, value);
+                                }
+                            }
+                        }
+                    } else {
+                        // Fallback to individual aggregation function queries (backward compatibility)
+                        Set<String> aggrFunctions = metric.getAggregationFunctions();
+                        for (String function : aggrFunctions) {
+                            String query = metric.getQuery(function);
+                            // Populate query params as defined in profile from standard list
+                            List<String> queryParamsFromProfile = metric.getQueryParams(function);
+                            for (String param : queryParamsFromProfile) {
+                                if ("container_name".equalsIgnoreCase(param))
+                                    queryParams.put("container_name", container_name);
+                                else if ("namepsace".equalsIgnoreCase(param))
+                                    queryParams.put("namepsace", namespace);
+                                else if ("experiment_name".equalsIgnoreCase(param))
+                                    queryParams.put("experiment_name", experiment_name);
+                                else if ("start_time".equalsIgnoreCase(param))
+                                    queryParams.put("start_time", startTimeLocalDateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+                                else if ("end_time".equalsIgnoreCase(param))
+                                    queryParams.put("end_time", endTimeLocalDateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+                            }
+                            //LOGGER.error("query = {}", query);
+                            List<Object[]> dbResult = metricsDBConnectionManager.getMetricsData(datasourceName, query, queryParams);
+                            if (dbResult == null) {
+                                return;
+                            }
+                            for (Object[] dbRow : dbResult) {
+                                Timestamp interval_start_time = (Timestamp) dbRow[0];
+                                Timestamp interval_end_time = (Timestamp) dbRow[1];
+                                Double value =  Double.valueOf((String) dbRow[2]);
+                                IntervalResults intervalResults = results.computeIfAbsent(interval_end_time, k -> new IntervalResults(interval_start_time, interval_end_time));
+                                intervalResults.setIntervalStartTime(interval_start_time);
+                                intervalResults.setIntervalEndTime(interval_end_time);
+                                intervalResults.addMetricResult(metricName, function, value);
+                            }
+                        }
+                    }
                             //LOGGER.error("interval_start_time = {}, interval_end_time = {}, metricName = {}, function = {}, value = {}", interval_start_time, interval_end_time, metricName, function, value);
                         }
                     }

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -1385,6 +1385,49 @@ public class RecommendationEngine implements RecommendationEngineService {
             throw new Exception(AnalyzerErrorConstants.APIErrors.UpdateRecommendationsAPI.METRIC_EXCEPTION + e.getMessage());
         }
     }
+private void populateQueryParams(
+        Map<String, String> queryParams,
+        List<String> params,
+        String container_name,
+        String namespace,
+        String experiment_name,
+        LocalDateTime startTime,
+        LocalDateTime endTime) {
+
+    for (String param : params) {
+        if ("container_name".equalsIgnoreCase(param))
+            queryParams.put("container_name", container_name);
+        else if ("namespace".equalsIgnoreCase(param))
+            queryParams.put("namespace", namespace);
+        else if ("experiment_name".equalsIgnoreCase(param))
+            queryParams.put("experiment_name", experiment_name);
+        else if ("start_time".equalsIgnoreCase(param))
+            queryParams.put("start_time", startTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+        else if ("end_time".equalsIgnoreCase(param))
+            queryParams.put("end_time", endTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+    }
+}
+
+// Method to validate if result_columns are maintained for a metric
+private void validateResultColumns(List<String> resultColumns,
+                                   String metricName,
+                                   String context) {
+
+    if (resultColumns == null || resultColumns.isEmpty()
+        || resultColumns.contains(null)
+        || resultColumns.stream().anyMatch(String::isBlank)) {
+
+        LOGGER.error("Invalid result_columns for metric {} ({}) : {}",
+                metricName,
+                context,
+                resultColumns);
+
+        throw new IllegalStateException(
+                "Invalid result_columns for metric: " + metricName +
+                " (" + context + ")"
+        );
+    }
+}
 
     private void fetchNamespaceMetricsBasedOnProfile(KruizeObject kruizeObject, Timestamp startTime, Timestamp endTime, PerformanceProfile profile) throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
         String experiment_name = kruizeObject.getExperimentName();
@@ -1404,84 +1447,123 @@ public class RecommendationEngine implements RecommendationEngineService {
                 }
                 List<Metric> metrics = profile.getNamespaceMetrics();
                 for (Metric metric : metrics) {
+                    boolean dataFound = false;
                     String metricName  = metric.getName();
-                    HashMap<Metric, MetricResults>  metricResults = new HashMap<>();
                     String datasourceName = metric.getDatasource();
                     MetricsDBConnectionManager metricsDBConnectionManager = MetricsDBConnectionManager.getInstance();
                     
-                    // Check if metric has unified query at metric level
-                    if (metric.hasUnifiedQuery()) {
-                        // Use unified query path - single query returns all aggregate values
-                        String unifiedQuery = metric.getQuery();
-                        List<String> queryParamsFromProfile = metric.getUnifiedQueryParams();
-                        List<String> expectedFunctions = metric.getExpectedResultColumns();
+                    // Check if metric has unified query at metric level (not null and not empty)
+                    String unifiedQuery = metric.getQuery();
+                    if (unifiedQuery != null && !unifiedQuery.trim().isEmpty()) {
+                        List<String> queryParamsFromProfile = metric.getQueryParams();
+                        LOGGER.error("Metric: {}, unifiedQueryPresent={}, queryParamsFromProfile={}",
+                        metric.getName(),
+                        unifiedQuery != null,
+                        queryParamsFromProfile);
+                        
+                        // Get result columns from profile (actual SQL column names)
+                        List<String> resultColumns = metric.getResultColumns();
+                        
+                        validateResultColumns(resultColumns, metricName, "unified");
                         
                         // Populate query parameters
                         queryParams.clear();
-                        for (String param : queryParamsFromProfile) {
-                            if ("container_name".equalsIgnoreCase(param))
-                                queryParams.put("container_name", container_name);
-                            else if ("namespace".equalsIgnoreCase(param))
-                                queryParams.put("namespace", namespace);
-                            else if ("experiment_name".equalsIgnoreCase(param))
-                                queryParams.put("experiment_name", experiment_name);
-                            else if ("start_time".equalsIgnoreCase(param)) {
-                            queryParams.put(
-                                "start_time",
-                                startTimeLocalDateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+                        if (queryParamsFromProfile != null && !queryParamsFromProfile.isEmpty()) {
+                            populateQueryParams(
+                                queryParams,
+                                queryParamsFromProfile,
+                                container_name,
+                                namespace,
+                                experiment_name,
+                                startTimeLocalDateTime,
+                                endTimeLocalDateTime
                             );
-                            }
+                        } else {
+                            LOGGER.warn("query_params is null or empty for metric: {} with unified query", metricName);
+                            continue;
                         }
-                        
-                        // Execute unified query
-                        List<Object[]> unifiedResults = metricsDBConnectionManager.getUnifiedMetricsData(
-                            datasourceName, unifiedQuery, queryParams, expectedFunctions);
+
+                        // Execute unified query with result_columns
+                        List<Object[]> unifiedResults = metricsDBConnectionManager.getMetricsData(datasourceName, unifiedQuery, queryParams, resultColumns);
                         
                         if (unifiedResults != null && !unifiedResults.isEmpty()) {
-                            // Process unified results - each row contains all aggregate values
+                            dataFound = true;
+                            
+                            // Build column index map once before processing rows
+                            Map<String, Integer> columnIndexMap = buildColumnIndexMap(resultColumns);
+                            
+                            // Process unified results using helper method
                             for (Object[] row : unifiedResults) {
-                                Timestamp interval_start_time = (Timestamp) row[0];
-                                Timestamp interval_end_time = (Timestamp) row[1];
+                                Timestamp start = (Timestamp) row[columnIndexMap.get("interval_start_time")];
+                                Timestamp end = (Timestamp) row[columnIndexMap.get("interval_end_time")];
                                 
                                 IntervalResults intervalResults = results.computeIfAbsent(
-                                    interval_end_time, k -> new IntervalResults());
+                                    end, k -> new IntervalResults(start, end));
+                                intervalResults.setIntervalStartTime(start);
+                                intervalResults.setIntervalEndTime(end);
                                 
-                                // Process each aggregate function value
-                                for (int i = 0; i < expectedFunctions.size(); i++) {
-                                    String function = expectedFunctions.get(i);
-                                    String valueStr = (String) row[2 + i];
-                                    if (valueStr != null) {
-                                        Double value = Double.valueOf(valueStr);
-                                        intervalResults.addMetricResult(metricName, function, value);
-                                    }
-                                }
+                                processResultRow(row, columnIndexMap, resultColumns, metricName, intervalResults);
                             }
                         }
-                    } else {
+                    }
+                    if (!dataFound && metric.getAggregationFunctions() != null) {
                         // Fallback to individual aggregation function queries (backward compatibility)
                         Set<String> aggrFunctions = metric.getAggregationFunctions();
                         for (String function : aggrFunctions) {
-                            String query = metric.getQuery(function).toLowerCase();
+                            queryParams.clear();
+                            String query = metric.getQuery(function);
                             List<String> queryParamsFromProfile = metric.getQueryParams(function);
-                            for (String param : queryParamsFromProfile) {
-                                if ("container_name".equalsIgnoreCase(param))
-                                    queryParams.put("container_name", container_name);
-                                else if ("namespace".equalsIgnoreCase(param))
-                                    queryParams.put("namespace", namespace);
-                                else if ("experiment_name".equalsIgnoreCase(param))
-                                    queryParams.put("experiment_name", experiment_name);
-                                else if ("start_time".equalsIgnoreCase(param))
-                                    queryParams.put("start_time", experiment_name);
-
+                            if (queryParamsFromProfile != null && !queryParamsFromProfile.isEmpty()){
+                                populateQueryParams(
+                                    queryParams,
+                                    queryParamsFromProfile,
+                                    container_name,
+                                    namespace,
+                                    experiment_name,
+                                    startTimeLocalDateTime,
+                                    endTimeLocalDateTime
+                                );
+                            } else {
+                                LOGGER.warn("query_params is null or empty for metric: {} function: {}", metricName, function);
+                                continue;
                             }
 
-                            List<Object[]> dbResult = metricsDBConnectionManager.getMetricsData(datasourceName, query, queryParams);
-                            for (Object[] dbRow : dbResult) {
-                                Timestamp interval_start_time = (Timestamp) dbRow[0];
-                                Timestamp interval_end_time = (Timestamp) dbRow[1];
-                                Double value =  Double.valueOf((String) dbRow[2]);
-                                IntervalResults intervalResults = results.computeIfAbsent(interval_end_time, k -> new IntervalResults());
-                                intervalResults.addMetricResult(metricName, function, value);
+                            // Get result_columns for this function
+                            List<String> functionResultColumns = metric.getResultColumns(function);
+
+                            validateResultColumns(functionResultColumns, metricName, function);
+                      
+                            
+                            List<Object[]> functionResults = metricsDBConnectionManager.getMetricsData(datasourceName, query, queryParams, functionResultColumns);
+                            
+                            if (functionResults != null && !functionResults.isEmpty()) {
+                                // Build column index map once before processing rows
+                                Map<String, Integer> columnIndexMap = buildColumnIndexMap(functionResultColumns);
+                                
+                                for (Object[] row : functionResults) {
+                                    Timestamp start = (Timestamp) row[columnIndexMap.get("interval_start_time")];
+                                    Timestamp end = (Timestamp) row[columnIndexMap.get("interval_end_time")];
+                                    
+                                    IntervalResults intervalResults = results.computeIfAbsent(
+                                        end, k -> new IntervalResults(start, end));
+                                    intervalResults.setIntervalStartTime(start);
+                                    intervalResults.setIntervalEndTime(end);
+                                    
+                                    // For fallback queries, we know the function name from the loop
+                                    // Get the value from the "value" column
+                                    Integer valueIndex = columnIndexMap.get("value");
+                                    if (valueIndex != null && valueIndex < row.length) {
+                                        Object valueObj = row[valueIndex];
+                                        if (valueObj != null) {
+                                            try {
+                                                Double value = Double.valueOf(valueObj.toString());
+                                                intervalResults.addMetricResult(metricName, function, value);
+                                            } catch (Exception e) {
+                                                LOGGER.warn("Failed parsing value for function {} in metric {}", function, metricName);
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
                     }
@@ -1507,95 +1589,122 @@ public class RecommendationEngine implements RecommendationEngineService {
                 }
                 List<Metric> metrics = profile.getContainerMetrics();
                 for (Metric metric : metrics) {
+                    boolean dataFound = false;
                     String metricName  = metric.getName();
                     LOGGER.error("metricName = {}", metricName);
-                    HashMap<Metric, MetricResults>  metricResults = new HashMap<>();
                     String datasourceName = metric.getDatasource();
                     MetricsDBConnectionManager metricsDBConnectionManager = MetricsDBConnectionManager.getInstance();
                     
-                    // Check if metric has unified query at metric level
-                    if (metric.hasUnifiedQuery()) {
+                    // Check if metric has unified query at metric level (not null and not empty)
+                    String unifiedQuery = metric.getQuery();
+                    if (unifiedQuery != null && !unifiedQuery.trim().isEmpty()) {
                         // Use unified query path - single query returns all aggregate values
-                        String unifiedQuery = metric.getQuery();
-                        List<String> queryParamsFromProfile = metric.getUnifiedQueryParams();
-                        List<String> expectedFunctions = metric.getExpectedResultColumns();
+                        List<String> queryParamsFromProfile = metric.getQueryParams();
+                        LOGGER.error("DEBUG: metricName={}, unifiedQuery={}, queryParamsFromProfile={}",
+                            metricName, unifiedQuery != null ? "present" : "null", queryParamsFromProfile);
+                        
+                        // Get result columns from profile (actual SQL column names)
+                        List<String> resultColumns = metric.getResultColumns();
+                        
+                       validateResultColumns(resultColumns, metricName, "unified");
                         
                         // Populate query parameters
                         queryParams.clear();
-                        for (String param : queryParamsFromProfile) {
-                            if ("container_name".equalsIgnoreCase(param))
-                                queryParams.put("container_name", container_name);
-                            else if ("namespace".equalsIgnoreCase(param))
-                                queryParams.put("namespace", namespace);
-                            else if ("experiment_name".equalsIgnoreCase(param))
-                                queryParams.put("experiment_name", experiment_name);
-                            else if ("start_time".equalsIgnoreCase(param))
-                                queryParams.put("start_time", startTimeLocalDateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
-                            else if ("end_time".equalsIgnoreCase(param))
-                                queryParams.put("end_time", endTimeLocalDateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
-                        }
-                        
-                        // Execute unified query
-                        List<Object[]> unifiedResults = metricsDBConnectionManager.getUnifiedMetricsData(
-                            datasourceName, unifiedQuery, queryParams, expectedFunctions);
-                        
-                        if (unifiedResults == null || unifiedResults.isEmpty()) {
+                        if (queryParamsFromProfile != null && !queryParamsFromProfile.isEmpty()) {
+                            populateQueryParams(
+                                queryParams,
+                                queryParamsFromProfile,
+                                container_name,
+                                namespace,
+                                experiment_name,
+                                startTimeLocalDateTime,
+                                endTimeLocalDateTime
+                            );
+                        } else {
+                            LOGGER.warn("query_params is null or empty for metric: {} with unified query", metricName);
                             continue;
                         }
+                       
+                        // Execute unified query with result_columns
+                        List<Object[]> unifiedResults = metricsDBConnectionManager.getMetricsData(datasourceName, unifiedQuery, queryParams, resultColumns);
                         
-                        // Process unified results - each row contains all aggregate values
-                        for (Object[] row : unifiedResults) {
-                            Timestamp interval_start_time = (Timestamp) row[0];
-                            Timestamp interval_end_time = (Timestamp) row[1];
+                        if (unifiedResults != null && !unifiedResults.isEmpty()) {
+                            dataFound = true;
                             
-                            IntervalResults intervalResults = results.computeIfAbsent(
-                                interval_end_time, k -> new IntervalResults(interval_start_time, interval_end_time));
-                            intervalResults.setIntervalStartTime(interval_start_time);
-                            intervalResults.setIntervalEndTime(interval_end_time);
+                            // Build column index map once before processing rows
+                            Map<String, Integer> columnIndexMap = buildColumnIndexMap(resultColumns);
                             
-                            // Process each aggregate function value
-                            for (int i = 0; i < expectedFunctions.size(); i++) {
-                                String function = expectedFunctions.get(i);
-                                String valueStr = (String) row[2 + i];
-                                if (valueStr != null) {
-                                    Double value = Double.valueOf(valueStr);
-                                    intervalResults.addMetricResult(metricName, function, value);
-                                }
+                            // Process unified results using helper method
+                            for (Object[] row : unifiedResults) {
+                                Timestamp start = (Timestamp) row[columnIndexMap.get("interval_start_time")];
+                                Timestamp end = (Timestamp) row[columnIndexMap.get("interval_end_time")];
+                                
+                                IntervalResults intervalResults = results.computeIfAbsent(
+                                    end, k -> new IntervalResults(start, end));
+                                intervalResults.setIntervalStartTime(start);
+                                intervalResults.setIntervalEndTime(end);
+                                
+                                processResultRow(row, columnIndexMap, resultColumns, metricName, intervalResults);
                             }
                         }
-                    } else {
+                    }
+                    if (!dataFound && metric.getAggregationFunctions() != null) {
                         // Fallback to individual aggregation function queries (backward compatibility)
                         Set<String> aggrFunctions = metric.getAggregationFunctions();
                         for (String function : aggrFunctions) {
-                            queryParams.clear(); 
+                            queryParams.clear();
                             String query = metric.getQuery(function);
                             // Populate query params as defined in profile from standard list
                             List<String> queryParamsFromProfile = metric.getQueryParams(function);
-                            for (String param : queryParamsFromProfile) {
-                                if ("container_name".equalsIgnoreCase(param))
-                                    queryParams.put("container_name", container_name);
-                                else if ("namespace".equalsIgnoreCase(param))
-                                    queryParams.put("namespace", namespace);
-                                else if ("experiment_name".equalsIgnoreCase(param))
-                                    queryParams.put("experiment_name", experiment_name);
-                                else if ("start_time".equalsIgnoreCase(param))
-                                    queryParams.put("start_time", startTimeLocalDateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
-                                else if ("end_time".equalsIgnoreCase(param))
-                                    queryParams.put("end_time", endTimeLocalDateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+                            if (queryParamsFromProfile != null && !queryParamsFromProfile.isEmpty()){
+                                populateQueryParams(
+                                    queryParams,
+                                    queryParamsFromProfile,
+                                    container_name,
+                                    namespace,
+                                    experiment_name,
+                                    startTimeLocalDateTime,
+                                    endTimeLocalDateTime
+                                );
+                            } else {
+                                LOGGER.warn("query_params is null or empty for metric: {} function: {}", metricName, function);
+                                continue;
                             }
-                            //LOGGER.error("query = {}", query);
-                            List<Object[]> dbResult = metricsDBConnectionManager.getMetricsData(datasourceName, query, queryParams);
-                            if (dbResult == null) {
-                                return;
-                            }
-                            for (Object[] dbRow : dbResult) {
-                                Timestamp interval_start_time = (Timestamp) dbRow[0];
-                                Timestamp interval_end_time = (Timestamp) dbRow[1];
-                                Double value =  Double.valueOf((String) dbRow[2]);
-                                IntervalResults intervalResults = results.computeIfAbsent(interval_end_time, k -> new IntervalResults(interval_start_time, interval_end_time));
-                                intervalResults.setIntervalStartTime(interval_start_time);
-                                intervalResults.setIntervalEndTime(interval_end_time);
-                                intervalResults.addMetricResult(metricName, function, value);
+                            
+                            // Get result_columns for this function
+                            List<String> functionResultColumns = metric.getResultColumns(function);
+                            validateResultColumns(functionResultColumns, metricName, function);
+                            
+                            List<Object[]> functionResults = metricsDBConnectionManager.getMetricsData(datasourceName, query, queryParams, functionResultColumns);
+                            
+                            if (functionResults != null && !functionResults.isEmpty()) {
+                                // Build column index map once before processing rows
+                                Map<String, Integer> columnIndexMap = buildColumnIndexMap(functionResultColumns);
+                                
+                                for (Object[] row : functionResults) {
+                                    Timestamp start = (Timestamp) row[columnIndexMap.get("interval_start_time")];
+                                    Timestamp end = (Timestamp) row[columnIndexMap.get("interval_end_time")];
+                                    
+                                    IntervalResults intervalResults = results.computeIfAbsent(
+                                        end, k -> new IntervalResults(start, end));
+                                    intervalResults.setIntervalStartTime(start);
+                                    intervalResults.setIntervalEndTime(end);
+                                    
+                                    // For fallback queries, we know the function name from the loop
+                                    // Get the value from the "value" column
+                                    Integer valueIndex = columnIndexMap.get("value");
+                                    if (valueIndex != null && valueIndex < row.length) {
+                                        Object valueObj = row[valueIndex];
+                                        if (valueObj != null) {
+                                            try {
+                                                Double value = Double.valueOf(valueObj.toString());
+                                                intervalResults.addMetricResult(metricName, function, value);
+                                            } catch (Exception e) {
+                                                LOGGER.warn("Failed parsing value for function {} in metric {}", function, metricName);
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
                     }
@@ -2153,6 +2262,100 @@ public class RecommendationEngine implements RecommendationEngineService {
                     );
                 })
                 .toList();
+    }
+
+    /**
+     * Process a result row and extract metric values based on result_columns.
+     *
+     * @param row The database result row
+     * @param columnIndexMap Map of column names to their indices
+     * @param resultColumns List of column names in the result
+     * @param metricName Name of the metric being processed
+     * @param intervalResults IntervalResults object to populate
+     * @throws InvocationTargetException if metric result addition fails
+     * @throws NoSuchMethodException if metric result addition fails
+     * @throws IllegalAccessException if metric result addition fails
+     */
+    private void processResultRow(
+            Object[] row,
+            Map<String, Integer> columnIndexMap,
+            List<String> resultColumns,
+            String metricName,
+            IntervalResults intervalResults) throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+
+        if (row == null || resultColumns == null || resultColumns.isEmpty()) {
+            LOGGER.warn("Invalid input for metric {}. Skipping row processing.", metricName);
+            return;
+        }
+
+        if (row.length < resultColumns.size()) {
+            LOGGER.error("Column mismatch for metric {}. Expected at least {}, got {}",
+                    metricName, resultColumns.size(), row.length);
+            return;
+        }
+
+        for (String columnName : resultColumns) {
+            // Skip timestamp columns
+            if ("interval_start_time".equals(columnName) ||
+                "interval_end_time".equals(columnName)) {
+                continue;
+            }
+
+            Integer columnIndex = columnIndexMap.get(columnName);
+            if (columnIndex == null || columnIndex >= row.length) {
+                LOGGER.warn("Column {} not found for metric {}", columnName, metricName);
+                continue;
+            }
+
+            Object valueObj = row[columnIndex];
+            if (valueObj == null) continue;
+
+            Double value;
+            try {
+                value = Double.valueOf(valueObj.toString());
+            } catch (Exception e) {
+                LOGGER.warn("Failed parsing value for {} in metric {}", columnName, metricName);
+                continue;
+            }
+
+            String functionName = deriveFunctionName(columnName);
+            intervalResults.addMetricResult(metricName, functionName, value);
+        }
+    }
+
+    /**
+     * Derive function name from column name by removing suffix.
+     * Examples: "avg_value" -> "avg", "sumValue" -> "sum"
+     *
+     * @param columnName The column name
+     * @return The derived function name
+     */
+    private String deriveFunctionName(String columnName) {
+        if (columnName == null) return null;
+
+        if (columnName.endsWith("_value")) {
+            return columnName.substring(0, columnName.length() - 6);
+        }
+
+        if (columnName.endsWith("Value")) {
+            return columnName.substring(0, columnName.length() - 5);
+        }
+
+        return columnName;
+    }
+
+    /**
+     * Build a map of column names to their indices for efficient lookup.
+     *
+     * @param resultColumns List of column names
+     * @return Map of column name to index
+     */
+    private Map<String, Integer> buildColumnIndexMap(List<String> resultColumns) {
+        Map<String, Integer> map = new HashMap<>();
+        for (int i = 0; i < resultColumns.size(); i++) {
+            map.put(resultColumns.get(i), i);
+        }
+        return map;
     }
 
 }

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -1389,6 +1389,8 @@ public class RecommendationEngine implements RecommendationEngineService {
     private void fetchNamespaceMetricsBasedOnProfile(KruizeObject kruizeObject, Timestamp startTime, Timestamp endTime, PerformanceProfile profile) throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
         String experiment_name = kruizeObject.getExperimentName();
         HashMap<String, String> queryParams = new HashMap<>();
+        LocalDateTime startTimeLocalDateTime = startTime.toLocalDateTime();
+        LocalDateTime endTimeLocalDateTime = endTime.toLocalDateTime();
         queryParams.put("experiment_name", experiment_name);
         for (K8sObject k8sObject : kruizeObject.getKubernetes_objects()) {
             String namespace = k8sObject.getNamespace();

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -1408,27 +1408,6 @@ private void populateQueryParams(
     }
 }
 
-// Method to validate if result_columns are maintained for a metric
-private void validateResultColumns(List<String> resultColumns,
-                                   String metricName,
-                                   String context) {
-
-    if (resultColumns == null || resultColumns.isEmpty()
-        || resultColumns.contains(null)
-        || resultColumns.stream().anyMatch(String::isBlank)) {
-
-        LOGGER.error("Invalid result_columns for metric {} ({}) : {}",
-                metricName,
-                context,
-                resultColumns);
-
-        throw new IllegalStateException(
-                "Invalid result_columns for metric: " + metricName +
-                " (" + context + ")"
-        );
-    }
-}
-
     private void fetchNamespaceMetricsBasedOnProfile(KruizeObject kruizeObject, Timestamp startTime, Timestamp endTime, PerformanceProfile profile) throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
         String experiment_name = kruizeObject.getExperimentName();
         HashMap<String, String> queryParams = new HashMap<>();
@@ -1464,8 +1443,6 @@ private void validateResultColumns(List<String> resultColumns,
                         // Get result columns from profile (actual SQL column names)
                         List<String> resultColumns = metric.getResultColumns();
                         
-                        validateResultColumns(resultColumns, metricName, "unified");
-                        
                         // Populate query parameters
                         queryParams.clear();
                         if (queryParamsFromProfile != null && !queryParamsFromProfile.isEmpty()) {
@@ -1479,30 +1456,30 @@ private void validateResultColumns(List<String> resultColumns,
                                 endTimeLocalDateTime
                             );
                         } else {
-                            LOGGER.warn("query_params is null or empty for metric: {} with unified query", metricName);
+                            LOGGER.error("query_params is null or empty for metric: {} with unified query", metricName);
                             continue;
                         }
 
-                        // Execute unified query with result_columns
-                        List<Object[]> unifiedResults = metricsDBConnectionManager.getMetricsData(datasourceName, unifiedQuery, queryParams, resultColumns);
+                        // single-aggregate-query changes: Execute unified query with result_columns
+                        // Returns List<Map<String, Object>> where each map has column names as keys
+                        List<Map<String, Object>> unifiedResults = metricsDBConnectionManager.getMetricsData(datasourceName, unifiedQuery, queryParams, resultColumns);
                         
                         if (unifiedResults != null && !unifiedResults.isEmpty()) {
                             dataFound = true;
                             
-                            // Build column index map once before processing rows
-                            Map<String, Integer> columnIndexMap = buildColumnIndexMap(resultColumns);
-                            
-                            // Process unified results using helper method
-                            for (Object[] row : unifiedResults) {
-                                Timestamp start = (Timestamp) row[columnIndexMap.get("interval_start_time")];
-                                Timestamp end = (Timestamp) row[columnIndexMap.get("interval_end_time")];
+                            // single-aggregate-query changes: Process unified results - no need for columnIndexMap
+                            // Access columns directly by name from the map
+                            for (Map<String, Object> row : unifiedResults) {
+                                Timestamp start = (Timestamp) row.get("interval_start_time");
+                                Timestamp end = (Timestamp) row.get("interval_end_time");
                                 
                                 IntervalResults intervalResults = results.computeIfAbsent(
                                     end, k -> new IntervalResults(start, end));
                                 intervalResults.setIntervalStartTime(start);
                                 intervalResults.setIntervalEndTime(end);
                                 
-                                processResultRow(row, columnIndexMap, resultColumns, metricName, intervalResults);
+                                // single-aggregate-query changes: Pass map directly to processResultRow
+                                processResultRow(row, resultColumns, metricName, intervalResults);
                             }
                         }
                     }
@@ -1524,43 +1501,35 @@ private void validateResultColumns(List<String> resultColumns,
                                     endTimeLocalDateTime
                                 );
                             } else {
-                                LOGGER.warn("query_params is null or empty for metric: {} function: {}", metricName, function);
+                                LOGGER.error("query_params is null or empty for metric: {} function: {}", metricName, function);
                                 continue;
                             }
 
                             // Get result_columns for this function
                             List<String> functionResultColumns = metric.getResultColumns(function);
-
-                            validateResultColumns(functionResultColumns, metricName, function);
-                      
                             
-                            List<Object[]> functionResults = metricsDBConnectionManager.getMetricsData(datasourceName, query, queryParams, functionResultColumns);
+                            // single-aggregate-query changes: Returns List<Map<String, Object>>
+                            List<Map<String, Object>> functionResults = metricsDBConnectionManager.getMetricsData(datasourceName, query, queryParams, functionResultColumns);
                             
                             if (functionResults != null && !functionResults.isEmpty()) {
-                                // Build column index map once before processing rows
-                                Map<String, Integer> columnIndexMap = buildColumnIndexMap(functionResultColumns);
-                                
-                                for (Object[] row : functionResults) {
-                                    Timestamp start = (Timestamp) row[columnIndexMap.get("interval_start_time")];
-                                    Timestamp end = (Timestamp) row[columnIndexMap.get("interval_end_time")];
+                                // single-aggregate-query changes: Access columns by name from map
+                                for (Map<String, Object> row : functionResults) {
+                                    Timestamp start = (Timestamp) row.get("interval_start_time");
+                                    Timestamp end = (Timestamp) row.get("interval_end_time");
                                     
                                     IntervalResults intervalResults = results.computeIfAbsent(
                                         end, k -> new IntervalResults(start, end));
                                     intervalResults.setIntervalStartTime(start);
                                     intervalResults.setIntervalEndTime(end);
                                     
-                                    // For fallback queries, we know the function name from the loop
-                                    // Get the value from the "value" column
-                                    Integer valueIndex = columnIndexMap.get("value");
-                                    if (valueIndex != null && valueIndex < row.length) {
-                                        Object valueObj = row[valueIndex];
-                                        if (valueObj != null) {
-                                            try {
-                                                Double value = Double.valueOf(valueObj.toString());
-                                                intervalResults.addMetricResult(metricName, function, value);
-                                            } catch (Exception e) {
-                                                LOGGER.warn("Failed parsing value for function {} in metric {}", function, metricName);
-                                            }
+                                    // single-aggregate-query changes: For fallback queries, get value directly by column name
+                                    Object valueObj = row.get("value");
+                                    if (valueObj != null) {
+                                        try {
+                                            Double value = Double.valueOf(valueObj.toString());
+                                            intervalResults.addMetricResult(metricName, function, value);
+                                        } catch (Exception e) {
+                                            LOGGER.warn("Failed parsing value for function {} in metric {}", function, metricName);
                                         }
                                     }
                                 }
@@ -1606,8 +1575,6 @@ private void validateResultColumns(List<String> resultColumns,
                         // Get result columns from profile (actual SQL column names)
                         List<String> resultColumns = metric.getResultColumns();
                         
-                       validateResultColumns(resultColumns, metricName, "unified");
-                        
                         // Populate query parameters
                         queryParams.clear();
                         if (queryParamsFromProfile != null && !queryParamsFromProfile.isEmpty()) {
@@ -1621,30 +1588,30 @@ private void validateResultColumns(List<String> resultColumns,
                                 endTimeLocalDateTime
                             );
                         } else {
-                            LOGGER.warn("query_params is null or empty for metric: {} with unified query", metricName);
+                            LOGGER.error("query_params is null or empty for metric: {} with unified query", metricName);
                             continue;
                         }
                        
-                        // Execute unified query with result_columns
-                        List<Object[]> unifiedResults = metricsDBConnectionManager.getMetricsData(datasourceName, unifiedQuery, queryParams, resultColumns);
+                        // single-aggregate-query changes: Execute unified query with result_columns
+                        // Returns List<Map<String, Object>> where each map has column names as keys
+                        List<Map<String, Object>> unifiedResults = metricsDBConnectionManager.getMetricsData(datasourceName, unifiedQuery, queryParams, resultColumns);
                         
                         if (unifiedResults != null && !unifiedResults.isEmpty()) {
                             dataFound = true;
                             
-                            // Build column index map once before processing rows
-                            Map<String, Integer> columnIndexMap = buildColumnIndexMap(resultColumns);
-                            
-                            // Process unified results using helper method
-                            for (Object[] row : unifiedResults) {
-                                Timestamp start = (Timestamp) row[columnIndexMap.get("interval_start_time")];
-                                Timestamp end = (Timestamp) row[columnIndexMap.get("interval_end_time")];
+                            // single-aggregate-query changes: Process unified results - no need for columnIndexMap
+                            // Access columns directly by name from the map
+                            for (Map<String, Object> row : unifiedResults) {
+                                Timestamp start = (Timestamp) row.get("interval_start_time");
+                                Timestamp end = (Timestamp) row.get("interval_end_time");
                                 
                                 IntervalResults intervalResults = results.computeIfAbsent(
                                     end, k -> new IntervalResults(start, end));
                                 intervalResults.setIntervalStartTime(start);
                                 intervalResults.setIntervalEndTime(end);
                                 
-                                processResultRow(row, columnIndexMap, resultColumns, metricName, intervalResults);
+                                // single-aggregate-query changes: Pass map directly to processResultRow
+                                processResultRow(row, resultColumns, metricName, intervalResults);
                             }
                         }
                     }
@@ -1667,41 +1634,35 @@ private void validateResultColumns(List<String> resultColumns,
                                     endTimeLocalDateTime
                                 );
                             } else {
-                                LOGGER.warn("query_params is null or empty for metric: {} function: {}", metricName, function);
+                                LOGGER.error("query_params is null or empty for metric: {} function: {}", metricName, function);
                                 continue;
                             }
                             
                             // Get result_columns for this function
                             List<String> functionResultColumns = metric.getResultColumns(function);
-                            validateResultColumns(functionResultColumns, metricName, function);
                             
-                            List<Object[]> functionResults = metricsDBConnectionManager.getMetricsData(datasourceName, query, queryParams, functionResultColumns);
+                            // single-aggregate-query changes: Returns List<Map<String, Object>>
+                            List<Map<String, Object>> functionResults = metricsDBConnectionManager.getMetricsData(datasourceName, query, queryParams, functionResultColumns);
                             
                             if (functionResults != null && !functionResults.isEmpty()) {
-                                // Build column index map once before processing rows
-                                Map<String, Integer> columnIndexMap = buildColumnIndexMap(functionResultColumns);
-                                
-                                for (Object[] row : functionResults) {
-                                    Timestamp start = (Timestamp) row[columnIndexMap.get("interval_start_time")];
-                                    Timestamp end = (Timestamp) row[columnIndexMap.get("interval_end_time")];
+                                // single-aggregate-query changes: Access columns by name from map
+                                for (Map<String, Object> row : functionResults) {
+                                    Timestamp start = (Timestamp) row.get("interval_start_time");
+                                    Timestamp end = (Timestamp) row.get("interval_end_time");
                                     
                                     IntervalResults intervalResults = results.computeIfAbsent(
                                         end, k -> new IntervalResults(start, end));
                                     intervalResults.setIntervalStartTime(start);
                                     intervalResults.setIntervalEndTime(end);
                                     
-                                    // For fallback queries, we know the function name from the loop
-                                    // Get the value from the "value" column
-                                    Integer valueIndex = columnIndexMap.get("value");
-                                    if (valueIndex != null && valueIndex < row.length) {
-                                        Object valueObj = row[valueIndex];
-                                        if (valueObj != null) {
-                                            try {
-                                                Double value = Double.valueOf(valueObj.toString());
-                                                intervalResults.addMetricResult(metricName, function, value);
-                                            } catch (Exception e) {
-                                                LOGGER.warn("Failed parsing value for function {} in metric {}", function, metricName);
-                                            }
+                                    // single-aggregate-query changes: For fallback queries, get value directly by column name
+                                    Object valueObj = row.get("value");
+                                    if (valueObj != null) {
+                                        try {
+                                            Double value = Double.valueOf(valueObj.toString());
+                                            intervalResults.addMetricResult(metricName, function, value);
+                                        } catch (Exception e) {
+                                            LOGGER.warn("Failed parsing value for function {} in metric {}", function, metricName);
                                         }
                                     }
                                 }
@@ -2276,24 +2237,20 @@ private void validateResultColumns(List<String> resultColumns,
      * @throws NoSuchMethodException if metric result addition fails
      * @throws IllegalAccessException if metric result addition fails
      */
+    // single-aggregate-query changes: Updated to accept Map<String, Object> instead of Object[]
+    // Removed columnIndexMap parameter as we can access columns directly by name
     private void processResultRow(
-            Object[] row,
-            Map<String, Integer> columnIndexMap,
+            Map<String, Object> row,
             List<String> resultColumns,
             String metricName,
             IntervalResults intervalResults) throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
 
-        if (row == null || resultColumns == null || resultColumns.isEmpty()) {
+        if (row == null) {
             LOGGER.warn("Invalid input for metric {}. Skipping row processing.", metricName);
             return;
         }
 
-        if (row.length < resultColumns.size()) {
-            LOGGER.error("Column mismatch for metric {}. Expected at least {}, got {}",
-                    metricName, resultColumns.size(), row.length);
-            return;
-        }
-
+        // single-aggregate-query changes: Iterate through result columns and access values by name
         for (String columnName : resultColumns) {
             // Skip timestamp columns
             if ("interval_start_time".equals(columnName) ||
@@ -2301,14 +2258,12 @@ private void validateResultColumns(List<String> resultColumns,
                 continue;
             }
 
-            Integer columnIndex = columnIndexMap.get(columnName);
-            if (columnIndex == null || columnIndex >= row.length) {
-                LOGGER.warn("Column {} not found for metric {}", columnName, metricName);
+            // single-aggregate-query changes: Direct access by column name from map
+            Object valueObj = row.get(columnName);
+            if (valueObj == null) {
+                LOGGER.debug("Column {} has null value for metric {}", columnName, metricName);
                 continue;
             }
-
-            Object valueObj = row[columnIndex];
-            if (valueObj == null) continue;
 
             Double value;
             try {
@@ -2344,19 +2299,8 @@ private void validateResultColumns(List<String> resultColumns,
         return columnName;
     }
 
-    /**
-     * Build a map of column names to their indices for efficient lookup.
-     *
-     * @param resultColumns List of column names
-     * @return Map of column name to index
-     */
-    private Map<String, Integer> buildColumnIndexMap(List<String> resultColumns) {
-        Map<String, Integer> map = new HashMap<>();
-        for (int i = 0; i < resultColumns.size(); i++) {
-            map.put(resultColumns.get(i), i);
-        }
-        return map;
-    }
+    // single-aggregate-query changes: Removed buildColumnIndexMap method
+    // No longer needed as we access columns directly by name from Map<String, Object>
 
 }
 

--- a/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
@@ -419,6 +419,27 @@ public class Converters {
                             String valueType = functionVarObj.optString(AnalyzerConstants.AutotuneObjectConstants.VALUE_TYPE, null);
                             String kubeObject = functionVarObj.optString(AnalyzerConstants.KUBERNETES_OBJECT, null);
                             Metric metric = new Metric(name, query, datasource, valueType, kubeObject);
+                            
+                            // Extract metric-level query_params
+                            JSONArray metricQueryParamsArray = functionVarObj.optJSONArray(KruizeConstants.JSONKeys.QUERY_PARAMS);
+                            if (metricQueryParamsArray != null) {
+                                List<String> metricQueryParams = new ArrayList<>();
+                                for (Object param : metricQueryParamsArray) {
+                                    metricQueryParams.add((String) param);
+                                }
+                                metric.setQueryParams(metricQueryParams);
+                            }
+                            
+                            // Extract metric-level result_columns (for unified queries)
+                            JSONArray metricResultColumnsArray = functionVarObj.optJSONArray(KruizeConstants.JSONKeys.RESULT_COLUMNS);
+                            if (metricResultColumnsArray != null) {
+                                List<String> metricResultColumns = new ArrayList<>();
+                                for (Object column : metricResultColumnsArray) {
+                                    metricResultColumns.add((String) column);
+                                }
+                                metric.setResultColumns(metricResultColumns);
+                            }
+                            
                             JSONArray aggrFunctionArray = functionVarObj.optJSONArray(AnalyzerConstants.AGGREGATION_FUNCTIONS);
                             if (aggrFunctionArray != null) {
                                 HashMap<String, AggregationFunctions> aggregationFunctionsMap = new HashMap<>();
@@ -436,6 +457,17 @@ public class Converters {
                                             }
                                         }
                                         AggregationFunctions aggregationFunctions = new AggregationFunctions(function, aggrFuncQuery, version, queryParams);
+                                        
+                                        // Extract aggregation function-level result_columns
+                                        JSONArray funcResultColumnsArray = aggrFuncJsonObject.optJSONArray(KruizeConstants.JSONKeys.RESULT_COLUMNS);
+                                        if (funcResultColumnsArray != null) {
+                                            List<String> funcResultColumns = new ArrayList<>();
+                                            for (Object column : funcResultColumnsArray) {
+                                                funcResultColumns.add((String) column);
+                                            }
+                                            aggregationFunctions.setResultColumns(funcResultColumns);
+                                        }
+                                        
                                         aggregationFunctionsMap.put(function, aggregationFunctions);
                                     } catch (Exception e) {
                                         LOGGER.info(e.getMessage());

--- a/src/main/java/com/autotune/common/data/metrics/AggregationFunctions.java
+++ b/src/main/java/com/autotune/common/data/metrics/AggregationFunctions.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package com.autotune.common.data.metrics;
 
+import com.google.gson.annotations.SerializedName;
+
 import java.util.List;
 
 public class AggregationFunctions {
@@ -22,6 +24,8 @@ public class AggregationFunctions {
     private String function;
     private String query;
     private List<String> queryParams;
+    @SerializedName("result_columns")
+    private List<String> resultColumns;
     private String version;
 
     public AggregationFunctions(String function, String query, String version, List<String> query_params) {
@@ -38,7 +42,15 @@ public class AggregationFunctions {
     public void setQueryParams(List<String> queryParams) {
         this.queryParams = queryParams;
     }
+// to support fetching result columns from profile creation payload start 
+    public List<String> getResultColumns() {
+        return resultColumns;
+    }
 
+    public void setResultColumns(List<String> resultColumns) {
+        this.resultColumns = resultColumns;
+    }
+// to support fetching result columns from profile creation payload end 
     public String getFunction() {
         return function;
     }

--- a/src/main/java/com/autotune/common/data/metrics/Metric.java
+++ b/src/main/java/com/autotune/common/data/metrics/Metric.java
@@ -143,4 +143,31 @@ public final class Metric {
         }
         return aggregationFunctionsMap.keySet();
     }
+// change added 
+    public boolean hasUnifiedQuery() {
+    // Unified query exists if query field is populated at metric level
+    // AND we have aggregation_functions to know what columns to expect
+    return query != null &&
+           !query.isEmpty() &&
+           aggregationFunctionsMap != null &&
+           !aggregationFunctionsMap.isEmpty();
+}
+
+    // Helper to get expected result columns from aggregation_functions
+    public List<String> getExpectedResultColumns() {
+        if (aggregationFunctionsMap == null) {
+            return Collections.emptyList();
+        }
+        return new ArrayList<>(aggregationFunctionsMap.keySet());
+    }
+
+    // Helper to get query_params from aggregation_functions 
+    public List<String> getUnifiedQueryParams() {
+        if (aggregationFunctionsMap == null || aggregationFunctionsMap.isEmpty()) {
+            return Collections.emptyList();
+        }
+        // Get query_params from first aggregation function
+        AggregationFunctions firstFunc = aggregationFunctionsMap.values().iterator().next();
+        return firstFunc.getQueryParams();
+    }
 }

--- a/src/main/java/com/autotune/common/data/metrics/Metric.java
+++ b/src/main/java/com/autotune/common/data/metrics/Metric.java
@@ -34,6 +34,10 @@ import java.util.*;
 public final class Metric {
     private String name;
     private String query;
+    @SerializedName("query_params")
+    private List<String> queryParams;
+    @SerializedName("result_columns")
+    private List<String> resultColumns;
     private String datasource;
     @SerializedName("value_type")
     private String valueType;
@@ -68,6 +72,22 @@ public final class Metric {
         return query;
     }
 
+    public List<String> getQueryParams() {
+        return queryParams;
+    }
+
+    public void setQueryParams(List<String> queryParams) {
+        this.queryParams = queryParams;
+    }
+// Adding Result columns - unified query change start
+    public List<String> getResultColumns() {
+        return resultColumns;
+    }
+
+    public void setResultColumns(List<String> resultColumns) {
+        this.resultColumns = resultColumns;
+    }
+// Adding Result columns - unified query change end 
     public String getDatasource() {
         return datasource;
     }
@@ -137,37 +157,62 @@ public final class Metric {
         return aggregationFunctions != null ? aggregationFunctions.getQueryParams() : null;
     }
 
+    /**
+     * Get result columns for a specific aggregation function query.
+     * Primary: Returns explicit result_columns from the aggregation function definition.
+     * Fallback: Returns function name as column (for old profiles without result_columns).
+     *
+     * @param function The aggregation function name (e.g., "avg", "sum")
+     * @return List of column names that the query returns, or null if function not found
+     */
+    public List<String> getResultColumns(String function) {
+        if (aggregationFunctionsMap == null) {
+            return null;
+        }
+        AggregationFunctions aggregationFunctions = aggregationFunctionsMap.get(function);
+        if (aggregationFunctions == null) {
+            return null;
+        }
+        
+        // Primary: Use explicit result_columns from profile
+        List<String> funcResultColumns = aggregationFunctions.getResultColumns();
+        if (funcResultColumns != null && !funcResultColumns.isEmpty()) {
+            return funcResultColumns;
+        }
+        
+        // Fallback: For old profiles without result_columns, assume column name = function name
+        // This maintains backward compatibility until all profiles are updated
+        return Collections.singletonList(function);
+    }
+
     public Set<String> getAggregationFunctions() {
         if (aggregationFunctionsMap == null) {
             return Collections.emptySet();
         }
         return aggregationFunctionsMap.keySet();
     }
-// change added 
-    public boolean hasUnifiedQuery() {
-    // Unified query exists if query field is populated at metric level
-    // AND we have aggregation_functions to know what columns to expect
-    return query != null &&
-           !query.isEmpty() &&
-           aggregationFunctionsMap != null &&
-           !aggregationFunctionsMap.isEmpty();
-}
 
-    // Helper to get expected result columns from aggregation_functions
+    /**
+     * Get expected result columns for unified query at metric level.
+     * Primary: Returns explicit result_columns from the metric definition.
+     * Fallback: Derives from aggregation function names (for old profiles without result_columns).
+     *
+     * For unified queries, result_columns explicitly defines what columns the query returns.
+     * Example: ["avg", "sum", "min", "max"] for a query that returns all these aggregates.
+     *
+     * @return List of column names that the unified query returns
+     */
     public List<String> getExpectedResultColumns() {
+        // Primary: Use explicit result_columns from profile (for unified queries)
+        if (resultColumns != null && !resultColumns.isEmpty()) {
+            return resultColumns;
+        }
+        
+        // Fallback: For old profiles without result_columns, derive from aggregation function keys
+        // This maintains backward compatibility until all profiles are updated with result_columns
         if (aggregationFunctionsMap == null) {
             return Collections.emptyList();
         }
         return new ArrayList<>(aggregationFunctionsMap.keySet());
-    }
-
-    // Helper to get query_params from aggregation_functions 
-    public List<String> getUnifiedQueryParams() {
-        if (aggregationFunctionsMap == null || aggregationFunctionsMap.isEmpty()) {
-            return Collections.emptyList();
-        }
-        // Get query_params from first aggregation function
-        AggregationFunctions firstFunc = aggregationFunctionsMap.values().iterator().next();
-        return firstFunc.getQueryParams();
     }
 }

--- a/src/main/java/com/autotune/database/init/MetricsDBConnectionManager.java
+++ b/src/main/java/com/autotune/database/init/MetricsDBConnectionManager.java
@@ -263,7 +263,7 @@ public class MetricsDBConnectionManager {
             return Collections.emptyList(); 
         }
 
-        Query query = session.createNativeQuery(sql)
+        NativeQuery query = session.createNativeQuery(sql)
                 .addScalar("interval_start_time", java.sql.Timestamp.class)
                 .addScalar("interval_end_time", java.sql.Timestamp.class);
 

--- a/src/main/java/com/autotune/database/init/MetricsDBConnectionManager.java
+++ b/src/main/java/com/autotune/database/init/MetricsDBConnectionManager.java
@@ -216,6 +216,10 @@ public class MetricsDBConnectionManager {
     }
 
     public List<Object[]> getMetricsData(String metricsDbRef, String sql, Map<String, String> params) {
+        return getMetricsData(metricsDbRef, sql, params, null);
+    }
+
+    public List<Object[]> getMetricsData(String metricsDbRef, String sql, Map<String, String> params, List<String> resultColumns) {
         Session session = null;
         try {
             session = getSession(metricsDbRef);
@@ -224,10 +228,22 @@ public class MetricsDBConnectionManager {
                 LOGGER.error("Metric DB POC: Connection failed - {}", err);
                 return null;
             }
-            Query query = session.createNativeQuery(sql)
-                    .addScalar("interval_start_time", java.sql.Timestamp.class)
-                    .addScalar("interval_end_time", java.sql.Timestamp.class)
-                    .addScalar("value", String.class);
+            
+            NativeQuery query = session.createNativeQuery(sql);
+            
+            // Dynamically add scalars based on result_columns if provided
+            if (resultColumns != null && !resultColumns.isEmpty()) {
+                for (String columnName : resultColumns) {
+                    if (columnName.contains("time")) {
+                        query.addScalar(columnName, java.sql.Timestamp.class);
+                    } else {
+                        query.addScalar(columnName, String.class);
+                    }
+                }
+            } 
+            // No Fallback is maingto default columns for backward compatibility as the result columns sequence should match the sequence in which query params are defined in query
+                
+            
             LOGGER.error("final query = {}", query.toString());
             if (params != null) {
                 for (String key : params.keySet()) {
@@ -235,11 +251,10 @@ public class MetricsDBConnectionManager {
                 }
             }
 
-
             List<Object[]> resultList = query.getResultList();
             return resultList;
 
-        }  catch (Exception e) {
+        } catch (Exception e) {
             LOGGER.error("Metric DB POC: Validation failed - {}", e);
             return null;
         } finally {
@@ -252,56 +267,7 @@ public class MetricsDBConnectionManager {
             }
         }
     }
-// change added getUnifiedMetricsData
-    public List<Object[]> getUnifiedMetricsData(String metricsDbRef,String sql,Map<String, String> params,List<String> expectedFunctions) {
 
-    Session session = null;
-    try {
-        session = getSession(metricsDbRef);
-        if (session == null) {
-            LOGGER.error("Metrics DB '{}' not configured", metricsDbRef);
-            return Collections.emptyList(); 
-        }
-
-        NativeQuery query = session.createNativeQuery(sql)
-                .addScalar("interval_start_time", java.sql.Timestamp.class)
-                .addScalar("interval_end_time", java.sql.Timestamp.class);
-
-        for (String function : expectedFunctions) {
-            query.addScalar(function + "_value", String.class);
-        }
-
-        if (params != null) {
-        for (String key : params.keySet()) {
-            if (!sql.contains(":" + key)) {
-                LOGGER.debug("Skipping unused param: {}", key);
-                continue;
-            }
-            query.setParameter(key, params.get(key));
-        }
-}
-
-        List<Object[]> resultList = query.getResultList();
-
-        if (resultList == null || resultList.isEmpty()) {
-            LOGGER.warn("No results returned for unified query. DB: {}, SQL: {}", metricsDbRef, sql);
-        }
-
-        return resultList;
-
-    } catch (Exception e) {
-        LOGGER.error("Unified query execution failed", e);
-        return Collections.emptyList(); 
-    } finally {
-        if (session != null) {
-            try {
-                session.close();
-            } catch (Exception e) {
-                LOGGER.error("Error closing session", e);
-            }
-        }
-    }
-}
 
     /**
      * Checks if a metrics database is configured.

--- a/src/main/java/com/autotune/database/init/MetricsDBConnectionManager.java
+++ b/src/main/java/com/autotune/database/init/MetricsDBConnectionManager.java
@@ -260,7 +260,7 @@ public class MetricsDBConnectionManager {
         session = getSession(metricsDbRef);
         if (session == null) {
             LOGGER.error("Metrics DB '{}' not configured", metricsDbRef);
-            return Collections.emptyList(); // ✅ avoid null
+            return Collections.emptyList(); 
         }
 
         Query query = session.createNativeQuery(sql)
@@ -272,13 +272,14 @@ public class MetricsDBConnectionManager {
         }
 
         if (params != null) {
-            for (String key : params.keySet()) {
-                if (!sql.contains(":" + key)) {
-                    LOGGER.warn("Parameter {} not found in SQL", key);
-                }
-                query.setParameter(key, params.get(key));
+        for (String key : params.keySet()) {
+            if (!sql.contains(":" + key)) {
+                LOGGER.debug("Skipping unused param: {}", key);
+                continue;
             }
+            query.setParameter(key, params.get(key));
         }
+}
 
         List<Object[]> resultList = query.getResultList();
 

--- a/src/main/java/com/autotune/database/init/MetricsDBConnectionManager.java
+++ b/src/main/java/com/autotune/database/init/MetricsDBConnectionManager.java
@@ -27,6 +27,7 @@ import org.hibernate.query.Query;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import java.util.Collections;
 
 import java.io.FileInputStream;
 import java.io.InputStream;
@@ -34,6 +35,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.sql.Timestamp;
+import java.util.ArrayList;
 
 /**
  * Manages Hibernate sessions for metrics databases (db1, db2) configured in KruizeConfig.
@@ -249,6 +252,55 @@ public class MetricsDBConnectionManager {
             }
         }
     }
+// change added getUnifiedMetricsData
+    public List<Object[]> getUnifiedMetricsData(String metricsDbRef,String sql,Map<String, String> params,List<String> expectedFunctions) {
+
+    Session session = null;
+    try {
+        session = getSession(metricsDbRef);
+        if (session == null) {
+            LOGGER.error("Metrics DB '{}' not configured", metricsDbRef);
+            return Collections.emptyList(); // ✅ avoid null
+        }
+
+        Query query = session.createNativeQuery(sql)
+                .addScalar("interval_start_time", java.sql.Timestamp.class)
+                .addScalar("interval_end_time", java.sql.Timestamp.class);
+
+        for (String function : expectedFunctions) {
+            query.addScalar(function + "_value", String.class);
+        }
+
+        if (params != null) {
+            for (String key : params.keySet()) {
+                if (!sql.contains(":" + key)) {
+                    LOGGER.warn("Parameter {} not found in SQL", key);
+                }
+                query.setParameter(key, params.get(key));
+            }
+        }
+
+        List<Object[]> resultList = query.getResultList();
+
+        if (resultList == null || resultList.isEmpty()) {
+            LOGGER.warn("No results returned for unified query. DB: {}, SQL: {}", metricsDbRef, sql);
+        }
+
+        return resultList;
+
+    } catch (Exception e) {
+        LOGGER.error("Unified query execution failed", e);
+        return Collections.emptyList(); 
+    } finally {
+        if (session != null) {
+            try {
+                session.close();
+            } catch (Exception e) {
+                LOGGER.error("Error closing session", e);
+            }
+        }
+    }
+}
 
     /**
      * Checks if a metrics database is configured.
@@ -278,4 +330,5 @@ public class MetricsDBConnectionManager {
         }
         sessionFactoryMap.clear();
     }
+
 }

--- a/src/main/java/com/autotune/database/init/MetricsDBConnectionManager.java
+++ b/src/main/java/com/autotune/database/init/MetricsDBConnectionManager.java
@@ -215,11 +215,13 @@ public class MetricsDBConnectionManager {
         }
     }
 
-    public List<Object[]> getMetricsData(String metricsDbRef, String sql, Map<String, String> params) {
+    public List<Map<String, Object>> getMetricsData(String metricsDbRef, String sql, Map<String, String> params) {
         return getMetricsData(metricsDbRef, sql, params, null);
     }
 
-    public List<Object[]> getMetricsData(String metricsDbRef, String sql, Map<String, String> params, List<String> resultColumns) {
+    // single-aggregate-query changes: Changed return type from List<Object[]> to List<Map<String, Object>>
+    // This allows column access by name instead of index, making code more maintainable and less error-prone
+    public List<Map<String, Object>> getMetricsData(String metricsDbRef, String sql, Map<String, String> params, List<String> resultColumns) {
         Session session = null;
         try {
             session = getSession(metricsDbRef);
@@ -231,18 +233,20 @@ public class MetricsDBConnectionManager {
             
             NativeQuery query = session.createNativeQuery(sql);
             
-            // Dynamically add scalars based on result_columns if provided
+            // single-aggregate-query changes: Use AliasToEntityMapResultTransformer for automatic column-to-map conversion
+            // Hibernate automatically maps column names to map keys and handles type conversion
+            query.setResultTransformer(org.hibernate.transform.AliasToEntityMapResultTransformer.INSTANCE);
+            
+            // single-aggregate-query changes: Dynamically add scalars for proper type mapping
             if (resultColumns != null && !resultColumns.isEmpty()) {
                 for (String columnName : resultColumns) {
-                    if (columnName.contains("time")) {
+                    if (columnName.toLowerCase().contains("time")) {
                         query.addScalar(columnName, java.sql.Timestamp.class);
                     } else {
                         query.addScalar(columnName, String.class);
                     }
                 }
-            } 
-            // No Fallback is maingto default columns for backward compatibility as the result columns sequence should match the sequence in which query params are defined in query
-                
+            }
             
             LOGGER.error("final query = {}", query.toString());
             if (params != null) {
@@ -251,7 +255,9 @@ public class MetricsDBConnectionManager {
                 }
             }
 
-            List<Object[]> resultList = query.getResultList();
+            // single-aggregate-query changes: Returns List<Map<String, Object>> where each map represents a row
+            // Map key = column name, Map value = column value (Timestamp, String, etc.)
+            List<Map<String, Object>> resultList = query.getResultList();
             return resultList;
 
         } catch (Exception e) {

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -205,6 +205,7 @@ public class KruizeConstants {
         public static final String NAME = "name";
         public static final String QUERY = "query";
         public static final String QUERY_PARAMS = "query_params";
+        public static final String RESULT_COLUMNS = "result_columns";
         public static final String DATASOURCE = "datasource";
         public static final String CPU = "cpu";
         public static final String MEMORY = "memory";


### PR DESCRIPTION
## Description

Please describe the issue or feature and the summary of changes made to fix this. 

Currently, multiple SQL queries are executed per metric attribute to compute aggregations like AVG, SUM, MIN, and MAX, leading to redundant scans.
This enhancement introduces a query attribute at the metric level to allow a single consolidated SQL query to return all required aggregation values, while still supporting the existing multi-query approach as a fallback when query is not provided.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

  Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

**Tests Performed**
- Created a profile using unified aggregate query (single query returning avg/sum/min/max) with datasource db1.
- Used pre-existing data in ros_metrics_db (no new metric ingestion done).
- Identified a valid experiment from workloads table in ros_metrics_db.
- Created a Kruize experiment using the same workload details.
- Invoked:
     updateRecommendations
     listRecommendations

**Steps to Reproduce**
- Configure datasource db1 in dbconfigjson pointing to ros_metrics_db.
- Create a profile with unified aggregate SQL query.
- Pick an existing experiment from workloads table in ros_metrics_db.
- Create a Kruize experiment using same details.
- Fetch a valid interval_end_time from workload_metrics.
- Call:
    updateRecommendations
    listRecommendations

**Test Configuration**
- Existing dataset in ros_metrics_db:
     - workloads
     - workload_metrics
- No new data ingestion performed
- Kruize deployed on Kubernetes
- db1 configured as external datasource

**Validation **
- Unified aggregate query executed successfully against db1
- Data was fetched correctly from ros_metrics_db
- updateRecommendations generated expected outputs
- listRecommendations returned valid results
- No impact on existing flows or APIs

- [x] New Test : Unified aggregate query using external datasource (db1)
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: Kind
*  Kruize deployed in monitoring namespace
* External datasource: ros_metrics_db configured as db.
* Existing data used from:
    workloads
    workload_metrics

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Introduce support for unified aggregate SQL queries at the metric level while retaining the existing per-aggregation query behavior as a fallback.

New Features:
- Allow metrics to define a single unified SQL query that returns multiple aggregation values (e.g., avg, min, max, sum) per interval.
- Add support in the metrics DB connection manager to execute unified aggregate queries and map multiple result columns for a metric.

Enhancements:
- Extend recommendation engine metric fetching to use the unified aggregate query path when configured, falling back to individual aggregation queries for backward compatibility.
- Augment the Metric model with helpers to detect unified queries, derive expected result columns, and reuse query parameters from aggregation function definitions.