### PR TITLE
[feat: podCount] 2. Java model changes to include current podCount metric

### DIFF
--- a/src/main/java/com/autotune/analyzer/recommendations/Config.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/Config.java
@@ -29,12 +29,10 @@ public class Config {
 
     // resources is a Map of map which wraps requests and limits.
     // New API endpoint make use of this to nest requests and limits under resources in its response.
-    // In such scenario, requests and limits are set to null
     @SerializedName(KruizeConstants.JSONKeys.RESOURCES)
     private Map<AnalyzerConstants.ResourceSetting, Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> resources;
 
     // Existing API endpoints use requests and limits as-is
-    // In such scenario, resources is set to null.
     private Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> requests;
     private Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> limits;
     private List<RecommendationConfigEnv> env;
@@ -53,11 +51,6 @@ public class Config {
 
     public void setResources(Map<AnalyzerConstants.ResourceSetting, Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> resources) {
         this.resources = resources;
-        if (resources != null) {
-            // When using the nested "resources" representation, keep the flat representation unset
-            this.requests = null;
-            this.limits = null;
-        }
     }
 
     public Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> getRequests() {
@@ -66,10 +59,6 @@ public class Config {
 
     public void setRequests(Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> requests) {
         this.requests = requests;
-        if (requests != null) {
-            // When using the flat "requests"/"limits" representation, keep the nested "resources" unset
-            this.resources = null;
-        }
     }
 
     public Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> getLimits() {
@@ -78,10 +67,6 @@ public class Config {
 
     public void setLimits(Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> limits) {
         this.limits = limits;
-        if (limits != null) {
-            // When using the flat "requests"/"limits" representation, keep the nested "resources" unset
-            this.resources = null;
-        }
     }
 
     public List<RecommendationConfigEnv> getEnv() {

--- a/src/main/java/com/autotune/analyzer/recommendations/Config.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/Config.java
@@ -17,14 +17,38 @@
 package com.autotune.analyzer.recommendations;
 
 import com.autotune.analyzer.utils.AnalyzerConstants;
+import com.autotune.utils.KruizeConstants;
+import com.google.gson.annotations.SerializedName;
 
 import java.util.List;
 import java.util.Map;
 
 public class Config {
+    @SerializedName(KruizeConstants.JSONKeys.REPLICAS)
+    private Integer replicas;
+
+    @SerializedName(KruizeConstants.JSONKeys.RESOURCES)
+    private Map<AnalyzerConstants.ResourceSetting, Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> resources;
+
     private Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> requests;
     private Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> limits;
     private List<RecommendationConfigEnv> env;
+
+    public Integer getReplicas() {
+        return replicas;
+    }
+
+    public void setReplicas(Integer replicas) {
+        this.replicas = replicas;
+    }
+
+    public Map<AnalyzerConstants.ResourceSetting, Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> getResources() {
+        return resources;
+    }
+
+    public void setResources(Map<AnalyzerConstants.ResourceSetting, Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> resources) {
+        this.resources = resources;
+    }
 
     public Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> getRequests() {
         return requests;

--- a/src/main/java/com/autotune/analyzer/recommendations/Config.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/Config.java
@@ -27,9 +27,14 @@ public class Config {
     @SerializedName(KruizeConstants.JSONKeys.REPLICAS)
     private Integer replicas;
 
+    // resources is a Map of map which wraps requests and limits.
+    // New API endpoint make use of this to nest requests and limits under resources in its response.
+    // In such scenario, requests and limits are set to null
     @SerializedName(KruizeConstants.JSONKeys.RESOURCES)
     private Map<AnalyzerConstants.ResourceSetting, Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> resources;
 
+    // Existing API endpoints use requests and limits as-is
+    // In such scenario, resources is set to null.
     private Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> requests;
     private Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> limits;
     private List<RecommendationConfigEnv> env;
@@ -48,6 +53,11 @@ public class Config {
 
     public void setResources(Map<AnalyzerConstants.ResourceSetting, Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> resources) {
         this.resources = resources;
+        if (resources != null) {
+            // When using the nested "resources" representation, keep the flat representation unset
+            this.requests = null;
+            this.limits = null;
+        }
     }
 
     public Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> getRequests() {
@@ -56,6 +66,10 @@ public class Config {
 
     public void setRequests(Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> requests) {
         this.requests = requests;
+        if (requests != null) {
+            // When using the flat "requests"/"limits" representation, keep the nested "resources" unset
+            this.resources = null;
+        }
     }
 
     public Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> getLimits() {
@@ -64,6 +78,10 @@ public class Config {
 
     public void setLimits(Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> limits) {
         this.limits = limits;
+        if (limits != null) {
+            // When using the flat "requests"/"limits" representation, keep the nested "resources" unset
+            this.resources = null;
+        }
     }
 
     public List<RecommendationConfigEnv> getEnv() {

--- a/src/main/java/com/autotune/analyzer/recommendations/objects/TermRecommendations.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/objects/TermRecommendations.java
@@ -3,6 +3,7 @@ package com.autotune.analyzer.recommendations.objects;
 import com.autotune.analyzer.plots.PlotData;
 import com.autotune.analyzer.recommendations.RecommendationConstants;
 import com.autotune.analyzer.recommendations.RecommendationNotification;
+import com.autotune.common.data.metrics.MetricAggregationInfoResults;
 import com.autotune.utils.KruizeConstants;
 import com.google.gson.annotations.SerializedName;
 
@@ -19,6 +20,10 @@ public class TermRecommendations implements MappedRecommendationForTerm {
 
     @SerializedName(KruizeConstants.JSONKeys.NOTIFICATIONS)
     private HashMap<Integer, RecommendationNotification> termLevelNotificationMap;
+
+    @SerializedName(KruizeConstants.JSONKeys.METRICS_INFO)
+    private HashMap<String, MetricAggregationInfoResults> metricsInfo = new HashMap<>();
+
     @SerializedName(KruizeConstants.JSONKeys.MONITORING_START_TIME)
     private Timestamp monitoringStartTime;
 
@@ -34,6 +39,10 @@ public class TermRecommendations implements MappedRecommendationForTerm {
     @Override
     public HashMap<Integer, RecommendationNotification> getNotifications() {
         return this.termLevelNotificationMap;
+    }
+
+    public HashMap<String, MetricAggregationInfoResults> getMetricsInfo() {
+        return metricsInfo;
     }
 
     @Override
@@ -57,6 +66,20 @@ public class TermRecommendations implements MappedRecommendationForTerm {
 
     public void setTermLevelNotificationMap(HashMap<Integer, RecommendationNotification> termLevelNotificationMap) {
         this.termLevelNotificationMap = termLevelNotificationMap;
+    }
+
+    /**
+     *
+     * MetricsInfo is a map in which key is metric name and value is aggregated values of metrics for a given term.
+     * For example, key is 'pod_count', value is min,max,avg of pod_count in a given time window.
+     *
+     * @param metricName
+     * @param metricAggregationInfoResults
+     */
+    public void setMetricsInfo(String metricName, MetricAggregationInfoResults metricAggregationInfoResults) {
+        if (null != metricName && null != metricAggregationInfoResults) {
+            this.metricsInfo.put(metricName, metricAggregationInfoResults);
+        }
     }
 
     public void setMonitoringStartTime(Timestamp monitoringStartTime) {

--- a/src/main/java/com/autotune/analyzer/recommendations/objects/TermRecommendations.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/objects/TermRecommendations.java
@@ -69,14 +69,14 @@ public class TermRecommendations implements MappedRecommendationForTerm {
     }
 
     /**
-     *
+     * Method to add metricsInfo for each metric.
      * MetricsInfo is a map in which key is metric name and value is aggregated values of metrics for a given term.
      * For example, key is 'pod_count', value is min,max,avg of pod_count in a given time window.
      *
      * @param metricName
      * @param metricAggregationInfoResults
      */
-    public void setMetricsInfo(String metricName, MetricAggregationInfoResults metricAggregationInfoResults) {
+    public void addMetricsInfo(String metricName, MetricAggregationInfoResults metricAggregationInfoResults) {
         if (null != metricName && null != metricAggregationInfoResults) {
             this.metricsInfo.put(metricName, metricAggregationInfoResults);
         }

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -306,6 +306,9 @@ public class KruizeConstants {
         public static final String DEVICE = "device";
         public static final String MODEL_NAME = "modelName";
         public static final String GPU_PROFILE = "GPU_I_PROFILE";
+        public static final String METRICS_INFO = "metrics_info";
+        public static final String POD_COUNT = "pod_count";
+        public static final String REPLICAS = "replicas";
 
         public static final String CREATION_DATE = "creation_date";
         public static final String UPDATE_DATE = "update_date";


### PR DESCRIPTION
## Description

This is part of current podCount feature and it contains changes to add new attributes corresponding Java model objects related to recommendation json.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 
No tests were run as the change is not functionally complete at this point. It just has structural changes which will be used to build functionality in coming PRs.

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Extend recommendation models to support new metrics and replica metadata for podCount-related functionality.

New Features:
- Add replicas field and nested resources representation to recommendation Config model to support both flat and nested JSON APIs.
- Capture per-metric aggregation results, including pod_count, in TermRecommendations via a metricsInfo map keyed by metric name.
- Introduce new JSON keys for metrics_info, pod_count, and replicas in KruizeConstants to align serialized recommendation payloads with the new schema.