### PR TITLE
Include min cpu throttle query in performance profile used in remote monitoring mode.

### DIFF
--- a/manifests/autotune/performance-profiles/resource_optimization_openshift.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_openshift.json
@@ -99,6 +99,10 @@
             "function": "avg",
             "query": "avg by(container,namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=”$CONTAINER_NAME$”}[15m]))"
           },
+	  {
+            "function": "min",
+            "query": "min by(container,namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=”$CONTAINER_NAME$”}[15m]))"
+          },
           {
             "function": "max",
             "query": "max by(container,namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=”$CONTAINER_NAME$”}[15m]))"

--- a/manifests/autotune/performance-profiles/resource_optimization_openshift.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_openshift.json
@@ -99,7 +99,7 @@
             "function": "avg",
             "query": "avg by(container,namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[15m]))"
           },
-	  {
+		  {
             "function": "min",
             "query": "min by(container,namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[15m]))"
           },

--- a/manifests/autotune/performance-profiles/resource_optimization_openshift.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_openshift.json
@@ -97,19 +97,19 @@
         "aggregation_functions": [
           {
             "function": "avg",
-            "query": "avg by(container,namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=”$CONTAINER_NAME$”}[15m]))"
+            "query": "avg by(container,namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[15m]))"
           },
 	  {
             "function": "min",
-            "query": "min by(container,namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=”$CONTAINER_NAME$”}[15m]))"
+            "query": "min by(container,namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[15m]))"
           },
           {
             "function": "max",
-            "query": "max by(container,namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=”$CONTAINER_NAME$”}[15m]))"
+            "query": "max by(container,namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[15m]))"
           },
           {
             "function": "sum",
-            "query": "sum by(container,namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=”$CONTAINER_NAME$”}[15m]))"
+            "query": "sum by(container,namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[15m]))"
           }
         ]
       },

--- a/manifests/autotune/performance-profiles/resource_optimization_openshift.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_openshift.yaml
@@ -118,6 +118,10 @@ slo:
     - function: avg
       query: 'avg by(container, namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container=”$CONTAINER_NAME$”}[15m]))'
 
+    # Minimum CPU throttling per container in a deployment
+    - function: min
+      query: 'min by(container, namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container=”$CONTAINER_NAME$”}[15m]))'
+
     # Maximum CPU throttling per container in a deployment
     - function: max
       query: 'max by(container, namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container=”$CONTAINER_NAME$”}[15m]))'

--- a/manifests/autotune/performance-profiles/resource_optimization_openshift.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_openshift.yaml
@@ -116,19 +116,19 @@ slo:
     aggregation_functions:
     # Average CPU throttling per container in a deployment
     - function: avg
-      query: 'avg by(container, namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container=”$CONTAINER_NAME$”}[15m]))'
+      query: 'avg by(container, namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[15m]))'
 
     # Minimum CPU throttling per container in a deployment
     - function: min
-      query: 'min by(container, namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container=”$CONTAINER_NAME$”}[15m]))'
+      query: 'min by(container, namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[15m]))'
 
     # Maximum CPU throttling per container in a deployment
     - function: max
-      query: 'max by(container, namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container=”$CONTAINER_NAME$”}[15m]))'
+      query: 'max by(container, namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[15m]))'
 
     # Sum of CPU throttling for a container in all pods of a deployment
     - function: sum
-      query: 'sum by(container, namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container=”$CONTAINER_NAME$”}[15m]))'
+      query: 'sum by(container, namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[15m]))'
 
 
 


### PR DESCRIPTION
## Description

Include min cpu throttle query in performance profile used in remote monitoring mode which is missing.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes
- [ X] Manifests fix

## Summary by Sourcery

Enhancements:
- Add a minimum CPU throttling query alongside existing average and maximum throttling metrics in the OpenShift resource optimization performance profile manifests.