### PR TITLE
Add notification when podcount is derived from other metrics

### DIFF
--- a/design/NotificationCodes.md
+++ b/design/NotificationCodes.md
@@ -74,6 +74,8 @@
 | 224002 |  ERROR   |   INVALID_AMOUNT_IN_MEMORY_SECTION    |         Specifies that there is an invalid amount in the Memory Section         |                       Invalid Amount in Memory Section                       | API USER  |
 | 224003 |  ERROR   |   FORMAT_MISSING_IN_MEMORY_SECTION    |        Specifies that the format field is missing in the Memory Section         |                  Format field is missing in Memory Section                   | API USER  |
 | 224004 |  ERROR   |   INVALID_FORMAT_IN_MEMORY_SECTION    |         Specifies that there is an invalid format in the Memory Section         |                       Invalid Format in Memory Section                       | API USER  |
+| 321001 |  NOTICE  |      POD_COUNT_DERIVED_FROM_CPU       |   Specifies that pod count is derived from CPU usage metrics (sum/avg) as actual pod count metric is not available   | Pod count is derived from CPU usage metrics (sum/avg) as actual pod count metric is not available | DATA USER |
+| 321002 |  NOTICE  |    POD_COUNT_DERIVED_FROM_MEMORY      | Specifies that pod count is derived from Memory usage metrics (sum/avg) as actual pod count metric is not available | Pod count is derived from Memory usage metrics (sum/avg) as actual pod count metric is not available | DATA USER |
 | 323001 |  NOTICE  |         CPU_RECORDS_ARE_IDLE          | Specifies that the CPU records in the observed period are less than a millicore | CPU Usage is less than a millicore, No CPU Recommendations can be generated  | DATA USER |
 | 323002 |  NOTICE  |         CPU_RECORDS_ARE_ZERO          |                   Specifies that the CPU recordings are ZERO                    |          CPU usage is zero, No CPU Recommendations can be generated          | DATA USER |
 | 323003 |  NOTICE  |       CPU_RECORDS_NOT_AVAILABLE       |               Specifies that the CPU recordings are NOT AVAILABLE               |    CPU metrics are not available, No CPU Recommendations can be generated    | DATA USER |
@@ -116,6 +118,8 @@
 | 223004              |  ERROR   |     INVALID_FORMAT_IN_CPU_SECTION     |                0                 |          1          |       1        |        0         |
 | 224003              |  ERROR   |   FORMAT_MISSING_IN_MEMORY_SECTION    |                0                 |          1          |       1        |        0         |
 | 224004              |  ERROR   |   INVALID_FORMAT_IN_MEMORY_SECTION    |                0                 |          1          |       1        |        0         |
+| 321001              |  NOTICE  |      POD_COUNT_DERIVED_FROM_CPU       |                0                 |          1          |       1        |        0         |
+| 321002              |  NOTICE  |    POD_COUNT_DERIVED_FROM_MEMORY      |                0                 |          1          |       1        |        0         |
 | 323001              |  NOTICE  |         CPU_RECORDS_ARE_IDLE          |                0                 |          0          |       1        |        0         |
 | 323002              |  NOTICE  |         CPU_RECORDS_ARE_ZERO          |                0                 |          0          |       1        |        0         |
 | 323003              |  NOTICE  |       CPU_RECORDS_NOT_AVAILABLE       |                0                 |          0          |       1        |        0         |

--- a/src/main/java/com/autotune/analyzer/recommendations/RecommendationConstants.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/RecommendationConstants.java
@@ -258,6 +258,16 @@ public class RecommendationConstants {
                 RecommendationConstants.RecommendationNotificationMsgConstant.ACCELERATOR_NOT_SUPPORTED,
                 RecommendationConstants.RecommendationNotificationTypes.NOTICE
         ),
+        NOTICE_POD_COUNT_DERIVED_FROM_CPU(
+                NotificationCodes.NOTICE_POD_COUNT_DERIVED_FROM_CPU,
+                RecommendationNotificationMsgConstant.POD_COUNT_DERIVED_FROM_CPU,
+                RecommendationNotificationTypes.NOTICE
+        ),
+        NOTICE_POD_COUNT_DERIVED_FROM_MEMORY(
+                NotificationCodes.NOTICE_POD_COUNT_DERIVED_FROM_MEMORY,
+                RecommendationNotificationMsgConstant.POD_COUNT_DERIVED_FROM_MEMORY,
+                RecommendationNotificationTypes.NOTICE
+        ),
         CRITICAL_CPU_REQUEST_NOT_SET(
                 RecommendationConstants.NotificationCodes.CRITICAL_CPU_REQUEST_NOT_SET,
                 RecommendationConstants.RecommendationNotificationMsgConstant.CPU_REQUEST_NOT_SET,
@@ -436,6 +446,9 @@ public class RecommendationConstants {
         public static final int SECTION_NOTICE_SUBSECTION_DATA_END = 329999;
         public static final int SECTION_NOTICE_SUBSECTION_DATA_SUBSYSTEM_GENERAL_START = 321000;
         public static final int SECTION_NOTICE_SUBSECTION_DATA_SUBSYSTEM_GENERAL_END = 322999;
+        // Pod count derivation notifications (321001-321002): Notifications when pod count is derived from other metrics
+        public static final int NOTICE_POD_COUNT_DERIVED_FROM_CPU = 321001;      // Pod count derived from CPU usage metrics
+        public static final int NOTICE_POD_COUNT_DERIVED_FROM_MEMORY = 321002;   // Pod count derived from Memory usage metrics
         public static final int SECTION_NOTICE_SUBSECTION_DATA_SUBSYSTEM_CPU_START = 323000;
         public static final int NOTICE_CPU_RECORDS_ARE_IDLE = 323001;
         public static final int NOTICE_CPU_RECORDS_ARE_ZERO = 323002;
@@ -715,6 +728,8 @@ public class RecommendationConstants {
         public static final String ADDING_RECOMMENDATIONS_TO_DB_FAILED = "Failed to add recommendations to the DB ";
         public static final String ACCELERATOR_RECOMMENDATIONS_AVAILABLE = "Accelerator Recommendations are available";
         public static final String ACCELERATOR_NOT_SUPPORTED = "Accelerator is not supported by kruize";
+        public static final String POD_COUNT_DERIVED_FROM_CPU = "Pod count is derived from CPU usage metrics (sum/avg) as actual pod count metric is not available";
+        public static final String POD_COUNT_DERIVED_FROM_MEMORY = "Pod count is derived from Memory usage metrics (sum/avg) as actual pod count metric is not available";
 
         private RecommendationNotificationMsgConstant() {
 

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
@@ -388,7 +388,8 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
                 metricAggregationInfoResults.setMin(Math.ceil(min));
                 metricAggregationInfoResults.setMax(Math.ceil(max));
                 LOGGER.info("Pod Count Aggregation Info calculated using cpuUsage metric : avg = {} min={}, max={}", avg, min, max);
-                notifications.add(new RecommendationNotification(RecommendationConstants.RecommendationNotification.NOTICE_POD_COUNT_DERIVED_FROM_CPU));
+                if (notifications != null)
+                    notifications.add(new RecommendationNotification(RecommendationConstants.RecommendationNotification.NOTICE_POD_COUNT_DERIVED_FROM_CPU));
                 return metricAggregationInfoResults;
             }
         }
@@ -416,7 +417,8 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
                 metricAggregationInfoResults.setMin(Math.ceil(min));
                 metricAggregationInfoResults.setMax(Math.ceil(max));
                 LOGGER.info("Pod Count Aggregation Info calculated using memoryUsage metric : avg = {} min={}, max={}", avg, min, max);
-                notifications.add(new RecommendationNotification(RecommendationConstants.RecommendationNotification.NOTICE_POD_COUNT_DERIVED_FROM_MEMORY));
+                if (notifications != null)
+                    notifications.add(new RecommendationNotification(RecommendationConstants.RecommendationNotification.NOTICE_POD_COUNT_DERIVED_FROM_MEMORY));
                 return metricAggregationInfoResults;
             }
         }

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
@@ -199,12 +199,12 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
                         RecommendationConstants.RecommendationNotification.INFO_NOT_ENOUGH_DATA);
                 mappedRecommendationForTerm.addNotification(recommendationNotification);
             } else {
+                ArrayList<RecommendationNotification> termLevelNotifications = new ArrayList<>();
                 // Determine min, max, avg pod count for a given term
-                MetricAggregationInfoResults podCountAggrInfo = getPodCountAggrInfo(filteredResultsMap);
+                MetricAggregationInfoResults podCountAggrInfo = getPodCountAggrInfo(filteredResultsMap, termLevelNotifications);
                 LOGGER.info("[{}] pod count aggr results: {}", kruizeObject.getExperimentName(), podCountAggrInfo);
                 mappedRecommendationForTerm.addMetricsInfo(KruizeConstants.JSONKeys.POD_COUNT, podCountAggrInfo);
 
-                ArrayList<RecommendationNotification> termLevelNotifications = new ArrayList<>();
                 for (RecommendationModel model : engineService.getModels()) {
                     MappedRecommendationForModel mappedRecommendationForModel = generateRecommendationBasedOnModel(model, containerData, filteredResultsMap, kruizeObject, currentConfig, termsEntry);
 
@@ -326,9 +326,10 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
      * To avoid issues with formulae, results are filtered to chose datapoints whose sum, avg is not null and avg is not 0.0.
      *
      * @param filteredResultsMap
+     * @param notifications
      * @return aggregated results like min, max, avg of pods from the results supplied.
      */
-    private static MetricAggregationInfoResults getPodCountAggrInfo(Map<Timestamp, IntervalResults> filteredResultsMap) {
+    private static MetricAggregationInfoResults getPodCountAggrInfo(Map<Timestamp, IntervalResults> filteredResultsMap, ArrayList<RecommendationNotification> notifications) {
         MetricAggregationInfoResults metricAggregationInfoResults = new MetricAggregationInfoResults();
         Double avg = 0.0, min = 0.0, max = 0.0;
         LOGGER.info("filteredResultsMap: size = {}", filteredResultsMap.size());
@@ -387,6 +388,7 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
                 metricAggregationInfoResults.setMin(Math.ceil(min));
                 metricAggregationInfoResults.setMax(Math.ceil(max));
                 LOGGER.info("Pod Count Aggregation Info calculated using cpuUsage metric : avg = {} min={}, max={}", avg, min, max);
+                notifications.add(new RecommendationNotification(RecommendationConstants.RecommendationNotification.NOTICE_POD_COUNT_DERIVED_FROM_CPU));
                 return metricAggregationInfoResults;
             }
         }
@@ -414,6 +416,7 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
                 metricAggregationInfoResults.setMin(Math.ceil(min));
                 metricAggregationInfoResults.setMax(Math.ceil(max));
                 LOGGER.info("Pod Count Aggregation Info calculated using memoryUsage metric : avg = {} min={}, max={}", avg, min, max);
+                notifications.add(new RecommendationNotification(RecommendationConstants.RecommendationNotification.NOTICE_POD_COUNT_DERIVED_FROM_MEMORY));
                 return metricAggregationInfoResults;
             }
         }

--- a/src/main/java/com/autotune/analyzer/recommendations/utils/RecommendationUtils.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/utils/RecommendationUtils.java
@@ -55,6 +55,8 @@ public class RecommendationUtils {
         Double currentValue = null;
         String format = null;
         IntervalResults intervalResults = filteredResultsMap.get(timestampToExtract);
+        boolean derivedFromCPUUsage = false;
+        boolean derivedFromMemoryUsage = false;
         if (null != intervalResults) {
             if (metricName == AnalyzerConstants.MetricName.podCount) { // replicas
                 // Determine current replicas from metric 'podCount'
@@ -74,6 +76,7 @@ public class RecommendationUtils {
                         MetricAggregationInfoResults metricAggregationInfoResults = metricResults.getAggregationInfoResult();
                         if (null != metricAggregationInfoResults && metricAggregationInfoResults.getSum() != null && metricAggregationInfoResults.getAvg() != null && metricAggregationInfoResults.getAvg() != 0.0) {
                             currentValue = metricAggregationInfoResults.getSum() / metricAggregationInfoResults.getAvg();
+                            derivedFromCPUUsage = true;
                         }
                         LOGGER.debug("current replicas from metric 'cpuUsage' is {}", currentValue);
                     }
@@ -86,6 +89,7 @@ public class RecommendationUtils {
                         MetricAggregationInfoResults metricAggregationInfoResults = metricResults.getAggregationInfoResult();
                         if (null != metricAggregationInfoResults && metricAggregationInfoResults.getSum() != null && metricAggregationInfoResults.getAvg() != null && metricAggregationInfoResults.getAvg() != 0.0) {
                             currentValue = metricAggregationInfoResults.getSum() / metricAggregationInfoResults.getAvg();
+                            derivedFromMemoryUsage = true;
                         }
                         LOGGER.debug("current replicas from metric 'memoryUsage' is {}", currentValue);
                     }
@@ -93,6 +97,11 @@ public class RecommendationUtils {
 
                 // if podCount is determined to be 0, return null.
                 if (currentValue != null && currentValue > 0.0) {
+                    if (derivedFromMemoryUsage)
+                        notifications.add(RecommendationConstants.RecommendationNotification.NOTICE_POD_COUNT_DERIVED_FROM_MEMORY);
+                    else if (derivedFromCPUUsage)
+                        notifications.add(RecommendationConstants.RecommendationNotification.NOTICE_POD_COUNT_DERIVED_FROM_CPU);
+
                     return new RecommendationConfigItem(Math.ceil(currentValue), format);
                 }
             } else { // limits & requests

--- a/src/test/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessorTest.java
+++ b/src/test/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessorTest.java
@@ -16,15 +16,20 @@
 
 package com.autotune.analyzer.recommendations.engine;
 
+import com.autotune.analyzer.recommendations.RecommendationConstants;
+import com.autotune.analyzer.recommendations.RecommendationNotification;
 import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.common.data.metrics.MetricAggregationInfoResults;
 import com.autotune.common.data.metrics.MetricResults;
 import com.autotune.common.data.result.IntervalResults;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
 import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -34,13 +39,20 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class ContainerRecommendationProcessorTest {
 
+    private ArrayList<RecommendationNotification> notifications;
+
+    @BeforeEach
+    public void setUp() {
+        notifications = new ArrayList<>();
+    }
+
     /**
      * Helper method to invoke the private static getPodCountAggrInfo method using reflection
      */
     private MetricAggregationInfoResults invokePodCountAggrInfo(Map<Timestamp, IntervalResults> filteredResultsMap) throws Exception {
-        Method method = ContainerRecommendationProcessor.class.getDeclaredMethod("getPodCountAggrInfo", Map.class);
+        Method method = ContainerRecommendationProcessor.class.getDeclaredMethod("getPodCountAggrInfo", Map.class, ArrayList.class);
         method.setAccessible(true);
-        return (MetricAggregationInfoResults) method.invoke(null, filteredResultsMap);
+        return (MetricAggregationInfoResults) method.invoke(null, filteredResultsMap, notifications);
     }
 
     /**
@@ -85,6 +97,8 @@ public class ContainerRecommendationProcessorTest {
         assertEquals(4.0, result.getAvg()); // ceil((3+4+5)/3) = ceil(4.0) = 4.0
         assertEquals(2.0, result.getMin()); // ceil(min(2,3,4)) = ceil(2.0) = 2.0
         assertEquals(6.0, result.getMax()); // ceil(max(4,5,6)) = ceil(6.0) = 6.0
+        // Verify no notification added when using actual podCount metric
+        assertEquals(0, notifications.size());
     }
 
     @Test
@@ -102,6 +116,8 @@ public class ContainerRecommendationProcessorTest {
         assertEquals(4.0, result.getAvg()); // ceil(3.5) = 4.0
         assertEquals(3.0, result.getMin()); // ceil(3.0) = 3.0
         assertEquals(4.0, result.getMax()); // ceil(4.0) = 4.0
+        // Verify no notification added when using actual podCount metric
+        assertEquals(0, notifications.size());
     }
 
     @Test
@@ -124,6 +140,12 @@ public class ContainerRecommendationProcessorTest {
         assertEquals(4.0, result.getAvg()); // ceil((3.0+4.0)/2) = ceil(3.5) = 4.0
         assertEquals(3.0, result.getMin()); // ceil(min(3.0, 4.0)) = ceil(3.0) = 3.0
         assertEquals(4.0, result.getMax()); // ceil(max(3.0, 4.0)) = ceil(4.0) = 4.0
+        // Verify notification added when podCount is derived from CPU usage
+        assertEquals(1, notifications.size());
+        assertEquals(RecommendationConstants.RecommendationNotification.NOTICE_POD_COUNT_DERIVED_FROM_CPU.getCode(),
+                     notifications.get(0).getCode());
+        assertEquals("Pod count is derived from CPU usage metrics (sum/avg) as actual pod count metric is not available",
+                     notifications.get(0).getMessage());
     }
 
     @Test
@@ -146,6 +168,12 @@ public class ContainerRecommendationProcessorTest {
         assertEquals(3.0, result.getAvg()); // ceil((2.0+4.0)/2) = ceil(3.0) = 3.0
         assertEquals(2.0, result.getMin()); // ceil(min(2.0, 4.0)) = ceil(2.0) = 2.0
         assertEquals(4.0, result.getMax()); // ceil(max(2.0, 4.0)) = ceil(4.0) = 4.0
+        // Verify notification added when podCount is derived from Memory usage
+        assertEquals(1, notifications.size());
+        assertEquals(RecommendationConstants.RecommendationNotification.NOTICE_POD_COUNT_DERIVED_FROM_MEMORY.getCode(),
+                     notifications.get(0).getCode());
+        assertEquals("Pod count is derived from Memory usage metrics (sum/avg) as actual pod count metric is not available",
+                     notifications.get(0).getMessage());
     }
 
     @Test
@@ -158,6 +186,8 @@ public class ContainerRecommendationProcessorTest {
 
         // Then
         assertNull(result);
+        // Verify no notification added when no data available
+        assertEquals(0, notifications.size());
     }
 
     @Test
@@ -174,6 +204,8 @@ public class ContainerRecommendationProcessorTest {
 
         // Then
         assertNull(result);
+        // Verify no notification added when no data available
+        assertEquals(0, notifications.size());
     }
 
     @Test
@@ -196,6 +228,8 @@ public class ContainerRecommendationProcessorTest {
 
         // Then
         assertNull(result);
+        // Verify no notification added when no valid data available
+        assertEquals(0, notifications.size());
     }
 
     @Test
@@ -220,6 +254,8 @@ public class ContainerRecommendationProcessorTest {
 
         // Then
         assertNull(result);
+        // Verify no notification added when no valid data available
+        assertEquals(0, notifications.size());
     }
 
     @Test
@@ -234,6 +270,8 @@ public class ContainerRecommendationProcessorTest {
 
         // Then
         assertNull(result);
+        // Verify no notification added when derivation fails
+        assertEquals(0, notifications.size());
     }
 
     @Test
@@ -248,6 +286,8 @@ public class ContainerRecommendationProcessorTest {
 
         // Then
         assertNull(result);
+        // Verify no notification added when derivation fails
+        assertEquals(0, notifications.size());
     }
 
     @Test
@@ -287,6 +327,8 @@ public class ContainerRecommendationProcessorTest {
         assertEquals(5.0, result.getAvg());
         assertEquals(4.0, result.getMin());
         assertEquals(6.0, result.getMax());
+        // Verify no notification added when actual podCount metric is available
+        assertEquals(0, notifications.size());
     }
 
     @Test
@@ -323,6 +365,10 @@ public class ContainerRecommendationProcessorTest {
         // Then - Should use CPU, not memory
         assertNotNull(result);
         assertEquals(4.0, result.getAvg());
+        // Verify CPU notification added (not memory) when CPU takes precedence
+        assertEquals(1, notifications.size());
+        assertEquals(RecommendationConstants.RecommendationNotification.NOTICE_POD_COUNT_DERIVED_FROM_CPU.getCode(),
+                     notifications.get(0).getCode());
     }
 
     @Test
@@ -340,6 +386,8 @@ public class ContainerRecommendationProcessorTest {
         assertEquals(4.0, result.getAvg()); // ceil(3.7) = 4.0
         assertEquals(3.0, result.getMin()); // ceil(2.3) = 3.0
         assertEquals(5.0, result.getMax()); // ceil(4.9) = 5.0
+        // Verify no notification added when using actual podCount metric
+        assertEquals(0, notifications.size());
     }
 
     @Test
@@ -361,6 +409,8 @@ public class ContainerRecommendationProcessorTest {
         assertEquals(4.0, result.getAvg()); // ceil((3.0+3.5+4.0+4.5+5.0)/5) = ceil(4.0) = 4.0
         assertEquals(3.0, result.getMin()); // ceil(min(2.5, 3.0, 3.5, 4.0, 4.5)) = ceil(2.5) = 3.0
         assertEquals(6.0, result.getMax()); // ceil(max(3.5, 4.0, 4.5, 5.0, 5.5)) = ceil(5.5) = 6.0
+        // Verify no notification added when using actual podCount metric
+        assertEquals(0, notifications.size());
     }
 
     @Test
@@ -385,6 +435,10 @@ public class ContainerRecommendationProcessorTest {
         // Then - Should only use valid data points
         assertNotNull(result);
         assertEquals(4.0, result.getAvg()); // ceil((3.0+4.0)/2) = ceil(3.5) = 4.0
+        // Verify CPU notification added when podCount is derived from CPU
+        assertEquals(1, notifications.size());
+        assertEquals(RecommendationConstants.RecommendationNotification.NOTICE_POD_COUNT_DERIVED_FROM_CPU.getCode(),
+                     notifications.get(0).getCode());
     }
 
     @Test
@@ -402,6 +456,8 @@ public class ContainerRecommendationProcessorTest {
         assertEquals(101.0, result.getAvg()); // ceil(100.5) = 101.0
         assertEquals(51.0, result.getMin()); // ceil(50.2) = 51.0
         assertEquals(151.0, result.getMax()); // ceil(150.8) = 151.0
+        // Verify no notification added when using actual podCount metric
+        assertEquals(0, notifications.size());
     }
 
     @Test
@@ -416,6 +472,8 @@ public class ContainerRecommendationProcessorTest {
 
         // Then
         assertNull(result);
+        // Verify no notification added when no relevant metrics available
+        assertEquals(0, notifications.size());
     }
 
     @Test
@@ -441,5 +499,7 @@ public class ContainerRecommendationProcessorTest {
 
         // Then - Should return null as avg is 0
         assertNull(result);
+        // Verify no notification added when derivation results in zero
+        assertEquals(0, notifications.size());
     }
 }

--- a/src/test/java/com/autotune/analyzer/recommendations/utils/RecommendationUtilsTest.java
+++ b/src/test/java/com/autotune/analyzer/recommendations/utils/RecommendationUtilsTest.java
@@ -174,7 +174,9 @@ public class RecommendationUtilsTest {
         // Then
         assertNotNull(result);
         assertEquals(3.0, result.getAmount()); // ceil(6.0/2.0) = ceil(3.0) = 3.0
-        assertTrue(notifications.isEmpty());
+        assertEquals(1, notifications.size());
+        assertEquals(RecommendationConstants.RecommendationNotification.NOTICE_POD_COUNT_DERIVED_FROM_CPU,
+                notifications.get(0), "Should have CPU derivation notification");
     }
 
     @Test
@@ -201,7 +203,9 @@ public class RecommendationUtilsTest {
         // Then
         assertNotNull(result);
         assertEquals(4.0, result.getAmount()); // ceil(2048.0/512.0) = ceil(4.0) = 4.0
-        assertTrue(notifications.isEmpty());
+        assertEquals(1, notifications.size());
+        assertEquals(RecommendationConstants.RecommendationNotification.NOTICE_POD_COUNT_DERIVED_FROM_MEMORY,
+                notifications.get(0), "Should have Memory derivation notification");
     }
 
     @Test
@@ -597,5 +601,362 @@ public class RecommendationUtilsTest {
         assertEquals(100000.0, result.getAmount());
         assertEquals("MiB", result.getFormat());
         assertTrue(notifications.isEmpty());
+    }
+
+    // ==================== Additional Notification Behavior Tests ====================
+
+    @Test
+    public void testGetCurrentValue_NotificationCodeAndMessage_CpuRequest() {
+        // Given - Empty interval results
+        IntervalResults intervalResults = new IntervalResults();
+        intervalResults.setMetricResultsMap(new HashMap<>());
+        filteredResultsMap.put(testTimestamp, intervalResults);
+
+        // When
+        RecommendationConfigItem result = RecommendationUtils.getCurrentValue(
+                AnalyzerConstants.MetricName.cpuRequest, filteredResultsMap, testTimestamp, notifications);
+
+        // Then
+        assertNull(result);
+        assertEquals(1, notifications.size());
+        RecommendationConstants.RecommendationNotification notification = notifications.get(0);
+        assertEquals(523001, notification.getCode(), "Should have correct notification code");
+        assertEquals("CPU Request Not Set", notification.getMessage(), "Should have correct message");
+        assertEquals(RecommendationConstants.RecommendationNotificationTypes.CRITICAL, notification.getType());
+    }
+
+    @Test
+    public void testGetCurrentValue_NotificationCodeAndMessage_MemoryRequest() {
+        // Given - Empty interval results
+        IntervalResults intervalResults = new IntervalResults();
+        intervalResults.setMetricResultsMap(new HashMap<>());
+        filteredResultsMap.put(testTimestamp, intervalResults);
+
+        // When
+        RecommendationConfigItem result = RecommendationUtils.getCurrentValue(
+                AnalyzerConstants.MetricName.memoryRequest, filteredResultsMap, testTimestamp, notifications);
+
+        // Then
+        assertNull(result);
+        assertEquals(1, notifications.size());
+        RecommendationConstants.RecommendationNotification notification = notifications.get(0);
+        assertEquals(524001, notification.getCode(), "Should have correct notification code");
+        assertEquals("Memory Request Not Set", notification.getMessage(), "Should have correct message");
+        assertEquals(RecommendationConstants.RecommendationNotificationTypes.CRITICAL, notification.getType());
+    }
+
+    @Test
+    public void testGetCurrentValue_NotificationCodeAndMessage_CpuLimit() {
+        // Given - Empty interval results
+        IntervalResults intervalResults = new IntervalResults();
+        intervalResults.setMetricResultsMap(new HashMap<>());
+        filteredResultsMap.put(testTimestamp, intervalResults);
+
+        // When
+        RecommendationConfigItem result = RecommendationUtils.getCurrentValue(
+                AnalyzerConstants.MetricName.cpuLimit, filteredResultsMap, testTimestamp, notifications);
+
+        // Then
+        assertNull(result);
+        assertEquals(1, notifications.size());
+        RecommendationConstants.RecommendationNotification notification = notifications.get(0);
+        assertEquals(423001, notification.getCode(), "Should have correct notification code");
+        assertEquals("CPU Limit Not Set", notification.getMessage(), "Should have correct message");
+        assertEquals(RecommendationConstants.RecommendationNotificationTypes.WARNING, notification.getType());
+    }
+
+    @Test
+    public void testGetCurrentValue_NotificationCodeAndMessage_MemoryLimit() {
+        // Given - Empty interval results
+        IntervalResults intervalResults = new IntervalResults();
+        intervalResults.setMetricResultsMap(new HashMap<>());
+        filteredResultsMap.put(testTimestamp, intervalResults);
+
+        // When
+        RecommendationConfigItem result = RecommendationUtils.getCurrentValue(
+                AnalyzerConstants.MetricName.memoryLimit, filteredResultsMap, testTimestamp, notifications);
+
+        // Then
+        assertNull(result);
+        assertEquals(1, notifications.size());
+        RecommendationConstants.RecommendationNotification notification = notifications.get(0);
+        assertEquals(524002, notification.getCode(), "Should have correct notification code");
+        assertEquals("Memory Limit Not Set", notification.getMessage(), "Should have correct message");
+        assertEquals(RecommendationConstants.RecommendationNotificationTypes.CRITICAL, notification.getType());
+    }
+
+    @Test
+    public void testGetCurrentValue_PodCountDerivedFromCpu_NotificationDetails() {
+        // Given - No podCount metric, but cpuUsage available
+        IntervalResults intervalResults = new IntervalResults();
+        HashMap<AnalyzerConstants.MetricName, MetricResults> metricResultsMap = new HashMap<>();
+        
+        MetricResults cpuMetric = new MetricResults();
+        MetricAggregationInfoResults cpuAggInfo = new MetricAggregationInfoResults();
+        cpuAggInfo.setAvg(2.0);
+        cpuAggInfo.setSum(6.0);
+        cpuMetric.setAggregationInfoResult(cpuAggInfo);
+        metricResultsMap.put(AnalyzerConstants.MetricName.cpuUsage, cpuMetric);
+        
+        intervalResults.setMetricResultsMap(metricResultsMap);
+        filteredResultsMap.put(testTimestamp, intervalResults);
+
+        // When
+        RecommendationConfigItem result = RecommendationUtils.getCurrentValue(
+                AnalyzerConstants.MetricName.podCount, filteredResultsMap, testTimestamp, notifications);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(1, notifications.size());
+        RecommendationConstants.RecommendationNotification notification = notifications.get(0);
+        assertEquals(321001, notification.getCode(), "Should have correct notification code");
+        assertEquals("Pod count is derived from CPU usage metrics (sum/avg) as actual pod count metric is not available", 
+                notification.getMessage(), "Should have correct message");
+        assertEquals(RecommendationConstants.RecommendationNotificationTypes.NOTICE, notification.getType());
+    }
+
+    @Test
+    public void testGetCurrentValue_PodCountDerivedFromMemory_NotificationDetails() {
+        // Given - No podCount or cpuUsage, but memoryUsage available
+        IntervalResults intervalResults = new IntervalResults();
+        HashMap<AnalyzerConstants.MetricName, MetricResults> metricResultsMap = new HashMap<>();
+        
+        MetricResults memMetric = new MetricResults();
+        MetricAggregationInfoResults memAggInfo = new MetricAggregationInfoResults();
+        memAggInfo.setAvg(512.0);
+        memAggInfo.setSum(2048.0);
+        memMetric.setAggregationInfoResult(memAggInfo);
+        metricResultsMap.put(AnalyzerConstants.MetricName.memoryUsage, memMetric);
+        
+        intervalResults.setMetricResultsMap(metricResultsMap);
+        filteredResultsMap.put(testTimestamp, intervalResults);
+
+        // When
+        RecommendationConfigItem result = RecommendationUtils.getCurrentValue(
+                AnalyzerConstants.MetricName.podCount, filteredResultsMap, testTimestamp, notifications);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(1, notifications.size());
+        RecommendationConstants.RecommendationNotification notification = notifications.get(0);
+        assertEquals(321002, notification.getCode(), "Should have correct notification code");
+        assertEquals("Pod count is derived from Memory usage metrics (sum/avg) as actual pod count metric is not available", 
+                notification.getMessage(), "Should have correct message");
+        assertEquals(RecommendationConstants.RecommendationNotificationTypes.NOTICE, notification.getType());
+    }
+
+    @Test
+    public void testGetCurrentValue_MultipleNotifications_Accumulation() {
+        // Given - Empty interval results
+        IntervalResults intervalResults = new IntervalResults();
+        intervalResults.setMetricResultsMap(new HashMap<>());
+        filteredResultsMap.put(testTimestamp, intervalResults);
+
+        // When - Multiple calls with same notification list
+        RecommendationUtils.getCurrentValue(
+                AnalyzerConstants.MetricName.cpuRequest, filteredResultsMap, testTimestamp, notifications);
+        RecommendationUtils.getCurrentValue(
+                AnalyzerConstants.MetricName.memoryRequest, filteredResultsMap, testTimestamp, notifications);
+        RecommendationUtils.getCurrentValue(
+                AnalyzerConstants.MetricName.cpuLimit, filteredResultsMap, testTimestamp, notifications);
+        RecommendationUtils.getCurrentValue(
+                AnalyzerConstants.MetricName.memoryLimit, filteredResultsMap, testTimestamp, notifications);
+
+        // Then
+        assertEquals(4, notifications.size(), "Should accumulate notifications from multiple calls");
+        // Verify all expected notifications are present
+        long cpuRequestCount = notifications.stream()
+                .filter(n -> n.equals(RecommendationConstants.RecommendationNotification.CRITICAL_CPU_REQUEST_NOT_SET))
+                .count();
+        long memRequestCount = notifications.stream()
+                .filter(n -> n.equals(RecommendationConstants.RecommendationNotification.CRITICAL_MEMORY_REQUEST_NOT_SET))
+                .count();
+        long cpuLimitCount = notifications.stream()
+                .filter(n -> n.equals(RecommendationConstants.RecommendationNotification.WARNING_CPU_LIMIT_NOT_SET))
+                .count();
+        long memLimitCount = notifications.stream()
+                .filter(n -> n.equals(RecommendationConstants.RecommendationNotification.CRITICAL_MEMORY_LIMIT_NOT_SET))
+                .count();
+        assertEquals(1, cpuRequestCount, "Should have CPU request notification");
+        assertEquals(1, memRequestCount, "Should have memory request notification");
+        assertEquals(1, cpuLimitCount, "Should have CPU limit notification");
+        assertEquals(1, memLimitCount, "Should have memory limit notification");
+    }
+
+    @Test
+    public void testGetCurrentValue_NoNotificationOnSuccess_AllMetrics() {
+        // Given - Complete set of metrics
+        IntervalResults intervalResults = new IntervalResults();
+        HashMap<AnalyzerConstants.MetricName, MetricResults> metricResultsMap = new HashMap<>();
+        
+        // Add CPU request
+        MetricResults cpuReqMetric = new MetricResults();
+        MetricAggregationInfoResults cpuReqAggInfo = new MetricAggregationInfoResults();
+        cpuReqAggInfo.setAvg(2.0);
+        cpuReqAggInfo.setFormat("cores");
+        cpuReqMetric.setAggregationInfoResult(cpuReqAggInfo);
+        metricResultsMap.put(AnalyzerConstants.MetricName.cpuRequest, cpuReqMetric);
+        
+        // Add memory request
+        MetricResults memReqMetric = new MetricResults();
+        MetricAggregationInfoResults memReqAggInfo = new MetricAggregationInfoResults();
+        memReqAggInfo.setAvg(4096.0);
+        memReqAggInfo.setFormat("MiB");
+        memReqMetric.setAggregationInfoResult(memReqAggInfo);
+        metricResultsMap.put(AnalyzerConstants.MetricName.memoryRequest, memReqMetric);
+        
+        // Add CPU limit
+        MetricResults cpuLimitMetric = new MetricResults();
+        MetricAggregationInfoResults cpuLimitAggInfo = new MetricAggregationInfoResults();
+        cpuLimitAggInfo.setAvg(4.0);
+        cpuLimitAggInfo.setFormat("cores");
+        cpuLimitMetric.setAggregationInfoResult(cpuLimitAggInfo);
+        metricResultsMap.put(AnalyzerConstants.MetricName.cpuLimit, cpuLimitMetric);
+        
+        // Add memory limit
+        MetricResults memLimitMetric = new MetricResults();
+        MetricAggregationInfoResults memLimitAggInfo = new MetricAggregationInfoResults();
+        memLimitAggInfo.setAvg(8192.0);
+        memLimitAggInfo.setFormat("MiB");
+        memLimitMetric.setAggregationInfoResult(memLimitAggInfo);
+        metricResultsMap.put(AnalyzerConstants.MetricName.memoryLimit, memLimitMetric);
+        
+        intervalResults.setMetricResultsMap(metricResultsMap);
+        filteredResultsMap.put(testTimestamp, intervalResults);
+
+        // When - Check all metrics
+        RecommendationUtils.getCurrentValue(
+                AnalyzerConstants.MetricName.cpuRequest, filteredResultsMap, testTimestamp, notifications);
+        RecommendationUtils.getCurrentValue(
+                AnalyzerConstants.MetricName.memoryRequest, filteredResultsMap, testTimestamp, notifications);
+        RecommendationUtils.getCurrentValue(
+                AnalyzerConstants.MetricName.cpuLimit, filteredResultsMap, testTimestamp, notifications);
+        RecommendationUtils.getCurrentValue(
+                AnalyzerConstants.MetricName.memoryLimit, filteredResultsMap, testTimestamp, notifications);
+
+        // Then
+        assertTrue(notifications.isEmpty(), "Should have no notifications when all metrics are available");
+    }
+
+    @Test
+    public void testGetCurrentValueForNamespace_NotificationCodeAndMessage_CpuRequest() {
+        // Given - Empty interval results
+        IntervalResults intervalResults = new IntervalResults();
+        intervalResults.setMetricResultsMap(new HashMap<>());
+        filteredResultsMap.put(testTimestamp, intervalResults);
+
+        // When
+        RecommendationConfigItem result = RecommendationUtils.getCurrentValueForNamespace(
+                AnalyzerConstants.MetricName.namespaceCpuRequest, filteredResultsMap, testTimestamp, notifications);
+
+        // Then
+        assertNull(result);
+        assertEquals(1, notifications.size());
+        RecommendationConstants.RecommendationNotification notification = notifications.get(0);
+        assertEquals(523001, notification.getCode(), "Should have correct notification code");
+        assertEquals("CPU Request Not Set", notification.getMessage(), "Should have correct message");
+        assertEquals(RecommendationConstants.RecommendationNotificationTypes.CRITICAL, notification.getType());
+    }
+
+    @Test
+    public void testGetCurrentValueForNamespace_NotificationCodeAndMessage_MemoryLimit() {
+        // Given - Empty interval results
+        IntervalResults intervalResults = new IntervalResults();
+        intervalResults.setMetricResultsMap(new HashMap<>());
+        filteredResultsMap.put(testTimestamp, intervalResults);
+
+        // When
+        RecommendationConfigItem result = RecommendationUtils.getCurrentValueForNamespace(
+                AnalyzerConstants.MetricName.namespaceMemoryLimit, filteredResultsMap, testTimestamp, notifications);
+
+        // Then
+        assertNull(result);
+        assertEquals(1, notifications.size());
+        RecommendationConstants.RecommendationNotification notification = notifications.get(0);
+        assertEquals(524002, notification.getCode(), "Should have correct notification code");
+        assertEquals("Memory Limit Not Set", notification.getMessage(), "Should have correct message");
+        assertEquals(RecommendationConstants.RecommendationNotificationTypes.CRITICAL, notification.getType());
+    }
+
+    @Test
+    public void testGetCurrentValue_NotificationSeverityLevels() {
+        // Given - Empty interval results
+        IntervalResults intervalResults = new IntervalResults();
+        intervalResults.setMetricResultsMap(new HashMap<>());
+        filteredResultsMap.put(testTimestamp, intervalResults);
+
+        // When - Get different types of notifications
+        ArrayList<RecommendationConstants.RecommendationNotification> cpuRequestNotifs = new ArrayList<>();
+        ArrayList<RecommendationConstants.RecommendationNotification> cpuLimitNotifs = new ArrayList<>();
+        
+        RecommendationUtils.getCurrentValue(
+                AnalyzerConstants.MetricName.cpuRequest, filteredResultsMap, testTimestamp, cpuRequestNotifs);
+        RecommendationUtils.getCurrentValue(
+                AnalyzerConstants.MetricName.cpuLimit, filteredResultsMap, testTimestamp, cpuLimitNotifs);
+
+        // Then - Verify severity levels
+        assertEquals(5, cpuRequestNotifs.get(0).getType().getSeverity(), 
+                "CPU request notification should have CRITICAL severity (5)");
+        assertEquals(4, cpuLimitNotifs.get(0).getType().getSeverity(), 
+                "CPU limit notification should have WARNING severity (4)");
+    }
+
+    @Test
+    public void testGetCurrentValue_PodCountFallback_PrefersCpuOverMemory() {
+        // Given - Both cpuUsage and memoryUsage available (no podCount)
+        IntervalResults intervalResults = new IntervalResults();
+        HashMap<AnalyzerConstants.MetricName, MetricResults> metricResultsMap = new HashMap<>();
+        
+        // Add CPU usage
+        MetricResults cpuMetric = new MetricResults();
+        MetricAggregationInfoResults cpuAggInfo = new MetricAggregationInfoResults();
+        cpuAggInfo.setAvg(2.0);
+        cpuAggInfo.setSum(8.0);
+        cpuMetric.setAggregationInfoResult(cpuAggInfo);
+        metricResultsMap.put(AnalyzerConstants.MetricName.cpuUsage, cpuMetric);
+        
+        // Add memory usage
+        MetricResults memMetric = new MetricResults();
+        MetricAggregationInfoResults memAggInfo = new MetricAggregationInfoResults();
+        memAggInfo.setAvg(512.0);
+        memAggInfo.setSum(2048.0);
+        memMetric.setAggregationInfoResult(memAggInfo);
+        metricResultsMap.put(AnalyzerConstants.MetricName.memoryUsage, memMetric);
+        
+        intervalResults.setMetricResultsMap(metricResultsMap);
+        filteredResultsMap.put(testTimestamp, intervalResults);
+
+        // When
+        RecommendationConfigItem result = RecommendationUtils.getCurrentValue(
+                AnalyzerConstants.MetricName.podCount, filteredResultsMap, testTimestamp, notifications);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(4.0, result.getAmount(), "Pod count should be calculated from CPU usage (8.0/2.0)");
+        assertEquals(1, notifications.size());
+        assertEquals(RecommendationConstants.RecommendationNotification.NOTICE_POD_COUNT_DERIVED_FROM_CPU,
+                notifications.get(0), "Should prefer CPU notification over memory");
+    }
+
+    @Test
+    public void testGetCurrentValue_NotificationTypes_AllTypes() {
+        // Verify all notification types have correct properties
+        RecommendationConstants.RecommendationNotification cpuRequestNotif = 
+                RecommendationConstants.RecommendationNotification.CRITICAL_CPU_REQUEST_NOT_SET;
+        RecommendationConstants.RecommendationNotification cpuLimitNotif = 
+                RecommendationConstants.RecommendationNotification.WARNING_CPU_LIMIT_NOT_SET;
+        RecommendationConstants.RecommendationNotification podCountCpuNotif = 
+                RecommendationConstants.RecommendationNotification.NOTICE_POD_COUNT_DERIVED_FROM_CPU;
+
+        // Verify types
+        assertEquals("critical", cpuRequestNotif.getType().getName());
+        assertEquals("warning", cpuLimitNotif.getType().getName());
+        assertEquals("notice", podCountCpuNotif.getType().getName());
+
+        // Verify severity ordering
+        assertTrue(cpuRequestNotif.getType().getSeverity() > cpuLimitNotif.getType().getSeverity(),
+                "CRITICAL should have higher severity than WARNING");
+        assertTrue(cpuLimitNotif.getType().getSeverity() > podCountCpuNotif.getType().getSeverity(),
+                "WARNING should have higher severity than NOTICE");
     }
 }


### PR DESCRIPTION
## Description

As part of feature to include current pod count / replicas in recommendation response, a notification needs to be added to indicate if the pod count / replicas is determined directly from pod metrics or derived from cpuUsage or memoryUsage using formulae (sum/avg).

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite
- [x] Local testing using kind/minikube cluster

**Test Configuration**
* Kubernetes clusters tested on: Kind

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Add notifications when pod count is derived from CPU or memory metrics instead of direct podCount metrics in recommendations.

New Features:
- Introduce new recommendation notifications indicating when pod count is derived from CPU usage metrics.
- Introduce new recommendation notifications indicating when pod count is derived from memory usage metrics.

Tests:
- Extend container recommendation processor tests to cover notification behavior for derived pod counts.
- Update recommendation utility tests to assert notifications are emitted when pod count falls back to CPU or memory metrics.