### PR TITLE
Update RH UBI minimal 10.1 to latest & postgres dependency to fix CVE

### DIFF
--- a/Dockerfile.autotune
+++ b/Dockerfile.autotune
@@ -16,7 +16,7 @@
 ##########################################################
 #            Build Docker Image
 ##########################################################
-FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1776071394 as mvnbuild-jdk25
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1778058333 as mvnbuild-jdk25
 ARG USER=autotune
 ARG AUTOTUNE_HOME=/home/$USER
 
@@ -49,7 +49,7 @@ RUN jlink --strip-debug --compress 2 --no-header-files --no-man-pages --module-p
 #            Runtime Docker Image
 ##########################################################
 # Use ubi-minimal as the base image
-FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1776071394
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1778058333
 
 ARG AUTOTUNE_VERSION
 ARG USER=autotune

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <maven-assembly-plugin-version>3.7.1</maven-assembly-plugin-version>
         <appassembler-maven-plugin-version>2.1.0</appassembler-maven-plugin-version>
         <apachehttpclient-version>4.5.14</apachehttpclient-version>
-        <postgresql-version>42.7.10</postgresql-version>
+        <postgresql-version>42.7.11</postgresql-version>
         <hibernate-version>6.6.45.Final</hibernate-version>
         <hibernate-Validator>8.0.3.Final</hibernate-Validator>
         <micrometer-version>1.12.10</micrometer-version>


### PR DESCRIPTION
## Description

Update RH UBI minimal 10.1 image tag to latest in the dockerfile & postgres dependency to fix CVE (https://nvd.nist.gov/vuln/detail/CVE-2026-42198)

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Tested using PR check

**Test Configuration**
* Kubernetes clusters tested on: minikube

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Update container base image and Postgres JDBC dependency to address security vulnerabilities.

Bug Fixes:
- Bump Postgres JDBC driver version to 42.7.11 to remediate reported CVEs.

Build:
- Update Docker image base (RH UBI minimal 10.1) to the latest available patched version.

## Summary by Sourcery

Update dependencies to address security vulnerabilities in the container image and PostgreSQL JDBC driver.

Bug Fixes:
- Bump PostgreSQL JDBC driver to version 42.7.11 to remediate reported CVEs.

Build:
- Update RH UBI minimal 10.1 base image tag in the Dockerfile to the latest patched version.