### PR TITLE
update performance profile version after adding podCount metric queries

### DIFF
--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.json
@@ -473,6 +473,30 @@
             "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info_total{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})"
           }
         ]
+      },
+      {
+        "name": "podCount",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "sum",
+            "query": "sum(kube_pod_container_status_ready{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})"
+          },
+          {
+            "function": "avg",
+            "query": "avg_over_time(sum(kube_pod_container_status_ready{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          },
+          {
+            "function": "max",
+            "query": "max_over_time(sum(kube_pod_container_status_ready{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          },
+          {
+            "function": "min",
+            "query": "min_over_time(sum(kube_pod_container_status_ready{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          }
+        ]
       }
     ]
   }

--- a/manifests/autotune/performance-profiles/resource_optimization_openshift.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_openshift.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-optimization-openshift",
-  "profile_version": 2.0,
+  "profile_version": 3.0,
   "k8s_type": "openshift",
   "slo": {
     "slo_class": "resource_usage",

--- a/manifests/autotune/performance-profiles/resource_optimization_openshift.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_openshift.yaml
@@ -2,7 +2,7 @@ apiVersion: "recommender.com/v1"
 kind: "KruizePerformanceProfile"
 metadata:
   name: "resource-optimization-openshift"
-profile_version: 2.0
+profile_version: 3.0
 k8s_type: openshift
 
 slo:


### PR DESCRIPTION
## Description

Please describe the issue or feature and the summary of changes made to fix this. 

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Bump the OpenShift resource optimization performance profile version to 3.0 to align with recent changes to the profile configuration.