### PR TITLE
Perf Profile Cache fix during validations

### DIFF
--- a/src/main/java/com/autotune/analyzer/serviceObjects/verification/validators/PerformanceProfileValidator.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/verification/validators/PerformanceProfileValidator.java
@@ -76,7 +76,7 @@ public class PerformanceProfileValidator implements ConstraintValidator<Performa
                 try {
                     new ExperimentDBService().loadPerformanceProfileFromDBByName(performanceProfilesMap, performanceProfileName); // loads from DB
                 } catch (Exception e) {
-                    LOGGER.error("Loading saved performance profiles failed: {}", e.getMessage());
+                    LOGGER.error("Loading saved performance profiles failed", e);
                     throw e;
                 }
                 performanceProfile = performanceProfilesMap.get(performanceProfileName);

--- a/src/main/java/com/autotune/analyzer/serviceObjects/verification/validators/PerformanceProfileValidator.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/verification/validators/PerformanceProfileValidator.java
@@ -21,6 +21,7 @@ import com.autotune.analyzer.performanceProfiles.utils.PerformanceProfileUtil;
 import com.autotune.analyzer.serviceObjects.UpdateResultsAPIObject;
 import com.autotune.analyzer.serviceObjects.verification.annotators.PerformanceProfileCheck;
 import com.autotune.database.service.ExperimentDBService;
+import com.autotune.utils.cache.PerformanceProfileCache;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import org.slf4j.Logger;
@@ -70,10 +71,28 @@ public class PerformanceProfileValidator implements ConstraintValidator<Performa
             if (errorMsg.isEmpty()) {
                 success = true;
             } else {
-                context.disableDefaultConstraintViolation();
-                context.buildConstraintViolationWithTemplate(errorMsg.toString())
-                        .addPropertyNode("Performance profile")
-                        .addConstraintViolation();
+                // Failure could be due to an incorrect version of the profile in the cache. So, clear the cache and try again with profile from the database
+                PerformanceProfileCache.remove(performanceProfileName); // prune cache
+                try {
+                    new ExperimentDBService().loadPerformanceProfileFromDBByName(performanceProfilesMap, performanceProfileName); // loads from DB
+                } catch (Exception e) {
+                    LOGGER.error("Loading saved performance profiles failed: {}", e.getMessage());
+                    throw e;
+                }
+                performanceProfile = performanceProfilesMap.get(performanceProfileName);
+                if (performanceProfile == null) {
+                    throw new Exception(String.format("%s%s", MISSING_PERF_PROFILE, performanceProfileName));
+                }
+                // validate the result value present in the updateResultsAPIObject
+                errorMsg = PerformanceProfileUtil.validateResults(performanceProfile, updateResultsAPIObject);
+                if (errorMsg.isEmpty()) {
+                    success = true;
+                } else {
+                    context.disableDefaultConstraintViolation();
+                    context.buildConstraintViolationWithTemplate(errorMsg.toString())
+                            .addPropertyNode("Performance profile")
+                            .addConstraintViolation();
+                }
             }
 
         } catch (Exception e) {

--- a/src/main/java/com/autotune/analyzer/serviceObjects/verification/validators/PerformanceProfileValidator.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/verification/validators/PerformanceProfileValidator.java
@@ -71,23 +71,36 @@ public class PerformanceProfileValidator implements ConstraintValidator<Performa
             if (errorMsg.isEmpty()) {
                 success = true;
             } else {
-                // Failure could be due to an incorrect version of the profile in the cache. So, clear the cache and try again with profile from the database
-                PerformanceProfileCache.remove(performanceProfileName); // prune cache
-                try {
-                    new ExperimentDBService().loadPerformanceProfileFromDBByName(performanceProfilesMap, performanceProfileName); // loads from DB
-                } catch (Exception e) {
-                    LOGGER.error("Loading saved performance profiles failed", e);
-                    throw e;
-                }
-                performanceProfile = performanceProfilesMap.get(performanceProfileName);
-                if (performanceProfile == null) {
-                    throw new Exception(String.format("%s%s", MISSING_PERF_PROFILE, performanceProfileName));
-                }
-                // validate the result value present in the updateResultsAPIObject
-                errorMsg = PerformanceProfileUtil.validateResults(performanceProfile, updateResultsAPIObject);
-                if (errorMsg.isEmpty()) {
-                    success = true;
+                // Check if the error is related to invalid metrics
+                boolean hasInvalidMetricsError = errorMsg.stream()
+                        .anyMatch(msg -> msg.contains("Invalid metrics found for experiment"));
+                
+                if (hasInvalidMetricsError) {
+                    // Clear the cache and try again with profile from the database
+                    LOGGER.debug("Invalid metrics error detected. Clearing cache and reloading from DB for profile: {}", performanceProfileName);
+                    PerformanceProfileCache.remove(performanceProfileName); // prune cache
+                    try {
+                        new ExperimentDBService().loadPerformanceProfileFromDBByName(performanceProfilesMap, performanceProfileName); // loads from DB
+                    } catch (Exception e) {
+                        LOGGER.error("Loading saved performance profiles failed", e);
+                        throw e;
+                    }
+                    performanceProfile = performanceProfilesMap.get(performanceProfileName);
+                    if (performanceProfile == null) {
+                        throw new Exception(String.format("%s%s", MISSING_PERF_PROFILE, performanceProfileName));
+                    }
+                    // validate the result value present in the updateResultsAPIObject
+                    errorMsg = PerformanceProfileUtil.validateResults(performanceProfile, updateResultsAPIObject);
+                    if (errorMsg.isEmpty()) {
+                        success = true;
+                    } else {
+                        context.disableDefaultConstraintViolation();
+                        context.buildConstraintViolationWithTemplate(errorMsg.toString())
+                                .addPropertyNode("Performance profile")
+                                .addConstraintViolation();
+                    }
                 } else {
+                    // For other validation errors, fail immediately without cache pruning
                     context.disableDefaultConstraintViolation();
                     context.buildConstraintViolationWithTemplate(errorMsg.toString())
                             .addPropertyNode("Performance profile")

--- a/src/main/java/com/autotune/analyzer/serviceObjects/verification/validators/PerformanceProfileValidator.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/verification/validators/PerformanceProfileValidator.java
@@ -38,11 +38,7 @@ import static com.autotune.analyzer.utils.AnalyzerErrorConstants.AutotuneObjectE
 
 public class PerformanceProfileValidator implements ConstraintValidator<PerformanceProfileCheck, UpdateResultsAPIObject> {
     private static final Logger LOGGER = LoggerFactory.getLogger(PerformanceProfileValidator.class);
-    private final ExperimentDBService experimentDBService;
-
-    public PerformanceProfileValidator() {
-        this.experimentDBService = new ExperimentDBService();
-    }
+    private final ExperimentDBService experimentDBService = new ExperimentDBService();
 
     @Override
     public void initialize(PerformanceProfileCheck constraintAnnotation) {
@@ -79,24 +75,24 @@ public class PerformanceProfileValidator implements ConstraintValidator<Performa
             } else {
                 // Check if the error is related to invalid metrics using the constant
                 boolean hasInvalidMetricsError = errorMsg.stream()
-                        .anyMatch(msg -> msg.contains(INVALID_METRICS_ERROR_PREFIX));
+                        .anyMatch(msg -> msg.startsWith(INVALID_METRICS_ERROR_PREFIX));
                 
                 if (hasInvalidMetricsError) {
-                    // Atomically refresh the cache and reload from database
-                    LOGGER.debug("Invalid metrics error detected. Refreshing cache for profile: {}", performanceProfileName);
-                    performanceProfile = PerformanceProfileCache.refresh(performanceProfileName, () -> {
-                        Map<String, PerformanceProfile> tempMap = new HashMap<>();
-                        try {
-                            experimentDBService.loadPerformanceProfileFromDBByName(tempMap, performanceProfileName);
-                        } catch (Exception e) {
-                            LOGGER.error("Loading saved performance profiles failed during refresh", e);
-                            return null;
-                        }
-                        return tempMap.get(performanceProfileName);
-                    });
+                    // Clear the cache and reload from database
+                    LOGGER.debug("Invalid metrics error detected. Clearing cache and reloading from DB for profile: {}", performanceProfileName);
+                    PerformanceProfileCache.remove(performanceProfileName);
+                    try {
+                        experimentDBService.loadPerformanceProfileFromDBByName(performanceProfilesMap, performanceProfileName);
+                    } catch (Exception e) {
+                        LOGGER.error("Loading saved performance profiles failed during refresh", e);
+                        throw e;
+                    }
+                    
+                    performanceProfile = performanceProfilesMap.get(performanceProfileName);
                     if (performanceProfile == null) {
                         throw new Exception(String.format("%s%s", MISSING_PERF_PROFILE, performanceProfileName));
                     }
+                    
                     // validate the result value present in the updateResultsAPIObject
                     errorMsg = PerformanceProfileUtil.validateResults(performanceProfile, updateResultsAPIObject);
                     if (errorMsg.isEmpty()) {

--- a/src/main/java/com/autotune/analyzer/serviceObjects/verification/validators/PerformanceProfileValidator.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/verification/validators/PerformanceProfileValidator.java
@@ -33,10 +33,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.autotune.analyzer.utils.AnalyzerErrorConstants.AutotuneObjectErrors.INVALID_METRICS_ERROR_PREFIX;
 import static com.autotune.analyzer.utils.AnalyzerErrorConstants.AutotuneObjectErrors.MISSING_PERF_PROFILE;
 
 public class PerformanceProfileValidator implements ConstraintValidator<PerformanceProfileCheck, UpdateResultsAPIObject> {
     private static final Logger LOGGER = LoggerFactory.getLogger(PerformanceProfileValidator.class);
+    private final ExperimentDBService experimentDBService;
+
+    public PerformanceProfileValidator() {
+        this.experimentDBService = new ExperimentDBService();
+    }
 
     @Override
     public void initialize(PerformanceProfileCheck constraintAnnotation) {
@@ -55,7 +61,7 @@ public class PerformanceProfileValidator implements ConstraintValidator<Performa
             KruizeObject kruizeObject = updateResultsAPIObject.getKruizeObject();
             String performanceProfileName = kruizeObject.getPerformanceProfile();
             try {
-                new ExperimentDBService().loadPerformanceProfileFromDBByName(performanceProfilesMap, performanceProfileName);
+                experimentDBService.loadPerformanceProfileFromDBByName(performanceProfilesMap, performanceProfileName);
             } catch (Exception e) {
                 LOGGER.error("Loading saved performance profiles failed: {}", e.getMessage());
                 throw e;
@@ -71,21 +77,23 @@ public class PerformanceProfileValidator implements ConstraintValidator<Performa
             if (errorMsg.isEmpty()) {
                 success = true;
             } else {
-                // Check if the error is related to invalid metrics
+                // Check if the error is related to invalid metrics using the constant
                 boolean hasInvalidMetricsError = errorMsg.stream()
-                        .anyMatch(msg -> msg.contains("Invalid metrics found for experiment"));
+                        .anyMatch(msg -> msg.contains(INVALID_METRICS_ERROR_PREFIX));
                 
                 if (hasInvalidMetricsError) {
-                    // Clear the cache and try again with profile from the database
-                    LOGGER.debug("Invalid metrics error detected. Clearing cache and reloading from DB for profile: {}", performanceProfileName);
-                    PerformanceProfileCache.remove(performanceProfileName); // prune cache
-                    try {
-                        new ExperimentDBService().loadPerformanceProfileFromDBByName(performanceProfilesMap, performanceProfileName); // loads from DB
-                    } catch (Exception e) {
-                        LOGGER.error("Loading saved performance profiles failed", e);
-                        throw e;
-                    }
-                    performanceProfile = performanceProfilesMap.get(performanceProfileName);
+                    // Atomically refresh the cache and reload from database
+                    LOGGER.debug("Invalid metrics error detected. Refreshing cache for profile: {}", performanceProfileName);
+                    performanceProfile = PerformanceProfileCache.refresh(performanceProfileName, () -> {
+                        Map<String, PerformanceProfile> tempMap = new HashMap<>();
+                        try {
+                            experimentDBService.loadPerformanceProfileFromDBByName(tempMap, performanceProfileName);
+                        } catch (Exception e) {
+                            LOGGER.error("Loading saved performance profiles failed during refresh", e);
+                            return null;
+                        }
+                        return tempMap.get(performanceProfileName);
+                    });
                     if (performanceProfile == null) {
                         throw new Exception(String.format("%s%s", MISSING_PERF_PROFILE, performanceProfileName));
                     }
@@ -94,17 +102,11 @@ public class PerformanceProfileValidator implements ConstraintValidator<Performa
                     if (errorMsg.isEmpty()) {
                         success = true;
                     } else {
-                        context.disableDefaultConstraintViolation();
-                        context.buildConstraintViolationWithTemplate(errorMsg.toString())
-                                .addPropertyNode("Performance profile")
-                                .addConstraintViolation();
+                        addConstraintViolation(context, errorMsg.toString(), "Performance profile");
                     }
                 } else {
                     // For other validation errors, fail immediately without cache pruning
-                    context.disableDefaultConstraintViolation();
-                    context.buildConstraintViolationWithTemplate(errorMsg.toString())
-                            .addPropertyNode("Performance profile")
-                            .addConstraintViolation();
+                    addConstraintViolation(context, errorMsg.toString(), "Performance profile");
                 }
             }
 
@@ -116,19 +118,28 @@ public class PerformanceProfileValidator implements ConstraintValidator<Performa
             String stackTrace = sw.toString();
             LOGGER.debug(stackTrace);
             if (null != e.getMessage()) {
-                context.disableDefaultConstraintViolation();
-                context.buildConstraintViolationWithTemplate(e.getMessage())
-                        .addPropertyNode("")
-                        .addConstraintViolation();
+                addConstraintViolation(context, e.getMessage(), "");
             } else {
-                context.disableDefaultConstraintViolation();
-                context.buildConstraintViolationWithTemplate("Null value found")
-                        .addPropertyNode("")
-                        .addConstraintViolation();
+                addConstraintViolation(context, "Null value found", "");
             }
 
         }
         LOGGER.debug("PerformanceProfileValidator success : {}", success);
         return success;
+    }
+
+    /**
+     * Helper method to add a constraint violation with a custom message.
+     * Centralizes the logic for disabling default violations and building custom ones.
+     *
+     * @param context the constraint validator context
+     * @param message the error message to include in the violation
+     * @param propertyNode the property node name for the violation
+     */
+    private void addConstraintViolation(ConstraintValidatorContext context, String message, String propertyNode) {
+        context.disableDefaultConstraintViolation();
+        context.buildConstraintViolationWithTemplate(message)
+                .addPropertyNode(propertyNode)
+                .addConstraintViolation();
     }
 }

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerErrorConstants.java
@@ -115,6 +115,7 @@ public class AnalyzerErrorConstants {
         public static final String DELETED_METADATA_PROFILE = "Deleted metadata profile object: %s";
         public static final String INVALID_METADATA_PROFILE_NAME = "MetadataProfile 'name' field is either null or empty!";
         public static final String INVALID_METRICS_FOUND = "Invalid metrics found for experiment - %s: %s";
+        public static final String INVALID_METRICS_ERROR_PREFIX = INVALID_METRICS_FOUND.split(" - ")[0];
         public static final String MISSING_MANDATORY_PARAMETERS = "Missing one of the following mandatory parameters for experiment - %s : %s";
         public static final String MISSING_NAMESPACE_SPECIFIC_UPDATE_RESULTS_FIELDS = "Expected namespace-level results, but found type, name, and namespace for experiment: %s.";
         public static final String MISSING_PERF_PROFILE_NAME = "Performance profile name is required.";

--- a/src/main/java/com/autotune/utils/cache/PerformanceProfileCache.java
+++ b/src/main/java/com/autotune/utils/cache/PerformanceProfileCache.java
@@ -17,17 +17,12 @@
 package com.autotune.utils.cache;
 
 import com.autotune.analyzer.performanceProfiles.PerformanceProfile;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Supplier;
 
 public class PerformanceProfileCache {
-    private static final Logger LOGGER = LoggerFactory.getLogger(PerformanceProfileCache.class);
     private static final Map<String, PerformanceProfile> performanceProfileMap = new ConcurrentHashMap<>();
-    private static final Map<String, Object> refreshLocks = new ConcurrentHashMap<>();
 
     private PerformanceProfileCache() {
 
@@ -47,43 +42,5 @@ public class PerformanceProfileCache {
 
     public static void remove(String performanceProfileName) {
         performanceProfileMap.remove(performanceProfileName);
-    }
-
-    /**
-     * Atomically refresh a performance profile from the database.
-     * Only one thread will reload a given profile at a time; other threads will block until the refresh completes.
-     *
-     * @param profileName the name of the profile to refresh
-     * @param loader a Supplier that loads the profile and returns it (or null if not found)
-     * @return the refreshed PerformanceProfile, or null if not found
-     */
-    public static PerformanceProfile refresh(String profileName, Supplier<PerformanceProfile> loader) {
-        // Get or create a lock object for this specific profile name
-        Object lock = refreshLocks.computeIfAbsent(profileName, k -> new Object());
-        
-        synchronized (lock) {
-            try {
-                LOGGER.debug("Refreshing performance profile from DB: {}", profileName);
-                
-                // Remove the stale entry from cache
-                performanceProfileMap.remove(profileName);
-                
-                // Load the fresh profile from DB
-                PerformanceProfile refreshedProfile = loader.get();
-                
-                // Update cache with the fresh profile (if found)
-                if (refreshedProfile != null) {
-                    performanceProfileMap.put(profileName, refreshedProfile);
-                    LOGGER.debug("Successfully refreshed performance profile: {}", profileName);
-                } else {
-                    LOGGER.debug("Performance profile not found in DB: {}", profileName);
-                }
-                
-                return refreshedProfile;
-            } finally {
-                // Clean up the lock object to prevent memory leak
-                refreshLocks.remove(profileName);
-            }
-        }
     }
 }

--- a/src/main/java/com/autotune/utils/cache/PerformanceProfileCache.java
+++ b/src/main/java/com/autotune/utils/cache/PerformanceProfileCache.java
@@ -17,12 +17,17 @@
 package com.autotune.utils.cache;
 
 import com.autotune.analyzer.performanceProfiles.PerformanceProfile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 
 public class PerformanceProfileCache {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PerformanceProfileCache.class);
     private static final Map<String, PerformanceProfile> performanceProfileMap = new ConcurrentHashMap<>();
+    private static final Map<String, Object> refreshLocks = new ConcurrentHashMap<>();
 
     private PerformanceProfileCache() {
 
@@ -42,5 +47,43 @@ public class PerformanceProfileCache {
 
     public static void remove(String performanceProfileName) {
         performanceProfileMap.remove(performanceProfileName);
+    }
+
+    /**
+     * Atomically refresh a performance profile from the database.
+     * Only one thread will reload a given profile at a time; other threads will block until the refresh completes.
+     *
+     * @param profileName the name of the profile to refresh
+     * @param loader a Supplier that loads the profile and returns it (or null if not found)
+     * @return the refreshed PerformanceProfile, or null if not found
+     */
+    public static PerformanceProfile refresh(String profileName, Supplier<PerformanceProfile> loader) {
+        // Get or create a lock object for this specific profile name
+        Object lock = refreshLocks.computeIfAbsent(profileName, k -> new Object());
+        
+        synchronized (lock) {
+            try {
+                LOGGER.debug("Refreshing performance profile from DB: {}", profileName);
+                
+                // Remove the stale entry from cache
+                performanceProfileMap.remove(profileName);
+                
+                // Load the fresh profile from DB
+                PerformanceProfile refreshedProfile = loader.get();
+                
+                // Update cache with the fresh profile (if found)
+                if (refreshedProfile != null) {
+                    performanceProfileMap.put(profileName, refreshedProfile);
+                    LOGGER.debug("Successfully refreshed performance profile: {}", profileName);
+                } else {
+                    LOGGER.debug("Performance profile not found in DB: {}", profileName);
+                }
+                
+                return refreshedProfile;
+            } finally {
+                // Clean up the lock object to prevent memory leak
+                refreshLocks.remove(profileName);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description

Updated `PerformanceProfileValidator` to handle stale cached performance profiles during result validation. If validation fails initially, the validator now clears the cached profile, reloads the latest version from the database, and retries validation before returning a constraint violation. This helps avoid false validation failures caused by outdated cache entries.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [x] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Bug Fixes:
- Retry performance profile validation by clearing the cached profile and reloading it from the database when an invalid-metrics error is detected, falling back to the original failure behavior for other validation errors.