### PR TITLE
[feat: podCount] 1. Add new metric 'podCount' to profiles

### DIFF
--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.json
@@ -496,6 +496,30 @@
             "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info_total{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})"
           }
         ]
+      },
+      {
+        "name": "podCount",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "sum",
+            "query": "sum(kube_pod_container_status_ready{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})"
+          },
+          {
+            "function": "avg",
+            "query": "avg_over_time(sum(kube_pod_container_status_ready{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          },
+          {
+            "function": "max",
+            "query": "max_over_time(sum(kube_pod_container_status_ready{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          },
+          {
+            "function": "min",
+            "query": "min_over_time(sum(kube_pod_container_status_ready{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          }
+        ]
       }
     ]
   }

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.yaml
@@ -236,7 +236,28 @@ slo:
     - function: sum
       query: 'sum by(container, namespace) (avg_over_time(container_memory_rss{container!="", container!="POD", pod!="", namespace="$NAMESPACE$", container="$CONTAINER_NAME$"}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
+  # Pod Count (based on READY containers, not total pods)
+  - name: podCount
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "container"
 
+    aggregation_functions:
+      # Current ready pods
+      - function: sum
+        query: 'sum(kube_pod_container_status_ready{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+
+      # Avg ready pods over time
+      - function: avg
+        query: 'avg_over_time(sum(kube_pod_container_status_ready{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+      # Max ready pods over time
+      - function: max
+        query: 'max_over_time(sum(kube_pod_container_status_ready{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+      # Min ready pods over time
+      - function: min
+        query: 'min_over_time(sum(kube_pod_container_status_ready{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})[$MEASUREMENT_DURATION_IN_MIN$m:])'
   # Container Last Active Timestamp
   - name: maxDate
     datasource: prometheus

--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.json
@@ -473,6 +473,30 @@
             "query": "sum by(container, namespace, runtime, vendor, version)(jvm_info_total{namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})"
           }
         ]
+      },
+      {
+        "name": "podCount",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "sum",
+            "query": "sum(kube_pod_container_status_ready{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})"
+          },
+          {
+            "function": "avg",
+            "query": "avg_over_time(sum(kube_pod_container_status_ready{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          },
+          {
+            "function": "max",
+            "query": "max_over_time(sum(kube_pod_container_status_ready{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          },
+          {
+            "function": "min",
+            "query": "min_over_time(sum(kube_pod_container_status_ready{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          }
+        ]
       }
     ]
   }

--- a/manifests/autotune/performance-profiles/resource_optimization_openshift.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_openshift.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-optimization-openshift",
-  "profile_version": 2.0,
+  "profile_version": 3.0,
   "k8s_type": "openshift",
   "slo": {
     "slo_class": "resource_usage",

--- a/manifests/autotune/performance-profiles/resource_optimization_openshift.json
+++ b/manifests/autotune/performance-profiles/resource_optimization_openshift.json
@@ -424,6 +424,30 @@
             "query": "avg(avg_over_time(DCGM_FI_DEV_FB_USED{exported_namespace != \"\", exported_container != \"\", exported_pod != \"\"}[15m])) by (modelName, GPU_I_PROFILE, exported_container, exported_namespace, exported_pod, Hostname)"
           }
         ]
+      },
+      {
+        "name": "podCount",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "sum",
+            "query": "sum(kube_pod_container_status_ready{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})"
+          },
+          {
+            "function": "avg",
+            "query": "avg_over_time(sum(kube_pod_container_status_ready{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          },
+          {
+            "function": "max",
+            "query": "max_over_time(sum(kube_pod_container_status_ready{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          },
+          {
+            "function": "min",
+            "query": "min_over_time(sum(kube_pod_container_status_ready{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"})[$MEASUREMENT_DURATION_IN_MIN$m:])"
+          }
+        ]
       }
     ]
   }

--- a/manifests/autotune/performance-profiles/resource_optimization_openshift.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_openshift.yaml
@@ -214,6 +214,28 @@ slo:
     - function: sum
       query: 'sum by(container, namespace)(avg_over_time(container_memory_rss{container!="", container!="POD", pod!="", namespace=$NAMESPACE$, container=”$CONTAINER_NAME$”}[15m]))'
 
+  # Pod Count (based on READY containers)
+  - name: podCount
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "container"
+
+    aggregation_functions:
+      # Current ready pods
+      - function: sum
+        query: 'sum(kube_pod_container_status_ready{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+
+      # Avg ready pods over time
+      - function: avg
+        query: 'avg_over_time(sum(kube_pod_container_status_ready{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+      # Max ready pods over time
+      - function: max
+        query: 'max_over_time(sum(kube_pod_container_status_ready{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+      # Min ready pods over time
+      - function: min
+        query: 'min_over_time(sum(kube_pod_container_status_ready{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})[$MEASUREMENT_DURATION_IN_MIN$m:])'
     ## namespace related queries
 
     # Namespace quota for CPU requests

--- a/manifests/autotune/performance-profiles/resource_optimization_openshift.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_openshift.yaml
@@ -2,7 +2,7 @@ apiVersion: "recommender.com/v1"
 kind: "KruizePerformanceProfile"
 metadata:
   name: "resource-optimization-openshift"
-profile_version: 2.0
+profile_version: 3.0
 k8s_type: openshift
 
 slo:


### PR DESCRIPTION
## Description

This PR include changes related to `current podCount`. As part of this, we added new metric `podCount` and associated queries to read from Prometheus to profile configuration.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: Kind

No tests were run part of this PR as these changes doesn't have any functional impact as of yet. However, I did build and deployed it using https://github.com/kruize/kruize-demos in both local and remote mode. Attached build and deploy results with this PR.

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Introduce a pod readiness count metric to performance profiles and bump the OpenShift resource optimization profile version.

New Features:
- Add a podCount metric based on ready containers to resource optimization performance profiles for OpenShift and local monitoring.

Enhancements:
- Update the OpenShift resource optimization performance profile version from 2.0 to 3.0.
- Align associated JSON performance profile definitions with the new podCount metric configuration.