### PR TITLE
[feat:podCount] Use Config class instead of Map to represent

### DIFF
--- a/src/main/java/com/autotune/analyzer/recommendations/engine/BaseRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/BaseRecommendationProcessor.java
@@ -17,6 +17,7 @@
 package com.autotune.analyzer.recommendations.engine;
 
 import com.autotune.analyzer.kruizeObject.RecommendationSettings;
+import com.autotune.analyzer.recommendations.Config;
 import com.autotune.analyzer.recommendations.RecommendationConfigItem;
 import com.autotune.analyzer.recommendations.RecommendationConstants;
 import com.autotune.analyzer.utils.AnalyzerConstants;
@@ -27,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
 
 import static com.autotune.analyzer.recommendations.RecommendationConstants.RecommendationValueConstants.DEFAULT_CPU_THRESHOLD;
 import static com.autotune.analyzer.recommendations.RecommendationConstants.RecommendationValueConstants.DEFAULT_MEMORY_THRESHOLD;
@@ -166,40 +168,22 @@ public abstract class BaseRecommendationProcessor {
      * @param currentConfigMap Map containing current configuration
      * @return CurrentConfigValues object containing CPU and memory request/limit values
      */
-    protected CurrentConfigValues extractCurrentConfig(
-            HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> currentConfigMap) {
+    protected CurrentConfigValues extractCurrentConfig(Config currentConfig) {
 
         RecommendationConfigItem currentCPURequest = null;
         RecommendationConfigItem currentCPULimit = null;
         RecommendationConfigItem currentMemRequest = null;
         RecommendationConfigItem currentMemLimit = null;
 
-        if (currentConfigMap.containsKey(AnalyzerConstants.ResourceSetting.requests) &&
-                null != currentConfigMap.get(AnalyzerConstants.ResourceSetting.requests)) {
-            HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> requestsMap =
-                    currentConfigMap.get(AnalyzerConstants.ResourceSetting.requests);
-            if (requestsMap.containsKey(AnalyzerConstants.RecommendationItem.CPU) &&
-                    null != requestsMap.get(AnalyzerConstants.RecommendationItem.CPU)) {
-                currentCPURequest = requestsMap.get(AnalyzerConstants.RecommendationItem.CPU);
-            }
-            if (requestsMap.containsKey(AnalyzerConstants.RecommendationItem.MEMORY) &&
-                    null != requestsMap.get(AnalyzerConstants.RecommendationItem.MEMORY)) {
-                currentMemRequest = requestsMap.get(AnalyzerConstants.RecommendationItem.MEMORY);
-            }
+        Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> requests = currentConfig.getRequests();
+        Map<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> limits = currentConfig.getLimits();
+        if (null != requests) {
+            currentCPURequest = requests.get(AnalyzerConstants.RecommendationItem.CPU);
+            currentMemRequest = requests.get(AnalyzerConstants.RecommendationItem.MEMORY);
         }
-
-        if (currentConfigMap.containsKey(AnalyzerConstants.ResourceSetting.limits) &&
-                null != currentConfigMap.get(AnalyzerConstants.ResourceSetting.limits)) {
-            HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> limitsMap =
-                    currentConfigMap.get(AnalyzerConstants.ResourceSetting.limits);
-            if (limitsMap.containsKey(AnalyzerConstants.RecommendationItem.CPU) &&
-                    null != limitsMap.get(AnalyzerConstants.RecommendationItem.CPU)) {
-                currentCPULimit = limitsMap.get(AnalyzerConstants.RecommendationItem.CPU);
-            }
-            if (limitsMap.containsKey(AnalyzerConstants.RecommendationItem.MEMORY) &&
-                    null != limitsMap.get(AnalyzerConstants.RecommendationItem.MEMORY)) {
-                currentMemLimit = limitsMap.get(AnalyzerConstants.RecommendationItem.MEMORY);
-            }
+        if (null != limits) {
+            currentCPULimit = limits.get(AnalyzerConstants.RecommendationItem.CPU);
+            currentMemLimit = limits.get(AnalyzerConstants.RecommendationItem.MEMORY);
         }
 
         return new CurrentConfigValues(currentCPURequest, currentCPULimit, currentMemRequest, currentMemLimit);

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
@@ -87,8 +87,7 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
 
         timestampRecommendation.setMonitoringEndTime(monitoringEndTime);
 
-        HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> currentConfig =
-                getCurrentConfigData(containerData, monitoringEndTime, timestampRecommendation);
+        Config currentConfig = getCurrentConfigData(containerData, monitoringEndTime, timestampRecommendation);
         timestampRecommendation.setCurrentConfig(currentConfig);
 
         boolean recommendationAvailable = generateRecommendationsBasedOnTerms(containerData, kruizeObject, monitoringEndTime, currentConfig, timestampRecommendation);
@@ -109,10 +108,9 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
         containerData.setContainerRecommendations(containerRecommendations);
     }
 
-    private HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> getCurrentConfigData(
-            ContainerData containerData, Timestamp monitoringEndTime, MappedRecommendationForTimestamp timestampRecommendation) {
+    private Config getCurrentConfigData(ContainerData containerData, Timestamp monitoringEndTime, MappedRecommendationForTimestamp timestampRecommendation) {
 
-        HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> currentConfig = new HashMap<>();
+        Config currentConfig = new Config();
         ArrayList<RecommendationConstants.RecommendationNotification> notifications = new ArrayList<>();
         HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> currentRequestsMap = new HashMap<>();
         HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> currentLimitsMap = new HashMap<>();
@@ -130,6 +128,7 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
                     continue;
                 }
 
+
                 if (resourceSetting == AnalyzerConstants.ResourceSetting.requests) {
                     currentRequestsMap.put(recommendationItem, configItem);
                 }
@@ -143,18 +142,17 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
             timestampRecommendation.addNotification(new RecommendationNotification(recommendationNotification));
         }
         if (!currentRequestsMap.isEmpty()) {
-            currentConfig.put(AnalyzerConstants.ResourceSetting.requests, currentRequestsMap);
+            currentConfig.setRequests(currentRequestsMap);
         }
         if (!currentLimitsMap.isEmpty()) {
-            currentConfig.put(AnalyzerConstants.ResourceSetting.limits, currentLimitsMap);
+            currentConfig.setLimits(currentLimitsMap);
         }
         return currentConfig;
     }
 
     private boolean generateRecommendationsBasedOnTerms(ContainerData containerData, KruizeObject kruizeObject,
                                                        Timestamp monitoringEndTime,
-                                                       HashMap<AnalyzerConstants.ResourceSetting,
-                                                               HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> currentConfig,
+                                                       Config currentConfig,
                                                        MappedRecommendationForTimestamp timestampRecommendation) {
         boolean recommendationAvailable = false;
         double measurementDuration = kruizeObject.getTrial_settings().getMeasurement_durationMinutes_inDouble();
@@ -238,8 +236,7 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
 
     private MappedRecommendationForModel generateRecommendationBasedOnModel(Timestamp monitoringStartTime, RecommendationModel model, ContainerData containerData,
                                                                             Timestamp monitoringEndTime, KruizeObject kruizeObject,
-                                                                            HashMap<AnalyzerConstants.ResourceSetting,
-                                                                                    HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> currentConfigMap,
+                                                                            Config currentConfig,
                                                                             Map.Entry<String, Terms> termEntry) {
 
         MappedRecommendationForModel mappedRecommendationForModel = new MappedRecommendationForModel();
@@ -250,11 +247,11 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
         double memoryThreshold = thresholds.memoryThreshold;
 
         // Extract current config using base class helper
-        CurrentConfigValues currentConfig = extractCurrentConfig(currentConfigMap);
-        RecommendationConfigItem currentCPURequest = currentConfig.cpuRequest;
-        RecommendationConfigItem currentCPULimit = currentConfig.cpuLimit;
-        RecommendationConfigItem currentMemRequest = currentConfig.memoryRequest;
-        RecommendationConfigItem currentMemLimit = currentConfig.memoryLimit;
+        CurrentConfigValues currentConfigValues = extractCurrentConfig(currentConfig);
+        RecommendationConfigItem currentCPURequest = currentConfigValues.cpuRequest;
+        RecommendationConfigItem currentCPULimit = currentConfigValues.cpuLimit;
+        RecommendationConfigItem currentMemRequest = currentConfigValues.memoryRequest;
+        RecommendationConfigItem currentMemLimit = currentConfigValues.memoryLimit;
 
         if (null != monitoringStartTime) {
             Timestamp finalMonitoringStartTime = monitoringStartTime;

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/NamespaceRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/NamespaceRecommendationProcessor.java
@@ -19,10 +19,7 @@ package com.autotune.analyzer.recommendations.engine;
 import com.autotune.analyzer.kruizeObject.KruizeObject;
 import com.autotune.analyzer.kruizeObject.RecommendationSettings;
 import com.autotune.analyzer.plots.PlotManager;
-import com.autotune.analyzer.recommendations.NamespaceRecommendations;
-import com.autotune.analyzer.recommendations.RecommendationConfigItem;
-import com.autotune.analyzer.recommendations.RecommendationConstants;
-import com.autotune.analyzer.recommendations.RecommendationNotification;
+import com.autotune.analyzer.recommendations.*;
 import com.autotune.analyzer.recommendations.model.RecommendationModel;
 import com.autotune.analyzer.recommendations.objects.MappedRecommendationForModel;
 import com.autotune.analyzer.recommendations.objects.MappedRecommendationForTimestamp;
@@ -94,8 +91,7 @@ public final class NamespaceRecommendationProcessor extends BaseRecommendationPr
 
             timestampRecommendation.setMonitoringEndTime(monitoringEndTime);
 
-            HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> currentConfig =
-                    getCurrentNamespaceConfigData(namespaceData, monitoringEndTime, timestampRecommendation);
+            Config currentConfig = getCurrentNamespaceConfigData(namespaceData, monitoringEndTime, timestampRecommendation);
             timestampRecommendation.setCurrentConfig(currentConfig);
 
             boolean recommendationAvailable = generateNamespaceRecommendationsBasedOnTerms(namespaceData, kruizeObject, monitoringEndTime, currentConfig, timestampRecommendation);
@@ -119,10 +115,9 @@ public final class NamespaceRecommendationProcessor extends BaseRecommendationPr
         }
     }
 
-    private HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> getCurrentNamespaceConfigData(
-            NamespaceData namespaceData, Timestamp monitoringEndTime, MappedRecommendationForTimestamp timestampRecommendation) {
+    private Config getCurrentNamespaceConfigData(NamespaceData namespaceData, Timestamp monitoringEndTime, MappedRecommendationForTimestamp timestampRecommendation) {
 
-        HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> currentNamespaceConfig = new HashMap<>();
+        Config currentNamespaceConfig = new Config();
         ArrayList<RecommendationConstants.RecommendationNotification> notifications = new ArrayList<>();
         HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> currentNamespaceRequestsMap = new HashMap<>();
         HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> currentNamespaceLimitsMap = new HashMap<>();
@@ -152,18 +147,17 @@ public final class NamespaceRecommendationProcessor extends BaseRecommendationPr
             timestampRecommendation.addNotification(new RecommendationNotification(recommendationNotification));
         }
         if (!currentNamespaceRequestsMap.isEmpty()) {
-            currentNamespaceConfig.put(AnalyzerConstants.ResourceSetting.requests, currentNamespaceRequestsMap);
+            currentNamespaceConfig.setRequests(currentNamespaceRequestsMap);
         }
         if (!currentNamespaceLimitsMap.isEmpty()) {
-            currentNamespaceConfig.put(AnalyzerConstants.ResourceSetting.limits, currentNamespaceLimitsMap);
+            currentNamespaceConfig.setLimits(currentNamespaceLimitsMap);
         }
         return currentNamespaceConfig;
     }
 
     private boolean generateNamespaceRecommendationsBasedOnTerms(NamespaceData namespaceData, KruizeObject kruizeObject,
                                                                 Timestamp monitoringEndTime,
-                                                                HashMap<AnalyzerConstants.ResourceSetting,
-                                                                        HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> currentConfig,
+                                                                Config currentConfig,
                                                                 MappedRecommendationForTimestamp timestampRecommendation) {
         boolean namespaceRecommendationAvailable = false;
         double measurementDuration = kruizeObject.getTrial_settings().getMeasurement_durationMinutes_inDouble();
@@ -250,8 +244,7 @@ public final class NamespaceRecommendationProcessor extends BaseRecommendationPr
                                                                                     NamespaceData namespaceData,
                                                                                     Timestamp monitoringEndTime,
                                                                                     RecommendationSettings recommendationSettings,
-                                                                                    HashMap<AnalyzerConstants.ResourceSetting,
-                                                                                            HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> currentNamespaceConfigMap,
+                                                                                    Config currentNamespaceConfig,
                                                                                     Map.Entry<String, Terms> termEntry) {
         MappedRecommendationForModel mappedRecommendationForModel = new MappedRecommendationForModel();
         
@@ -261,7 +254,7 @@ public final class NamespaceRecommendationProcessor extends BaseRecommendationPr
         double namespaceMemoryThreshold = thresholds.memoryThreshold;
 
         // Extract current config using base class helper
-        CurrentConfigValues currentConfig = extractCurrentConfig(currentNamespaceConfigMap);
+        CurrentConfigValues currentConfig = extractCurrentConfig(currentNamespaceConfig);
         RecommendationConfigItem currentNamespaceCPURequest = currentConfig.cpuRequest;
         RecommendationConfigItem currentNamespaceCPULimit = currentConfig.cpuLimit;
         RecommendationConfigItem currentNamespaceMemRequest = currentConfig.memoryRequest;

--- a/src/main/java/com/autotune/analyzer/recommendations/objects/MappedRecommendationForTimestamp.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/objects/MappedRecommendationForTimestamp.java
@@ -1,5 +1,6 @@
 package com.autotune.analyzer.recommendations.objects;
 
+import com.autotune.analyzer.recommendations.Config;
 import com.autotune.analyzer.recommendations.RecommendationConfigItem;
 import com.autotune.analyzer.recommendations.RecommendationConstants;
 import com.autotune.analyzer.recommendations.RecommendationNotification;
@@ -22,8 +23,10 @@ public class MappedRecommendationForTimestamp {
     @SerializedName(KruizeConstants.JSONKeys.MONITORING_END_TIME)
     private Timestamp monitoringEndTime;
 
+    // Current config is same as recommended config in terms of the properties.
+    // So, reuse same Config.class for representing current config as well.
     @SerializedName(KruizeConstants.JSONKeys.CURRENT)
-    private HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> currentConfig;
+    private Config currentConfig;
 
     @SerializedName(KruizeConstants.JSONKeys.RECOMMENDATION_TERMS)
     private HashMap<String, TermRecommendations> recommendationForTermHashMap;
@@ -44,11 +47,11 @@ public class MappedRecommendationForTimestamp {
         this.monitoringEndTime = monitoringEndTime;
     }
 
-    public HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> getCurrentConfig() {
+    public Config getCurrentConfig() {
         return currentConfig;
     }
 
-    public void setCurrentConfig(HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> currentConfig) {
+    public void setCurrentConfig(Config currentConfig) {
         this.currentConfig = currentConfig;
     }
 


### PR DESCRIPTION
## Description

This PR contains code optimization to replace Map with Config object to hold current config in MappedRecommendationForTimestamp model. 

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Refactor recommendation processing to represent current configuration using the existing Config object instead of nested maps for both container- and namespace-level recommendations.

Enhancements:
- Replace nested HashMap-based current config representation with the Config class across recommendation processors and timestamp recommendation objects.
- Simplify extraction of current CPU and memory request/limit values by leveraging Config accessors for requests and limits.