### PR TITLE
Bump kruize release to 0.10

### DIFF
--- a/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
@@ -92,7 +92,7 @@ spec:
               done
       containers:
         - name: kruize
-          image: quay.io/kruize/autotune_operator:0.9
+          image: quay.io/kruize/autotune_operator:0.10
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume

--- a/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
@@ -120,7 +120,7 @@ spec:
               done
       containers:
         - name: kruize
-          image: quay.io/kruize/autotune_operator:0.9
+          image: quay.io/kruize/autotune_operator:0.10
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume

--- a/manifests/crc/default-db-included-installation/aks/kruize-crc-aks.yaml
+++ b/manifests/crc/default-db-included-installation/aks/kruize-crc-aks.yaml
@@ -156,7 +156,7 @@ spec:
     spec:
       containers:
         - name: kruize
-          image: quay.io/kruize/autotune_operator:0.9
+          image: quay.io/kruize/autotune_operator:0.10
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume
@@ -221,7 +221,7 @@ spec:
         spec:
           containers:
             - name: kruizecronjob
-              image: quay.io/kruize/autotune_operator:0.9
+              image: quay.io/kruize/autotune_operator:0.10
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume
@@ -356,7 +356,7 @@ spec:
         spec:
           containers:
             - name: kruizedeletejob
-              image: quay.io/kruize/autotune_operator:0.9
+              image: quay.io/kruize/autotune_operator:0.10
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume

--- a/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
@@ -285,7 +285,7 @@ spec:
               done
       containers:
         - name: kruize
-          image: quay.io/kruize/autotune_operator:0.9
+          image: quay.io/kruize/autotune_operator:0.10
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume
@@ -358,7 +358,7 @@ spec:
         spec:
           containers:
             - name: kruizecronjob
-              image: quay.io/kruize/autotune_operator:0.9
+              image: quay.io/kruize/autotune_operator:0.10
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume
@@ -493,7 +493,7 @@ spec:
         spec:
           containers:
             - name: kruizedeletejob
-              image: quay.io/kruize/autotune_operator:0.9
+              image: quay.io/kruize/autotune_operator:0.10
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume

--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -363,7 +363,7 @@ spec:
               done
       containers:
         - name: kruize
-          image: quay.io/kruize/autotune_operator:0.9
+          image: quay.io/kruize/autotune_operator:0.10
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume
@@ -443,7 +443,7 @@ spec:
         spec:
           containers:
             - name: kruizecronjob
-              image: quay.io/kruize/autotune_operator:0.9
+              image: quay.io/kruize/autotune_operator:0.10
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume
@@ -484,7 +484,7 @@ spec:
         spec:
           containers:
             - name: kruizedeletejob
-              image: quay.io/kruize/autotune_operator:0.9
+              image: quay.io/kruize/autotune_operator:0.10
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.autotune</groupId>
     <artifactId>autotune</artifactId>
-    <version>0.9</version>
+    <version>0.10</version>
     <properties>
         <fabric8-version>7.6.0</fabric8-version>
         <org-json-version>20250107</org-json-version>


### PR DESCRIPTION
## Summary by Sourcery

Bump Kruize operator to version 0.10 across manifests and build configuration.

Build:
- Update Maven project version to 0.10 in pom.xml.

Deployment:
- Update Kubernetes/OpenShift/Minikube deployment manifests to use kruize/autotune_operator:0.10 images for main deployment and related cron/delete jobs across CRC default and BYODB installations.