### PR TITLE
remove the target query param

### DIFF
--- a/src/main/java/com/autotune/analyzer/services/RecommendationsResource.java
+++ b/src/main/java/com/autotune/analyzer/services/RecommendationsResource.java
@@ -352,7 +352,7 @@ public class RecommendationsResource extends HttpServlet {
             }
             RecommendationEngine recommendationEngine = new RecommendationEngine(experimentName, intervalEndTimeStr, intervalStartTimeStr);
             String validationMessage;
-            if (KruizeDeploymentInfo.local) {
+            if (target.equals(LOCAL)) {
                 validationMessage = recommendationEngine.validate_local();
             } else {
                 validationMessage = recommendationEngine.validate();

--- a/src/main/java/com/autotune/analyzer/services/RecommendationsResource.java
+++ b/src/main/java/com/autotune/analyzer/services/RecommendationsResource.java
@@ -337,16 +337,8 @@ public class RecommendationsResource extends HttpServlet {
         Timer.Sample timerBRecommendationResource = Timer.start(MetricsConfig.meterRegistry());
         
         try {
-            // Get the target parameter (default to "remote" if not specified)
-            String target = request.getParameter("target");
-            
-            // Normalize target value: treat null, empty, or blank as "remote"
-            if (target == null || target.trim().isEmpty()) {
-                target = REMOTE;
-            } else {
-                target = target.trim().toLowerCase();
-            }
-            
+            // Get the target from the config
+            String target = KruizeDeploymentInfo.local ? LOCAL : REMOTE;
             LOGGER.info("RecommendationsResource POST - target: {}", target);
 
             String experimentName = request.getParameter(KruizeConstants.JSONKeys.EXPERIMENT_NAME);
@@ -360,14 +352,10 @@ public class RecommendationsResource extends HttpServlet {
             }
             RecommendationEngine recommendationEngine = new RecommendationEngine(experimentName, intervalEndTimeStr, intervalStartTimeStr);
             String validationMessage;
-            if (REMOTE.equals(target)) {
-                validationMessage = recommendationEngine.validate();
-            } else if (LOCAL.equals(target)) {
+            if (KruizeDeploymentInfo.local) {
                 validationMessage = recommendationEngine.validate_local();
             } else {
-                // Invalid target value
-                validationMessage = String.format("Invalid target cluster: '%s'. Valid values are 'remote' or 'local'.", target);
-                LOGGER.error(validationMessage);
+                validationMessage = recommendationEngine.validate();
             }
             if (validationMessage.isEmpty()) {
                 KruizeObject kruizeObject = recommendationEngine.prepareRecommendations(calCount, target, bulkJobID);


### PR DESCRIPTION
## Description

This PR contains the changes to remove the `target` query param and get the target value from the config itself to decide the flow.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Derive the recommendation target from deployment configuration instead of a request parameter and adjust validation flow accordingly.

Enhancements:
- Use deployment configuration (KruizeDeploymentInfo.local) to determine whether recommendations run against a local or remote target instead of relying on a request query parameter.
- Simplify recommendation validation logic by branching directly on deployment mode and removing handling for invalid target query values.