### PR TITLE
Enable TLS protocol negotiation in HTTP client

### DIFF
--- a/src/main/java/com/autotune/utils/GenericRestApiClient.java
+++ b/src/main/java/com/autotune/utils/GenericRestApiClient.java
@@ -160,8 +160,9 @@ public class GenericRestApiClient {
             throw new KeyManagementException("Failed to setup SSL context: " + e.getMessage(), e);
         }
         
+        // Use "TLS" to allow protocol version negotiation based on system TLS profile
         SSLConnectionSocketFactory sslConnectionSocketFactory =
-                new SSLConnectionSocketFactory(sslContext, new String[]{"TLSv1.2", "TLSv1.3"}, null, NoopHostnameVerifier.INSTANCE);
+                new SSLConnectionSocketFactory(sslContext, new String[]{"TLS"}, null, NoopHostnameVerifier.INSTANCE);
         return HttpClients.custom().setSSLSocketFactory(sslConnectionSocketFactory).build();
     }
 

--- a/src/main/java/com/autotune/utils/GenericRestApiClient.java
+++ b/src/main/java/com/autotune/utils/GenericRestApiClient.java
@@ -50,6 +50,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * This is generic wrapper class used to retrieve RESTAPI response.
@@ -59,7 +60,7 @@ import java.security.NoSuchAlgorithmException;
 public class GenericRestApiClient {
     private static final long serialVersionUID = 1L;
     private static final Logger LOGGER = LoggerFactory.getLogger(GenericRestApiClient.class);
-    private static volatile boolean tlsConfigLogged = false;
+    private static final AtomicBoolean tlsConfigLogged = new AtomicBoolean(false);
     private String baseURL;
     private BasicAuthentication basicAuthentication;
     private BearerAccessToken bearerAccessToken;
@@ -162,15 +163,28 @@ public class GenericRestApiClient {
         }
         
         // Pass null for protocols to use system's default TLS configuration, respecting the system TLS profile and avoiding JVM-specific protocol mapping issues
-        SSLConnectionSocketFactory sslConnectionSocketFactory =
-                new SSLConnectionSocketFactory(sslContext, null, null, NoopHostnameVerifier.INSTANCE);
-        
-        // Log the actual SSL/TLS configuration once for debugging purposes
-        if (!tlsConfigLogged) {
-            String[] defaultProtocols = sslContext.getDefaultSSLParameters().getProtocols();
-            LOGGER.info("SSL/TLS Configuration - Enabled Protocols: {}", String.join(", ", defaultProtocols));
-            tlsConfigLogged = true;
-        }
+        SSLConnectionSocketFactory sslConnectionSocketFactory = new SSLConnectionSocketFactory(
+                sslContext,
+                null,
+                null,
+                NoopHostnameVerifier.INSTANCE) {
+            @Override
+            protected void prepareSocket(javax.net.ssl.SSLSocket socket) throws IOException {
+                super.prepareSocket(socket);
+                // Add handshake listener only to the first socket to log the negotiated protocol
+                if (tlsConfigLogged.compareAndSet(false, true)) {
+                    socket.addHandshakeCompletedListener(event -> {
+                        try {
+                            String protocol = event.getSession().getProtocol();
+                            String cipherSuite = event.getSession().getCipherSuite();
+                            LOGGER.info("TLS Handshake completed - Protocol: {}, Cipher Suite: {}", protocol, cipherSuite);
+                        } catch (Exception e) {
+                            LOGGER.debug("Failed to log TLS handshake details", e);
+                        }
+                    });
+                }
+            }
+        };
         
         return HttpClients.custom().setSSLSocketFactory(sslConnectionSocketFactory).build();
     }

--- a/src/main/java/com/autotune/utils/GenericRestApiClient.java
+++ b/src/main/java/com/autotune/utils/GenericRestApiClient.java
@@ -160,9 +160,9 @@ public class GenericRestApiClient {
             throw new KeyManagementException("Failed to setup SSL context: " + e.getMessage(), e);
         }
         
-        // Use "TLS" to allow protocol version negotiation based on system TLS profile
+        // Pass null for protocols to use system's default TLS configuration, respecting the system TLS profile and avoiding JVM-specific protocol mapping issues
         SSLConnectionSocketFactory sslConnectionSocketFactory =
-                new SSLConnectionSocketFactory(sslContext, new String[]{"TLS"}, null, NoopHostnameVerifier.INSTANCE);
+                new SSLConnectionSocketFactory(sslContext, null, null, NoopHostnameVerifier.INSTANCE);
         return HttpClients.custom().setSSLSocketFactory(sslConnectionSocketFactory).build();
     }
 

--- a/src/main/java/com/autotune/utils/GenericRestApiClient.java
+++ b/src/main/java/com/autotune/utils/GenericRestApiClient.java
@@ -59,6 +59,7 @@ import java.security.NoSuchAlgorithmException;
 public class GenericRestApiClient {
     private static final long serialVersionUID = 1L;
     private static final Logger LOGGER = LoggerFactory.getLogger(GenericRestApiClient.class);
+    private static volatile boolean tlsConfigLogged = false;
     private String baseURL;
     private BasicAuthentication basicAuthentication;
     private BearerAccessToken bearerAccessToken;
@@ -163,6 +164,14 @@ public class GenericRestApiClient {
         // Pass null for protocols to use system's default TLS configuration, respecting the system TLS profile and avoiding JVM-specific protocol mapping issues
         SSLConnectionSocketFactory sslConnectionSocketFactory =
                 new SSLConnectionSocketFactory(sslContext, null, null, NoopHostnameVerifier.INSTANCE);
+        
+        // Log the actual SSL/TLS configuration once for debugging purposes
+        if (!tlsConfigLogged) {
+            String[] defaultProtocols = sslContext.getDefaultSSLParameters().getProtocols();
+            LOGGER.info("SSL/TLS Configuration - Enabled Protocols: {}", String.join(", ", defaultProtocols));
+            tlsConfigLogged = true;
+        }
+        
         return HttpClients.custom().setSSLSocketFactory(sslConnectionSocketFactory).build();
     }
 


### PR DESCRIPTION
## Description
Thanos datasource connection was failing with "protocol version" error when using `modern` TLS security profile, caused by hardcoded `TLSv1.2` in the SSL configuration.
Updated the SSL configuration to pass `null` for the enabled protocols parameter, allowing the SSL/TLS stack to use the system's default configuration and enabling automatic version negotiation.

Fixes #1891 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Docker image: `quay.io/shbirada/autotune:tls_protocol_fix`

## Summary by Sourcery

Bug Fixes:
- Fix Thanos datasource connection failures caused by enforcing TLSv1.2/TLSv1.3 and allow connections to comply with the configured TLS security profile.