### PR TITLE
Unit tests for TLS protocol validation

### DIFF
--- a/.github/workflows/test-on-pr.yaml
+++ b/.github/workflows/test-on-pr.yaml
@@ -24,6 +24,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: kruize/autotune
+      - name: Set up JDK 25 (OpenJDK)
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin' # This pulls the Eclipse Temurin OpenJDK build
+      - name: Verify Java Version
+        run: java -version
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.15.0
         with:

--- a/.github/workflows/test-on-pr.yaml
+++ b/.github/workflows/test-on-pr.yaml
@@ -24,13 +24,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: kruize/autotune
-      - name: Set up JDK 25 (OpenJDK)
-        uses: actions/setup-java@v4
-        with:
-          java-version: '25'
-          distribution: 'temurin' # This pulls the Eclipse Temurin OpenJDK build
-      - name: Verify Java Version
-        run: java -version
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.15.0
         with:
@@ -43,11 +36,6 @@ jobs:
           echo "pr_number=${pr_number}" >> "$GITHUB_ENV"
           ./build.sh -i autotune_operator:pr_${pr_number}
           docker images | grep autotune
-      - name: Run unit tests
-        run: |
-          echo "Running Maven unit tests"
-          mvn clean test
-          echo "Unit tests completed"
       - name: Check cluster info on minikube
         run: |
           kubectl cluster-info

--- a/.github/workflows/test-on-pr.yaml
+++ b/.github/workflows/test-on-pr.yaml
@@ -36,6 +36,11 @@ jobs:
           echo "pr_number=${pr_number}" >> "$GITHUB_ENV"
           ./build.sh -i autotune_operator:pr_${pr_number}
           docker images | grep autotune
+      - name: Run unit tests
+        run: |
+          echo "Running Maven unit tests"
+          mvn clean test
+          echo "Unit tests completed"
       - name: Check cluster info on minikube
         run: |
           kubectl cluster-info

--- a/src/main/java/com/autotune/utils/GenericRestApiClient.java
+++ b/src/main/java/com/autotune/utils/GenericRestApiClient.java
@@ -315,7 +315,7 @@ public class GenericRestApiClient {
 
     }
 
-    public class HttpResponseWrapper {
+    public static class HttpResponseWrapper {
         private int statusCode;
         private Object responseBody;
 

--- a/src/test/java/com/autotune/utils/GenericRestApiClientTLSTest.java
+++ b/src/test/java/com/autotune/utils/GenericRestApiClientTLSTest.java
@@ -26,17 +26,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSocket;
-import javax.net.ssl.SSLSocketFactory;
-import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 /**
  * Unit tests for TLS version validation in GenericRestApiClient.

--- a/src/test/java/com/autotune/utils/GenericRestApiClientTLSTest.java
+++ b/src/test/java/com/autotune/utils/GenericRestApiClientTLSTest.java
@@ -15,9 +15,7 @@
  *******************************************************************************/
 package com.autotune.utils;
 
-import com.autotune.common.datasource.DataSourceInfo;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -34,72 +32,62 @@ import static org.mockito.Mockito.*;
 
 /**
  * Unit tests for TLS version validation in GenericRestApiClient.
- * 
- * These tests verify that Kruize:
+ *
+ * These tests verify that Kruize's TLS configuration:
  * - Accepts TLS 1.3 connections
  * - Accepts TLS 1.2 connections
- * - Rejects TLS 1.1 connections
- * - Rejects TLS 1.0 connections
- * 
- * The tests use mocking to simulate SSL/TLS handshake behavior without
- * requiring actual network connections or mock servers.
- * 
+ * - Rejects TLS 1.1 connections (via system defaults)
+ * - Rejects TLS 1.0 connections (via system defaults)
+ *
+ * The tests exercise the actual SSLConnectionSocketFactory configuration used by
+ * GenericRestApiClient (passing null for protocols parameter), ensuring that
+ * regressions in client TLS configuration are caught.
+ *
  * Test Principles:
- * 1. Mock SSL socket behavior to simulate different TLS versions
- * 2. Verify that the client delegates protocol selection to system defaults
- * 3. Ensure legacy TLS versions (1.0, 1.1) are rejected
- * 4. Confirm modern TLS versions (1.2, 1.3) are accepted
+ * 1. Test the actual SSLConnectionSocketFactory configuration pattern used by GenericRestApiClient
+ * 2. Verify that passing null for protocols delegates to system defaults
+ * 3. Assert on sockets created through the factory to verify TLS configuration
+ * 4. Ensure legacy TLS versions (1.0, 1.1) are rejected by system defaults
+ * 5. Confirm modern TLS versions (1.2, 1.3) are accepted by system defaults
  */
 class GenericRestApiClientTLSTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GenericRestApiClientTLSTest.class);
-    
-    private GenericRestApiClient client;
-    private DataSourceInfo mockDataSourceInfo;
-    private SSLContext mockSSLContext;
-    private SSLSocketFactory mockSSLSocketFactory;
-    private SSLSocket mockSSLSocket;
-
-    @BeforeEach
-    void setup() throws Exception {
-        // Create mock objects
-        mockDataSourceInfo = mock(DataSourceInfo.class);
-        mockSSLContext = mock(SSLContext.class);
-        mockSSLSocketFactory = mock(SSLSocketFactory.class);
-        mockSSLSocket = mock(SSLSocket.class);
-
-        // Setup basic mock behavior
-        when(mockSSLContext.getSocketFactory()).thenReturn(mockSSLSocketFactory);
-        when(mockSSLSocketFactory.createSocket()).thenReturn(mockSSLSocket);
-        
-        // Initialize client
-        client = new GenericRestApiClient();
-        client.setBaseURL("https://test-prometheus.example.com:9090");
-    }
-
-    @AfterEach
-    void tearDown() {
-        client = null;
-    }
 
     @Test
-    @DisplayName("Should accept TLS 1.3 connections")
-    void shouldAcceptTLS13() {
-        LOGGER.info("=== Testing TLS 1.3 Acceptance ===");
+    @DisplayName("Should accept TLS 1.3 connections with SSLConnectionSocketFactory configured like GenericRestApiClient")
+    void shouldAcceptTLS13ThroughClientConfiguration() throws Exception {
+        LOGGER.info("=== Testing TLS 1.3 Acceptance via GenericRestApiClient Configuration ===");
         
-        // Given: A mock SSL socket that supports TLS 1.3
+        // Given: Mock SSL components configured to support TLS 1.3
+        SSLContext mockSSLContext = mock(SSLContext.class);
+        SSLSocketFactory mockSSLSocketFactory = mock(SSLSocketFactory.class);
+        SSLSocket mockSSLSocket = mock(SSLSocket.class);
+        
         String[] supportedProtocols = {"TLSv1.3", "TLSv1.2"};
         String[] enabledProtocols = {"TLSv1.3"};
         
+        when(mockSSLContext.getSocketFactory()).thenReturn(mockSSLSocketFactory);
+        when(mockSSLSocketFactory.createSocket()).thenReturn(mockSSLSocket);
         when(mockSSLSocket.getSupportedProtocols()).thenReturn(supportedProtocols);
         when(mockSSLSocket.getEnabledProtocols()).thenReturn(enabledProtocols);
         
-        // When: Check the enabled protocols
+        // When: Create SSLConnectionSocketFactory exactly as GenericRestApiClient does
+        SSLConnectionSocketFactory factory = new SSLConnectionSocketFactory(
+                mockSSLContext,
+                null,  // protocols - null delegates to system defaults
+                null,  // cipher suites
+                null   // hostname verifier
+        );
+        
+        // Verify the factory was created successfully
+        assertNotNull(factory, "SSLConnectionSocketFactory should be created");
+        
+        // Then: Verify the mock socket has TLS 1.3 enabled
         String[] protocols = mockSSLSocket.getEnabledProtocols();
         
-        LOGGER.info("✅ TLS 1.3 connection ACCEPTED - Enabled protocols: {}", Arrays.toString(protocols));
+        LOGGER.info("TLS 1.3 connection ACCEPTED - Enabled protocols: {}", Arrays.toString(protocols));
         
-        // Then: TLS 1.3 should be enabled
         assertNotNull(protocols);
         assertTrue(Arrays.asList(protocols).contains("TLSv1.3"),
                 "TLS 1.3 should be in enabled protocols");
@@ -110,23 +98,38 @@ class GenericRestApiClientTLSTest {
     }
 
     @Test
-    @DisplayName("Should accept TLS 1.2 connections")
-    void shouldAcceptTLS12() {
-        LOGGER.info("=== Testing TLS 1.2 Acceptance ===");
+    @DisplayName("Should accept TLS 1.2 connections with SSLConnectionSocketFactory configured like GenericRestApiClient")
+    void shouldAcceptTLS12ThroughClientConfiguration() throws Exception {
+        LOGGER.info("=== Testing TLS 1.2 Acceptance via GenericRestApiClient Configuration ===");
         
-        // Given: A mock SSL socket that supports TLS 1.2
+        // Given: Mock SSL components configured to support TLS 1.2
+        SSLContext mockSSLContext = mock(SSLContext.class);
+        SSLSocketFactory mockSSLSocketFactory = mock(SSLSocketFactory.class);
+        SSLSocket mockSSLSocket = mock(SSLSocket.class);
+        
         String[] supportedProtocols = {"TLSv1.3", "TLSv1.2"};
         String[] enabledProtocols = {"TLSv1.2"};
         
+        when(mockSSLContext.getSocketFactory()).thenReturn(mockSSLSocketFactory);
+        when(mockSSLSocketFactory.createSocket()).thenReturn(mockSSLSocket);
         when(mockSSLSocket.getSupportedProtocols()).thenReturn(supportedProtocols);
         when(mockSSLSocket.getEnabledProtocols()).thenReturn(enabledProtocols);
         
-        // When: Check the enabled protocols
+        // When: Create SSLConnectionSocketFactory exactly as GenericRestApiClient does
+        SSLConnectionSocketFactory factory = new SSLConnectionSocketFactory(
+                mockSSLContext,
+                null,  // protocols - null delegates to system defaults
+                null,  // cipher suites
+                null   // hostname verifier
+        );
+        
+        assertNotNull(factory, "SSLConnectionSocketFactory should be created");
+        
+        // Then: Verify the mock socket has TLS 1.2 enabled
         String[] protocols = mockSSLSocket.getEnabledProtocols();
         
-        LOGGER.info("✅ TLS 1.2 connection ACCEPTED - Enabled protocols: {}", Arrays.toString(protocols));
+        LOGGER.info("TLS 1.2 connection ACCEPTED - Enabled protocols: {}", Arrays.toString(protocols));
         
-        // Then: TLS 1.2 should be enabled
         assertNotNull(protocols);
         assertTrue(Arrays.asList(protocols).contains("TLSv1.2"),
                 "TLS 1.2 should be in enabled protocols");
@@ -137,77 +140,128 @@ class GenericRestApiClientTLSTest {
     }
 
     @Test
-    @DisplayName("Should reject TLS 1.1 connections")
-    void shouldRejectTLS11() throws Exception {
-        LOGGER.info("=== Testing TLS 1.1 Rejection ===");
+    @DisplayName("Should reject TLS 1.1 connections through system defaults")
+    void shouldRejectTLS11ThroughSystemDefaults() throws Exception {
+        LOGGER.info("=== Testing TLS 1.1 Rejection via System Defaults ===");
         
-        // Given: A mock SSL socket that only supports TLS 1.1
-        String[] supportedProtocols = {"TLSv1.1"};
-        String[] enabledProtocols = {"TLSv1.1"};
+        // Given: Mock SSL components where only TLS 1.1 is available
+        SSLContext mockSSLContext = mock(SSLContext.class);
+        SSLSocketFactory mockSSLSocketFactory = mock(SSLSocketFactory.class);
+        SSLSocket mockSSLSocket = mock(SSLSocket.class);
         
-        LOGGER.info("Attempting connection with TLS 1.1...");
-        when(mockSSLSocket.getSupportedProtocols()).thenReturn(supportedProtocols);
-        when(mockSSLSocket.getEnabledProtocols()).thenReturn(enabledProtocols);
+        String[] legacyProtocols = {"TLSv1.1"};
+        
+        when(mockSSLContext.getSocketFactory()).thenReturn(mockSSLSocketFactory);
+        when(mockSSLSocketFactory.createSocket()).thenReturn(mockSSLSocket);
+        when(mockSSLSocket.getSupportedProtocols()).thenReturn(legacyProtocols);
+        when(mockSSLSocket.getEnabledProtocols()).thenReturn(legacyProtocols);
         
         // Simulate handshake failure for TLS 1.1
         doThrow(new SSLHandshakeException("Received fatal alert: protocol_version"))
                 .when(mockSSLSocket).startHandshake();
         
-        // When/Then: Attempting handshake should throw SSLHandshakeException
+        LOGGER.info("Attempting connection with TLS 1.1...");
+        
+        // When: Create SSLConnectionSocketFactory with null protocols (system defaults)
+        SSLConnectionSocketFactory factory = new SSLConnectionSocketFactory(
+                mockSSLContext,
+                null,  // protocols - null delegates to system defaults
+                null,  // cipher suites
+                null   // hostname verifier
+        );
+        
+        assertNotNull(factory, "SSLConnectionSocketFactory should be created");
+        
+        // Then: Attempting handshake should throw SSLHandshakeException
         SSLHandshakeException exception = assertThrows(
                 SSLHandshakeException.class,
-                () -> mockSSLSocket.startHandshake(),
+                mockSSLSocket::startHandshake,
                 "TLS 1.1 connection should be rejected with SSLHandshakeException"
         );
         
-        LOGGER.warn("✅ TLS 1.1 connection REJECTED as expected: {}", exception.getMessage());
-        LOGGER.info("Security validation: Legacy TLS 1.1 protocol properly blocked");
+        LOGGER.warn("TLS 1.1 connection REJECTED as expected: {}", exception.getMessage());
+        LOGGER.info("Security validation: Legacy TLS 1.1 protocol properly blocked by system defaults");
         
         assertTrue(exception.getMessage().contains("protocol_version"),
                 "Exception should indicate protocol version mismatch");
     }
 
     @Test
-    @DisplayName("Should reject TLS 1.0 connections")
-    void shouldRejectTLS10() throws Exception {
-        LOGGER.info("=== Testing TLS 1.0 Rejection ===");
+    @DisplayName("Should reject TLS 1.0 connections through system defaults")
+    void shouldRejectTLS10ThroughSystemDefaults() throws Exception {
+        LOGGER.info("=== Testing TLS 1.0 Rejection via System Defaults ===");
         
-        // Given: A mock SSL socket that only supports TLS 1.0
-        String[] supportedProtocols = {"TLSv1"};
-        String[] enabledProtocols = {"TLSv1"};
+        // Given: Mock SSL components where only TLS 1.0 is available
+        SSLContext mockSSLContext = mock(SSLContext.class);
+        SSLSocketFactory mockSSLSocketFactory = mock(SSLSocketFactory.class);
+        SSLSocket mockSSLSocket = mock(SSLSocket.class);
         
-        LOGGER.info("Attempting connection with TLS 1.0...");
-        when(mockSSLSocket.getSupportedProtocols()).thenReturn(supportedProtocols);
-        when(mockSSLSocket.getEnabledProtocols()).thenReturn(enabledProtocols);
+        String[] legacyProtocols = {"TLSv1"};
+        
+        when(mockSSLContext.getSocketFactory()).thenReturn(mockSSLSocketFactory);
+        when(mockSSLSocketFactory.createSocket()).thenReturn(mockSSLSocket);
+        when(mockSSLSocket.getSupportedProtocols()).thenReturn(legacyProtocols);
+        when(mockSSLSocket.getEnabledProtocols()).thenReturn(legacyProtocols);
         
         // Simulate handshake failure for TLS 1.0
         doThrow(new SSLHandshakeException("Received fatal alert: protocol_version"))
                 .when(mockSSLSocket).startHandshake();
         
-        // When/Then: Attempting handshake should throw SSLHandshakeException
+        LOGGER.info("Attempting connection with TLS 1.0...");
+        
+        // When: Create SSLConnectionSocketFactory with null protocols (system defaults)
+        SSLConnectionSocketFactory factory = new SSLConnectionSocketFactory(
+                mockSSLContext,
+                null,  // protocols - null delegates to system defaults
+                null,  // cipher suites
+                null   // hostname verifier
+        );
+        
+        assertNotNull(factory, "SSLConnectionSocketFactory should be created");
+        
+        // Then: Attempting handshake should throw SSLHandshakeException
         SSLHandshakeException exception = assertThrows(
                 SSLHandshakeException.class,
-                () -> mockSSLSocket.startHandshake(),
+                mockSSLSocket::startHandshake,
                 "TLS 1.0 connection should be rejected with SSLHandshakeException"
         );
         
-        LOGGER.warn("✅ TLS 1.0 connection REJECTED as expected: {}", exception.getMessage());
-        LOGGER.info("Security validation: Legacy TLS 1.0 protocol properly blocked");
+        LOGGER.warn("TLS 1.0 connection REJECTED as expected: {}", exception.getMessage());
+        LOGGER.info("Security validation: Legacy TLS 1.0 protocol properly blocked by system defaults");
         
         assertTrue(exception.getMessage().contains("protocol_version"),
                 "Exception should indicate protocol version mismatch");
     }
 
     @Test
-    @DisplayName("Should use system default TLS protocols when null is passed")
-    void shouldUseSystemDefaultProtocols() {
-        // Given: System default protocols (simulating JVM defaults)
+    @DisplayName("Should use system default TLS protocols when null is passed to SSLConnectionSocketFactory")
+    void shouldUseSystemDefaultProtocolsInFactory() throws Exception {
+        LOGGER.info("=== Testing System Default Protocol Configuration ===");
+        
+        // Given: Mock SSL components with system default protocols
+        SSLContext mockSSLContext = mock(SSLContext.class);
+        SSLSocketFactory mockSSLSocketFactory = mock(SSLSocketFactory.class);
+        SSLSocket mockSSLSocket = mock(SSLSocket.class);
+        
         String[] systemDefaultProtocols = {"TLSv1.3", "TLSv1.2"};
         
+        when(mockSSLContext.getSocketFactory()).thenReturn(mockSSLSocketFactory);
+        when(mockSSLSocketFactory.createSocket()).thenReturn(mockSSLSocket);
         when(mockSSLSocket.getEnabledProtocols()).thenReturn(systemDefaultProtocols);
         
-        // When: Get the enabled protocols (simulating null parameter behavior)
+        // When: Create SSLConnectionSocketFactory with null protocols (as GenericRestApiClient does)
+        SSLConnectionSocketFactory factory = new SSLConnectionSocketFactory(
+                mockSSLContext,
+                null,  // protocols parameter - null delegates to system defaults
+                null,  // cipher suites
+                null   // hostname verifier
+        );
+        
+        assertNotNull(factory, "SSLConnectionSocketFactory should be created");
+        
         String[] protocols = mockSSLSocket.getEnabledProtocols();
+        
+        LOGGER.info("System default protocols: {}", Arrays.toString(protocols));
         
         // Then: Only modern TLS versions should be enabled
         assertNotNull(protocols);
@@ -223,33 +277,71 @@ class GenericRestApiClientTLSTest {
     }
 
     @Test
-    @DisplayName("Should verify SSLConnectionSocketFactory is created with null protocols parameter")
-    void shouldCreateSSLConnectionSocketFactoryWithNullProtocols() {
-        // GenericRestApiClient passes null for protocols parameter, delegating to system defaults
-        assertTrue(true, "This test documents the expected null parameter behavior");
-    }
-
-    @Test
-    @DisplayName("Should handle protocol_version error for legacy TLS")
-    void shouldHandleProtocolVersionError() {
-        String errorMessage = "Received fatal alert: protocol_version";
-        boolean isProtocolVersionError = errorMessage.contains("protocol_version");
+    @DisplayName("Should verify GenericRestApiClient creates SSLConnectionSocketFactory with null protocols")
+    void shouldVerifyClientCreatesFactoryWithNullProtocols() throws Exception {
+        LOGGER.info("=== Verifying GenericRestApiClient TLS Configuration ===");
         
-        assertTrue(isProtocolVersionError,
-                "Error message should indicate protocol version mismatch");
+        // Given: Mock SSL components with system defaults
+        SSLContext mockSSLContext = mock(SSLContext.class);
+        SSLSocketFactory mockSSLSocketFactory = mock(SSLSocketFactory.class);
+        SSLSocket mockSSLSocket = mock(SSLSocket.class);
+        
+        String[] systemDefaults = {"TLSv1.3", "TLSv1.2"};
+        
+        when(mockSSLContext.getSocketFactory()).thenReturn(mockSSLSocketFactory);
+        when(mockSSLSocketFactory.createSocket()).thenReturn(mockSSLSocket);
+        when(mockSSLSocket.getEnabledProtocols()).thenReturn(systemDefaults);
+        
+        // When: Create factory as GenericRestApiClient does
+        SSLConnectionSocketFactory factory = new SSLConnectionSocketFactory(
+                mockSSLContext,
+                null,  // This is the critical parameter - null means use system defaults
+                null,
+                null
+        );
+        
+        assertNotNull(factory, "SSLConnectionSocketFactory should be created");
+        
+        // Then: Verify system defaults are used
+        String[] protocols = mockSSLSocket.getEnabledProtocols();
+        assertNotNull(protocols);
+        assertTrue(protocols.length >= 1, "Should have at least one protocol enabled");
+        
+        // Verify no legacy protocols
+        for (String protocol : protocols) {
+            assertFalse(protocol.equals("TLSv1.1") || protocol.equals("TLSv1") ||
+                       protocol.equals("SSLv3") || protocol.equals("SSLv2"),
+                    "Legacy protocol " + protocol + " should not be enabled");
+        }
+        
+        LOGGER.info("Verified: GenericRestApiClient correctly delegates to system TLS defaults");
+        LOGGER.info("Enabled protocols: {}", Arrays.toString(protocols));
     }
 
     @Test
     @DisplayName("Should verify TLS 1.3 is preferred over TLS 1.2 when both are available")
     void shouldPreferTLS13OverTLS12() throws Exception {
-        // Given: A socket that supports both TLS 1.3 and TLS 1.2
+        LOGGER.info("=== Testing TLS Version Preference ===");
+        
+        // Given: Mock SSL components with both TLS 1.3 and 1.2
+        SSLContext mockSSLContext = mock(SSLContext.class);
+        SSLSocketFactory mockSSLSocketFactory = mock(SSLSocketFactory.class);
+        SSLSocket mockSSLSocket = mock(SSLSocket.class);
+        
         String[] supportedProtocols = {"TLSv1.3", "TLSv1.2"};
         String[] enabledProtocols = {"TLSv1.3", "TLSv1.2"};
         
+        when(mockSSLContext.getSocketFactory()).thenReturn(mockSSLSocketFactory);
+        when(mockSSLSocketFactory.createSocket()).thenReturn(mockSSLSocket);
         when(mockSSLSocket.getSupportedProtocols()).thenReturn(supportedProtocols);
         when(mockSSLSocket.getEnabledProtocols()).thenReturn(enabledProtocols);
         
-        // When: Both protocols are available
+        // When: Create factory
+        SSLConnectionSocketFactory factory = new SSLConnectionSocketFactory(
+                mockSSLContext, null, null, null);
+        
+        assertNotNull(factory, "SSLConnectionSocketFactory should be created");
+        
         String[] protocols = mockSSLSocket.getEnabledProtocols();
         
         // Then: Both should be enabled, with TLS 1.3 listed first (preferred)
@@ -257,24 +349,56 @@ class GenericRestApiClientTLSTest {
         assertTrue(protocols.length >= 2, "Should have at least 2 protocols");
         assertEquals("TLSv1.3", protocols[0], "TLS 1.3 should be first (preferred)");
         assertEquals("TLSv1.2", protocols[1], "TLS 1.2 should be second");
+        
+        LOGGER.info("Protocol preference verified: {}", Arrays.toString(protocols));
     }
 
     @Test
-    @DisplayName("Should not include SSLv3 in supported protocols")
-    void shouldNotSupportSSLv3() {
-        // Given: System default protocols
+    @DisplayName("Should not include SSLv3 or SSLv2 in supported protocols")
+    void shouldNotSupportLegacySSLVersions() throws Exception {
+        LOGGER.info("=== Testing Legacy SSL Version Exclusion ===");
+        
+        // Given: Mock SSL components with system protocols (no legacy SSL)
+        SSLContext mockSSLContext = mock(SSLContext.class);
+        SSLSocketFactory mockSSLSocketFactory = mock(SSLSocketFactory.class);
+        SSLSocket mockSSLSocket = mock(SSLSocket.class);
+        
         String[] systemProtocols = {"TLSv1.3", "TLSv1.2"};
         
+        when(mockSSLContext.getSocketFactory()).thenReturn(mockSSLSocketFactory);
+        when(mockSSLSocketFactory.createSocket()).thenReturn(mockSSLSocket);
         when(mockSSLSocket.getEnabledProtocols()).thenReturn(systemProtocols);
         
-        // When: Check enabled protocols
+        // When: Create factory
+        SSLConnectionSocketFactory factory = new SSLConnectionSocketFactory(
+                mockSSLContext, null, null, null);
+        
+        assertNotNull(factory, "SSLConnectionSocketFactory should be created");
+        
         String[] protocols = mockSSLSocket.getEnabledProtocols();
         
-        // Then: SSLv3 should not be present
+        // Then: SSLv3 and SSLv2 should not be present
         assertNotNull(protocols);
         assertFalse(Arrays.asList(protocols).contains("SSLv3"),
                 "SSLv3 should never be enabled");
         assertFalse(Arrays.asList(protocols).contains("SSLv2"),
                 "SSLv2 should never be enabled");
+        
+        LOGGER.info("Verified: No legacy SSL versions enabled");
+        LOGGER.info("Enabled protocols: {}", Arrays.toString(protocols));
+    }
+
+    @Test
+    @DisplayName("Should handle protocol_version error for legacy TLS")
+    void shouldHandleProtocolVersionError() {
+        LOGGER.info("=== Testing Protocol Version Error Handling ===");
+        
+        String errorMessage = "Received fatal alert: protocol_version";
+        boolean isProtocolVersionError = errorMessage.contains("protocol_version");
+        
+        assertTrue(isProtocolVersionError,
+                "Error message should indicate protocol version mismatch");
+        
+        LOGGER.info("Protocol version error correctly identified");
     }
 }

--- a/src/test/java/com/autotune/utils/GenericRestApiClientTLSTest.java
+++ b/src/test/java/com/autotune/utils/GenericRestApiClientTLSTest.java
@@ -80,27 +80,178 @@ class GenericRestApiClientTLSTest {
         );
     }
 
+    /**
+     * Helper method to verify GenericRestApiClient.setupHttpClient() works correctly.
+     * Uses reflection to access the private setupHttpClient method.
+     *
+     * @return The CloseableHttpClient created by GenericRestApiClient
+     * @throws Exception if reflection or client setup fails
+     */
+    private CloseableHttpClient setupAndVerifyHttpClient() throws Exception {
+        Method setupMethod = GenericRestApiClient.class.getDeclaredMethod("setupHttpClient");
+        setupMethod.setAccessible(true);
+        CloseableHttpClient httpClient = (CloseableHttpClient) setupMethod.invoke(client);
+        assertNotNull(httpClient, "HTTP client should be created by GenericRestApiClient");
+        return httpClient;
+    }
+
+    /**
+     * Helper method to create an SSLContext configured to trust all certificates.
+     * This is used for testing purposes to simulate various TLS scenarios.
+     *
+     * @return SSLContext configured with a trust-all trust manager
+     * @throws Exception if SSLContext creation fails
+     */
+    private SSLContext createTrustAllSSLContext() throws Exception {
+        return SSLContexts.custom()
+                .loadTrustMaterial((chain, authType) -> true)
+                .build();
+    }
+
+    /**
+     * Helper method to create an SSLSocket with system default protocols.
+     *
+     * @param sslContext The SSLContext to use for creating the socket
+     * @return SSLSocket configured with system default protocols
+     * @throws Exception if socket creation fails
+     */
+    private SSLSocket createSocketWithSystemDefaults(SSLContext sslContext) throws Exception {
+        return (SSLSocket) sslContext.getSocketFactory().createSocket();
+    }
+
+    /**
+     * Helper method to create an SSLSocket configured for a specific TLS protocol.
+     *
+     * @param sslContext The SSLContext to use for creating the socket
+     * @param protocol The TLS protocol to enable (e.g., "TLSv1", "TLSv1.1")
+     * @return SSLSocket configured with the specified protocol only
+     * @throws Exception if socket creation fails
+     */
+    private SSLSocket createSocketWithProtocol(SSLContext sslContext, String protocol) throws Exception {
+        SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket();
+        socket.setEnabledProtocols(new String[]{protocol});
+        return socket;
+    }
+
+    /**
+     * Helper method to verify that no common protocol exists between two protocol lists.
+     * This simulates a handshake failure scenario.
+     *
+     * @param clientProtocols Array of protocols supported by the client
+     * @param serverProtocols Array of protocols supported by the server
+     * @return true if there is at least one common protocol, false otherwise
+     */
+    private boolean hasCommonProtocol(String[] clientProtocols, String[] serverProtocols) {
+        List<String> serverList = Arrays.asList(serverProtocols);
+        for (String clientProto : clientProtocols) {
+            if (serverList.contains(clientProto)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Test
+    @DisplayName("Should reject TLS 1.1 handshake with SSLHandshakeException")
+    void shouldRejectTLS11HandshakeWithException() throws Exception {
+        LOGGER.info("=== Testing TLS 1.1 Handshake Rejection with SSLHandshakeException ===");
+        
+        // Given: Create server and client contexts
+        SSLContext serverContext = createTrustAllSSLContext();
+        SSLContext clientContext = createTrustAllSSLContext();
+        
+        // Server socket with system defaults (modern TLS only)
+        SSLSocket serverSocket = createSocketWithSystemDefaults(serverContext);
+        String[] serverProtocols = serverSocket.getEnabledProtocols();
+        
+        // Client socket configured to only use TLS 1.1
+        SSLSocket clientSocket = createSocketWithProtocol(clientContext, "TLSv1.1");
+        String[] clientProtocols = clientSocket.getEnabledProtocols();
+        
+        LOGGER.info("Server (system defaults) protocols: {}", Arrays.toString(serverProtocols));
+        LOGGER.info("Client (TLS 1.1 only) protocols: {}", Arrays.toString(clientProtocols));
+        
+        // Then: Verify handshake would fail due to protocol mismatch
+        List<String> serverList = Arrays.asList(serverProtocols);
+        
+        // Assert that TLS 1.1 is not in server's enabled protocols
+        assertFalse(serverList.contains("TLSv1.1"),
+                "TLS 1.1 should not be in system defaults - handshake will fail with SSLHandshakeException");
+        
+        // Assert that client only has TLS 1.1
+        assertEquals(1, clientProtocols.length, "Client should have exactly one protocol");
+        assertEquals("TLSv1.1", clientProtocols[0], "Client should only support TLS 1.1");
+        
+        // Verify no common protocol exists between client and server
+        assertFalse(hasCommonProtocol(clientProtocols, serverProtocols),
+                "No common TLS protocol between client (TLS 1.1) and server (system defaults) - " +
+                "handshake would fail with SSLHandshakeException: 'No appropriate protocol'");
+        
+        LOGGER.info("Verified: TLS 1.1 handshake would fail with SSLHandshakeException");
+        LOGGER.info("Reason: No common protocol between client and server");
+        LOGGER.info("Expected exception message: 'No appropriate protocol' or 'protocol version'");
+        
+        clientSocket.close();
+        serverSocket.close();
+    }
+
+    @Test
+    @DisplayName("Should reject TLS 1.0 handshake with SSLHandshakeException")
+    void shouldRejectTLS10HandshakeWithException() throws Exception {
+        LOGGER.info("=== Testing TLS 1.0 Handshake Rejection with SSLHandshakeException ===");
+        
+        // Given: Create server and client contexts
+        SSLContext serverContext = createTrustAllSSLContext();
+        SSLContext clientContext = createTrustAllSSLContext();
+        
+        // Server socket with system defaults (modern TLS only)
+        SSLSocket serverSocket = createSocketWithSystemDefaults(serverContext);
+        String[] serverProtocols = serverSocket.getEnabledProtocols();
+        
+        // Client socket configured to only use TLS 1.0
+        SSLSocket clientSocket = createSocketWithProtocol(clientContext, "TLSv1");
+        String[] clientProtocols = clientSocket.getEnabledProtocols();
+        
+        LOGGER.info("Server (system defaults) protocols: {}", Arrays.toString(serverProtocols));
+        LOGGER.info("Client (TLS 1.0 only) protocols: {}", Arrays.toString(clientProtocols));
+        
+        // Then: Verify handshake would fail due to protocol mismatch
+        List<String> serverList = Arrays.asList(serverProtocols);
+        
+        // Assert that TLS 1.0 is not in server's enabled protocols
+        assertFalse(serverList.contains("TLSv1"),
+                "TLS 1.0 should not be in system defaults - handshake will fail with SSLHandshakeException");
+        
+        // Assert that client only has TLS 1.0
+        assertEquals(1, clientProtocols.length, "Client should have exactly one protocol");
+        assertEquals("TLSv1", clientProtocols[0], "Client should only support TLS 1.0");
+        
+        // Verify no common protocol exists between client and server
+        assertFalse(hasCommonProtocol(clientProtocols, serverProtocols),
+                "No common TLS protocol between client (TLS 1.0) and server (system defaults) - " +
+                "handshake would fail with SSLHandshakeException: 'No appropriate protocol'");
+        
+        LOGGER.info("Verified: TLS 1.0 handshake would fail with SSLHandshakeException");
+        LOGGER.info("Reason: No common protocol between client and server");
+        LOGGER.info("Expected exception message: 'No appropriate protocol' or 'protocol version'");
+        
+        clientSocket.close();
+        serverSocket.close();
+    }
+
     @Test
     @DisplayName("Should accept TLS 1.3 connections using GenericRestApiClient's configuration pattern")
     void shouldAcceptTLS13ThroughClientConfiguration() throws Exception {
         LOGGER.info("=== Testing TLS 1.3 Acceptance via Client Configuration Pattern ===");
         
         // Given: Verify GenericRestApiClient.setupHttpClient() works
-        Method setupMethod = GenericRestApiClient.class.getDeclaredMethod("setupHttpClient");
-        setupMethod.setAccessible(true);
-        CloseableHttpClient httpClient = (CloseableHttpClient) setupMethod.invoke(client);
-        
-        assertNotNull(httpClient, "HTTP client should be created by GenericRestApiClient");
+        CloseableHttpClient httpClient = setupAndVerifyHttpClient();
         
         // When: Test the same configuration pattern (null protocols) that GenericRestApiClient uses
-        SSLContext sslContext = SSLContexts.custom()
-                .loadTrustMaterial((chain, authType) -> true)
-                .build();
-        
-        SSLConnectionSocketFactory factory = createTestFactory(sslContext);
+        SSLContext sslContext = createTrustAllSSLContext();
         
         // Create a socket using the same SSLContext to verify system defaults
-        SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket();
+        SSLSocket socket = createSocketWithSystemDefaults(sslContext);
         
         // Then: Verify system defaults provide secure TLS configuration
         String[] enabledProtocols = socket.getEnabledProtocols();
@@ -126,21 +277,11 @@ class GenericRestApiClientTLSTest {
         LOGGER.info("=== Testing TLS 1.2 Acceptance via Client Configuration Pattern ===");
         
         // Given: Verify GenericRestApiClient.setupHttpClient() works
-        Method setupMethod = GenericRestApiClient.class.getDeclaredMethod("setupHttpClient");
-        setupMethod.setAccessible(true);
-        CloseableHttpClient httpClient = (CloseableHttpClient) setupMethod.invoke(client);
-        
-        assertNotNull(httpClient, "HTTP client should be created by GenericRestApiClient");
+        CloseableHttpClient httpClient = setupAndVerifyHttpClient();
         
         // When: Test the same configuration pattern (null protocols) that GenericRestApiClient uses
-        SSLContext sslContext = SSLContexts.custom()
-                .loadTrustMaterial((chain, authType) -> true)
-                .build();
-        
-        SSLConnectionSocketFactory factory = createTestFactory(sslContext);
-        
-        SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket();
-        
+        SSLContext sslContext = createTrustAllSSLContext();
+        SSLSocket socket = createSocketWithSystemDefaults(sslContext);
         String[] enabledProtocols = socket.getEnabledProtocols();
         
         LOGGER.info("System defaults with null protocols - Enabled: {}", Arrays.toString(enabledProtocols));
@@ -159,74 +300,84 @@ class GenericRestApiClientTLSTest {
     }
 
     @Test
-    @DisplayName("Should reject TLS 1.1 through system defaults (as GenericRestApiClient does)")
+    @DisplayName("Should reject TLS 1.1 through system defaults and verify handshake failure")
     void shouldRejectTLS11ThroughSystemDefaults() throws Exception {
-        LOGGER.info("=== Testing TLS 1.1 Rejection via System Defaults ===");
+        LOGGER.info("=== Testing TLS 1.1 Rejection via System Defaults with Handshake Validation ===");
         
         // Given: Verify GenericRestApiClient.setupHttpClient() works
-        Method setupMethod = GenericRestApiClient.class.getDeclaredMethod("setupHttpClient");
-        setupMethod.setAccessible(true);
-        CloseableHttpClient httpClient = (CloseableHttpClient) setupMethod.invoke(client);
-        
-        assertNotNull(httpClient, "HTTP client should be created by GenericRestApiClient");
+        CloseableHttpClient httpClient = setupAndVerifyHttpClient();
         
         // When: Test the same configuration pattern (null protocols) that GenericRestApiClient uses
-        SSLContext sslContext = SSLContexts.custom()
-                .loadTrustMaterial((chain, authType) -> true)
-                .build();
+        SSLContext sslContext = createTrustAllSSLContext();
         
-        SSLConnectionSocketFactory factory = createTestFactory(sslContext);
-        
-        SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket();
-        
-        String[] enabledProtocols = socket.getEnabledProtocols();
+        // Create socket with system defaults (as GenericRestApiClient does)
+        SSLSocket systemDefaultSocket = createSocketWithSystemDefaults(sslContext);
+        String[] enabledProtocols = systemDefaultSocket.getEnabledProtocols();
         
         LOGGER.info("System defaults - Enabled protocols: {}", Arrays.toString(enabledProtocols));
         
+        // Then: Verify TLS 1.1 is not in system defaults
         assertNotNull(enabledProtocols);
         List<String> protocolList = Arrays.asList(enabledProtocols);
         assertFalse(protocolList.contains("TLSv1.1"),
                 "TLS 1.1 should not be enabled by system defaults");
         
-        LOGGER.info("Security validation: Legacy TLS 1.1 protocol properly blocked by system defaults");
+        // Additionally: Simulate handshake scenario to verify rejection behavior
+        // Create a client socket that only supports TLS 1.1
+        SSLSocket tls11ClientSocket = createSocketWithProtocol(sslContext, "TLSv1.1");
+        String[] clientProtocols = tls11ClientSocket.getEnabledProtocols();
         
-        socket.close();
+        // Verify no protocol overlap exists (handshake would fail)
+        assertFalse(hasCommonProtocol(clientProtocols, enabledProtocols),
+                "No common protocol between TLS 1.1 client and system defaults - " +
+                "handshake would fail with SSLHandshakeException");
+        
+        LOGGER.info("Security validation: Legacy TLS 1.1 protocol properly blocked by system defaults");
+        LOGGER.info("Handshake validation: TLS 1.1 client would receive SSLHandshakeException");
+        
+        tls11ClientSocket.close();
+        systemDefaultSocket.close();
         httpClient.close();
     }
 
     @Test
-    @DisplayName("Should reject TLS 1.0 through system defaults (as GenericRestApiClient does)")
+    @DisplayName("Should reject TLS 1.0 through system defaults and verify handshake failure")
     void shouldRejectTLS10ThroughSystemDefaults() throws Exception {
-        LOGGER.info("=== Testing TLS 1.0 Rejection via System Defaults ===");
+        LOGGER.info("=== Testing TLS 1.0 Rejection via System Defaults with Handshake Validation ===");
         
         // Given: Verify GenericRestApiClient.setupHttpClient() works
-        Method setupMethod = GenericRestApiClient.class.getDeclaredMethod("setupHttpClient");
-        setupMethod.setAccessible(true);
-        CloseableHttpClient httpClient = (CloseableHttpClient) setupMethod.invoke(client);
-        
-        assertNotNull(httpClient, "HTTP client should be created by GenericRestApiClient");
+        CloseableHttpClient httpClient = setupAndVerifyHttpClient();
         
         // When: Test the same configuration pattern (null protocols) that GenericRestApiClient uses
-        SSLContext sslContext = SSLContexts.custom()
-                .loadTrustMaterial((chain, authType) -> true)
-                .build();
+        SSLContext sslContext = createTrustAllSSLContext();
         
-        SSLConnectionSocketFactory factory = createTestFactory(sslContext);
-        
-        SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket();
-        
-        String[] enabledProtocols = socket.getEnabledProtocols();
+        // Create socket with system defaults (as GenericRestApiClient does)
+        SSLSocket systemDefaultSocket = createSocketWithSystemDefaults(sslContext);
+        String[] enabledProtocols = systemDefaultSocket.getEnabledProtocols();
         
         LOGGER.info("System defaults - Enabled protocols: {}", Arrays.toString(enabledProtocols));
         
+        // Then: Verify TLS 1.0 is not in system defaults
         assertNotNull(enabledProtocols);
         List<String> protocolList = Arrays.asList(enabledProtocols);
         assertFalse(protocolList.contains("TLSv1"),
                 "TLS 1.0 should not be enabled by system defaults");
         
-        LOGGER.info("Security validation: Legacy TLS 1.0 protocol properly blocked by system defaults");
+        // Additionally: Simulate handshake scenario to verify rejection behavior
+        // Create a client socket that only supports TLS 1.0
+        SSLSocket tls10ClientSocket = createSocketWithProtocol(sslContext, "TLSv1");
+        String[] clientProtocols = tls10ClientSocket.getEnabledProtocols();
         
-        socket.close();
+        // Verify no protocol overlap exists (handshake would fail)
+        assertFalse(hasCommonProtocol(clientProtocols, enabledProtocols),
+                "No common protocol between TLS 1.0 client and system defaults - " +
+                "handshake would fail with SSLHandshakeException");
+        
+        LOGGER.info("Security validation: Legacy TLS 1.0 protocol properly blocked by system defaults");
+        LOGGER.info("Handshake validation: TLS 1.0 client would receive SSLHandshakeException");
+        
+        tls10ClientSocket.close();
+        systemDefaultSocket.close();
         httpClient.close();
     }
 
@@ -236,21 +387,11 @@ class GenericRestApiClientTLSTest {
         LOGGER.info("=== Testing System Default Protocol Configuration ===");
         
         // Given: Verify GenericRestApiClient.setupHttpClient() works
-        Method setupMethod = GenericRestApiClient.class.getDeclaredMethod("setupHttpClient");
-        setupMethod.setAccessible(true);
-        CloseableHttpClient httpClient = (CloseableHttpClient) setupMethod.invoke(client);
-        
-        assertNotNull(httpClient, "HTTP client should be created by GenericRestApiClient");
+        CloseableHttpClient httpClient = setupAndVerifyHttpClient();
         
         // When: Test the same configuration pattern (null protocols) that GenericRestApiClient uses
-        SSLContext sslContext = SSLContexts.custom()
-                .loadTrustMaterial((chain, authType) -> true)
-                .build();
-        
-        SSLConnectionSocketFactory factory = createTestFactory(sslContext);
-        
-        SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket();
-        
+        SSLContext sslContext = createTrustAllSSLContext();
+        SSLSocket socket = createSocketWithSystemDefaults(sslContext);
         String[] protocols = socket.getEnabledProtocols();
         
         LOGGER.info("System default protocols: {}", Arrays.toString(protocols));
@@ -277,21 +418,11 @@ class GenericRestApiClientTLSTest {
         LOGGER.info("=== Verifying Client Configuration Pattern TLS Settings ===");
         
         // Given: Verify GenericRestApiClient.setupHttpClient() works
-        Method setupMethod = GenericRestApiClient.class.getDeclaredMethod("setupHttpClient");
-        setupMethod.setAccessible(true);
-        CloseableHttpClient httpClient = (CloseableHttpClient) setupMethod.invoke(client);
-        
-        assertNotNull(httpClient, "HTTP client should be created by GenericRestApiClient");
+        CloseableHttpClient httpClient = setupAndVerifyHttpClient();
         
         // When: Test the same configuration pattern (null protocols) that GenericRestApiClient uses
-        SSLContext sslContext = SSLContexts.custom()
-                .loadTrustMaterial((chain, authType) -> true)
-                .build();
-        
-        SSLConnectionSocketFactory factory = createTestFactory(sslContext);
-        
-        SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket();
-        
+        SSLContext sslContext = createTrustAllSSLContext();
+        SSLSocket socket = createSocketWithSystemDefaults(sslContext);
         String[] protocols = socket.getEnabledProtocols();
         
         assertNotNull(protocols);
@@ -317,21 +448,11 @@ class GenericRestApiClientTLSTest {
         LOGGER.info("=== Testing TLS Version Preference in System Defaults ===");
         
         // Given: Verify GenericRestApiClient.setupHttpClient() works
-        Method setupMethod = GenericRestApiClient.class.getDeclaredMethod("setupHttpClient");
-        setupMethod.setAccessible(true);
-        CloseableHttpClient httpClient = (CloseableHttpClient) setupMethod.invoke(client);
-        
-        assertNotNull(httpClient, "HTTP client should be created by GenericRestApiClient");
+        CloseableHttpClient httpClient = setupAndVerifyHttpClient();
         
         // When: Test the same configuration pattern (null protocols) that GenericRestApiClient uses
-        SSLContext sslContext = SSLContexts.custom()
-                .loadTrustMaterial((chain, authType) -> true)
-                .build();
-        
-        SSLConnectionSocketFactory factory = createTestFactory(sslContext);
-        
-        SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket();
-        
+        SSLContext sslContext = createTrustAllSSLContext();
+        SSLSocket socket = createSocketWithSystemDefaults(sslContext);
         String[] protocols = socket.getEnabledProtocols();
         
         // Then: Verify protocol preference
@@ -359,21 +480,11 @@ class GenericRestApiClientTLSTest {
         LOGGER.info("=== Testing Legacy SSL Version Exclusion in System Defaults ===");
         
         // Given: Verify GenericRestApiClient.setupHttpClient() works
-        Method setupMethod = GenericRestApiClient.class.getDeclaredMethod("setupHttpClient");
-        setupMethod.setAccessible(true);
-        CloseableHttpClient httpClient = (CloseableHttpClient) setupMethod.invoke(client);
-        
-        assertNotNull(httpClient, "HTTP client should be created by GenericRestApiClient");
+        CloseableHttpClient httpClient = setupAndVerifyHttpClient();
         
         // When: Test the same configuration pattern (null protocols) that GenericRestApiClient uses
-        SSLContext sslContext = SSLContexts.custom()
-                .loadTrustMaterial((chain, authType) -> true)
-                .build();
-        
-        SSLConnectionSocketFactory factory = createTestFactory(sslContext);
-        
-        SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket();
-        
+        SSLContext sslContext = createTrustAllSSLContext();
+        SSLSocket socket = createSocketWithSystemDefaults(sslContext);
         String[] protocols = socket.getEnabledProtocols();
         
         // Then: SSLv3 and SSLv2 should not be present
@@ -392,16 +503,51 @@ class GenericRestApiClientTLSTest {
     }
 
     @Test
-    @DisplayName("Should handle protocol_version error for legacy TLS")
-    void shouldHandleProtocolVersionError() {
-        LOGGER.info("=== Testing Protocol Version Error Handling ===");
+    @DisplayName("Should verify protocol_version error occurs when legacy TLS is attempted")
+    void shouldHandleProtocolVersionError() throws Exception {
+        LOGGER.info("=== Testing Protocol Version Error Handling for Legacy TLS ===");
         
-        String errorMessage = "Received fatal alert: protocol_version";
-        boolean isProtocolVersionError = errorMessage.contains("protocol_version");
+        // Given: Create SSLContext with system defaults (modern TLS only)
+        SSLContext serverContext = createTrustAllSSLContext();
+        SSLSocket serverSocket = createSocketWithSystemDefaults(serverContext);
+        String[] serverProtocols = serverSocket.getEnabledProtocols();
         
-        assertTrue(isProtocolVersionError,
-                "Error message should indicate protocol version mismatch");
+        LOGGER.info("Server protocols (system defaults): {}", Arrays.toString(serverProtocols));
         
-        LOGGER.info("Protocol version error correctly identified");
+        // When: Simulate legacy TLS client attempts (TLS 1.0 and TLS 1.1)
+        SSLContext clientContext = createTrustAllSSLContext();
+        
+        // Test TLS 1.0 client
+        SSLSocket tls10Client = createSocketWithProtocol(clientContext, "TLSv1");
+        
+        // Test TLS 1.1 client
+        SSLSocket tls11Client = createSocketWithProtocol(clientContext, "TLSv1.1");
+        
+        // Then: Verify that protocol version mismatch would occur
+        List<String> serverList = Arrays.asList(serverProtocols);
+        
+        // Verify TLS 1.0 would cause protocol_version error
+        assertFalse(serverList.contains("TLSv1"),
+                "TLS 1.0 not supported by server - would cause 'protocol_version' alert");
+        
+        // Verify TLS 1.1 would cause protocol_version error
+        assertFalse(serverList.contains("TLSv1.1"),
+                "TLS 1.1 not supported by server - would cause 'protocol_version' alert");
+        
+        // Verify the expected error message pattern
+        String expectedErrorPattern = "protocol_version";
+        LOGGER.info("Expected SSLHandshakeException message pattern: 'Received fatal alert: {}'", expectedErrorPattern);
+        LOGGER.info("This error occurs when client and server have no common TLS protocol version");
+        
+        // Verify that modern TLS is supported
+        assertTrue(serverList.contains("TLSv1.2") || serverList.contains("TLSv1.3"),
+                "Server should support modern TLS (1.2 or 1.3)");
+        
+        LOGGER.info("Verified: Legacy TLS clients would receive 'protocol_version' fatal alert");
+        LOGGER.info("This confirms GenericRestApiClient properly rejects TLS 1.0/1.1 via system defaults");
+        
+        tls10Client.close();
+        tls11Client.close();
+        serverSocket.close();
     }
 }

--- a/src/test/java/com/autotune/utils/GenericRestApiClientTLSTest.java
+++ b/src/test/java/com/autotune/utils/GenericRestApiClientTLSTest.java
@@ -84,7 +84,7 @@ class GenericRestApiClientTLSTest {
                     .build();
         } catch (Exception e) {
             LOGGER.error("Failed to create SSLContext: {}", e.getMessage(), e);
-            throw e;
+            throw new Exception(e.getMessage());
         }
     }
 
@@ -100,7 +100,7 @@ class GenericRestApiClientTLSTest {
             return (SSLSocket) sslContext.getSocketFactory().createSocket();
         } catch (Exception e) {
             LOGGER.error("Failed to create socket with system defaults: {}", e.getMessage(), e);
-            throw e;
+            throw new Exception(e.getMessage());
         }
     }
 
@@ -120,7 +120,7 @@ class GenericRestApiClientTLSTest {
             return supported;
         } catch (Exception e) {
             LOGGER.error("Failed to get supported protocols: {}", e.getMessage(), e);
-            throw e;
+            throw new Exception(e.getMessage());
         }
     }
 
@@ -139,7 +139,7 @@ class GenericRestApiClientTLSTest {
             return socket;
         } catch (Exception e) {
             LOGGER.error("Failed to create socket with protocol {}: {}", protocol, e.getMessage(), e);
-            throw e;
+            throw new Exception(e.getMessage());
         }
     }
 
@@ -216,7 +216,7 @@ class GenericRestApiClientTLSTest {
             serverSocket.close();
         } catch (Exception e) {
             LOGGER.error("Test failed for {} rejection: {}", protocolDisplayName, e.getMessage(), e);
-            throw e;
+            throw new Exception(e.getMessage());
         }
     }
 
@@ -283,7 +283,7 @@ class GenericRestApiClientTLSTest {
             socket.close();
         } catch (Exception e) {
             LOGGER.error("Test failed for {} acceptance: {}", protocolDisplayName, e.getMessage(), e);
-            throw e;
+            throw new Exception(e.getMessage());
         }
     }
 

--- a/src/test/java/com/autotune/utils/GenericRestApiClientTLSTest.java
+++ b/src/test/java/com/autotune/utils/GenericRestApiClientTLSTest.java
@@ -15,9 +15,6 @@
  *******************************************************************************/
 package com.autotune.utils;
 
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.ssl.SSLContexts;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -27,7 +24,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocket;
-import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 
@@ -43,56 +39,34 @@ import static org.junit.jupiter.api.Assertions.*;
  * - Reject TLS 1.1 connections (via system defaults)
  * - Reject TLS 1.0 connections (via system defaults)
  *
- * The tests verify that GenericRestApiClient's setupHttpClient() can be invoked successfully,
- * then test the same TLS configuration pattern (null protocols parameter) that the client uses
+ * The tests verify the TLS configuration pattern (null protocols parameter) that the client uses
  * to ensure system defaults provide the expected security posture.
  *
  * Test Principles:
- * 1. Verify GenericRestApiClient.setupHttpClient() executes without errors
- * 2. Test the same SSLConnectionSocketFactory configuration pattern used by the client
- * 3. Verify that passing null for protocols (as the client does) results in secure defaults
- * 4. Assert that system defaults reject legacy TLS versions (1.0, 1.1)
- * 5. Confirm system defaults accept modern TLS versions (1.2, 1.3)
+ * 1. Test the same SSLConnectionSocketFactory configuration pattern used by the client
+ * 2. Verify that passing null for protocols (as the client does) results in secure defaults
+ * 3. Assert that system defaults reject legacy TLS versions (1.0, 1.1) when supported by JDK
+ * 4. Confirm system defaults accept modern TLS versions (1.2, 1.3)
+ * 5. Focus on public TLS behavior rather than private implementation details
  */
 class GenericRestApiClientTLSTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GenericRestApiClientTLSTest.class);
+    
+    // TLS Protocol Version Constants
+    private static final String TLS_1_0 = "TLSv1";
+    private static final String TLS_1_1 = "TLSv1.1";
+    private static final String TLS_1_2 = "TLSv1.2";
+    private static final String TLS_1_3 = "TLSv1.3";
+    private static final String SSL_V2 = "SSLv2";
+    private static final String SSL_V3 = "SSLv3";
+    
     private GenericRestApiClient client;
 
     @BeforeEach
     void setUp() {
         client = new GenericRestApiClient();
         client.setBaseURL("https://test.example.com");
-    }
-
-    /**
-     * Helper method to create an SSLConnectionSocketFactory using the same configuration
-     * pattern as GenericRestApiClient: passing null for protocols to delegate to system defaults.
-     * This allows us to verify that the configuration approach used by the client results in
-     * secure TLS settings.
-     */
-    private SSLConnectionSocketFactory createTestFactory(SSLContext sslContext) {
-        return new SSLConnectionSocketFactory(
-                sslContext,
-                null,  // protocols - null delegates to system defaults (as GenericRestApiClient does)
-                null,  // cipher suites
-                NoopHostnameVerifier.INSTANCE
-        );
-    }
-
-    /**
-     * Helper method to verify GenericRestApiClient.setupHttpClient() works correctly.
-     * Uses reflection to access the private setupHttpClient method.
-     *
-     * @return The CloseableHttpClient created by GenericRestApiClient
-     * @throws Exception if reflection or client setup fails
-     */
-    private CloseableHttpClient setupAndVerifyHttpClient() throws Exception {
-        Method setupMethod = GenericRestApiClient.class.getDeclaredMethod("setupHttpClient");
-        setupMethod.setAccessible(true);
-        CloseableHttpClient httpClient = (CloseableHttpClient) setupMethod.invoke(client);
-        assertNotNull(httpClient, "HTTP client should be created by GenericRestApiClient");
-        return httpClient;
     }
 
     /**
@@ -117,6 +91,21 @@ class GenericRestApiClientTLSTest {
      */
     private SSLSocket createSocketWithSystemDefaults(SSLContext sslContext) throws Exception {
         return (SSLSocket) sslContext.getSocketFactory().createSocket();
+    }
+
+    /**
+     * Helper method to get supported protocols from the JDK.
+     * This returns all protocols that the JDK supports, regardless of whether they're enabled by default.
+     *
+     * @param sslContext The SSLContext to use
+     * @return Array of supported protocol names
+     * @throws Exception if socket creation fails
+     */
+    private String[] getSupportedProtocols(SSLContext sslContext) throws Exception {
+        SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket();
+        String[] supported = socket.getSupportedProtocols();
+        socket.close();
+        return supported;
     }
 
     /**
@@ -151,152 +140,142 @@ class GenericRestApiClientTLSTest {
         return false;
     }
 
-    @Test
-    @DisplayName("Should reject TLS 1.1 handshake with SSLHandshakeException")
-    void shouldRejectTLS11HandshakeWithException() throws Exception {
-        LOGGER.info("=== Testing TLS 1.1 Handshake Rejection with SSLHandshakeException ===");
+    /**
+     * Helper method to test legacy TLS protocol rejection with handshake validation.
+     * This method consolidates common logic for testing TLS 1.0 and TLS 1.1 rejection.
+     *
+     * @param protocol The legacy TLS protocol to test (e.g., TLS_1_0, TLS_1_1)
+     * @param protocolDisplayName Human-readable protocol name for logging
+     * @throws Exception if socket creation or validation fails
+     */
+    private void testLegacyTLSRejection(String protocol, String protocolDisplayName) throws Exception {
+        LOGGER.info("=== Testing {} Handshake Rejection with SSLHandshakeException ===", protocolDisplayName);
         
         // Given: Create server and client contexts
         SSLContext serverContext = createTrustAllSSLContext();
         SSLContext clientContext = createTrustAllSSLContext();
         
+        // Get supported protocols to check if the protocol is available in this JDK
+        String[] supportedProtocols = getSupportedProtocols(serverContext);
+        List<String> supportedList = Arrays.asList(supportedProtocols);
+        
+        LOGGER.info("JDK supported protocols: {}", Arrays.toString(supportedProtocols));
+        
+        // Only run this test if the protocol is supported by the JDK
+        if (!supportedList.contains(protocol)) {
+            LOGGER.info("{} not supported by JDK - skipping test as it's already disabled at JDK level",
+                    protocolDisplayName);
+            return;
+        }
+        
         // Server socket with system defaults (modern TLS only)
         SSLSocket serverSocket = createSocketWithSystemDefaults(serverContext);
         String[] serverProtocols = serverSocket.getEnabledProtocols();
         
-        // Client socket configured to only use TLS 1.1
-        SSLSocket clientSocket = createSocketWithProtocol(clientContext, "TLSv1.1");
+        // Client socket configured to only use the legacy protocol
+        SSLSocket clientSocket = createSocketWithProtocol(clientContext, protocol);
         String[] clientProtocols = clientSocket.getEnabledProtocols();
         
         LOGGER.info("Server (system defaults) protocols: {}", Arrays.toString(serverProtocols));
-        LOGGER.info("Client (TLS 1.1 only) protocols: {}", Arrays.toString(clientProtocols));
+        LOGGER.info("Client ({} only) protocols: {}", protocolDisplayName, Arrays.toString(clientProtocols));
         
         // Then: Verify handshake would fail due to protocol mismatch
         List<String> serverList = Arrays.asList(serverProtocols);
         
-        // Assert that TLS 1.1 is not in server's enabled protocols
-        assertFalse(serverList.contains("TLSv1.1"),
-                "TLS 1.1 should not be in system defaults - handshake will fail with SSLHandshakeException");
+        // Assert that the legacy protocol is not in server's enabled protocols
+        assertFalse(serverList.contains(protocol),
+                protocolDisplayName + " should not be in system defaults - handshake will fail with SSLHandshakeException");
         
-        // Assert that client only has TLS 1.1
+        // Assert that client only has the legacy protocol
         assertEquals(1, clientProtocols.length, "Client should have exactly one protocol");
-        assertEquals("TLSv1.1", clientProtocols[0], "Client should only support TLS 1.1");
+        assertEquals(protocol, clientProtocols[0], "Client should only support " + protocolDisplayName);
         
         // Verify no common protocol exists between client and server
         assertFalse(hasCommonProtocol(clientProtocols, serverProtocols),
-                "No common TLS protocol between client (TLS 1.1) and server (system defaults) - " +
+                "No common TLS protocol between client (" + protocolDisplayName + ") and server (system defaults) - " +
                 "handshake would fail with SSLHandshakeException: 'No appropriate protocol'");
         
-        LOGGER.info("Verified: TLS 1.1 handshake would fail with SSLHandshakeException");
+        LOGGER.info("Verified: {} handshake would fail with SSLHandshakeException", protocolDisplayName);
         LOGGER.info("Reason: No common protocol between client and server");
         LOGGER.info("Expected exception message: 'No appropriate protocol' or 'protocol version'");
         
         clientSocket.close();
         serverSocket.close();
+    }
+
+    @Test
+    @DisplayName("Should reject TLS 1.1 handshake with SSLHandshakeException")
+    void shouldRejectTLS11HandshakeWithException() throws Exception {
+        testLegacyTLSRejection(TLS_1_1, "TLS 1.1");
     }
 
     @Test
     @DisplayName("Should reject TLS 1.0 handshake with SSLHandshakeException")
     void shouldRejectTLS10HandshakeWithException() throws Exception {
-        LOGGER.info("=== Testing TLS 1.0 Handshake Rejection with SSLHandshakeException ===");
-        
-        // Given: Create server and client contexts
-        SSLContext serverContext = createTrustAllSSLContext();
-        SSLContext clientContext = createTrustAllSSLContext();
-        
-        // Server socket with system defaults (modern TLS only)
-        SSLSocket serverSocket = createSocketWithSystemDefaults(serverContext);
-        String[] serverProtocols = serverSocket.getEnabledProtocols();
-        
-        // Client socket configured to only use TLS 1.0
-        SSLSocket clientSocket = createSocketWithProtocol(clientContext, "TLSv1");
-        String[] clientProtocols = clientSocket.getEnabledProtocols();
-        
-        LOGGER.info("Server (system defaults) protocols: {}", Arrays.toString(serverProtocols));
-        LOGGER.info("Client (TLS 1.0 only) protocols: {}", Arrays.toString(clientProtocols));
-        
-        // Then: Verify handshake would fail due to protocol mismatch
-        List<String> serverList = Arrays.asList(serverProtocols);
-        
-        // Assert that TLS 1.0 is not in server's enabled protocols
-        assertFalse(serverList.contains("TLSv1"),
-                "TLS 1.0 should not be in system defaults - handshake will fail with SSLHandshakeException");
-        
-        // Assert that client only has TLS 1.0
-        assertEquals(1, clientProtocols.length, "Client should have exactly one protocol");
-        assertEquals("TLSv1", clientProtocols[0], "Client should only support TLS 1.0");
-        
-        // Verify no common protocol exists between client and server
-        assertFalse(hasCommonProtocol(clientProtocols, serverProtocols),
-                "No common TLS protocol between client (TLS 1.0) and server (system defaults) - " +
-                "handshake would fail with SSLHandshakeException: 'No appropriate protocol'");
-        
-        LOGGER.info("Verified: TLS 1.0 handshake would fail with SSLHandshakeException");
-        LOGGER.info("Reason: No common protocol between client and server");
-        LOGGER.info("Expected exception message: 'No appropriate protocol' or 'protocol version'");
-        
-        clientSocket.close();
-        serverSocket.close();
+        testLegacyTLSRejection(TLS_1_0, "TLS 1.0");
     }
 
-    @Test
-    @DisplayName("Should accept TLS 1.3 connections using GenericRestApiClient's configuration pattern")
-    void shouldAcceptTLS13ThroughClientConfiguration() throws Exception {
-        LOGGER.info("=== Testing TLS 1.3 Acceptance via Client Configuration Pattern ===");
-        
-        // Given: Verify GenericRestApiClient.setupHttpClient() works
-        CloseableHttpClient httpClient = setupAndVerifyHttpClient();
+    /**
+     * Helper method to verify system defaults enable modern TLS and exclude legacy protocols.
+     * This method consolidates common validation logic for TLS acceptance tests.
+     *
+     * @param requiredProtocol The modern TLS protocol that must be enabled (e.g., TLS_1_2, TLS_1_3)
+     * @param protocolDisplayName Human-readable protocol name for logging
+     * @throws Exception if socket creation or validation fails
+     */
+    private void verifyModernTLSAcceptance(String requiredProtocol, String protocolDisplayName) throws Exception {
+        LOGGER.info("=== Testing {} Acceptance via System Default Configuration ===", protocolDisplayName);
         
         // When: Test the same configuration pattern (null protocols) that GenericRestApiClient uses
         SSLContext sslContext = createTrustAllSSLContext();
-        
-        // Create a socket using the same SSLContext to verify system defaults
         SSLSocket socket = createSocketWithSystemDefaults(sslContext);
         
         // Then: Verify system defaults provide secure TLS configuration
         String[] enabledProtocols = socket.getEnabledProtocols();
+        String[] supportedProtocols = socket.getSupportedProtocols();
         
         LOGGER.info("System defaults with null protocols - Enabled: {}", Arrays.toString(enabledProtocols));
+        LOGGER.info("JDK supported protocols: {}", Arrays.toString(supportedProtocols));
         
         assertNotNull(enabledProtocols);
-        List<String> protocolList = Arrays.asList(enabledProtocols);
-        assertTrue(protocolList.contains("TLSv1.3") || protocolList.contains("TLSv1.2"),
-                "Modern TLS (1.3 or 1.2) should be enabled by system defaults");
-        assertFalse(protocolList.contains("TLSv1.1"),
-                "TLS 1.1 should not be enabled by system defaults");
-        assertFalse(protocolList.contains("TLSv1"),
-                "TLS 1.0 should not be enabled by system defaults");
+        assertTrue(enabledProtocols.length >= 1, "Should have at least one protocol enabled");
+        
+        List<String> enabledList = Arrays.asList(enabledProtocols);
+        List<String> supportedList = Arrays.asList(supportedProtocols);
+        
+        // Verify the required modern TLS protocol is enabled
+        if (requiredProtocol.equals(TLS_1_3)) {
+            // For TLS 1.3, accept either 1.3 or 1.2 as modern TLS
+            assertTrue(enabledList.contains(TLS_1_3) || enabledList.contains(TLS_1_2),
+                    "Modern TLS (1.3 or 1.2) should be enabled by system defaults");
+        } else {
+            assertTrue(enabledList.contains(requiredProtocol),
+                    protocolDisplayName + " should be enabled by system defaults");
+        }
+        
+        // Only assert legacy protocol exclusion if the JDK supports them
+        if (supportedList.contains(TLS_1_1)) {
+            assertFalse(enabledList.contains(TLS_1_1),
+                    "TLS 1.1 should not be enabled by system defaults");
+        }
+        if (supportedList.contains(TLS_1_0)) {
+            assertFalse(enabledList.contains(TLS_1_0),
+                    "TLS 1.0 should not be enabled by system defaults");
+        }
         
         socket.close();
-        httpClient.close();
     }
 
     @Test
-    @DisplayName("Should accept TLS 1.2 connections using GenericRestApiClient's configuration pattern")
+    @DisplayName("Should accept TLS 1.3 connections using system default configuration pattern")
+    void shouldAcceptTLS13ThroughClientConfiguration() throws Exception {
+        verifyModernTLSAcceptance(TLS_1_3, "TLS 1.3");
+    }
+
+    @Test
+    @DisplayName("Should accept TLS 1.2 connections using system default configuration pattern")
     void shouldAcceptTLS12ThroughClientConfiguration() throws Exception {
-        LOGGER.info("=== Testing TLS 1.2 Acceptance via Client Configuration Pattern ===");
-        
-        // Given: Verify GenericRestApiClient.setupHttpClient() works
-        CloseableHttpClient httpClient = setupAndVerifyHttpClient();
-        
-        // When: Test the same configuration pattern (null protocols) that GenericRestApiClient uses
-        SSLContext sslContext = createTrustAllSSLContext();
-        SSLSocket socket = createSocketWithSystemDefaults(sslContext);
-        String[] enabledProtocols = socket.getEnabledProtocols();
-        
-        LOGGER.info("System defaults with null protocols - Enabled: {}", Arrays.toString(enabledProtocols));
-        
-        assertNotNull(enabledProtocols);
-        List<String> protocolList = Arrays.asList(enabledProtocols);
-        assertTrue(protocolList.contains("TLSv1.2"),
-                "TLS 1.2 should be enabled by system defaults");
-        assertFalse(protocolList.contains("TLSv1.1"),
-                "TLS 1.1 should not be enabled by system defaults");
-        assertFalse(protocolList.contains("TLSv1"),
-                "TLS 1.0 should not be enabled by system defaults");
-        
-        socket.close();
-        httpClient.close();
+        verifyModernTLSAcceptance(TLS_1_2, "TLS 1.2");
     }
 
     @Test
@@ -304,9 +283,6 @@ class GenericRestApiClientTLSTest {
     void shouldRejectTLS11ThroughSystemDefaults() throws Exception {
         LOGGER.info("=== Testing TLS 1.1 Rejection via System Defaults with Handshake Validation ===");
         
-        // Given: Verify GenericRestApiClient.setupHttpClient() works
-        CloseableHttpClient httpClient = setupAndVerifyHttpClient();
-        
         // When: Test the same configuration pattern (null protocols) that GenericRestApiClient uses
         SSLContext sslContext = createTrustAllSSLContext();
         
@@ -314,30 +290,41 @@ class GenericRestApiClientTLSTest {
         SSLSocket systemDefaultSocket = createSocketWithSystemDefaults(sslContext);
         String[] enabledProtocols = systemDefaultSocket.getEnabledProtocols();
         
+        String[] supportedProtocols = systemDefaultSocket.getSupportedProtocols();
+        
         LOGGER.info("System defaults - Enabled protocols: {}", Arrays.toString(enabledProtocols));
+        LOGGER.info("JDK supported protocols: {}", Arrays.toString(supportedProtocols));
         
-        // Then: Verify TLS 1.1 is not in system defaults
+        // Then: Verify basic non-emptiness
         assertNotNull(enabledProtocols);
-        List<String> protocolList = Arrays.asList(enabledProtocols);
-        assertFalse(protocolList.contains("TLSv1.1"),
-                "TLS 1.1 should not be enabled by system defaults");
+        assertTrue(enabledProtocols.length >= 1, "Should have at least one protocol enabled");
         
-        // Additionally: Simulate handshake scenario to verify rejection behavior
-        // Create a client socket that only supports TLS 1.1
-        SSLSocket tls11ClientSocket = createSocketWithProtocol(sslContext, "TLSv1.1");
-        String[] clientProtocols = tls11ClientSocket.getEnabledProtocols();
+        List<String> enabledList = Arrays.asList(enabledProtocols);
+        List<String> supportedList = Arrays.asList(supportedProtocols);
         
-        // Verify no protocol overlap exists (handshake would fail)
-        assertFalse(hasCommonProtocol(clientProtocols, enabledProtocols),
-                "No common protocol between TLS 1.1 client and system defaults - " +
-                "handshake would fail with SSLHandshakeException");
-        
-        LOGGER.info("Security validation: Legacy TLS 1.1 protocol properly blocked by system defaults");
-        LOGGER.info("Handshake validation: TLS 1.1 client would receive SSLHandshakeException");
-        
-        tls11ClientSocket.close();
+        // Only assert TLS 1.1 exclusion if the JDK supports it
+        if (supportedList.contains("TLSv1.1")) {
+            assertFalse(enabledList.contains("TLSv1.1"),
+                    "TLS 1.1 should not be enabled by system defaults");
+            
+            // Additionally: Simulate handshake scenario to verify rejection behavior
+            // Create a client socket that only supports TLS 1.1
+            SSLSocket tls11ClientSocket = createSocketWithProtocol(sslContext, "TLSv1.1");
+            String[] clientProtocols = tls11ClientSocket.getEnabledProtocols();
+            
+            // Verify no protocol overlap exists (handshake would fail)
+            assertFalse(hasCommonProtocol(clientProtocols, enabledProtocols),
+                    "No common protocol between TLS 1.1 client and system defaults - " +
+                    "handshake would fail with SSLHandshakeException");
+            
+            LOGGER.info("Security validation: Legacy TLS 1.1 protocol properly blocked by system defaults");
+            LOGGER.info("Handshake validation: TLS 1.1 client would receive SSLHandshakeException");
+            
+            tls11ClientSocket.close();
+        } else {
+            LOGGER.info("TLS 1.1 not supported by JDK - already disabled at JDK level");
+        }
         systemDefaultSocket.close();
-        httpClient.close();
     }
 
     @Test
@@ -345,9 +332,6 @@ class GenericRestApiClientTLSTest {
     void shouldRejectTLS10ThroughSystemDefaults() throws Exception {
         LOGGER.info("=== Testing TLS 1.0 Rejection via System Defaults with Handshake Validation ===");
         
-        // Given: Verify GenericRestApiClient.setupHttpClient() works
-        CloseableHttpClient httpClient = setupAndVerifyHttpClient();
-        
         // When: Test the same configuration pattern (null protocols) that GenericRestApiClient uses
         SSLContext sslContext = createTrustAllSSLContext();
         
@@ -355,100 +339,47 @@ class GenericRestApiClientTLSTest {
         SSLSocket systemDefaultSocket = createSocketWithSystemDefaults(sslContext);
         String[] enabledProtocols = systemDefaultSocket.getEnabledProtocols();
         
+        String[] supportedProtocols = systemDefaultSocket.getSupportedProtocols();
+        
         LOGGER.info("System defaults - Enabled protocols: {}", Arrays.toString(enabledProtocols));
+        LOGGER.info("JDK supported protocols: {}", Arrays.toString(supportedProtocols));
         
-        // Then: Verify TLS 1.0 is not in system defaults
+        // Then: Verify basic non-emptiness
         assertNotNull(enabledProtocols);
-        List<String> protocolList = Arrays.asList(enabledProtocols);
-        assertFalse(protocolList.contains("TLSv1"),
-                "TLS 1.0 should not be enabled by system defaults");
+        assertTrue(enabledProtocols.length >= 1, "Should have at least one protocol enabled");
         
-        // Additionally: Simulate handshake scenario to verify rejection behavior
-        // Create a client socket that only supports TLS 1.0
-        SSLSocket tls10ClientSocket = createSocketWithProtocol(sslContext, "TLSv1");
-        String[] clientProtocols = tls10ClientSocket.getEnabledProtocols();
+        List<String> enabledList = Arrays.asList(enabledProtocols);
+        List<String> supportedList = Arrays.asList(supportedProtocols);
         
-        // Verify no protocol overlap exists (handshake would fail)
-        assertFalse(hasCommonProtocol(clientProtocols, enabledProtocols),
-                "No common protocol between TLS 1.0 client and system defaults - " +
-                "handshake would fail with SSLHandshakeException");
-        
-        LOGGER.info("Security validation: Legacy TLS 1.0 protocol properly blocked by system defaults");
-        LOGGER.info("Handshake validation: TLS 1.0 client would receive SSLHandshakeException");
-        
-        tls10ClientSocket.close();
-        systemDefaultSocket.close();
-        httpClient.close();
-    }
-
-    @Test
-    @DisplayName("Should use system default TLS protocols (as GenericRestApiClient does)")
-    void shouldUseSystemDefaultProtocolsInClient() throws Exception {
-        LOGGER.info("=== Testing System Default Protocol Configuration ===");
-        
-        // Given: Verify GenericRestApiClient.setupHttpClient() works
-        CloseableHttpClient httpClient = setupAndVerifyHttpClient();
-        
-        // When: Test the same configuration pattern (null protocols) that GenericRestApiClient uses
-        SSLContext sslContext = createTrustAllSSLContext();
-        SSLSocket socket = createSocketWithSystemDefaults(sslContext);
-        String[] protocols = socket.getEnabledProtocols();
-        
-        LOGGER.info("System default protocols: {}", Arrays.toString(protocols));
-        
-        // Then: Only modern TLS versions should be enabled
-        assertNotNull(protocols);
-        assertTrue(protocols.length >= 1, "Should have at least 1 protocol enabled");
-        
-        List<String> protocolList = Arrays.asList(protocols);
-        assertTrue(protocolList.contains("TLSv1.3") || protocolList.contains("TLSv1.2"),
-                "Modern TLS (1.3 or 1.2) should be enabled by system defaults");
-        assertFalse(protocolList.contains("TLSv1.1"),
-                "TLS 1.1 should not be enabled by system defaults");
-        assertFalse(protocolList.contains("TLSv1"),
-                "TLS 1.0 should not be enabled by system defaults");
-        
-        socket.close();
-        httpClient.close();
-    }
-
-    @Test
-    @DisplayName("Should verify client's configuration pattern creates proper TLS configuration")
-    void shouldVerifyClientSetupHttpClientTLSConfiguration() throws Exception {
-        LOGGER.info("=== Verifying Client Configuration Pattern TLS Settings ===");
-        
-        // Given: Verify GenericRestApiClient.setupHttpClient() works
-        CloseableHttpClient httpClient = setupAndVerifyHttpClient();
-        
-        // When: Test the same configuration pattern (null protocols) that GenericRestApiClient uses
-        SSLContext sslContext = createTrustAllSSLContext();
-        SSLSocket socket = createSocketWithSystemDefaults(sslContext);
-        String[] protocols = socket.getEnabledProtocols();
-        
-        assertNotNull(protocols);
-        assertTrue(protocols.length >= 1, "Should have at least one protocol enabled");
-        
-        // Verify no legacy protocols
-        for (String protocol : protocols) {
-            assertFalse(protocol.equals("TLSv1.1") || protocol.equals("TLSv1") ||
-                       protocol.equals("SSLv3") || protocol.equals("SSLv2"),
-                    "Legacy protocol " + protocol + " should not be enabled by system defaults");
+        // Only assert TLS 1.0 exclusion if the JDK supports it
+        if (supportedList.contains("TLSv1")) {
+            assertFalse(enabledList.contains("TLSv1"),
+                    "TLS 1.0 should not be enabled by system defaults");
+            
+            // Additionally: Simulate handshake scenario to verify rejection behavior
+            // Create a client socket that only supports TLS 1.0
+            SSLSocket tls10ClientSocket = createSocketWithProtocol(sslContext, "TLSv1");
+            String[] clientProtocols = tls10ClientSocket.getEnabledProtocols();
+            
+            // Verify no protocol overlap exists (handshake would fail)
+            assertFalse(hasCommonProtocol(clientProtocols, enabledProtocols),
+                    "No common protocol between TLS 1.0 client and system defaults - " +
+                    "handshake would fail with SSLHandshakeException");
+            
+            LOGGER.info("Security validation: Legacy TLS 1.0 protocol properly blocked by system defaults");
+            LOGGER.info("Handshake validation: TLS 1.0 client would receive SSLHandshakeException");
+            
+            tls10ClientSocket.close();
+        } else {
+            LOGGER.info("TLS 1.0 not supported by JDK - already disabled at JDK level");
         }
-        
-        LOGGER.info("Verified: null protocols parameter correctly delegates to secure system TLS defaults");
-        LOGGER.info("Enabled protocols: {}", Arrays.toString(protocols));
-        
-        socket.close();
-        httpClient.close();
+        systemDefaultSocket.close();
     }
 
     @Test
     @DisplayName("Should verify TLS 1.3 is preferred by system defaults when available")
     void shouldPreferTLS13OverTLS12InClient() throws Exception {
         LOGGER.info("=== Testing TLS Version Preference in System Defaults ===");
-        
-        // Given: Verify GenericRestApiClient.setupHttpClient() works
-        CloseableHttpClient httpClient = setupAndVerifyHttpClient();
         
         // When: Test the same configuration pattern (null protocols) that GenericRestApiClient uses
         SSLContext sslContext = createTrustAllSSLContext();
@@ -471,16 +402,12 @@ class GenericRestApiClientTLSTest {
         LOGGER.info("Enabled protocols: {}", Arrays.toString(protocols));
         
         socket.close();
-        httpClient.close();
     }
 
     @Test
     @DisplayName("Should not include SSLv3 or SSLv2 in system defaults")
     void shouldNotSupportLegacySSLVersionsInClient() throws Exception {
         LOGGER.info("=== Testing Legacy SSL Version Exclusion in System Defaults ===");
-        
-        // Given: Verify GenericRestApiClient.setupHttpClient() works
-        CloseableHttpClient httpClient = setupAndVerifyHttpClient();
         
         // When: Test the same configuration pattern (null protocols) that GenericRestApiClient uses
         SSLContext sslContext = createTrustAllSSLContext();
@@ -499,7 +426,6 @@ class GenericRestApiClientTLSTest {
         LOGGER.info("Enabled protocols: {}", Arrays.toString(protocols));
         
         socket.close();
-        httpClient.close();
     }
 
     @Test
@@ -518,21 +444,30 @@ class GenericRestApiClientTLSTest {
         SSLContext clientContext = createTrustAllSSLContext();
         
         // Test TLS 1.0 client
-        SSLSocket tls10Client = createSocketWithProtocol(clientContext, "TLSv1");
+        SSLSocket tls10Client = createSocketWithProtocol(clientContext, TLS_1_0);
         
         // Test TLS 1.1 client
-        SSLSocket tls11Client = createSocketWithProtocol(clientContext, "TLSv1.1");
+        SSLSocket tls11Client = createSocketWithProtocol(clientContext, TLS_1_1);
+        
+        // Get supported protocols to check what the JDK supports
+        String[] supportedProtocols = serverSocket.getSupportedProtocols();
+        List<String> supportedList = Arrays.asList(supportedProtocols);
+        
+        LOGGER.info("JDK supported protocols: {}", Arrays.toString(supportedProtocols));
         
         // Then: Verify that protocol version mismatch would occur
         List<String> serverList = Arrays.asList(serverProtocols);
         
-        // Verify TLS 1.0 would cause protocol_version error
-        assertFalse(serverList.contains("TLSv1"),
-                "TLS 1.0 not supported by server - would cause 'protocol_version' alert");
+        // Only assert legacy protocol exclusion if the JDK supports them
+        if (supportedList.contains(TLS_1_0)) {
+            assertFalse(serverList.contains(TLS_1_0),
+                    "TLS 1.0 not supported by server - would cause 'protocol_version' alert");
+        }
         
-        // Verify TLS 1.1 would cause protocol_version error
-        assertFalse(serverList.contains("TLSv1.1"),
-                "TLS 1.1 not supported by server - would cause 'protocol_version' alert");
+        if (supportedList.contains(TLS_1_1)) {
+            assertFalse(serverList.contains(TLS_1_1),
+                    "TLS 1.1 not supported by server - would cause 'protocol_version' alert");
+        }
         
         // Verify the expected error message pattern
         String expectedErrorPattern = "protocol_version";
@@ -540,7 +475,7 @@ class GenericRestApiClientTLSTest {
         LOGGER.info("This error occurs when client and server have no common TLS protocol version");
         
         // Verify that modern TLS is supported
-        assertTrue(serverList.contains("TLSv1.2") || serverList.contains("TLSv1.3"),
+        assertTrue(serverList.contains(TLS_1_2) || serverList.contains(TLS_1_3),
                 "Server should support modern TLS (1.2 or 1.3)");
         
         LOGGER.info("Verified: Legacy TLS clients would receive 'protocol_version' fatal alert");

--- a/src/test/java/com/autotune/utils/GenericRestApiClientTLSTest.java
+++ b/src/test/java/com/autotune/utils/GenericRestApiClientTLSTest.java
@@ -15,7 +15,11 @@
  *******************************************************************************/
 package com.autotune.utils;
 
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.ssl.SSLContexts;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -25,7 +29,11 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
+import java.io.IOException;
+import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -33,277 +41,264 @@ import static org.mockito.Mockito.*;
 /**
  * Unit tests for TLS version validation in GenericRestApiClient.
  *
- * These tests verify that Kruize's TLS configuration:
- * - Accepts TLS 1.3 connections
- * - Accepts TLS 1.2 connections
- * - Rejects TLS 1.1 connections (via system defaults)
- * - Rejects TLS 1.0 connections (via system defaults)
+ * These tests verify that Kruize's TLS configuration approach (passing null for protocols
+ * to SSLConnectionSocketFactory) correctly delegates to system defaults, which:
+ * - Accept TLS 1.3 connections
+ * - Accept TLS 1.2 connections
+ * - Reject TLS 1.1 connections (via system defaults)
+ * - Reject TLS 1.0 connections (via system defaults)
  *
- * The tests exercise the actual SSLConnectionSocketFactory configuration used by
- * GenericRestApiClient (passing null for protocols parameter), ensuring that
- * regressions in client TLS configuration are caught.
+ * The tests verify that GenericRestApiClient's setupHttpClient() can be invoked successfully,
+ * then test the same TLS configuration pattern (null protocols parameter) that the client uses
+ * to ensure system defaults provide the expected security posture.
  *
  * Test Principles:
- * 1. Test the actual SSLConnectionSocketFactory configuration pattern used by GenericRestApiClient
- * 2. Verify that passing null for protocols delegates to system defaults
- * 3. Assert on sockets created through the factory to verify TLS configuration
- * 4. Ensure legacy TLS versions (1.0, 1.1) are rejected by system defaults
- * 5. Confirm modern TLS versions (1.2, 1.3) are accepted by system defaults
+ * 1. Verify GenericRestApiClient.setupHttpClient() executes without errors
+ * 2. Test the same SSLConnectionSocketFactory configuration pattern used by the client
+ * 3. Verify that passing null for protocols (as the client does) results in secure defaults
+ * 4. Assert that system defaults reject legacy TLS versions (1.0, 1.1)
+ * 5. Confirm system defaults accept modern TLS versions (1.2, 1.3)
  */
 class GenericRestApiClientTLSTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GenericRestApiClientTLSTest.class);
+    private GenericRestApiClient client;
+
+    @BeforeEach
+    void setUp() {
+        client = new GenericRestApiClient();
+        client.setBaseURL("https://test.example.com");
+    }
+
+    /**
+     * Helper method to create an SSLConnectionSocketFactory using the same configuration
+     * pattern as GenericRestApiClient: passing null for protocols to delegate to system defaults.
+     * This allows us to verify that the configuration approach used by the client results in
+     * secure TLS settings.
+     */
+    private SSLConnectionSocketFactory createTestFactory(SSLContext sslContext) {
+        return new SSLConnectionSocketFactory(
+                sslContext,
+                null,  // protocols - null delegates to system defaults (as GenericRestApiClient does)
+                null,  // cipher suites
+                NoopHostnameVerifier.INSTANCE
+        );
+    }
 
     @Test
-    @DisplayName("Should accept TLS 1.3 connections with SSLConnectionSocketFactory configured like GenericRestApiClient")
+    @DisplayName("Should accept TLS 1.3 connections using GenericRestApiClient's configuration pattern")
     void shouldAcceptTLS13ThroughClientConfiguration() throws Exception {
-        LOGGER.info("=== Testing TLS 1.3 Acceptance via GenericRestApiClient Configuration ===");
+        LOGGER.info("=== Testing TLS 1.3 Acceptance via Client Configuration Pattern ===");
         
-        // Given: Mock SSL components configured to support TLS 1.3
-        SSLContext mockSSLContext = mock(SSLContext.class);
-        SSLSocketFactory mockSSLSocketFactory = mock(SSLSocketFactory.class);
-        SSLSocket mockSSLSocket = mock(SSLSocket.class);
+        // Given: Verify GenericRestApiClient.setupHttpClient() works
+        Method setupMethod = GenericRestApiClient.class.getDeclaredMethod("setupHttpClient");
+        setupMethod.setAccessible(true);
+        CloseableHttpClient httpClient = (CloseableHttpClient) setupMethod.invoke(client);
         
-        String[] supportedProtocols = {"TLSv1.3", "TLSv1.2"};
-        String[] enabledProtocols = {"TLSv1.3"};
+        assertNotNull(httpClient, "HTTP client should be created by GenericRestApiClient");
         
-        when(mockSSLContext.getSocketFactory()).thenReturn(mockSSLSocketFactory);
-        when(mockSSLSocketFactory.createSocket()).thenReturn(mockSSLSocket);
-        when(mockSSLSocket.getSupportedProtocols()).thenReturn(supportedProtocols);
-        when(mockSSLSocket.getEnabledProtocols()).thenReturn(enabledProtocols);
+        // When: Test the same configuration pattern (null protocols) that GenericRestApiClient uses
+        SSLContext sslContext = SSLContexts.custom()
+                .loadTrustMaterial((chain, authType) -> true)
+                .build();
         
-        // When: Create SSLConnectionSocketFactory exactly as GenericRestApiClient does
-        SSLConnectionSocketFactory factory = new SSLConnectionSocketFactory(
-                mockSSLContext,
-                null,  // protocols - null delegates to system defaults
-                null,  // cipher suites
-                null   // hostname verifier
-        );
+        SSLConnectionSocketFactory factory = createTestFactory(sslContext);
         
-        // Verify the factory was created successfully
-        assertNotNull(factory, "SSLConnectionSocketFactory should be created");
+        // Create a socket using the same SSLContext to verify system defaults
+        SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket();
         
-        // Then: Verify the mock socket has TLS 1.3 enabled
-        String[] protocols = mockSSLSocket.getEnabledProtocols();
+        // Then: Verify system defaults provide secure TLS configuration
+        String[] enabledProtocols = socket.getEnabledProtocols();
         
-        LOGGER.info("TLS 1.3 connection ACCEPTED - Enabled protocols: {}", Arrays.toString(protocols));
+        LOGGER.info("System defaults with null protocols - Enabled: {}", Arrays.toString(enabledProtocols));
         
-        assertNotNull(protocols);
-        assertTrue(Arrays.asList(protocols).contains("TLSv1.3"),
-                "TLS 1.3 should be in enabled protocols");
-        assertFalse(Arrays.asList(protocols).contains("TLSv1.1"),
-                "TLS 1.1 should not be in enabled protocols");
-        assertFalse(Arrays.asList(protocols).contains("TLSv1"),
-                "TLS 1.0 should not be in enabled protocols");
+        assertNotNull(enabledProtocols);
+        List<String> protocolList = Arrays.asList(enabledProtocols);
+        assertTrue(protocolList.contains("TLSv1.3") || protocolList.contains("TLSv1.2"),
+                "Modern TLS (1.3 or 1.2) should be enabled by system defaults");
+        assertFalse(protocolList.contains("TLSv1.1"),
+                "TLS 1.1 should not be enabled by system defaults");
+        assertFalse(protocolList.contains("TLSv1"),
+                "TLS 1.0 should not be enabled by system defaults");
+        
+        socket.close();
+        httpClient.close();
     }
 
     @Test
-    @DisplayName("Should accept TLS 1.2 connections with SSLConnectionSocketFactory configured like GenericRestApiClient")
+    @DisplayName("Should accept TLS 1.2 connections using GenericRestApiClient's configuration pattern")
     void shouldAcceptTLS12ThroughClientConfiguration() throws Exception {
-        LOGGER.info("=== Testing TLS 1.2 Acceptance via GenericRestApiClient Configuration ===");
+        LOGGER.info("=== Testing TLS 1.2 Acceptance via Client Configuration Pattern ===");
         
-        // Given: Mock SSL components configured to support TLS 1.2
-        SSLContext mockSSLContext = mock(SSLContext.class);
-        SSLSocketFactory mockSSLSocketFactory = mock(SSLSocketFactory.class);
-        SSLSocket mockSSLSocket = mock(SSLSocket.class);
+        // Given: Verify GenericRestApiClient.setupHttpClient() works
+        Method setupMethod = GenericRestApiClient.class.getDeclaredMethod("setupHttpClient");
+        setupMethod.setAccessible(true);
+        CloseableHttpClient httpClient = (CloseableHttpClient) setupMethod.invoke(client);
         
-        String[] supportedProtocols = {"TLSv1.3", "TLSv1.2"};
-        String[] enabledProtocols = {"TLSv1.2"};
+        assertNotNull(httpClient, "HTTP client should be created by GenericRestApiClient");
         
-        when(mockSSLContext.getSocketFactory()).thenReturn(mockSSLSocketFactory);
-        when(mockSSLSocketFactory.createSocket()).thenReturn(mockSSLSocket);
-        when(mockSSLSocket.getSupportedProtocols()).thenReturn(supportedProtocols);
-        when(mockSSLSocket.getEnabledProtocols()).thenReturn(enabledProtocols);
+        // When: Test the same configuration pattern (null protocols) that GenericRestApiClient uses
+        SSLContext sslContext = SSLContexts.custom()
+                .loadTrustMaterial((chain, authType) -> true)
+                .build();
         
-        // When: Create SSLConnectionSocketFactory exactly as GenericRestApiClient does
-        SSLConnectionSocketFactory factory = new SSLConnectionSocketFactory(
-                mockSSLContext,
-                null,  // protocols - null delegates to system defaults
-                null,  // cipher suites
-                null   // hostname verifier
-        );
+        SSLConnectionSocketFactory factory = createTestFactory(sslContext);
         
-        assertNotNull(factory, "SSLConnectionSocketFactory should be created");
+        SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket();
         
-        // Then: Verify the mock socket has TLS 1.2 enabled
-        String[] protocols = mockSSLSocket.getEnabledProtocols();
+        String[] enabledProtocols = socket.getEnabledProtocols();
         
-        LOGGER.info("TLS 1.2 connection ACCEPTED - Enabled protocols: {}", Arrays.toString(protocols));
+        LOGGER.info("System defaults with null protocols - Enabled: {}", Arrays.toString(enabledProtocols));
         
-        assertNotNull(protocols);
-        assertTrue(Arrays.asList(protocols).contains("TLSv1.2"),
-                "TLS 1.2 should be in enabled protocols");
-        assertFalse(Arrays.asList(protocols).contains("TLSv1.1"),
-                "TLS 1.1 should not be in enabled protocols");
-        assertFalse(Arrays.asList(protocols).contains("TLSv1"),
-                "TLS 1.0 should not be in enabled protocols");
+        assertNotNull(enabledProtocols);
+        List<String> protocolList = Arrays.asList(enabledProtocols);
+        assertTrue(protocolList.contains("TLSv1.2"),
+                "TLS 1.2 should be enabled by system defaults");
+        assertFalse(protocolList.contains("TLSv1.1"),
+                "TLS 1.1 should not be enabled by system defaults");
+        assertFalse(protocolList.contains("TLSv1"),
+                "TLS 1.0 should not be enabled by system defaults");
+        
+        socket.close();
+        httpClient.close();
     }
 
     @Test
-    @DisplayName("Should reject TLS 1.1 connections through system defaults")
+    @DisplayName("Should reject TLS 1.1 through system defaults (as GenericRestApiClient does)")
     void shouldRejectTLS11ThroughSystemDefaults() throws Exception {
         LOGGER.info("=== Testing TLS 1.1 Rejection via System Defaults ===");
         
-        // Given: Mock SSL components where only TLS 1.1 is available
-        SSLContext mockSSLContext = mock(SSLContext.class);
-        SSLSocketFactory mockSSLSocketFactory = mock(SSLSocketFactory.class);
-        SSLSocket mockSSLSocket = mock(SSLSocket.class);
+        // Given: Verify GenericRestApiClient.setupHttpClient() works
+        Method setupMethod = GenericRestApiClient.class.getDeclaredMethod("setupHttpClient");
+        setupMethod.setAccessible(true);
+        CloseableHttpClient httpClient = (CloseableHttpClient) setupMethod.invoke(client);
         
-        String[] legacyProtocols = {"TLSv1.1"};
+        assertNotNull(httpClient, "HTTP client should be created by GenericRestApiClient");
         
-        when(mockSSLContext.getSocketFactory()).thenReturn(mockSSLSocketFactory);
-        when(mockSSLSocketFactory.createSocket()).thenReturn(mockSSLSocket);
-        when(mockSSLSocket.getSupportedProtocols()).thenReturn(legacyProtocols);
-        when(mockSSLSocket.getEnabledProtocols()).thenReturn(legacyProtocols);
+        // When: Test the same configuration pattern (null protocols) that GenericRestApiClient uses
+        SSLContext sslContext = SSLContexts.custom()
+                .loadTrustMaterial((chain, authType) -> true)
+                .build();
         
-        // Simulate handshake failure for TLS 1.1
-        doThrow(new SSLHandshakeException("Received fatal alert: protocol_version"))
-                .when(mockSSLSocket).startHandshake();
+        SSLConnectionSocketFactory factory = createTestFactory(sslContext);
         
-        LOGGER.info("Attempting connection with TLS 1.1...");
+        SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket();
         
-        // When: Create SSLConnectionSocketFactory with null protocols (system defaults)
-        SSLConnectionSocketFactory factory = new SSLConnectionSocketFactory(
-                mockSSLContext,
-                null,  // protocols - null delegates to system defaults
-                null,  // cipher suites
-                null   // hostname verifier
-        );
+        String[] enabledProtocols = socket.getEnabledProtocols();
         
-        assertNotNull(factory, "SSLConnectionSocketFactory should be created");
+        LOGGER.info("System defaults - Enabled protocols: {}", Arrays.toString(enabledProtocols));
         
-        // Then: Attempting handshake should throw SSLHandshakeException
-        SSLHandshakeException exception = assertThrows(
-                SSLHandshakeException.class,
-                mockSSLSocket::startHandshake,
-                "TLS 1.1 connection should be rejected with SSLHandshakeException"
-        );
+        assertNotNull(enabledProtocols);
+        List<String> protocolList = Arrays.asList(enabledProtocols);
+        assertFalse(protocolList.contains("TLSv1.1"),
+                "TLS 1.1 should not be enabled by system defaults");
         
-        LOGGER.warn("TLS 1.1 connection REJECTED as expected: {}", exception.getMessage());
         LOGGER.info("Security validation: Legacy TLS 1.1 protocol properly blocked by system defaults");
         
-        assertTrue(exception.getMessage().contains("protocol_version"),
-                "Exception should indicate protocol version mismatch");
+        socket.close();
+        httpClient.close();
     }
 
     @Test
-    @DisplayName("Should reject TLS 1.0 connections through system defaults")
+    @DisplayName("Should reject TLS 1.0 through system defaults (as GenericRestApiClient does)")
     void shouldRejectTLS10ThroughSystemDefaults() throws Exception {
         LOGGER.info("=== Testing TLS 1.0 Rejection via System Defaults ===");
         
-        // Given: Mock SSL components where only TLS 1.0 is available
-        SSLContext mockSSLContext = mock(SSLContext.class);
-        SSLSocketFactory mockSSLSocketFactory = mock(SSLSocketFactory.class);
-        SSLSocket mockSSLSocket = mock(SSLSocket.class);
+        // Given: Verify GenericRestApiClient.setupHttpClient() works
+        Method setupMethod = GenericRestApiClient.class.getDeclaredMethod("setupHttpClient");
+        setupMethod.setAccessible(true);
+        CloseableHttpClient httpClient = (CloseableHttpClient) setupMethod.invoke(client);
         
-        String[] legacyProtocols = {"TLSv1"};
+        assertNotNull(httpClient, "HTTP client should be created by GenericRestApiClient");
         
-        when(mockSSLContext.getSocketFactory()).thenReturn(mockSSLSocketFactory);
-        when(mockSSLSocketFactory.createSocket()).thenReturn(mockSSLSocket);
-        when(mockSSLSocket.getSupportedProtocols()).thenReturn(legacyProtocols);
-        when(mockSSLSocket.getEnabledProtocols()).thenReturn(legacyProtocols);
+        // When: Test the same configuration pattern (null protocols) that GenericRestApiClient uses
+        SSLContext sslContext = SSLContexts.custom()
+                .loadTrustMaterial((chain, authType) -> true)
+                .build();
         
-        // Simulate handshake failure for TLS 1.0
-        doThrow(new SSLHandshakeException("Received fatal alert: protocol_version"))
-                .when(mockSSLSocket).startHandshake();
+        SSLConnectionSocketFactory factory = createTestFactory(sslContext);
         
-        LOGGER.info("Attempting connection with TLS 1.0...");
+        SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket();
         
-        // When: Create SSLConnectionSocketFactory with null protocols (system defaults)
-        SSLConnectionSocketFactory factory = new SSLConnectionSocketFactory(
-                mockSSLContext,
-                null,  // protocols - null delegates to system defaults
-                null,  // cipher suites
-                null   // hostname verifier
-        );
+        String[] enabledProtocols = socket.getEnabledProtocols();
         
-        assertNotNull(factory, "SSLConnectionSocketFactory should be created");
+        LOGGER.info("System defaults - Enabled protocols: {}", Arrays.toString(enabledProtocols));
         
-        // Then: Attempting handshake should throw SSLHandshakeException
-        SSLHandshakeException exception = assertThrows(
-                SSLHandshakeException.class,
-                mockSSLSocket::startHandshake,
-                "TLS 1.0 connection should be rejected with SSLHandshakeException"
-        );
+        assertNotNull(enabledProtocols);
+        List<String> protocolList = Arrays.asList(enabledProtocols);
+        assertFalse(protocolList.contains("TLSv1"),
+                "TLS 1.0 should not be enabled by system defaults");
         
-        LOGGER.warn("TLS 1.0 connection REJECTED as expected: {}", exception.getMessage());
         LOGGER.info("Security validation: Legacy TLS 1.0 protocol properly blocked by system defaults");
         
-        assertTrue(exception.getMessage().contains("protocol_version"),
-                "Exception should indicate protocol version mismatch");
+        socket.close();
+        httpClient.close();
     }
 
     @Test
-    @DisplayName("Should use system default TLS protocols when null is passed to SSLConnectionSocketFactory")
-    void shouldUseSystemDefaultProtocolsInFactory() throws Exception {
+    @DisplayName("Should use system default TLS protocols (as GenericRestApiClient does)")
+    void shouldUseSystemDefaultProtocolsInClient() throws Exception {
         LOGGER.info("=== Testing System Default Protocol Configuration ===");
         
-        // Given: Mock SSL components with system default protocols
-        SSLContext mockSSLContext = mock(SSLContext.class);
-        SSLSocketFactory mockSSLSocketFactory = mock(SSLSocketFactory.class);
-        SSLSocket mockSSLSocket = mock(SSLSocket.class);
+        // Given: Verify GenericRestApiClient.setupHttpClient() works
+        Method setupMethod = GenericRestApiClient.class.getDeclaredMethod("setupHttpClient");
+        setupMethod.setAccessible(true);
+        CloseableHttpClient httpClient = (CloseableHttpClient) setupMethod.invoke(client);
         
-        String[] systemDefaultProtocols = {"TLSv1.3", "TLSv1.2"};
+        assertNotNull(httpClient, "HTTP client should be created by GenericRestApiClient");
         
-        when(mockSSLContext.getSocketFactory()).thenReturn(mockSSLSocketFactory);
-        when(mockSSLSocketFactory.createSocket()).thenReturn(mockSSLSocket);
-        when(mockSSLSocket.getEnabledProtocols()).thenReturn(systemDefaultProtocols);
+        // When: Test the same configuration pattern (null protocols) that GenericRestApiClient uses
+        SSLContext sslContext = SSLContexts.custom()
+                .loadTrustMaterial((chain, authType) -> true)
+                .build();
         
-        // When: Create SSLConnectionSocketFactory with null protocols (as GenericRestApiClient does)
-        SSLConnectionSocketFactory factory = new SSLConnectionSocketFactory(
-                mockSSLContext,
-                null,  // protocols parameter - null delegates to system defaults
-                null,  // cipher suites
-                null   // hostname verifier
-        );
+        SSLConnectionSocketFactory factory = createTestFactory(sslContext);
         
-        assertNotNull(factory, "SSLConnectionSocketFactory should be created");
+        SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket();
         
-        String[] protocols = mockSSLSocket.getEnabledProtocols();
+        String[] protocols = socket.getEnabledProtocols();
         
         LOGGER.info("System default protocols: {}", Arrays.toString(protocols));
         
         // Then: Only modern TLS versions should be enabled
         assertNotNull(protocols);
-        assertEquals(2, protocols.length, "Should have exactly 2 protocols enabled");
-        assertTrue(Arrays.asList(protocols).contains("TLSv1.3"),
-                "TLS 1.3 should be enabled by default");
-        assertTrue(Arrays.asList(protocols).contains("TLSv1.2"),
-                "TLS 1.2 should be enabled by default");
-        assertFalse(Arrays.asList(protocols).contains("TLSv1.1"),
-                "TLS 1.1 should not be enabled by default");
-        assertFalse(Arrays.asList(protocols).contains("TLSv1"),
-                "TLS 1.0 should not be enabled by default");
+        assertTrue(protocols.length >= 1, "Should have at least 1 protocol enabled");
+        
+        List<String> protocolList = Arrays.asList(protocols);
+        assertTrue(protocolList.contains("TLSv1.3") || protocolList.contains("TLSv1.2"),
+                "Modern TLS (1.3 or 1.2) should be enabled by system defaults");
+        assertFalse(protocolList.contains("TLSv1.1"),
+                "TLS 1.1 should not be enabled by system defaults");
+        assertFalse(protocolList.contains("TLSv1"),
+                "TLS 1.0 should not be enabled by system defaults");
+        
+        socket.close();
+        httpClient.close();
     }
 
     @Test
-    @DisplayName("Should verify GenericRestApiClient creates SSLConnectionSocketFactory with null protocols")
-    void shouldVerifyClientCreatesFactoryWithNullProtocols() throws Exception {
-        LOGGER.info("=== Verifying GenericRestApiClient TLS Configuration ===");
+    @DisplayName("Should verify client's configuration pattern creates proper TLS configuration")
+    void shouldVerifyClientSetupHttpClientTLSConfiguration() throws Exception {
+        LOGGER.info("=== Verifying Client Configuration Pattern TLS Settings ===");
         
-        // Given: Mock SSL components with system defaults
-        SSLContext mockSSLContext = mock(SSLContext.class);
-        SSLSocketFactory mockSSLSocketFactory = mock(SSLSocketFactory.class);
-        SSLSocket mockSSLSocket = mock(SSLSocket.class);
+        // Given: Verify GenericRestApiClient.setupHttpClient() works
+        Method setupMethod = GenericRestApiClient.class.getDeclaredMethod("setupHttpClient");
+        setupMethod.setAccessible(true);
+        CloseableHttpClient httpClient = (CloseableHttpClient) setupMethod.invoke(client);
         
-        String[] systemDefaults = {"TLSv1.3", "TLSv1.2"};
+        assertNotNull(httpClient, "HTTP client should be created by GenericRestApiClient");
         
-        when(mockSSLContext.getSocketFactory()).thenReturn(mockSSLSocketFactory);
-        when(mockSSLSocketFactory.createSocket()).thenReturn(mockSSLSocket);
-        when(mockSSLSocket.getEnabledProtocols()).thenReturn(systemDefaults);
+        // When: Test the same configuration pattern (null protocols) that GenericRestApiClient uses
+        SSLContext sslContext = SSLContexts.custom()
+                .loadTrustMaterial((chain, authType) -> true)
+                .build();
         
-        // When: Create factory as GenericRestApiClient does
-        SSLConnectionSocketFactory factory = new SSLConnectionSocketFactory(
-                mockSSLContext,
-                null,  // This is the critical parameter - null means use system defaults
-                null,
-                null
-        );
+        SSLConnectionSocketFactory factory = createTestFactory(sslContext);
         
-        assertNotNull(factory, "SSLConnectionSocketFactory should be created");
+        SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket();
         
-        // Then: Verify system defaults are used
-        String[] protocols = mockSSLSocket.getEnabledProtocols();
+        String[] protocols = socket.getEnabledProtocols();
+        
         assertNotNull(protocols);
         assertTrue(protocols.length >= 1, "Should have at least one protocol enabled");
         
@@ -311,81 +306,94 @@ class GenericRestApiClientTLSTest {
         for (String protocol : protocols) {
             assertFalse(protocol.equals("TLSv1.1") || protocol.equals("TLSv1") ||
                        protocol.equals("SSLv3") || protocol.equals("SSLv2"),
-                    "Legacy protocol " + protocol + " should not be enabled");
+                    "Legacy protocol " + protocol + " should not be enabled by system defaults");
         }
         
-        LOGGER.info("Verified: GenericRestApiClient correctly delegates to system TLS defaults");
+        LOGGER.info("Verified: null protocols parameter correctly delegates to secure system TLS defaults");
         LOGGER.info("Enabled protocols: {}", Arrays.toString(protocols));
+        
+        socket.close();
+        httpClient.close();
     }
 
     @Test
-    @DisplayName("Should verify TLS 1.3 is preferred over TLS 1.2 when both are available")
-    void shouldPreferTLS13OverTLS12() throws Exception {
-        LOGGER.info("=== Testing TLS Version Preference ===");
+    @DisplayName("Should verify TLS 1.3 is preferred by system defaults when available")
+    void shouldPreferTLS13OverTLS12InClient() throws Exception {
+        LOGGER.info("=== Testing TLS Version Preference in System Defaults ===");
         
-        // Given: Mock SSL components with both TLS 1.3 and 1.2
-        SSLContext mockSSLContext = mock(SSLContext.class);
-        SSLSocketFactory mockSSLSocketFactory = mock(SSLSocketFactory.class);
-        SSLSocket mockSSLSocket = mock(SSLSocket.class);
+        // Given: Verify GenericRestApiClient.setupHttpClient() works
+        Method setupMethod = GenericRestApiClient.class.getDeclaredMethod("setupHttpClient");
+        setupMethod.setAccessible(true);
+        CloseableHttpClient httpClient = (CloseableHttpClient) setupMethod.invoke(client);
         
-        String[] supportedProtocols = {"TLSv1.3", "TLSv1.2"};
-        String[] enabledProtocols = {"TLSv1.3", "TLSv1.2"};
+        assertNotNull(httpClient, "HTTP client should be created by GenericRestApiClient");
         
-        when(mockSSLContext.getSocketFactory()).thenReturn(mockSSLSocketFactory);
-        when(mockSSLSocketFactory.createSocket()).thenReturn(mockSSLSocket);
-        when(mockSSLSocket.getSupportedProtocols()).thenReturn(supportedProtocols);
-        when(mockSSLSocket.getEnabledProtocols()).thenReturn(enabledProtocols);
+        // When: Test the same configuration pattern (null protocols) that GenericRestApiClient uses
+        SSLContext sslContext = SSLContexts.custom()
+                .loadTrustMaterial((chain, authType) -> true)
+                .build();
         
-        // When: Create factory
-        SSLConnectionSocketFactory factory = new SSLConnectionSocketFactory(
-                mockSSLContext, null, null, null);
+        SSLConnectionSocketFactory factory = createTestFactory(sslContext);
         
-        assertNotNull(factory, "SSLConnectionSocketFactory should be created");
+        SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket();
         
-        String[] protocols = mockSSLSocket.getEnabledProtocols();
+        String[] protocols = socket.getEnabledProtocols();
         
-        // Then: Both should be enabled, with TLS 1.3 listed first (preferred)
+        // Then: Verify protocol preference
         assertNotNull(protocols);
-        assertTrue(protocols.length >= 2, "Should have at least 2 protocols");
-        assertEquals("TLSv1.3", protocols[0], "TLS 1.3 should be first (preferred)");
-        assertEquals("TLSv1.2", protocols[1], "TLS 1.2 should be second");
+        assertTrue(protocols.length >= 1, "Should have at least 1 protocol");
         
-        LOGGER.info("Protocol preference verified: {}", Arrays.toString(protocols));
+        List<String> protocolList = Arrays.asList(protocols);
+        if (protocolList.contains("TLSv1.3")) {
+            assertEquals("TLSv1.3", protocols[0], "TLS 1.3 should be first (preferred) when available");
+            LOGGER.info("Protocol preference verified: TLS 1.3 is preferred by system defaults");
+        } else {
+            assertTrue(protocolList.contains("TLSv1.2"), "TLS 1.2 should be available");
+            LOGGER.info("Protocol preference verified: TLS 1.2 is available in system defaults");
+        }
+        
+        LOGGER.info("Enabled protocols: {}", Arrays.toString(protocols));
+        
+        socket.close();
+        httpClient.close();
     }
 
     @Test
-    @DisplayName("Should not include SSLv3 or SSLv2 in supported protocols")
-    void shouldNotSupportLegacySSLVersions() throws Exception {
-        LOGGER.info("=== Testing Legacy SSL Version Exclusion ===");
+    @DisplayName("Should not include SSLv3 or SSLv2 in system defaults")
+    void shouldNotSupportLegacySSLVersionsInClient() throws Exception {
+        LOGGER.info("=== Testing Legacy SSL Version Exclusion in System Defaults ===");
         
-        // Given: Mock SSL components with system protocols (no legacy SSL)
-        SSLContext mockSSLContext = mock(SSLContext.class);
-        SSLSocketFactory mockSSLSocketFactory = mock(SSLSocketFactory.class);
-        SSLSocket mockSSLSocket = mock(SSLSocket.class);
+        // Given: Verify GenericRestApiClient.setupHttpClient() works
+        Method setupMethod = GenericRestApiClient.class.getDeclaredMethod("setupHttpClient");
+        setupMethod.setAccessible(true);
+        CloseableHttpClient httpClient = (CloseableHttpClient) setupMethod.invoke(client);
         
-        String[] systemProtocols = {"TLSv1.3", "TLSv1.2"};
+        assertNotNull(httpClient, "HTTP client should be created by GenericRestApiClient");
         
-        when(mockSSLContext.getSocketFactory()).thenReturn(mockSSLSocketFactory);
-        when(mockSSLSocketFactory.createSocket()).thenReturn(mockSSLSocket);
-        when(mockSSLSocket.getEnabledProtocols()).thenReturn(systemProtocols);
+        // When: Test the same configuration pattern (null protocols) that GenericRestApiClient uses
+        SSLContext sslContext = SSLContexts.custom()
+                .loadTrustMaterial((chain, authType) -> true)
+                .build();
         
-        // When: Create factory
-        SSLConnectionSocketFactory factory = new SSLConnectionSocketFactory(
-                mockSSLContext, null, null, null);
+        SSLConnectionSocketFactory factory = createTestFactory(sslContext);
         
-        assertNotNull(factory, "SSLConnectionSocketFactory should be created");
+        SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket();
         
-        String[] protocols = mockSSLSocket.getEnabledProtocols();
+        String[] protocols = socket.getEnabledProtocols();
         
         // Then: SSLv3 and SSLv2 should not be present
         assertNotNull(protocols);
-        assertFalse(Arrays.asList(protocols).contains("SSLv3"),
-                "SSLv3 should never be enabled");
-        assertFalse(Arrays.asList(protocols).contains("SSLv2"),
-                "SSLv2 should never be enabled");
+        List<String> protocolList = Arrays.asList(protocols);
+        assertFalse(protocolList.contains("SSLv3"),
+                "SSLv3 should never be enabled by system defaults");
+        assertFalse(protocolList.contains("SSLv2"),
+                "SSLv2 should never be enabled by system defaults");
         
-        LOGGER.info("Verified: No legacy SSL versions enabled");
+        LOGGER.info("Verified: No legacy SSL versions enabled in system defaults");
         LOGGER.info("Enabled protocols: {}", Arrays.toString(protocols));
+        
+        socket.close();
+        httpClient.close();
     }
 
     @Test

--- a/src/test/java/com/autotune/utils/GenericRestApiClientTLSTest.java
+++ b/src/test/java/com/autotune/utils/GenericRestApiClientTLSTest.java
@@ -417,9 +417,9 @@ class GenericRestApiClientTLSTest {
         // Then: SSLv3 and SSLv2 should not be present
         assertNotNull(protocols);
         List<String> protocolList = Arrays.asList(protocols);
-        assertFalse(protocolList.contains("SSLv3"),
+        assertFalse(protocolList.contains(SSL_V3),
                 "SSLv3 should never be enabled by system defaults");
-        assertFalse(protocolList.contains("SSLv2"),
+        assertFalse(protocolList.contains(SSL_V2),
                 "SSLv2 should never be enabled by system defaults");
         
         LOGGER.info("Verified: No legacy SSL versions enabled in system defaults");

--- a/src/test/java/com/autotune/utils/GenericRestApiClientTLSTest.java
+++ b/src/test/java/com/autotune/utils/GenericRestApiClientTLSTest.java
@@ -16,6 +16,7 @@
 package com.autotune.utils;
 
 import org.apache.http.ssl.SSLContexts;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -77,9 +78,14 @@ class GenericRestApiClientTLSTest {
      * @throws Exception if SSLContext creation fails
      */
     private SSLContext createTrustAllSSLContext() throws Exception {
-        return SSLContexts.custom()
-                .loadTrustMaterial((chain, authType) -> true)
-                .build();
+        try {
+            return SSLContexts.custom()
+                    .loadTrustMaterial((chain, authType) -> true)
+                    .build();
+        } catch (Exception e) {
+            LOGGER.error("Failed to create SSLContext: {}", e.getMessage(), e);
+            throw e;
+        }
     }
 
     /**
@@ -90,7 +96,12 @@ class GenericRestApiClientTLSTest {
      * @throws Exception if socket creation fails
      */
     private SSLSocket createSocketWithSystemDefaults(SSLContext sslContext) throws Exception {
-        return (SSLSocket) sslContext.getSocketFactory().createSocket();
+        try {
+            return (SSLSocket) sslContext.getSocketFactory().createSocket();
+        } catch (Exception e) {
+            LOGGER.error("Failed to create socket with system defaults: {}", e.getMessage(), e);
+            throw e;
+        }
     }
 
     /**
@@ -102,10 +113,15 @@ class GenericRestApiClientTLSTest {
      * @throws Exception if socket creation fails
      */
     private String[] getSupportedProtocols(SSLContext sslContext) throws Exception {
-        SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket();
-        String[] supported = socket.getSupportedProtocols();
-        socket.close();
-        return supported;
+        try {
+            SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket();
+            String[] supported = socket.getSupportedProtocols();
+            socket.close();
+            return supported;
+        } catch (Exception e) {
+            LOGGER.error("Failed to get supported protocols: {}", e.getMessage(), e);
+            throw e;
+        }
     }
 
     /**
@@ -117,9 +133,14 @@ class GenericRestApiClientTLSTest {
      * @throws Exception if socket creation fails
      */
     private SSLSocket createSocketWithProtocol(SSLContext sslContext, String protocol) throws Exception {
-        SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket();
-        socket.setEnabledProtocols(new String[]{protocol});
-        return socket;
+        try {
+            SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket();
+            socket.setEnabledProtocols(new String[]{protocol});
+            return socket;
+        } catch (Exception e) {
+            LOGGER.error("Failed to create socket with protocol {}: {}", protocol, e.getMessage(), e);
+            throw e;
+        }
     }
 
     /**
@@ -149,58 +170,54 @@ class GenericRestApiClientTLSTest {
      * @throws Exception if socket creation or validation fails
      */
     private void testLegacyTLSRejection(String protocol, String protocolDisplayName) throws Exception {
-        LOGGER.info("=== Testing {} Handshake Rejection with SSLHandshakeException ===", protocolDisplayName);
+        LOGGER.info("Testing {} handshake rejection", protocolDisplayName);
         
-        // Given: Create server and client contexts
-        SSLContext serverContext = createTrustAllSSLContext();
-        SSLContext clientContext = createTrustAllSSLContext();
-        
-        // Get supported protocols to check if the protocol is available in this JDK
-        String[] supportedProtocols = getSupportedProtocols(serverContext);
-        List<String> supportedList = Arrays.asList(supportedProtocols);
-        
-        LOGGER.info("JDK supported protocols: {}", Arrays.toString(supportedProtocols));
-        
-        // Only run this test if the protocol is supported by the JDK
-        if (!supportedList.contains(protocol)) {
-            LOGGER.info("{} not supported by JDK - skipping test as it's already disabled at JDK level",
-                    protocolDisplayName);
-            return;
+        try {
+            // Given: Create server and client contexts
+            SSLContext serverContext = createTrustAllSSLContext();
+            SSLContext clientContext = createTrustAllSSLContext();
+            
+            // Get supported protocols to check if the protocol is available in this JDK
+            String[] supportedProtocols = getSupportedProtocols(serverContext);
+            List<String> supportedList = Arrays.asList(supportedProtocols);
+            
+            // Only run this test if the protocol is supported by the JDK
+            Assumptions.assumeTrue(supportedList.contains(protocol),
+                    String.format("%s not supported by JDK - skipping test as it's already disabled at JDK level",
+                            protocolDisplayName));
+            
+            // Server socket with system defaults (modern TLS only)
+            SSLSocket serverSocket = createSocketWithSystemDefaults(serverContext);
+            String[] serverProtocols = serverSocket.getEnabledProtocols();
+            
+            // Client socket configured to only use the legacy protocol
+            SSLSocket clientSocket = createSocketWithProtocol(clientContext, protocol);
+            String[] clientProtocols = clientSocket.getEnabledProtocols();
+            
+            // Then: Verify handshake would fail due to protocol mismatch
+            List<String> serverList = Arrays.asList(serverProtocols);
+            
+            // Assert that the legacy protocol is not in server's enabled protocols
+            assertFalse(serverList.contains(protocol),
+                    protocolDisplayName + " should not be in system defaults - handshake will fail with SSLHandshakeException");
+            
+            // Assert that client only has the legacy protocol
+            assertEquals(1, clientProtocols.length, "Client should have exactly one protocol");
+            assertEquals(protocol, clientProtocols[0], "Client should only support " + protocolDisplayName);
+            
+            // Verify no common protocol exists between client and server
+            assertFalse(hasCommonProtocol(clientProtocols, serverProtocols),
+                    "No common TLS protocol between client (" + protocolDisplayName + ") and server (system defaults) - " +
+                     "handshake would fail with SSLHandshakeException: 'No appropriate protocol'");
+            
+            LOGGER.info("Verified: {} handshake would fail - no common protocol", protocolDisplayName);
+            
+            clientSocket.close();
+            serverSocket.close();
+        } catch (Exception e) {
+            LOGGER.error("Test failed for {} rejection: {}", protocolDisplayName, e.getMessage(), e);
+            throw e;
         }
-        
-        // Server socket with system defaults (modern TLS only)
-        SSLSocket serverSocket = createSocketWithSystemDefaults(serverContext);
-        String[] serverProtocols = serverSocket.getEnabledProtocols();
-        
-        // Client socket configured to only use the legacy protocol
-        SSLSocket clientSocket = createSocketWithProtocol(clientContext, protocol);
-        String[] clientProtocols = clientSocket.getEnabledProtocols();
-        
-        LOGGER.info("Server (system defaults) protocols: {}", Arrays.toString(serverProtocols));
-        LOGGER.info("Client ({} only) protocols: {}", protocolDisplayName, Arrays.toString(clientProtocols));
-        
-        // Then: Verify handshake would fail due to protocol mismatch
-        List<String> serverList = Arrays.asList(serverProtocols);
-        
-        // Assert that the legacy protocol is not in server's enabled protocols
-        assertFalse(serverList.contains(protocol),
-                protocolDisplayName + " should not be in system defaults - handshake will fail with SSLHandshakeException");
-        
-        // Assert that client only has the legacy protocol
-        assertEquals(1, clientProtocols.length, "Client should have exactly one protocol");
-        assertEquals(protocol, clientProtocols[0], "Client should only support " + protocolDisplayName);
-        
-        // Verify no common protocol exists between client and server
-        assertFalse(hasCommonProtocol(clientProtocols, serverProtocols),
-                "No common TLS protocol between client (" + protocolDisplayName + ") and server (system defaults) - " +
-                "handshake would fail with SSLHandshakeException: 'No appropriate protocol'");
-        
-        LOGGER.info("Verified: {} handshake would fail with SSLHandshakeException", protocolDisplayName);
-        LOGGER.info("Reason: No common protocol between client and server");
-        LOGGER.info("Expected exception message: 'No appropriate protocol' or 'protocol version'");
-        
-        clientSocket.close();
-        serverSocket.close();
     }
 
     @Test
@@ -224,46 +241,50 @@ class GenericRestApiClientTLSTest {
      * @throws Exception if socket creation or validation fails
      */
     private void verifyModernTLSAcceptance(String requiredProtocol, String protocolDisplayName) throws Exception {
-        LOGGER.info("=== Testing {} Acceptance via System Default Configuration ===", protocolDisplayName);
+        LOGGER.info("Testing {} acceptance via system defaults", protocolDisplayName);
         
-        // When: Test the same configuration pattern (null protocols) that GenericRestApiClient uses
-        SSLContext sslContext = createTrustAllSSLContext();
-        SSLSocket socket = createSocketWithSystemDefaults(sslContext);
-        
-        // Then: Verify system defaults provide secure TLS configuration
-        String[] enabledProtocols = socket.getEnabledProtocols();
-        String[] supportedProtocols = socket.getSupportedProtocols();
-        
-        LOGGER.info("System defaults with null protocols - Enabled: {}", Arrays.toString(enabledProtocols));
-        LOGGER.info("JDK supported protocols: {}", Arrays.toString(supportedProtocols));
-        
-        assertNotNull(enabledProtocols);
-        assertTrue(enabledProtocols.length >= 1, "Should have at least one protocol enabled");
-        
-        List<String> enabledList = Arrays.asList(enabledProtocols);
-        List<String> supportedList = Arrays.asList(supportedProtocols);
-        
-        // Verify the required modern TLS protocol is enabled
-        if (requiredProtocol.equals(TLS_1_3)) {
-            // For TLS 1.3, accept either 1.3 or 1.2 as modern TLS
-            assertTrue(enabledList.contains(TLS_1_3) || enabledList.contains(TLS_1_2),
-                    "Modern TLS (1.3 or 1.2) should be enabled by system defaults");
-        } else {
-            assertTrue(enabledList.contains(requiredProtocol),
-                    protocolDisplayName + " should be enabled by system defaults");
+        try {
+            // When: Test the same configuration pattern (null protocols) that GenericRestApiClient uses
+            SSLContext sslContext = createTrustAllSSLContext();
+            SSLSocket socket = createSocketWithSystemDefaults(sslContext);
+            
+            // Then: Verify system defaults provide secure TLS configuration
+            String[] enabledProtocols = socket.getEnabledProtocols();
+            String[] supportedProtocols = socket.getSupportedProtocols();
+            
+            assertNotNull(enabledProtocols);
+            assertTrue(enabledProtocols.length >= 1, "Should have at least one protocol enabled");
+            
+            List<String> enabledList = Arrays.asList(enabledProtocols);
+            List<String> supportedList = Arrays.asList(supportedProtocols);
+            
+            // Verify the required modern TLS protocol is enabled
+            if (requiredProtocol.equals(TLS_1_3)) {
+                // For TLS 1.3, accept either 1.3 or 1.2 as modern TLS
+                assertTrue(enabledList.contains(TLS_1_3) || enabledList.contains(TLS_1_2),
+                        "Modern TLS (1.3 or 1.2) should be enabled by system defaults");
+            } else {
+                assertTrue(enabledList.contains(requiredProtocol),
+                        protocolDisplayName + " should be enabled by system defaults");
+            }
+            
+            // Only assert legacy protocol exclusion if the JDK supports them
+            if (supportedList.contains(TLS_1_1)) {
+                assertFalse(enabledList.contains(TLS_1_1),
+                        "TLS 1.1 should not be enabled by system defaults");
+            }
+            if (supportedList.contains(TLS_1_0)) {
+                assertFalse(enabledList.contains(TLS_1_0),
+                        "TLS 1.0 should not be enabled by system defaults");
+            }
+            
+            LOGGER.info("Verified: {} enabled by system defaults", protocolDisplayName);
+            
+            socket.close();
+        } catch (Exception e) {
+            LOGGER.error("Test failed for {} acceptance: {}", protocolDisplayName, e.getMessage(), e);
+            throw e;
         }
-        
-        // Only assert legacy protocol exclusion if the JDK supports them
-        if (supportedList.contains(TLS_1_1)) {
-            assertFalse(enabledList.contains(TLS_1_1),
-                    "TLS 1.1 should not be enabled by system defaults");
-        }
-        if (supportedList.contains(TLS_1_0)) {
-            assertFalse(enabledList.contains(TLS_1_0),
-                    "TLS 1.0 should not be enabled by system defaults");
-        }
-        
-        socket.close();
     }
 
     @Test
@@ -281,7 +302,7 @@ class GenericRestApiClientTLSTest {
     @Test
     @DisplayName("Should reject TLS 1.1 through system defaults and verify handshake failure")
     void shouldRejectTLS11ThroughSystemDefaults() throws Exception {
-        LOGGER.info("=== Testing TLS 1.1 Rejection via System Defaults with Handshake Validation ===");
+        LOGGER.info("Testing TLS 1.1 rejection via system defaults");
         
         // When: Test the same configuration pattern (null protocols) that GenericRestApiClient uses
         SSLContext sslContext = createTrustAllSSLContext();
@@ -291,9 +312,6 @@ class GenericRestApiClientTLSTest {
         String[] enabledProtocols = systemDefaultSocket.getEnabledProtocols();
         
         String[] supportedProtocols = systemDefaultSocket.getSupportedProtocols();
-        
-        LOGGER.info("System defaults - Enabled protocols: {}", Arrays.toString(enabledProtocols));
-        LOGGER.info("JDK supported protocols: {}", Arrays.toString(supportedProtocols));
         
         // Then: Verify basic non-emptiness
         assertNotNull(enabledProtocols);
@@ -303,13 +321,13 @@ class GenericRestApiClientTLSTest {
         List<String> supportedList = Arrays.asList(supportedProtocols);
         
         // Only assert TLS 1.1 exclusion if the JDK supports it
-        if (supportedList.contains("TLSv1.1")) {
-            assertFalse(enabledList.contains("TLSv1.1"),
+        if (supportedList.contains(TLS_1_1)) {
+            assertFalse(enabledList.contains(TLS_1_1),
                     "TLS 1.1 should not be enabled by system defaults");
             
             // Additionally: Simulate handshake scenario to verify rejection behavior
             // Create a client socket that only supports TLS 1.1
-            SSLSocket tls11ClientSocket = createSocketWithProtocol(sslContext, "TLSv1.1");
+            SSLSocket tls11ClientSocket = createSocketWithProtocol(sslContext, TLS_1_1);
             String[] clientProtocols = tls11ClientSocket.getEnabledProtocols();
             
             // Verify no protocol overlap exists (handshake would fail)
@@ -317,12 +335,11 @@ class GenericRestApiClientTLSTest {
                     "No common protocol between TLS 1.1 client and system defaults - " +
                     "handshake would fail with SSLHandshakeException");
             
-            LOGGER.info("Security validation: Legacy TLS 1.1 protocol properly blocked by system defaults");
-            LOGGER.info("Handshake validation: TLS 1.1 client would receive SSLHandshakeException");
+            LOGGER.info("Verified: TLS 1.1 properly blocked by system defaults");
             
             tls11ClientSocket.close();
         } else {
-            LOGGER.info("TLS 1.1 not supported by JDK - already disabled at JDK level");
+            LOGGER.info("TLS 1.1 not supported by JDK - already disabled");
         }
         systemDefaultSocket.close();
     }
@@ -330,7 +347,7 @@ class GenericRestApiClientTLSTest {
     @Test
     @DisplayName("Should reject TLS 1.0 through system defaults and verify handshake failure")
     void shouldRejectTLS10ThroughSystemDefaults() throws Exception {
-        LOGGER.info("=== Testing TLS 1.0 Rejection via System Defaults with Handshake Validation ===");
+        LOGGER.info("Testing TLS 1.0 rejection via system defaults");
         
         // When: Test the same configuration pattern (null protocols) that GenericRestApiClient uses
         SSLContext sslContext = createTrustAllSSLContext();
@@ -341,9 +358,6 @@ class GenericRestApiClientTLSTest {
         
         String[] supportedProtocols = systemDefaultSocket.getSupportedProtocols();
         
-        LOGGER.info("System defaults - Enabled protocols: {}", Arrays.toString(enabledProtocols));
-        LOGGER.info("JDK supported protocols: {}", Arrays.toString(supportedProtocols));
-        
         // Then: Verify basic non-emptiness
         assertNotNull(enabledProtocols);
         assertTrue(enabledProtocols.length >= 1, "Should have at least one protocol enabled");
@@ -352,13 +366,13 @@ class GenericRestApiClientTLSTest {
         List<String> supportedList = Arrays.asList(supportedProtocols);
         
         // Only assert TLS 1.0 exclusion if the JDK supports it
-        if (supportedList.contains("TLSv1")) {
-            assertFalse(enabledList.contains("TLSv1"),
+        if (supportedList.contains(TLS_1_0)) {
+            assertFalse(enabledList.contains(TLS_1_0),
                     "TLS 1.0 should not be enabled by system defaults");
             
             // Additionally: Simulate handshake scenario to verify rejection behavior
             // Create a client socket that only supports TLS 1.0
-            SSLSocket tls10ClientSocket = createSocketWithProtocol(sslContext, "TLSv1");
+            SSLSocket tls10ClientSocket = createSocketWithProtocol(sslContext, TLS_1_0);
             String[] clientProtocols = tls10ClientSocket.getEnabledProtocols();
             
             // Verify no protocol overlap exists (handshake would fail)
@@ -366,12 +380,11 @@ class GenericRestApiClientTLSTest {
                     "No common protocol between TLS 1.0 client and system defaults - " +
                     "handshake would fail with SSLHandshakeException");
             
-            LOGGER.info("Security validation: Legacy TLS 1.0 protocol properly blocked by system defaults");
-            LOGGER.info("Handshake validation: TLS 1.0 client would receive SSLHandshakeException");
+            LOGGER.info("Verified: TLS 1.0 properly blocked by system defaults");
             
             tls10ClientSocket.close();
         } else {
-            LOGGER.info("TLS 1.0 not supported by JDK - already disabled at JDK level");
+            LOGGER.info("TLS 1.0 not supported by JDK - already disabled");
         }
         systemDefaultSocket.close();
     }
@@ -379,7 +392,7 @@ class GenericRestApiClientTLSTest {
     @Test
     @DisplayName("Should verify TLS 1.3 is preferred by system defaults when available")
     void shouldPreferTLS13OverTLS12InClient() throws Exception {
-        LOGGER.info("=== Testing TLS Version Preference in System Defaults ===");
+        LOGGER.info("Testing TLS version preference in system defaults");
         
         // When: Test the same configuration pattern (null protocols) that GenericRestApiClient uses
         SSLContext sslContext = createTrustAllSSLContext();
@@ -391,15 +404,27 @@ class GenericRestApiClientTLSTest {
         assertTrue(protocols.length >= 1, "Should have at least 1 protocol");
         
         List<String> protocolList = Arrays.asList(protocols);
-        if (protocolList.contains("TLSv1.3")) {
-            assertEquals("TLSv1.3", protocols[0], "TLS 1.3 should be first (preferred) when available");
-            LOGGER.info("Protocol preference verified: TLS 1.3 is preferred by system defaults");
-        } else {
-            assertTrue(protocolList.contains("TLSv1.2"), "TLS 1.2 should be available");
-            LOGGER.info("Protocol preference verified: TLS 1.2 is available in system defaults");
-        }
         
-        LOGGER.info("Enabled protocols: {}", Arrays.toString(protocols));
+        // Check if both TLS 1.3 and TLS 1.2 are present to verify ordering
+        boolean hasTLS13 = protocolList.contains(TLS_1_3);
+        boolean hasTLS12 = protocolList.contains(TLS_1_2);
+        
+        if (hasTLS13 && hasTLS12) {
+            // Only assert ordering if both protocols are present
+            int tls13Index = protocolList.indexOf(TLS_1_3);
+            int tls12Index = protocolList.indexOf(TLS_1_2);
+            assertTrue(tls13Index < tls12Index,
+                    "TLS 1.3 should be preferred over TLS 1.2 (appear earlier in enabled protocols list)");
+            LOGGER.info("Verified: TLS 1.3 preferred over TLS 1.2");
+        } else if (hasTLS13) {
+            // TLS 1.3 is available (preferred modern protocol)
+            assertTrue(true, "TLS 1.3 is enabled");
+            LOGGER.info("Verified: TLS 1.3 is enabled");
+        } else {
+            // At minimum, TLS 1.2 should be available
+            assertTrue(hasTLS12, "TLS 1.2 should be available");
+            LOGGER.info("Verified: TLS 1.2 is available");
+        }
         
         socket.close();
     }
@@ -407,7 +432,7 @@ class GenericRestApiClientTLSTest {
     @Test
     @DisplayName("Should not include SSLv3 or SSLv2 in system defaults")
     void shouldNotSupportLegacySSLVersionsInClient() throws Exception {
-        LOGGER.info("=== Testing Legacy SSL Version Exclusion in System Defaults ===");
+        LOGGER.info("Testing legacy SSL version exclusion");
         
         // When: Test the same configuration pattern (null protocols) that GenericRestApiClient uses
         SSLContext sslContext = createTrustAllSSLContext();
@@ -422,8 +447,7 @@ class GenericRestApiClientTLSTest {
         assertFalse(protocolList.contains(SSL_V2),
                 "SSLv2 should never be enabled by system defaults");
         
-        LOGGER.info("Verified: No legacy SSL versions enabled in system defaults");
-        LOGGER.info("Enabled protocols: {}", Arrays.toString(protocols));
+        LOGGER.info("Verified: No legacy SSL versions enabled");
         
         socket.close();
     }
@@ -431,14 +455,12 @@ class GenericRestApiClientTLSTest {
     @Test
     @DisplayName("Should verify protocol_version error occurs when legacy TLS is attempted")
     void shouldHandleProtocolVersionError() throws Exception {
-        LOGGER.info("=== Testing Protocol Version Error Handling for Legacy TLS ===");
+        LOGGER.info("Testing protocol version error handling for legacy TLS");
         
         // Given: Create SSLContext with system defaults (modern TLS only)
         SSLContext serverContext = createTrustAllSSLContext();
         SSLSocket serverSocket = createSocketWithSystemDefaults(serverContext);
         String[] serverProtocols = serverSocket.getEnabledProtocols();
-        
-        LOGGER.info("Server protocols (system defaults): {}", Arrays.toString(serverProtocols));
         
         // When: Simulate legacy TLS client attempts (TLS 1.0 and TLS 1.1)
         SSLContext clientContext = createTrustAllSSLContext();
@@ -452,8 +474,6 @@ class GenericRestApiClientTLSTest {
         // Get supported protocols to check what the JDK supports
         String[] supportedProtocols = serverSocket.getSupportedProtocols();
         List<String> supportedList = Arrays.asList(supportedProtocols);
-        
-        LOGGER.info("JDK supported protocols: {}", Arrays.toString(supportedProtocols));
         
         // Then: Verify that protocol version mismatch would occur
         List<String> serverList = Arrays.asList(serverProtocols);
@@ -469,17 +489,11 @@ class GenericRestApiClientTLSTest {
                     "TLS 1.1 not supported by server - would cause 'protocol_version' alert");
         }
         
-        // Verify the expected error message pattern
-        String expectedErrorPattern = "protocol_version";
-        LOGGER.info("Expected SSLHandshakeException message pattern: 'Received fatal alert: {}'", expectedErrorPattern);
-        LOGGER.info("This error occurs when client and server have no common TLS protocol version");
-        
         // Verify that modern TLS is supported
         assertTrue(serverList.contains(TLS_1_2) || serverList.contains(TLS_1_3),
                 "Server should support modern TLS (1.2 or 1.3)");
         
-        LOGGER.info("Verified: Legacy TLS clients would receive 'protocol_version' fatal alert");
-        LOGGER.info("This confirms GenericRestApiClient properly rejects TLS 1.0/1.1 via system defaults");
+        LOGGER.info("Verified: Legacy TLS clients would receive protocol_version error");
         
         tls10Client.close();
         tls11Client.close();

--- a/src/test/java/com/autotune/utils/GenericRestApiClientTLSTest.java
+++ b/src/test/java/com/autotune/utils/GenericRestApiClientTLSTest.java
@@ -1,0 +1,280 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.autotune.utils;
+
+import com.autotune.common.datasource.DataSourceInfo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for TLS version validation in GenericRestApiClient.
+ * 
+ * These tests verify that Kruize:
+ * - Accepts TLS 1.3 connections
+ * - Accepts TLS 1.2 connections
+ * - Rejects TLS 1.1 connections
+ * - Rejects TLS 1.0 connections
+ * 
+ * The tests use mocking to simulate SSL/TLS handshake behavior without
+ * requiring actual network connections or mock servers.
+ * 
+ * Test Principles:
+ * 1. Mock SSL socket behavior to simulate different TLS versions
+ * 2. Verify that the client delegates protocol selection to system defaults
+ * 3. Ensure legacy TLS versions (1.0, 1.1) are rejected
+ * 4. Confirm modern TLS versions (1.2, 1.3) are accepted
+ */
+class GenericRestApiClientTLSTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GenericRestApiClientTLSTest.class);
+    
+    private GenericRestApiClient client;
+    private DataSourceInfo mockDataSourceInfo;
+    private SSLContext mockSSLContext;
+    private SSLSocketFactory mockSSLSocketFactory;
+    private SSLSocket mockSSLSocket;
+
+    @BeforeEach
+    void setup() throws Exception {
+        // Create mock objects
+        mockDataSourceInfo = mock(DataSourceInfo.class);
+        mockSSLContext = mock(SSLContext.class);
+        mockSSLSocketFactory = mock(SSLSocketFactory.class);
+        mockSSLSocket = mock(SSLSocket.class);
+
+        // Setup basic mock behavior
+        when(mockSSLContext.getSocketFactory()).thenReturn(mockSSLSocketFactory);
+        when(mockSSLSocketFactory.createSocket()).thenReturn(mockSSLSocket);
+        
+        // Initialize client
+        client = new GenericRestApiClient();
+        client.setBaseURL("https://test-prometheus.example.com:9090");
+    }
+
+    @AfterEach
+    void tearDown() {
+        client = null;
+    }
+
+    @Test
+    @DisplayName("Should accept TLS 1.3 connections")
+    void shouldAcceptTLS13() {
+        LOGGER.info("=== Testing TLS 1.3 Acceptance ===");
+        
+        // Given: A mock SSL socket that supports TLS 1.3
+        String[] supportedProtocols = {"TLSv1.3", "TLSv1.2"};
+        String[] enabledProtocols = {"TLSv1.3"};
+        
+        when(mockSSLSocket.getSupportedProtocols()).thenReturn(supportedProtocols);
+        when(mockSSLSocket.getEnabledProtocols()).thenReturn(enabledProtocols);
+        
+        // When: Check the enabled protocols
+        String[] protocols = mockSSLSocket.getEnabledProtocols();
+        
+        LOGGER.info("✅ TLS 1.3 connection ACCEPTED - Enabled protocols: {}", Arrays.toString(protocols));
+        
+        // Then: TLS 1.3 should be enabled
+        assertNotNull(protocols);
+        assertTrue(Arrays.asList(protocols).contains("TLSv1.3"),
+                "TLS 1.3 should be in enabled protocols");
+        assertFalse(Arrays.asList(protocols).contains("TLSv1.1"),
+                "TLS 1.1 should not be in enabled protocols");
+        assertFalse(Arrays.asList(protocols).contains("TLSv1"),
+                "TLS 1.0 should not be in enabled protocols");
+    }
+
+    @Test
+    @DisplayName("Should accept TLS 1.2 connections")
+    void shouldAcceptTLS12() {
+        LOGGER.info("=== Testing TLS 1.2 Acceptance ===");
+        
+        // Given: A mock SSL socket that supports TLS 1.2
+        String[] supportedProtocols = {"TLSv1.3", "TLSv1.2"};
+        String[] enabledProtocols = {"TLSv1.2"};
+        
+        when(mockSSLSocket.getSupportedProtocols()).thenReturn(supportedProtocols);
+        when(mockSSLSocket.getEnabledProtocols()).thenReturn(enabledProtocols);
+        
+        // When: Check the enabled protocols
+        String[] protocols = mockSSLSocket.getEnabledProtocols();
+        
+        LOGGER.info("✅ TLS 1.2 connection ACCEPTED - Enabled protocols: {}", Arrays.toString(protocols));
+        
+        // Then: TLS 1.2 should be enabled
+        assertNotNull(protocols);
+        assertTrue(Arrays.asList(protocols).contains("TLSv1.2"),
+                "TLS 1.2 should be in enabled protocols");
+        assertFalse(Arrays.asList(protocols).contains("TLSv1.1"),
+                "TLS 1.1 should not be in enabled protocols");
+        assertFalse(Arrays.asList(protocols).contains("TLSv1"),
+                "TLS 1.0 should not be in enabled protocols");
+    }
+
+    @Test
+    @DisplayName("Should reject TLS 1.1 connections")
+    void shouldRejectTLS11() throws Exception {
+        LOGGER.info("=== Testing TLS 1.1 Rejection ===");
+        
+        // Given: A mock SSL socket that only supports TLS 1.1
+        String[] supportedProtocols = {"TLSv1.1"};
+        String[] enabledProtocols = {"TLSv1.1"};
+        
+        LOGGER.info("Attempting connection with TLS 1.1...");
+        when(mockSSLSocket.getSupportedProtocols()).thenReturn(supportedProtocols);
+        when(mockSSLSocket.getEnabledProtocols()).thenReturn(enabledProtocols);
+        
+        // Simulate handshake failure for TLS 1.1
+        doThrow(new SSLHandshakeException("Received fatal alert: protocol_version"))
+                .when(mockSSLSocket).startHandshake();
+        
+        // When/Then: Attempting handshake should throw SSLHandshakeException
+        SSLHandshakeException exception = assertThrows(
+                SSLHandshakeException.class,
+                () -> mockSSLSocket.startHandshake(),
+                "TLS 1.1 connection should be rejected with SSLHandshakeException"
+        );
+        
+        LOGGER.warn("✅ TLS 1.1 connection REJECTED as expected: {}", exception.getMessage());
+        LOGGER.info("Security validation: Legacy TLS 1.1 protocol properly blocked");
+        
+        assertTrue(exception.getMessage().contains("protocol_version"),
+                "Exception should indicate protocol version mismatch");
+    }
+
+    @Test
+    @DisplayName("Should reject TLS 1.0 connections")
+    void shouldRejectTLS10() throws Exception {
+        LOGGER.info("=== Testing TLS 1.0 Rejection ===");
+        
+        // Given: A mock SSL socket that only supports TLS 1.0
+        String[] supportedProtocols = {"TLSv1"};
+        String[] enabledProtocols = {"TLSv1"};
+        
+        LOGGER.info("Attempting connection with TLS 1.0...");
+        when(mockSSLSocket.getSupportedProtocols()).thenReturn(supportedProtocols);
+        when(mockSSLSocket.getEnabledProtocols()).thenReturn(enabledProtocols);
+        
+        // Simulate handshake failure for TLS 1.0
+        doThrow(new SSLHandshakeException("Received fatal alert: protocol_version"))
+                .when(mockSSLSocket).startHandshake();
+        
+        // When/Then: Attempting handshake should throw SSLHandshakeException
+        SSLHandshakeException exception = assertThrows(
+                SSLHandshakeException.class,
+                () -> mockSSLSocket.startHandshake(),
+                "TLS 1.0 connection should be rejected with SSLHandshakeException"
+        );
+        
+        LOGGER.warn("✅ TLS 1.0 connection REJECTED as expected: {}", exception.getMessage());
+        LOGGER.info("Security validation: Legacy TLS 1.0 protocol properly blocked");
+        
+        assertTrue(exception.getMessage().contains("protocol_version"),
+                "Exception should indicate protocol version mismatch");
+    }
+
+    @Test
+    @DisplayName("Should use system default TLS protocols when null is passed")
+    void shouldUseSystemDefaultProtocols() {
+        // Given: System default protocols (simulating JVM defaults)
+        String[] systemDefaultProtocols = {"TLSv1.3", "TLSv1.2"};
+        
+        when(mockSSLSocket.getEnabledProtocols()).thenReturn(systemDefaultProtocols);
+        
+        // When: Get the enabled protocols (simulating null parameter behavior)
+        String[] protocols = mockSSLSocket.getEnabledProtocols();
+        
+        // Then: Only modern TLS versions should be enabled
+        assertNotNull(protocols);
+        assertEquals(2, protocols.length, "Should have exactly 2 protocols enabled");
+        assertTrue(Arrays.asList(protocols).contains("TLSv1.3"),
+                "TLS 1.3 should be enabled by default");
+        assertTrue(Arrays.asList(protocols).contains("TLSv1.2"),
+                "TLS 1.2 should be enabled by default");
+        assertFalse(Arrays.asList(protocols).contains("TLSv1.1"),
+                "TLS 1.1 should not be enabled by default");
+        assertFalse(Arrays.asList(protocols).contains("TLSv1"),
+                "TLS 1.0 should not be enabled by default");
+    }
+
+    @Test
+    @DisplayName("Should verify SSLConnectionSocketFactory is created with null protocols parameter")
+    void shouldCreateSSLConnectionSocketFactoryWithNullProtocols() {
+        // GenericRestApiClient passes null for protocols parameter, delegating to system defaults
+        assertTrue(true, "This test documents the expected null parameter behavior");
+    }
+
+    @Test
+    @DisplayName("Should handle protocol_version error for legacy TLS")
+    void shouldHandleProtocolVersionError() {
+        String errorMessage = "Received fatal alert: protocol_version";
+        boolean isProtocolVersionError = errorMessage.contains("protocol_version");
+        
+        assertTrue(isProtocolVersionError,
+                "Error message should indicate protocol version mismatch");
+    }
+
+    @Test
+    @DisplayName("Should verify TLS 1.3 is preferred over TLS 1.2 when both are available")
+    void shouldPreferTLS13OverTLS12() throws Exception {
+        // Given: A socket that supports both TLS 1.3 and TLS 1.2
+        String[] supportedProtocols = {"TLSv1.3", "TLSv1.2"};
+        String[] enabledProtocols = {"TLSv1.3", "TLSv1.2"};
+        
+        when(mockSSLSocket.getSupportedProtocols()).thenReturn(supportedProtocols);
+        when(mockSSLSocket.getEnabledProtocols()).thenReturn(enabledProtocols);
+        
+        // When: Both protocols are available
+        String[] protocols = mockSSLSocket.getEnabledProtocols();
+        
+        // Then: Both should be enabled, with TLS 1.3 listed first (preferred)
+        assertNotNull(protocols);
+        assertTrue(protocols.length >= 2, "Should have at least 2 protocols");
+        assertEquals("TLSv1.3", protocols[0], "TLS 1.3 should be first (preferred)");
+        assertEquals("TLSv1.2", protocols[1], "TLS 1.2 should be second");
+    }
+
+    @Test
+    @DisplayName("Should not include SSLv3 in supported protocols")
+    void shouldNotSupportSSLv3() {
+        // Given: System default protocols
+        String[] systemProtocols = {"TLSv1.3", "TLSv1.2"};
+        
+        when(mockSSLSocket.getEnabledProtocols()).thenReturn(systemProtocols);
+        
+        // When: Check enabled protocols
+        String[] protocols = mockSSLSocket.getEnabledProtocols();
+        
+        // Then: SSLv3 should not be present
+        assertNotNull(protocols);
+        assertFalse(Arrays.asList(protocols).contains("SSLv3"),
+                "SSLv3 should never be enabled");
+        assertFalse(Arrays.asList(protocols).contains("SSLv2"),
+                "SSLv2 should never be enabled");
+    }
+}


### PR DESCRIPTION
## Description

Add unit tests `GenericRestApiClientTLSTest.java`  for TLS protocol validation in `GenericRestApiClient` to ensure secure communication standards. 

- Updates `HttpResponseWrapper` to a static inner class.

- Tests use real SSLSocket instances (not mocks) configured with system default protocols to validate that: modern TLS is enabled, legacy TLS is excluded, and handshake simulations confirm protocol mismatch scenarios. This mirrors the production code's approach of passing null for protocols to delegate to JVM system defaults.

## Test Cases:
- TLS 1.1 handshake rejection with SSLHandshakeException
- TLS 1.0 handshake rejection with SSLHandshakeException
- TLS 1.3 acceptance via client configuration
- TLS 1.2 acceptance via client configuration
- TLS 1.1 rejection through system defaults
- TLS 1.0 rejection through system defaults
- TLS 1.3 preference validation
- Legacy SSL (SSLv3/SSLv2) exclusion
- Protocol version error handling

Unit tests output: 
```
[INFO] Running com.autotune.utils.GenericRestApiClientTLSTest
2026-05-1318:12:50.835 INFO [main][GenericRestApiClientTLSTest.java(173)]-Testing TLS 1.0 handshake rejection
2026-05-1318:12:50.940 INFO [main][GenericRestApiClientTLSTest.java(213)]-Verified: TLS 1.0 handshake would fail - no common protocol
2026-05-1318:12:50.949 INFO [main][GenericRestApiClientTLSTest.java(244)]-Testing TLS 1.2 acceptance via system defaults
2026-05-1318:12:50.950 INFO [main][GenericRestApiClientTLSTest.java(281)]-Verified: TLS 1.2 enabled by system defaults
2026-05-1318:12:50.952 INFO [main][GenericRestApiClientTLSTest.java(305)]-Testing TLS 1.1 rejection via system defaults
2026-05-1318:12:50.952 INFO [main][GenericRestApiClientTLSTest.java(338)]-Verified: TLS 1.1 properly blocked by system defaults
2026-05-1318:12:50.954 INFO [main][GenericRestApiClientTLSTest.java(173)]-Testing TLS 1.1 handshake rejection
2026-05-1318:12:50.954 INFO [main][GenericRestApiClientTLSTest.java(213)]-Verified: TLS 1.1 handshake would fail - no common protocol
2026-05-1318:12:50.956 INFO [main][GenericRestApiClientTLSTest.java(435)]-Testing legacy SSL version exclusion
2026-05-1318:12:50.957 INFO [main][GenericRestApiClientTLSTest.java(450)]-Verified: No legacy SSL versions enabled
2026-05-1318:12:50.958 INFO [main][GenericRestApiClientTLSTest.java(244)]-Testing TLS 1.3 acceptance via system defaults
2026-05-1318:12:50.958 INFO [main][GenericRestApiClientTLSTest.java(281)]-Verified: TLS 1.3 enabled by system defaults
2026-05-1318:12:50.960 INFO [main][GenericRestApiClientTLSTest.java(395)]-Testing TLS version preference in system defaults
2026-05-1318:12:50.960 INFO [main][GenericRestApiClientTLSTest.java(418)]-Verified: TLS 1.3 preferred over TLS 1.2
2026-05-1318:12:50.961 INFO [main][GenericRestApiClientTLSTest.java(458)]-Testing protocol version error handling for legacy TLS
2026-05-1318:12:50.962 INFO [main][GenericRestApiClientTLSTest.java(496)]-Verified: Legacy TLS clients would receive protocol_version error
2026-05-1318:12:50.963 INFO [main][GenericRestApiClientTLSTest.java(350)]-Testing TLS 1.0 rejection via system defaults
2026-05-1318:12:50.964 INFO [main][GenericRestApiClientTLSTest.java(383)]-Verified: TLS 1.0 properly blocked by system defaults
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.490 s -- in com.autotune.utils.GenericRestApiClientTLSTest
```
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [x] New Test X
- [ ] Functional testsuite

**Test Configuration**
```
mvn test -Dtest=GenericRestApiClientTLSTest
```

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [x] Dependent changes merged
- [ ] Documentation updated
- [x] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Tests:
- Introduce GenericRestApiClientTLSTest to cover acceptance of TLS 1.2/1.3, rejection of TLS 1.0/1.1 with SSLHandshakeException, system default protocol usage, null-parameter behavior, protocol_version error handling, TLS 1.3 preference, and exclusion of SSLv2/SSLv3.

## Summary by Sourcery

Add TLS protocol validation coverage for GenericRestApiClient and adjust response wrapper accessibility to support the new tests.

New Features:
- Introduce GenericRestApiClientTLSTest to validate TLS 1.2/1.3 acceptance, TLS 1.0/1.1 rejection, and protocol preference using the client’s TLS configuration pattern.

Enhancements:
- Make HttpResponseWrapper a static inner class to allow usage without an instance of GenericRestApiClient, enabling improved testability.

Tests:
- Add unit tests ensuring GenericRestApiClient delegates to secure system default TLS protocols, excludes legacy SSL/TLS versions, and correctly identifies protocol_version errors.

## Summary by Sourcery

Add TLS protocol validation tests for GenericRestApiClient to ensure it relies on secure system default TLS settings and rejects legacy protocols.

Enhancements:
- Make HttpResponseWrapper a static inner class to allow it to be used independently of GenericRestApiClient instances and improve testability.

Tests:
- Introduce GenericRestApiClientTLSTest to validate acceptance of TLS 1.2/1.3, rejection of TLS 1.0/1.1, exclusion of legacy SSL versions, TLS 1.3 preference, and correct handling of protocol version handshake errors when using system default TLS configuration.