### PR TITLE
Update the existing structures to support accelerator array in variation and current sections

### DIFF
--- a/src/main/java/com/autotune/analyzer/adapters/MultiResourceRecommendationAdapter.java
+++ b/src/main/java/com/autotune/analyzer/adapters/MultiResourceRecommendationAdapter.java
@@ -1,0 +1,28 @@
+package com.autotune.analyzer.adapters;
+
+import com.autotune.analyzer.recommendations.AcceleratorRecommendationItem;
+import com.autotune.analyzer.recommendations.MultiResourceRecommendation;
+import com.google.gson.*;
+import java.lang.reflect.Type;
+import java.util.List;
+
+/**
+ * Serializes MultiResourceRecommendation as array (unwraps the wrapper)
+ */
+public class MultiResourceRecommendationAdapter
+        implements JsonSerializer<MultiResourceRecommendation>, JsonDeserializer<MultiResourceRecommendation> {
+
+    @Override
+    public JsonElement serialize(MultiResourceRecommendation src, Type typeOfSrc, JsonSerializationContext context) {
+        return context.serialize(src.getItems());
+    }
+
+    @Override
+    public MultiResourceRecommendation deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+            throws JsonParseException {
+        Type listType = new com.google.gson.reflect.TypeToken<List<AcceleratorRecommendationItem>>(){}.getType();
+        List<AcceleratorRecommendationItem> items = context.deserialize(json, listType);
+        return new MultiResourceRecommendation(items);
+    }
+}
+

--- a/src/main/java/com/autotune/analyzer/adapters/MultiResourceRecommendationAdapter.java
+++ b/src/main/java/com/autotune/analyzer/adapters/MultiResourceRecommendationAdapter.java
@@ -29,6 +29,11 @@ public class MultiResourceRecommendationAdapter
 
     @Override
     public JsonElement serialize(MultiResourceRecommendation src, Type typeOfSrc, JsonSerializationContext context) {
+        if (src == null
+                || src.getAcceleratorRecommendationItems() == null
+                || src.getAcceleratorRecommendationItems().isEmpty()) {
+            return JsonNull.INSTANCE;
+        }
         return context.serialize(src.getAcceleratorRecommendationItems());
     }
 

--- a/src/main/java/com/autotune/analyzer/adapters/MultiResourceRecommendationAdapter.java
+++ b/src/main/java/com/autotune/analyzer/adapters/MultiResourceRecommendationAdapter.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
 package com.autotune.analyzer.adapters;
 
 import com.autotune.analyzer.recommendations.AcceleratorRecommendationItem;

--- a/src/main/java/com/autotune/analyzer/adapters/MultiResourceRecommendationAdapter.java
+++ b/src/main/java/com/autotune/analyzer/adapters/MultiResourceRecommendationAdapter.java
@@ -55,7 +55,7 @@ public class MultiResourceRecommendationAdapter
         Type listType = new com.google.gson.reflect.TypeToken<List<AcceleratorRecommendationItem>>(){}.getType();
         List<AcceleratorRecommendationItem> items = context.deserialize(json, listType);
 
-        // Returning null and not empty list as we don't wanna show empty array in JSON at the time if serialization
+        // Returning null instead of an empty list to avoid emitting an empty array in the JSON during serialization
         if (items == null || items.isEmpty()) {
             return null;
         }

--- a/src/main/java/com/autotune/analyzer/adapters/MultiResourceRecommendationAdapter.java
+++ b/src/main/java/com/autotune/analyzer/adapters/MultiResourceRecommendationAdapter.java
@@ -29,14 +29,32 @@ public class MultiResourceRecommendationAdapter
 
     @Override
     public JsonElement serialize(MultiResourceRecommendation src, Type typeOfSrc, JsonSerializationContext context) {
-        return context.serialize(src.getItems());
+        return context.serialize(src.getAcceleratorRecommendationItems());
     }
 
     @Override
     public MultiResourceRecommendation deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
             throws JsonParseException {
+
+        // if accelerators or any multi object array field missing or null
+        if (json == null || json.isJsonNull()) {
+            return null;
+        }
+
+        if (!json.isJsonArray()) {
+            throw new JsonParseException(
+                    "Expected a JSON array for MultiResourceRecommendation but found: "
+                            + json);
+        }
+
         Type listType = new com.google.gson.reflect.TypeToken<List<AcceleratorRecommendationItem>>(){}.getType();
         List<AcceleratorRecommendationItem> items = context.deserialize(json, listType);
+
+        // Returning null and not empty list as we don't wanna show empty array in JSON at the time if serialization
+        if (items == null || items.isEmpty()) {
+            return null;
+        }
+
         return new MultiResourceRecommendation(items);
     }
 }

--- a/src/main/java/com/autotune/analyzer/recommendations/AcceleratorRecommendationItem.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/AcceleratorRecommendationItem.java
@@ -16,11 +16,11 @@
 package com.autotune.analyzer.recommendations;
 
 public class AcceleratorRecommendationItem implements ResourceRecommendation {
-    private String model;
-    private String partition;
-    private Integer count;
-    private RecommendationConfigItem compute;
-    private RecommendationConfigItem memory;
+    private final String model;
+    private final String partition;
+    private final Integer count;
+    private final RecommendationConfigItem compute;
+    private final RecommendationConfigItem memory;
 
     public AcceleratorRecommendationItem(String model, String partition, Integer count, RecommendationConfigItem compute, RecommendationConfigItem memory) {
         this.model = model;

--- a/src/main/java/com/autotune/analyzer/recommendations/AcceleratorRecommendationItem.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/AcceleratorRecommendationItem.java
@@ -1,0 +1,37 @@
+package com.autotune.analyzer.recommendations;
+
+public class AcceleratorRecommendationItem implements ResourceRecommendation {
+    private String model;
+    private String partition;
+    private Integer count;
+    private RecommendationConfigItem compute;
+    private RecommendationConfigItem memory;
+
+    public AcceleratorRecommendationItem(String model, String partition, Integer count, RecommendationConfigItem compute, RecommendationConfigItem memory) {
+        this.model = model;
+        this.partition = partition;
+        this.count = count;
+        this.compute = compute;
+        this.memory = memory;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public String getPartition() {
+        return partition;
+    }
+
+    public Integer getCount() {
+        return count;
+    }
+
+    public RecommendationConfigItem getCompute() {
+        return compute;
+    }
+
+    public RecommendationConfigItem getMemory() {
+        return memory;
+    }
+}

--- a/src/main/java/com/autotune/analyzer/recommendations/AcceleratorRecommendationItem.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/AcceleratorRecommendationItem.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
 package com.autotune.analyzer.recommendations;
 
 public class AcceleratorRecommendationItem implements ResourceRecommendation {

--- a/src/main/java/com/autotune/analyzer/recommendations/AcceleratorRecommendationItem.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/AcceleratorRecommendationItem.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package com.autotune.analyzer.recommendations;
 
+import java.util.Objects;
+
 public class AcceleratorRecommendationItem implements ResourceRecommendation {
     private final String model;
     private final String partition;
@@ -23,11 +25,11 @@ public class AcceleratorRecommendationItem implements ResourceRecommendation {
     private final RecommendationConfigItem memory;
 
     public AcceleratorRecommendationItem(String model, String partition, Integer count, RecommendationConfigItem compute, RecommendationConfigItem memory) {
-        this.model = model;
+        this.model = Objects.requireNonNull(model, "model must not be null");
         this.partition = partition;
         this.count = count;
-        this.compute = compute;
-        this.memory = memory;
+        this.compute = Objects.requireNonNull(compute, "compute must not be null");
+        this.memory = Objects.requireNonNull(memory, "memory must not be null");
     }
 
     public String getModel() {

--- a/src/main/java/com/autotune/analyzer/recommendations/AcceleratorRecommendationItem.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/AcceleratorRecommendationItem.java
@@ -18,11 +18,11 @@ package com.autotune.analyzer.recommendations;
 import java.util.Objects;
 
 public class AcceleratorRecommendationItem implements ResourceRecommendation {
-    private final String model;
-    private final String partition;
-    private final Integer count;
-    private final RecommendationConfigItem compute;
-    private final RecommendationConfigItem memory;
+    private String model;
+    private String partition;
+    private Integer count;
+    private RecommendationConfigItem compute;
+    private RecommendationConfigItem memory;
 
     public AcceleratorRecommendationItem(String model, String partition, Integer count, RecommendationConfigItem compute, RecommendationConfigItem memory) {
         this.model = Objects.requireNonNull(model, "model must not be null");

--- a/src/main/java/com/autotune/analyzer/recommendations/Config.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/Config.java
@@ -22,23 +22,23 @@ import java.util.List;
 import java.util.Map;
 
 public class Config {
-    private Map<AnalyzerConstants.RecommendationItem, ResourceRecommendation> requests;
-    private Map<AnalyzerConstants.RecommendationItem, ResourceRecommendation> limits;
+    private Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> requests;
+    private Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> limits;
     private List<RecommendationConfigEnv> env;
 
-    public Map<AnalyzerConstants.RecommendationItem, ResourceRecommendation> getRequests() {
+    public Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> getRequests() {
         return requests;
     }
 
-    public void setRequests(Map<AnalyzerConstants.RecommendationItem, ResourceRecommendation> requests) {
+    public void setRequests(Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> requests) {
         this.requests = requests;
     }
 
-    public Map<AnalyzerConstants.RecommendationItem, ResourceRecommendation> getLimits() {
+    public Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> getLimits() {
         return limits;
     }
 
-    public void setLimits(Map<AnalyzerConstants.RecommendationItem, ResourceRecommendation> limits) {
+    public void setLimits(Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> limits) {
         this.limits = limits;
     }
 

--- a/src/main/java/com/autotune/analyzer/recommendations/Config.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/Config.java
@@ -22,23 +22,23 @@ import java.util.List;
 import java.util.Map;
 
 public class Config {
-    private Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> requests;
-    private Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> limits;
+    private Map<AnalyzerConstants.RecommendationItem, ResourceRecommendation> requests;
+    private Map<AnalyzerConstants.RecommendationItem, ResourceRecommendation> limits;
     private List<RecommendationConfigEnv> env;
 
-    public Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> getRequests() {
+    public Map<AnalyzerConstants.RecommendationItem, ResourceRecommendation> getRequests() {
         return requests;
     }
 
-    public void setRequests(Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> requests) {
+    public void setRequests(Map<AnalyzerConstants.RecommendationItem, ResourceRecommendation> requests) {
         this.requests = requests;
     }
 
-    public Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> getLimits() {
+    public Map<AnalyzerConstants.RecommendationItem, ResourceRecommendation> getLimits() {
         return limits;
     }
 
-    public void setLimits(Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> limits) {
+    public void setLimits(Map<AnalyzerConstants.RecommendationItem, ResourceRecommendation> limits) {
         this.limits = limits;
     }
 

--- a/src/main/java/com/autotune/analyzer/recommendations/ExtendedConfig.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/ExtendedConfig.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.autotune.analyzer.recommendations;
+
+import com.autotune.analyzer.utils.AnalyzerConstants;
+
+import java.util.Map;
+
+public class ExtendedConfig {
+    private Map<AnalyzerConstants.RecommendationItem, ResourceRecommendation> requests;
+    private Map<AnalyzerConstants.RecommendationItem, ResourceRecommendation> limits;
+
+    public Map<AnalyzerConstants.RecommendationItem, ResourceRecommendation> getRequests() {
+        return requests;
+    }
+
+    public void setRequests(Map<AnalyzerConstants.RecommendationItem, ResourceRecommendation> requests) {
+        this.requests = requests;
+    }
+
+    public Map<AnalyzerConstants.RecommendationItem, ResourceRecommendation> getLimits() {
+        return limits;
+    }
+
+    public void setLimits(Map<AnalyzerConstants.RecommendationItem, ResourceRecommendation> limits) {
+        this.limits = limits;
+    }
+}

--- a/src/main/java/com/autotune/analyzer/recommendations/MultiResourceRecommendation.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/MultiResourceRecommendation.java
@@ -1,0 +1,31 @@
+package com.autotune.analyzer.recommendations;
+
+import com.autotune.analyzer.adapters.MultiResourceRecommendationAdapter;
+import com.google.gson.annotations.JsonAdapter;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents multiple resource recommendations (Accelerators array)
+ * Custom adapter ensures it serializes as array, not object
+ */
+@JsonAdapter(MultiResourceRecommendationAdapter.class)
+public final class MultiResourceRecommendation implements ResourceRecommendation {
+    private List<AcceleratorRecommendationItem> items;
+
+    public MultiResourceRecommendation() {
+        this.items = new ArrayList<>();
+    }
+
+    public MultiResourceRecommendation(List<AcceleratorRecommendationItem> items) {
+        this.items = items;
+    }
+
+    public List<AcceleratorRecommendationItem> getItems() {
+        return items;
+    }
+
+    public void setItems(List<AcceleratorRecommendationItem> items) {
+        this.items = items;
+    }
+}

--- a/src/main/java/com/autotune/analyzer/recommendations/MultiResourceRecommendation.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/MultiResourceRecommendation.java
@@ -26,21 +26,21 @@ import java.util.List;
  */
 @JsonAdapter(MultiResourceRecommendationAdapter.class)
 public final class MultiResourceRecommendation implements ResourceRecommendation {
-    private List<AcceleratorRecommendationItem> items;
+    private List<AcceleratorRecommendationItem> acceleratorRecommendationItems;
 
     public MultiResourceRecommendation() {
-        this.items = new ArrayList<>();
+        this.acceleratorRecommendationItems = new ArrayList<>();
     }
 
-    public MultiResourceRecommendation(List<AcceleratorRecommendationItem> items) {
-        this.items = items;
+    public MultiResourceRecommendation(List<AcceleratorRecommendationItem> acceleratorRecommendationItems) {
+        this.acceleratorRecommendationItems = acceleratorRecommendationItems;
     }
 
-    public List<AcceleratorRecommendationItem> getItems() {
-        return items;
+    public List<AcceleratorRecommendationItem> getAcceleratorRecommendationItems() {
+        return acceleratorRecommendationItems;
     }
 
-    public void setItems(List<AcceleratorRecommendationItem> items) {
-        this.items = items;
+    public void setAcceleratorRecommendationItems(List<AcceleratorRecommendationItem> acceleratorRecommendationItems) {
+        this.acceleratorRecommendationItems = acceleratorRecommendationItems;
     }
 }

--- a/src/main/java/com/autotune/analyzer/recommendations/MultiResourceRecommendation.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/MultiResourceRecommendation.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
 package com.autotune.analyzer.recommendations;
 
 import com.autotune.analyzer.adapters.MultiResourceRecommendationAdapter;

--- a/src/main/java/com/autotune/analyzer/recommendations/RecommendationConfigItem.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/RecommendationConfigItem.java
@@ -15,7 +15,7 @@
  *******************************************************************************/
 package com.autotune.analyzer.recommendations;
 
-public class RecommendationConfigItem {
+public class RecommendationConfigItem implements ResourceRecommendation {
     private Double amount;
     private String format;
     private String errorMsg;

--- a/src/main/java/com/autotune/analyzer/recommendations/ResourceRecommendation.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/ResourceRecommendation.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
 package com.autotune.analyzer.recommendations;
 
 public interface ResourceRecommendation {

--- a/src/main/java/com/autotune/analyzer/recommendations/ResourceRecommendation.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/ResourceRecommendation.java
@@ -1,0 +1,4 @@
+package com.autotune.analyzer.recommendations;
+
+public interface ResourceRecommendation {
+}

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -903,7 +903,7 @@ public class RecommendationEngine implements RecommendationEngineService {
 
                     // Alternative - CPU REQUEST VALUE
                     // Accessing existing recommendation item
-                    RecommendationConfigItem tempAccessedRecCPURequest = (RecommendationConfigItem) requestsMap.get(AnalyzerConstants.RecommendationItem.CPU);
+                    RecommendationConfigItem tempAccessedRecCPURequest = requestsMap.get(AnalyzerConstants.RecommendationItem.CPU);
                     if (null != tempAccessedRecCPURequest) {
                         // Updating it with desired value
                         tempAccessedRecCPURequest.setAmount(currentCpuRequestValue);
@@ -943,7 +943,7 @@ public class RecommendationEngine implements RecommendationEngineService {
 
                     // Alternative - CPU LIMIT VALUE
                     // Accessing existing recommendation item
-                    RecommendationConfigItem tempAccessedRecCPULimit = (RecommendationConfigItem) limitsMap.get(AnalyzerConstants.RecommendationItem.CPU);
+                    RecommendationConfigItem tempAccessedRecCPULimit = limitsMap.get(AnalyzerConstants.RecommendationItem.CPU);
                     if (null != tempAccessedRecCPULimit) {
                         // Updating it with desired value
                         tempAccessedRecCPULimit.setAmount(currentCpuLimitValue);
@@ -983,7 +983,7 @@ public class RecommendationEngine implements RecommendationEngineService {
 
                     // Alternative - MEMORY REQUEST VALUE
                     // Accessing existing recommendation item
-                    RecommendationConfigItem tempAccessedRecMemoryRequest = (RecommendationConfigItem) requestsMap.get(AnalyzerConstants.RecommendationItem.MEMORY);
+                    RecommendationConfigItem tempAccessedRecMemoryRequest = requestsMap.get(AnalyzerConstants.RecommendationItem.MEMORY);
                     if (null != tempAccessedRecMemoryRequest) {
                         // Updating it with desired value
                         tempAccessedRecMemoryRequest.setAmount(currentMemRequestValue);
@@ -1023,7 +1023,7 @@ public class RecommendationEngine implements RecommendationEngineService {
 
                     // Alternative - MEMORY LIMIT VALUE
                     // Accessing existing recommendation item
-                    RecommendationConfigItem tempAccessedRecMemoryLimit = (RecommendationConfigItem) limitsMap.get(AnalyzerConstants.RecommendationItem.MEMORY);
+                    RecommendationConfigItem tempAccessedRecMemoryLimit = limitsMap.get(AnalyzerConstants.RecommendationItem.MEMORY);
                     if (null != tempAccessedRecMemoryLimit) {
                         // Updating it with desired value
                         tempAccessedRecMemoryLimit.setAmount(currentMemLimitValue);

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
 package com.autotune.analyzer.recommendations.engine;
 
 import com.autotune.analyzer.autoscaler.instaslice.InstasliceHelper;

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -617,7 +617,7 @@ public class RecommendationEngine implements RecommendationEngineService {
 
         Config config = new Config();
         // Create Request Map
-        HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> requestsMap = new HashMap<>();
+        HashMap<AnalyzerConstants.RecommendationItem, ResourceRecommendation> requestsMap = new HashMap<>();
         // Recommendation Item checks
         boolean isCpuRequestValid = true;
         boolean isMemoryRequestValid = true;
@@ -668,7 +668,7 @@ public class RecommendationEngine implements RecommendationEngineService {
         }
 
         // Create Limits Map
-        HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> limitsMap = new HashMap<>();
+        HashMap<AnalyzerConstants.RecommendationItem, ResourceRecommendation> limitsMap = new HashMap<>();
         // Recommendation Item checks (adding additional check for limits even though they are same as limits to maintain code to be flexible to add limits in future)
         boolean isCpuLimitValid = true;
         boolean isMemoryLimitValid = true;
@@ -903,7 +903,7 @@ public class RecommendationEngine implements RecommendationEngineService {
 
                     // Alternative - CPU REQUEST VALUE
                     // Accessing existing recommendation item
-                    RecommendationConfigItem tempAccessedRecCPURequest = requestsMap.get(AnalyzerConstants.RecommendationItem.CPU);
+                    RecommendationConfigItem tempAccessedRecCPURequest = (RecommendationConfigItem) requestsMap.get(AnalyzerConstants.RecommendationItem.CPU);
                     if (null != tempAccessedRecCPURequest) {
                         // Updating it with desired value
                         tempAccessedRecCPURequest.setAmount(currentCpuRequestValue);
@@ -943,7 +943,7 @@ public class RecommendationEngine implements RecommendationEngineService {
 
                     // Alternative - CPU LIMIT VALUE
                     // Accessing existing recommendation item
-                    RecommendationConfigItem tempAccessedRecCPULimit = limitsMap.get(AnalyzerConstants.RecommendationItem.CPU);
+                    RecommendationConfigItem tempAccessedRecCPULimit = (RecommendationConfigItem) limitsMap.get(AnalyzerConstants.RecommendationItem.CPU);
                     if (null != tempAccessedRecCPULimit) {
                         // Updating it with desired value
                         tempAccessedRecCPULimit.setAmount(currentCpuLimitValue);
@@ -983,7 +983,7 @@ public class RecommendationEngine implements RecommendationEngineService {
 
                     // Alternative - MEMORY REQUEST VALUE
                     // Accessing existing recommendation item
-                    RecommendationConfigItem tempAccessedRecMemoryRequest = requestsMap.get(AnalyzerConstants.RecommendationItem.MEMORY);
+                    RecommendationConfigItem tempAccessedRecMemoryRequest = (RecommendationConfigItem) requestsMap.get(AnalyzerConstants.RecommendationItem.MEMORY);
                     if (null != tempAccessedRecMemoryRequest) {
                         // Updating it with desired value
                         tempAccessedRecMemoryRequest.setAmount(currentMemRequestValue);
@@ -1023,7 +1023,7 @@ public class RecommendationEngine implements RecommendationEngineService {
 
                     // Alternative - MEMORY LIMIT VALUE
                     // Accessing existing recommendation item
-                    RecommendationConfigItem tempAccessedRecMemoryLimit = limitsMap.get(AnalyzerConstants.RecommendationItem.MEMORY);
+                    RecommendationConfigItem tempAccessedRecMemoryLimit = (RecommendationConfigItem) limitsMap.get(AnalyzerConstants.RecommendationItem.MEMORY);
                     if (null != tempAccessedRecMemoryLimit) {
                         // Updating it with desired value
                         tempAccessedRecMemoryLimit.setAmount(currentMemLimitValue);

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -617,7 +617,7 @@ public class RecommendationEngine implements RecommendationEngineService {
 
         Config config = new Config();
         // Create Request Map
-        HashMap<AnalyzerConstants.RecommendationItem, ResourceRecommendation> requestsMap = new HashMap<>();
+        HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> requestsMap = new HashMap<>();
         // Recommendation Item checks
         boolean isCpuRequestValid = true;
         boolean isMemoryRequestValid = true;
@@ -668,7 +668,7 @@ public class RecommendationEngine implements RecommendationEngineService {
         }
 
         // Create Limits Map
-        HashMap<AnalyzerConstants.RecommendationItem, ResourceRecommendation> limitsMap = new HashMap<>();
+        HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> limitsMap = new HashMap<>();
         // Recommendation Item checks (adding additional check for limits even though they are same as limits to maintain code to be flexible to add limits in future)
         boolean isCpuLimitValid = true;
         boolean isMemoryLimitValid = true;

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -195,7 +195,10 @@ public class AnalyzerConstants {
         // H100 96GB related partitions
         NVIDIA_GPU_PARTITION_3_CORES_48GB("nvidia.com/mig-3g.48gb"),
         NVIDIA_GPU_PARTITION_4_CORES_48GB("nvidia.com/mig-4g.48gb"),
-        NVIDIA_GPU_PARTITION_7_CORES_96GB("nvidia.com/mig-7g.96gb");
+        NVIDIA_GPU_PARTITION_7_CORES_96GB("nvidia.com/mig-7g.96gb"),
+
+        // Non-Kubernetes items, maintained for internal JSON representation
+        ACCELERATORS("accelerators");
 
 
         private final String value;


### PR DESCRIPTION
## Description

This PR adds the structural changes needed to export the accelerator info in current and variation sections of the recommendation JSON.

Finalized JSON designs:

**Current Section:**
```json
{
  "current": {
    "requests": {
      "memory": {
        "amount": 490.93,
        "format": "MiB"
      },
      "cpu": {
        "amount": 1.46,
        "format": "cores"
      }
    },
    "limits": {
      "memory": {
        "amount": 712.21,
        "format": "MiB"
      },
      "cpu": {
        "amount": 1.54,
        "format": "cores"
      },
      "accelerators": [
        {
          "model": "nvidia-a100-80gb",
          "partition": "full-gpu",
          "compute": {
            "amount": 7,
            "format": "slices"
          },
          "memory": {
            "amount": 80,
            "format": "GiB"
          }
        }
      ]
    }
  }
}
```

**Variation Section:**
```json
{
  "variation": {
    "requests": {
      "memory": {
        "amount": 707.05,
        "format": "MiB"
      },
      "cpu": {
        "amount": 6.22,
        "format": "cores"
      }
    },
    "limits": {
      "memory": {
        "amount": 485.77,
        "format": "MiB"
      },
      "cpu": {
        "amount": 6.14,
        "format": "cores"
      },
      "accelerators": [
        {
          "model": "nvidia-a100-80gb",
          "compute": {
            "amount": -57.14,
            "format": "percentage"
          },
          "memory": {
            "amount": -50.0,
            "format": "percentage"
          }
        }
      ]
    }
  }
}
```

From a code stand point you can see that the same structure should support a map for `cpu`, `memory` and an array for the `accelerator`. 

Maintaining the map with generic `Object` will cause type check issues and also the de-serialization efforts will be huge, So we went ahead to have a interface which is implemented by two types, also this helps to keep the structure extendable and also we can maintain common functions at interface level in future.

As we need to have a wrapper class around the list, direct conversion makes it a nested structure of `items` as key in the JSON, so we need to have an adapter which skips that structure and adds the list values directly to the parent

Fixes #1920 

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Support extended resource recommendations including accelerator arrays in current and variation sections of the recommendation JSON.

New Features:
- Introduce a polymorphic ResourceRecommendation model to represent both scalar resources and accelerator arrays in recommendations.
- Add accelerator-specific recommendation types and wrapper structures to model accelerator details under requests and limits.
- Register a JSON adapter to serialize and deserialize multi-resource accelerator recommendations as plain arrays instead of nested wrapper objects.

Enhancements:
- Extend recommendation item constants with a non-Kubernetes accelerators key for internal JSON representation.