### PR TITLE
Updated UBI minimal version and fixed CVE

### DIFF
--- a/Dockerfile.autotune
+++ b/Dockerfile.autotune
@@ -16,7 +16,7 @@
 ##########################################################
 #            Build Docker Image
 ##########################################################
-FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1778058333 as mvnbuild-jdk25
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2-1780550715 as mvnbuild-jdk25
 ARG USER=autotune
 ARG AUTOTUNE_HOME=/home/$USER
 
@@ -49,7 +49,7 @@ RUN jlink --strip-debug --compress 2 --no-header-files --no-man-pages --module-p
 #            Runtime Docker Image
 ##########################################################
 # Use ubi-minimal as the base image
-FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1778058333
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2-1780550715
 
 ARG AUTOTUNE_VERSION
 ARG USER=autotune

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>autotune</artifactId>
     <version>0.10</version>
     <properties>
-        <fabric8-version>7.6.0</fabric8-version>
+        <fabric8-version>7.7.0</fabric8-version>
         <org-json-version>20250107</org-json-version>
         <jetty-version>12.1.7</jetty-version>
         <log4j-version>2.25.4</log4j-version>
@@ -23,7 +23,7 @@
         <hibernate-version>6.6.45.Final</hibernate-version>
         <hibernate-Validator>8.0.3.Final</hibernate-Validator>
         <micrometer-version>1.12.10</micrometer-version>
-        <awssdk-version>2.42.25</awssdk-version>
+        <awssdk-version>2.46.5</awssdk-version>
         <jackson-version>2.21.4</jackson-version>
         <evalex-version>3.6.0</evalex-version>
         <mockito-version>5.21.0</mockito-version>


### PR DESCRIPTION
## Description

Updated UBI minimal version and fixed CVE

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Verified quay scan report for CVE issues. PR check test will be run as well


**Test Configuration**
* Kubernetes clusters tested on: minikube

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Update dependencies and container base to address security vulnerabilities and align with newer platform versions.

Bug Fixes:
- Update Fabric8 Kubernetes client and AWS SDK versions to address known CVEs and security issues in dependencies.

Build:
- Bump Fabric8 and AWS SDK versions in Maven configuration to use newer, secure releases.

Deployment:
- Update the container image base (UBI minimal) to a newer version to resolve security vulnerabilities.