### PR TITLE
[feat:podCount] add new helper method to construct aggregated values for podCount

### DIFF
--- a/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
@@ -325,102 +325,107 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
      * 2. From 'cpuUsage' metric data using formulae avg(sum/avg), min(sum/avg), max(sum/avg).
      * 3. From 'memoryUsage' metric data using formulae avg(sum/avg), min(sum/avg), max(sum/avg).
      *
-     * To avoid issues with formulae, results are filtered to chose datapoints whose sum, avg is not null and avg is not 0.0.
+     * To avoid issues with formulae, results are filtered to choose datapoints whose sum and avg are not null,
+     * avg is strictly greater than 0.0, sum is greater than or equal to 0.0, and the derived pod count (sum/avg)
+     * is finite (i.e., not NaN or infinite).
      *
      * @param filteredResultsMap
      * @return aggregated results like min, max, avg of pods from the results supplied.
      */
     private static MetricAggregationInfoResults getPodCountAggrInfo(Map<Timestamp, IntervalResults> filteredResultsMap) {
-        MetricAggregationInfoResults metricAggregationInfoResults = new MetricAggregationInfoResults();
+        MetricAggregationInfoResults metricAggregationInfoResults = null;
         Double avg = 0.0, min = 0.0, max = 0.0;
-        LOGGER.info("filteredResultsMap: size = {}", filteredResultsMap.size());
+        LOGGER.debug("filteredResultsMap: size = {}", filteredResultsMap.size());
 
         // 1. Use 'podCount' metric data points
-        List<MetricAggregationInfoResults> podCountMetrics = filteredResultsMap.values().stream()
-                .filter(results -> results.getMetricResultsMap() != null)
-                .flatMap(results -> results.getMetricResultsMap().entrySet().stream())
-                .filter(metricEntry -> metricEntry.getKey() == AnalyzerConstants.MetricName.podCount)
-                .map(metricEntry -> metricEntry.getValue().getAggregationInfoResult())
-                .filter(aggInfo -> aggInfo != null && aggInfo.getAvg() != null)
-                .toList();
-        LOGGER.info("podCountMetrics : size = {}, content = {}", podCountMetrics.size(), podCountMetrics);
-        if (!podCountMetrics.isEmpty()) {
-            avg = podCountMetrics.stream()
-                    .mapToDouble(MetricAggregationInfoResults::getAvg)
-                    .average()
-                    .orElse(0.0);
-            if (avg > 0.0) {
-                min = podCountMetrics.stream()
-                        .mapToDouble(MetricAggregationInfoResults::getMin)
-                        .min()
-                        .orElse(0.0);
-                max = podCountMetrics.stream()
-                        .mapToDouble(MetricAggregationInfoResults::getMax)
-                        .max()
-                        .orElse(0.0);
-                metricAggregationInfoResults.setAvg(Math.ceil(avg));
-                metricAggregationInfoResults.setMin(Math.ceil(min));
-                metricAggregationInfoResults.setMax(Math.ceil(max));
-                LOGGER.info("Pod Count Aggregation Info: avg = {} min={}, max={}", avg, min, max);
-                return metricAggregationInfoResults;
-            }
-        }
+        metricAggregationInfoResults = getPodCountAggrInfoFromMetric(filteredResultsMap, AnalyzerConstants.MetricName.podCount);
 
         // 2. Calculate from 'cpuUsage' datapoints using formulae avg of 'sum/avg', min of 'sum/avg', max of 'sum/avg'
-        List<MetricAggregationInfoResults> cpuUsageMetrics = filteredResultsMap.values().stream()
-                .filter(results -> results.getMetricResultsMap() != null)
-                .flatMap(results -> results.getMetricResultsMap().entrySet().stream())
-                .filter(metricEntry -> metricEntry.getKey() == AnalyzerConstants.MetricName.cpuUsage)
-                .map(metricEntry -> metricEntry.getValue().getAggregationInfoResult())
-                .filter(aggInfo -> (aggInfo != null && aggInfo.getAvg() != null && aggInfo.getAvg() != 0.0 && aggInfo.getSum() != null))
-                .toList();
-        LOGGER.info("cpuUsageMetrics : size = {}, content = {}", cpuUsageMetrics.size(), cpuUsageMetrics);
-        if (!cpuUsageMetrics.isEmpty()) {
-            List<Double> calcPodCounts = cpuUsageMetrics.stream()
-                    .mapToDouble(aggInfo -> aggInfo.getSum() / aggInfo.getAvg())
-                    .boxed()
-                    .toList();
-
-            avg = calcPodCounts.stream().mapToDouble(Double::doubleValue).average().orElse(0.0);
-            min = calcPodCounts.stream().mapToDouble(Double::doubleValue).min().orElse(0.0);
-            max = calcPodCounts.stream().mapToDouble(Double::doubleValue).max().orElse(0.0);
-            if (avg > 0.0) {
-                metricAggregationInfoResults.setAvg(Math.ceil(avg));
-                metricAggregationInfoResults.setMin(Math.ceil(min));
-                metricAggregationInfoResults.setMax(Math.ceil(max));
-                LOGGER.info("Pod Count Aggregation Info calculated using cpuUsage metric : avg = {} min={}, max={}", avg, min, max);
-                return metricAggregationInfoResults;
-            }
+        if (null == metricAggregationInfoResults) {
+            metricAggregationInfoResults = getPodCountAggrInfoFromMetric(filteredResultsMap, AnalyzerConstants.MetricName.cpuUsage);
         }
 
         // 3. Calculate from 'memoryUsage' datapoints using formulae avg of 'sum/avg', min of 'sum/avg', max of 'sum/avg'
-        List<MetricAggregationInfoResults> memoryUsageMetrics = filteredResultsMap.values().stream()
-                .filter(results -> results.getMetricResultsMap() != null)
-                .flatMap(results -> results.getMetricResultsMap().entrySet().stream())
-                .filter(metricEntry -> metricEntry.getKey() == AnalyzerConstants.MetricName.memoryUsage)
-                .map(metricEntry -> metricEntry.getValue().getAggregationInfoResult())
-                .filter(aggInfo -> (aggInfo != null && aggInfo.getAvg() != null && aggInfo.getAvg() != 0.0 && aggInfo.getSum() != null))
-                .toList();
-        LOGGER.info("memoryUsageMetrics : size = {}, content = {}", memoryUsageMetrics.size(), memoryUsageMetrics);
-        if (!memoryUsageMetrics.isEmpty()) {
-            List<Double> calcPodCounts = memoryUsageMetrics.stream()
-                    .mapToDouble(aggInfo -> aggInfo.getSum() / aggInfo.getAvg())
-                    .boxed()
-                    .toList();
-
-            avg = calcPodCounts.stream().mapToDouble(Double::doubleValue).average().orElse(0.0);
-            min = calcPodCounts.stream().mapToDouble(Double::doubleValue).min().orElse(0.0);
-            max = calcPodCounts.stream().mapToDouble(Double::doubleValue).max().orElse(0.0);
-            if (avg > 0.0) {
-                metricAggregationInfoResults.setAvg(Math.ceil(avg));
-                metricAggregationInfoResults.setMin(Math.ceil(min));
-                metricAggregationInfoResults.setMax(Math.ceil(max));
-                LOGGER.info("Pod Count Aggregation Info calculated using memoryUsage metric : avg = {} min={}, max={}", avg, min, max);
-                return metricAggregationInfoResults;
-            }
+        if (null == metricAggregationInfoResults) {
+            metricAggregationInfoResults = getPodCountAggrInfoFromMetric(filteredResultsMap, AnalyzerConstants.MetricName.memoryUsage);
         }
 
-        LOGGER.error("Failed to calculate Pod Count Aggregation Info. Size of : podCountMetrics = {}, cpuUsageMetrics = {}, memoryUsageMetrics = {}", podCountMetrics.size(), cpuUsageMetrics.size(), memoryUsageMetrics.size());
-        return null;
+        return metricAggregationInfoResults;
+    }
+
+    private static MetricAggregationInfoResults getPodCountAggrInfoFromMetric(Map<Timestamp, IntervalResults> filteredResultsMap, AnalyzerConstants.MetricName metricName) {
+        Double avg = 0.0, min = 0.0, max = 0.0;
+        MetricAggregationInfoResults metricAggregationInfoResults = null;
+        List<MetricAggregationInfoResults> metricDatapoints = filteredResultsMap.values().stream()
+                .filter(results -> results.getMetricResultsMap() != null)
+                .flatMap(results -> results.getMetricResultsMap().entrySet().stream())
+                .filter(metricEntry -> metricEntry.getKey() == metricName)
+                .map(metricEntry -> metricEntry.getValue().getAggregationInfoResult())
+                .filter(aggInfo -> isValid(metricName, aggInfo))
+                .toList();
+        if (!metricDatapoints.isEmpty()) {
+            // When podCount is computed from cpuUsage or memoryUsage, we need to first compute sum/avg for all datapoints to get podCount.
+            // Then, we compute min, max, avg of these computed datapoints for podCount.
+            if (metricName == AnalyzerConstants.MetricName.cpuUsage || metricName == AnalyzerConstants.MetricName.memoryUsage) {
+                List<Double> calcPodCounts = metricDatapoints.stream()
+                        .mapToDouble(aggInfo -> aggInfo.getSum() / aggInfo.getAvg())
+                        .filter(Double::isFinite)
+                        .boxed()
+                        .toList();
+
+                avg = calcPodCounts.stream().mapToDouble(Double::doubleValue).average().orElse(0.0);
+                min = calcPodCounts.stream().mapToDouble(Double::doubleValue).min().orElse(0.0);
+                max = calcPodCounts.stream().mapToDouble(Double::doubleValue).max().orElse(0.0);
+            } else if (metricName == AnalyzerConstants.MetricName.podCount) { // Compute min, max, avg directly from podCount datapoints.
+                avg = metricDatapoints.stream()
+                        .mapToDouble(MetricAggregationInfoResults::getAvg)
+                        .average()
+                        .orElse(0.0);
+                if (avg > 0.0) {
+                    min = metricDatapoints.stream()
+                            .mapToDouble(MetricAggregationInfoResults::getMin)
+                            .min()
+                            .orElse(0.0);
+                    max = metricDatapoints.stream()
+                            .mapToDouble(MetricAggregationInfoResults::getMax)
+                            .max()
+                            .orElse(0.0);
+                }
+            }
+            metricAggregationInfoResults = new MetricAggregationInfoResults();
+            metricAggregationInfoResults.setAvg(Math.ceil(avg));
+            metricAggregationInfoResults.setMin(Math.ceil(min));
+            metricAggregationInfoResults.setMax(Math.ceil(max));
+        }
+
+        LOGGER.debug("Aggregation Info for metric {}: avg = {} min={}, max={}", metricName, avg, min, max);
+        return metricAggregationInfoResults; // no datapoints available for given metric to compute podCount. So, return null;
+    }
+
+    private static boolean isValid(AnalyzerConstants.MetricName metricName, MetricAggregationInfoResults aggInfo) {
+        if (aggInfo == null) {
+            return false;
+        }
+
+        switch (metricName) {
+            case podCount:
+                // For podCount we later use avg, min, and max; sum is not required.
+                return aggInfo.getAvg() != null
+                        && aggInfo.getMin() != null
+                        && aggInfo.getMax() != null;
+            case cpuUsage:
+            case memoryUsage:
+                // For cpu/memory we compute podCount from sum/avg and don't use min/max.
+                return aggInfo.getAvg() != null
+                        && aggInfo.getAvg() != 0.0
+                        && aggInfo.getSum() != null
+                        && aggInfo.getSum() >= 0.0;
+            default:
+                // Fallback: keep the original stricter behavior.
+                return aggInfo.getAvg() != null
+                        && aggInfo.getAvg() != 0.0
+                        && aggInfo.getSum() != null
+                        && aggInfo.getSum() >= 0.0;
+        }
     }
 }

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
@@ -28,6 +28,7 @@ import com.autotune.analyzer.recommendations.term.Terms;
 import com.autotune.analyzer.recommendations.utils.RecommendationUtils;
 import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.analyzer.utils.AnalyzerErrorConstants;
+import com.autotune.common.data.metrics.MetricAggregationInfoResults;
 import com.autotune.common.data.metrics.MetricResults;
 import com.autotune.common.data.result.ContainerData;
 import com.autotune.common.data.result.IntervalResults;
@@ -315,5 +316,111 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
                 })
                 .max(Double::compareTo).get();
         return (int) Math.ceil(max_pods_cpu);
+    }
+
+    /**
+     * getPodCountAggrInfo is utility function responsible to determine min, max and avg of pods based on following sequence
+     *
+     * 1. From 'podCount' metric data if exists.
+     * 2. From 'cpuUsage' metric data using formulae avg(sum/avg), min(sum/avg), max(sum/avg).
+     * 3. From 'memoryUsage' metric data using formulae avg(sum/avg), min(sum/avg), max(sum/avg).
+     *
+     * To avoid issues with formulae, results are filtered to chose datapoints whose sum, avg is not null and avg is not 0.0.
+     *
+     * @param filteredResultsMap
+     * @return aggregated results like min, max, avg of pods from the results supplied.
+     */
+    private static MetricAggregationInfoResults getPodCountAggrInfo(Map<Timestamp, IntervalResults> filteredResultsMap) {
+        MetricAggregationInfoResults metricAggregationInfoResults = new MetricAggregationInfoResults();
+        Double avg = 0.0, min = 0.0, max = 0.0;
+        LOGGER.info("filteredResultsMap: size = {}", filteredResultsMap.size());
+
+        // 1. Use 'podCount' metric data points
+        List<MetricAggregationInfoResults> podCountMetrics = filteredResultsMap.values().stream()
+                .filter(results -> results.getMetricResultsMap() != null)
+                .flatMap(results -> results.getMetricResultsMap().entrySet().stream())
+                .filter(metricEntry -> metricEntry.getKey() == AnalyzerConstants.MetricName.podCount)
+                .map(metricEntry -> metricEntry.getValue().getAggregationInfoResult())
+                .filter(aggInfo -> aggInfo != null && aggInfo.getAvg() != null)
+                .toList();
+        LOGGER.info("podCountMetrics : size = {}, content = {}", podCountMetrics.size(), podCountMetrics);
+        if (!podCountMetrics.isEmpty()) {
+            avg = podCountMetrics.stream()
+                    .mapToDouble(MetricAggregationInfoResults::getAvg)
+                    .average()
+                    .orElse(0.0);
+            if (avg > 0.0) {
+                min = podCountMetrics.stream()
+                        .mapToDouble(MetricAggregationInfoResults::getMin)
+                        .min()
+                        .orElse(0.0);
+                max = podCountMetrics.stream()
+                        .mapToDouble(MetricAggregationInfoResults::getMax)
+                        .max()
+                        .orElse(0.0);
+                metricAggregationInfoResults.setAvg(Math.ceil(avg));
+                metricAggregationInfoResults.setMin(Math.ceil(min));
+                metricAggregationInfoResults.setMax(Math.ceil(max));
+                LOGGER.info("Pod Count Aggregation Info: avg = {} min={}, max={}", avg, min, max);
+                return metricAggregationInfoResults;
+            }
+        }
+
+        // 2. Calculate from 'cpuUsage' datapoints using formulae avg of 'sum/avg', min of 'sum/avg', max of 'sum/avg'
+        List<MetricAggregationInfoResults> cpuUsageMetrics = filteredResultsMap.values().stream()
+                .filter(results -> results.getMetricResultsMap() != null)
+                .flatMap(results -> results.getMetricResultsMap().entrySet().stream())
+                .filter(metricEntry -> metricEntry.getKey() == AnalyzerConstants.MetricName.cpuUsage)
+                .map(metricEntry -> metricEntry.getValue().getAggregationInfoResult())
+                .filter(aggInfo -> (aggInfo != null && aggInfo.getAvg() != null && aggInfo.getAvg() != 0.0 && aggInfo.getSum() != null))
+                .toList();
+        LOGGER.info("cpuUsageMetrics : size = {}, content = {}", cpuUsageMetrics.size(), cpuUsageMetrics);
+        if (!cpuUsageMetrics.isEmpty()) {
+            List<Double> calcPodCounts = cpuUsageMetrics.stream()
+                    .mapToDouble(aggInfo -> aggInfo.getSum() / aggInfo.getAvg())
+                    .boxed()
+                    .toList();
+
+            avg = calcPodCounts.stream().mapToDouble(Double::doubleValue).average().orElse(0.0);
+            min = calcPodCounts.stream().mapToDouble(Double::doubleValue).min().orElse(0.0);
+            max = calcPodCounts.stream().mapToDouble(Double::doubleValue).max().orElse(0.0);
+            if (avg > 0.0) {
+                metricAggregationInfoResults.setAvg(Math.ceil(avg));
+                metricAggregationInfoResults.setMin(Math.ceil(min));
+                metricAggregationInfoResults.setMax(Math.ceil(max));
+                LOGGER.info("Pod Count Aggregation Info calculated using cpuUsage metric : avg = {} min={}, max={}", avg, min, max);
+                return metricAggregationInfoResults;
+            }
+        }
+
+        // 3. Calculate from 'memoryUsage' datapoints using formulae avg of 'sum/avg', min of 'sum/avg', max of 'sum/avg'
+        List<MetricAggregationInfoResults> memoryUsageMetrics = filteredResultsMap.values().stream()
+                .filter(results -> results.getMetricResultsMap() != null)
+                .flatMap(results -> results.getMetricResultsMap().entrySet().stream())
+                .filter(metricEntry -> metricEntry.getKey() == AnalyzerConstants.MetricName.memoryUsage)
+                .map(metricEntry -> metricEntry.getValue().getAggregationInfoResult())
+                .filter(aggInfo -> (aggInfo != null && aggInfo.getAvg() != null && aggInfo.getAvg() != 0.0 && aggInfo.getSum() != null))
+                .toList();
+        LOGGER.info("memoryUsageMetrics : size = {}, content = {}", memoryUsageMetrics.size(), memoryUsageMetrics);
+        if (!memoryUsageMetrics.isEmpty()) {
+            List<Double> calcPodCounts = memoryUsageMetrics.stream()
+                    .mapToDouble(aggInfo -> aggInfo.getSum() / aggInfo.getAvg())
+                    .boxed()
+                    .toList();
+
+            avg = calcPodCounts.stream().mapToDouble(Double::doubleValue).average().orElse(0.0);
+            min = calcPodCounts.stream().mapToDouble(Double::doubleValue).min().orElse(0.0);
+            max = calcPodCounts.stream().mapToDouble(Double::doubleValue).max().orElse(0.0);
+            if (avg > 0.0) {
+                metricAggregationInfoResults.setAvg(Math.ceil(avg));
+                metricAggregationInfoResults.setMin(Math.ceil(min));
+                metricAggregationInfoResults.setMax(Math.ceil(max));
+                LOGGER.info("Pod Count Aggregation Info calculated using memoryUsage metric : avg = {} min={}, max={}", avg, min, max);
+                return metricAggregationInfoResults;
+            }
+        }
+
+        LOGGER.error("Failed to calculate Pod Count Aggregation Info. Size of : podCountMetrics = {}, cpuUsageMetrics = {}, memoryUsageMetrics = {}", podCountMetrics.size(), cpuUsageMetrics.size(), memoryUsageMetrics.size());
+        return null;
     }
 }

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -283,7 +283,8 @@ public class AnalyzerConstants {
         acceleratorMemoryUsage,
         acceleratorFrameBufferUsage,
         jvmInfo,
-        jvmInfoTotal
+        jvmInfoTotal,
+        podCount
     }
 
     public enum K8S_OBJECT_TYPES {


### PR DESCRIPTION
## Description

Changes are related to current podCount featured. This PR added a new helper function `getPodCountAggrInfo` which construct `metrics_info` entry with aggregated values for podCount metrics.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

No tests are run as this method is not used functionally yet.

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Add support utilities to compute aggregated pod count metrics from existing metric results.

New Features:
- Introduce helper methods to derive pod count aggregation (min, max, avg) from podCount, cpuUsage, or memoryUsage metrics.
- Extend the AnalyzerConstants.MetricName enum with a podCount entry for identifying pod count metrics.