### PR TITLE
Add support for multiple datasources in createExperiment and generate Recommendations.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -22,7 +22,7 @@ AUTOTUNE_DOCKER_REPO="kruize/autotune_operator"
 AUTOTUNE_VERSION="$(grep -A 1 "autotune" "${ROOT_DIR}"/pom.xml | grep version | awk -F '>' '{ split($2, a, "<"); print a[1] }')"
 AUTOTUNE_DOCKER_IMAGE=${AUTOTUNE_DOCKER_REPO}:${AUTOTUNE_VERSION}
 DEV_MODE=0
-BUILD_PARAMS="--pull --no-cache"
+BUILD_PARAMS="--pull --no-cache --platform linux/amd64"
 
 function usage() {
 	echo "Usage: $0 [-d] [-v version_string] [-i autotune_docker_image]"
@@ -88,14 +88,14 @@ fi
 echo ${BUILD_PARAMS}
 
 BUILDTMPFILE=/tmp/docker_build_log.$$
-BUILDER="docker"
+BUILDER="podman"
 
-${BUILDER} build ${BUILD_PARAMS} --format=docker --build-arg AUTOTUNE_VERSION=${DOCKER_TAG} -t ${AUTOTUNE_DOCKER_IMAGE} -f ${AUTOTUNE_DOCKERFILE} . 2>${BUILDTMPFILE}
+${BUILDER} build ${BUILD_PARAMS} --platform linux/amd64 --format=docker --build-arg AUTOTUNE_VERSION=${DOCKER_TAG} -t ${AUTOTUNE_DOCKER_IMAGE} -f ${AUTOTUNE_DOCKERFILE} . 2>${BUILDTMPFILE}
 build_error=$(grep 'Error:\|unknown flag:' ${BUILDTMPFILE})
 
 if [ -n "${build_error}" ]; then
 	echo '--format=docker not supported'
-	${BUILDER} build ${BUILD_PARAMS} --build-arg AUTOTUNE_VERSION=${DOCKER_TAG} -t ${AUTOTUNE_DOCKER_IMAGE} -f ${AUTOTUNE_DOCKERFILE} .
+	${BUILDER} build ${BUILD_PARAMS} --platform linux/amd64 --build-arg AUTOTUNE_VERSION=${DOCKER_TAG} -t ${AUTOTUNE_DOCKER_IMAGE} -f ${AUTOTUNE_DOCKERFILE} .
 	check_err "Docker build of ${AUTOTUNE_DOCKER_IMAGE} failed."
 fi
 

--- a/manifests/autotune/layers/hotspot-micrometer-config.json
+++ b/manifests/autotune/layers/hotspot-micrometer-config.json
@@ -40,7 +40,7 @@
       },
       {
         "datasource": "cryostat",
-        "query": "{\"query\":\"{ environmentNodes(filter:{ nodeTypes:[\"Pod\"] name:\"$POD_NAME$\" }) { name descendantTargets { name target { alias id jvmId } } } }\"}",
+        "query": "{\"query\":\"{ environmentNodes(filter:{ nodeTypes:[\\\"Pod\\\"] name:\\\"$POD_NAME$\\\" }) { name descendantTargets { name target { alias id jvmId } } } }\"}",
         "key": "pod"
       }
     ]

--- a/manifests/autotune/layers/hotspot-micrometer-config.json
+++ b/manifests/autotune/layers/hotspot-micrometer-config.json
@@ -37,6 +37,11 @@
         "datasource": "prometheus",
         "query": "jvm_memory_used_bytes{area=\"heap\",id=~\"Old.+\"}",
         "key": "pod"
+      },
+      {
+        "datasource": "cryostat",
+        "query": "{\"query\":\"{ environmentNodes(filter:{ nodeTypes:[\"Pod\"] name:\"$POD_NAME$\" }) { name descendantTargets { name target { alias id jvmId } } } }\"}",
+        "key": "pod"
       }
     ]
   },

--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -262,9 +262,44 @@ data:
                 "tokenFilePath": "/var/run/secrets/kubernetes.io/serviceaccount/token"
               }
           }
+        },
+        {
+          "name": "cryostat",
+          "provider": "cryostat",
+          "serviceName": "",
+          "namespace": "",
+          "url": "https://cryostat-ultron.cryostat-ultron.svc.cluster.local:4180",
+          "authentication": {
+            "type": "bearer",
+            "credentials": {
+              "tokenFilePath": "/var/run/secrets/kubernetes.io/serviceaccount/token"
+            }
+          }
         }
       ]
     }
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cryostat-access-role
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kruize-cryostat-access
+subjects:
+  - kind: ServiceAccount
+    name: kruize-sa
+    namespace: openshift-tuning
+roleRef:
+  kind: ClusterRole
+  name: cryostat-access-role
+  apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -363,7 +398,7 @@ spec:
               done
       containers:
         - name: kruize
-          image: quay.io/kruize/autotune_operator:0.10
+          image: quay.io/bharathappali/exman:cryostat-layer-detect
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume
@@ -601,7 +636,7 @@ spec:
     spec:
       containers:
         - name: kruize-ui-nginx-container
-          image: quay.io/kruize/kruize-ui:0.0.9
+          image: quay.io/kruize/kruize-ui:0.1.0
           imagePullPolicy: Always
           env:
             - name: KRUIZE_UI_ENV
@@ -614,3 +649,15 @@ spec:
         - name: nginx-config-volume
           configMap:
             name: nginx-config
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: kruize-route
+  namespace: openshift-tuning
+spec:
+  to:
+    kind: Service
+    name: kruize
+  port:
+    targetPort: kruize-port

--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -264,11 +264,11 @@ data:
           }
         },
         {
-          "name": "cryostat",
+          "name": "cryostat-sample",
           "provider": "cryostat",
           "serviceName": "",
           "namespace": "",
-          "url": "https://cryostat-ultron.cryostat-ultron.svc.cluster.local:4180",
+          "url": "https://cryostat-sample.cryostat.svc.cluster.local:4180",
           "authentication": {
             "type": "bearer",
             "credentials": {
@@ -398,7 +398,7 @@ spec:
               done
       containers:
         - name: kruize
-          image: quay.io/bharathappali/exman:cryostat-layer-detect
+          image: quay.io/khansaad/autotune_operator:iirj
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume

--- a/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
+++ b/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
@@ -187,7 +187,7 @@ public class ExperimentValidation {
                                 }
                             }
                         } else {
-                            errorMsg = "No datasources specified in the experiment";
+                            errorMsg = KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.NO_DATASOURCE_SERVICEABLE;
                             validationOutputData.setErrorCode(HttpServletResponse.SC_BAD_REQUEST);
                             proceed = false;
                         }
@@ -411,7 +411,7 @@ public class ExperimentValidation {
                         }
                     }
                 } else if (expObj.getExperiment_usecase_type().isLocal_monitoring()) {
-                    // Check both single datasource (deprecated) and datasources list (new)
+                    // Check both single datasource and datasources list
                     if (null == expObj.getDataSource() && (null == expObj.getDatasources() || expObj.getDatasources().isEmpty())) {
                         errorMsg = errorMsg.concat(String.format(LOCAL_MONITORING_DATASOURCE_MANDATORY, expObj.getExperimentName()));
                         missingLocalDatasource = true;

--- a/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
+++ b/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
@@ -172,12 +172,22 @@ public class ExperimentValidation {
                             validationOutputData.setErrorCode(HttpServletResponse.SC_BAD_REQUEST);
                             proceed = false;
                         }
-                        // check if the provided datasource name exists
-                        DataSourceInfo dataSourceInfo = DataSourceCollection.getInstance().getDataSourcesCollection().get(kruizeObject.getDataSource());
-                        if (dataSourceInfo != null) {
-                            LOGGER.debug("DataSource {} exists", kruizeObject.getDataSource());
+                        // check if the provided datasource name(s) exist
+                        List<String> datasources = kruizeObject.getDatasources();
+                        if (datasources != null && !datasources.isEmpty()) {
+                            for (String datasourceName : datasources) {
+                                DataSourceInfo dataSourceInfo = DataSourceCollection.getInstance().getDataSourcesCollection().get(datasourceName);
+                                if (dataSourceInfo != null) {
+                                    LOGGER.debug("DataSource {} exists", datasourceName);
+                                } else {
+                                    errorMsg = String.format(AnalyzerErrorConstants.APIErrors.ListDataSourcesAPI.INVALID_DATASOURCE_NAME_MSG, datasourceName);
+                                    validationOutputData.setErrorCode(HttpServletResponse.SC_BAD_REQUEST);
+                                    proceed = false;
+                                    break;
+                                }
+                            }
                         } else {
-                            errorMsg = String.format(AnalyzerErrorConstants.APIErrors.ListDataSourcesAPI.INVALID_DATASOURCE_NAME_MSG, kruizeObject.getDataSource());
+                            errorMsg = "No datasources specified in the experiment";
                             validationOutputData.setErrorCode(HttpServletResponse.SC_BAD_REQUEST);
                             proceed = false;
                         }
@@ -401,7 +411,8 @@ public class ExperimentValidation {
                         }
                     }
                 } else if (expObj.getExperiment_usecase_type().isLocal_monitoring()) {
-                    if (null == expObj.getDataSource()) {
+                    // Check both single datasource (deprecated) and datasources list (new)
+                    if (null == expObj.getDataSource() && (null == expObj.getDatasources() || expObj.getDatasources().isEmpty())) {
                         errorMsg = errorMsg.concat(String.format(LOCAL_MONITORING_DATASOURCE_MANDATORY, expObj.getExperimentName()));
                         missingLocalDatasource = true;
                     }

--- a/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
+++ b/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
@@ -411,8 +411,8 @@ public class ExperimentValidation {
                         }
                     }
                 } else if (expObj.getExperiment_usecase_type().isLocal_monitoring()) {
-                    // Check both single datasource and datasources list
-                    if (null == expObj.getDataSource() && (null == expObj.getDatasources() || expObj.getDatasources().isEmpty())) {
+                    List<String> datasources = expObj.getDatasources();
+                    if (datasources == null || datasources.isEmpty()) {
                         errorMsg = errorMsg.concat(String.format(LOCAL_MONITORING_DATASOURCE_MANDATORY, expObj.getExperimentName()));
                         missingLocalDatasource = true;
                     }

--- a/src/main/java/com/autotune/analyzer/kruizeLayer/presence/LabelBasedPresence.java
+++ b/src/main/java/com/autotune/analyzer/kruizeLayer/presence/LabelBasedPresence.java
@@ -43,7 +43,7 @@ public class LabelBasedPresence implements LayerPresenceDetector {
     }
 
     @Override
-    public boolean detectPresence(String namespace, String containerName, String datasourceName) throws Exception {
+    public boolean detectPresence(String namespace, String containerName, List<String> datasourceNames) throws Exception {
         // TODO: Implement label-based presence detection
         throw new UnsupportedOperationException("Label-based presence detection not yet implemented");
     }

--- a/src/main/java/com/autotune/analyzer/kruizeLayer/presence/LayerPresenceDetector.java
+++ b/src/main/java/com/autotune/analyzer/kruizeLayer/presence/LayerPresenceDetector.java
@@ -17,6 +17,7 @@
 package com.autotune.analyzer.kruizeLayer.presence;
 
 import com.autotune.analyzer.utils.AnalyzerConstants.LayerConstants.PresenceType;
+import java.util.List;
 
 /**
  * Interface for different layer presence detection strategies
@@ -33,11 +34,11 @@ public interface LayerPresenceDetector {
      * Detect if the layer is present in the given namespace and container
      * @param namespace The Kubernetes namespace to check
      * @param containerName The container name to check (optional, can be null)
-     * @param datasourceName The datasource name to use for detection
+     * @param datasourceNames The datasource names configured for the experiment
      * @return true if the layer is detected, false otherwise
      * @throws Exception if detection fails due to connectivity or other issues
      */
-    boolean detectPresence(String namespace, String containerName, String datasourceName) throws Exception;
+    boolean detectPresence(String namespace, String containerName, List<String> datasourceNames) throws Exception;
 
 
 }

--- a/src/main/java/com/autotune/analyzer/kruizeLayer/presence/PresenceAlways.java
+++ b/src/main/java/com/autotune/analyzer/kruizeLayer/presence/PresenceAlways.java
@@ -17,6 +17,7 @@
 package com.autotune.analyzer.kruizeLayer.presence;
 
 import com.autotune.analyzer.utils.AnalyzerConstants.LayerConstants.PresenceType;
+import java.util.List;
 
 /**
  * Implementation for layers that are always present
@@ -31,7 +32,7 @@ public class PresenceAlways implements LayerPresenceDetector {
     }
 
     @Override
-    public boolean detectPresence(String namespace, String containerName, String datasourceName) throws Exception {
+    public boolean detectPresence(String namespace, String containerName, List<String> datasourceNames) throws Exception {
         // Layers with ALWAYS presence type are always detected
         return true;
     }

--- a/src/main/java/com/autotune/analyzer/kruizeLayer/presence/QueryBasedPresence.java
+++ b/src/main/java/com/autotune/analyzer/kruizeLayer/presence/QueryBasedPresence.java
@@ -120,6 +120,7 @@ public class QueryBasedPresence implements LayerPresenceDetector {
 
                     if (!pods.isEmpty()) {
                         for (String pod: pods) {
+                            System.out.println("Checking Cryostat targets for pod: " + pod);
                             String queryToTry = modifiedQuery.replace("$POD_NAME$", pod);
                             JSONObject graphQlJson = operator.getJsonObjectForQuery(cryostatDatasourceInfo, queryToTry);
                             JSONArray envNodes = graphQlJson
@@ -127,6 +128,8 @@ public class QueryBasedPresence implements LayerPresenceDetector {
                                     .optJSONArray("environmentNodes");
 
                             if (envNodes != null && !envNodes.isEmpty()) {
+                                System.out.println(
+                                        "SUCCESS: Found Cryostat target(s) for pod '" + pod);
                                 return true;
                             }
                         }

--- a/src/main/java/com/autotune/analyzer/kruizeLayer/presence/QueryBasedPresence.java
+++ b/src/main/java/com/autotune/analyzer/kruizeLayer/presence/QueryBasedPresence.java
@@ -17,13 +17,18 @@
 package com.autotune.analyzer.kruizeLayer.presence;
 
 import com.autotune.analyzer.kruizeLayer.LayerPresenceQuery;
+import com.autotune.analyzer.kruizeLayer.utils.LayerUtils;
 import com.autotune.analyzer.utils.AnalyzerConstants.LayerConstants;
 import com.autotune.analyzer.utils.AnalyzerConstants.LayerConstants.LogMessages;
 import com.autotune.analyzer.utils.AnalyzerConstants.LayerConstants.PresenceType;
 import com.autotune.common.datasource.DataSourceCollection;
 import com.autotune.common.datasource.DataSourceInfo;
 import com.autotune.common.datasource.DataSourceOperatorImpl;
+import com.autotune.utils.KruizeConstants;
 import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -96,26 +101,58 @@ public class QueryBasedPresence implements LayerPresenceDetector {
                 // Start with the original query
                 String modifiedQuery = query.getLayerPresenceQuery();
 
-                // Append dynamic filters for namespace, container
-                if (namespace != null && !namespace.isBlank()) {
-                    modifiedQuery = appendFilter(modifiedQuery, LayerConstants.LABEL_NAMESPACE, namespace);
-                }
-                if (containerName != null && !containerName.isBlank()) {
-                    modifiedQuery = appendFilter(modifiedQuery, LayerConstants.LABEL_CONTAINER, containerName);
-                }
+                if (query.getDataSource().equalsIgnoreCase(KruizeConstants.SupportedDatasources.CRYOSTAT)) {
+                    DataSourceOperatorImpl tmpPromOperator = DataSourceOperatorImpl.getInstance()
+                            .getOperator(KruizeConstants.SupportedDatasources.PROMETHEUS);
+                    DataSourceInfo promDatasourceInfo = DataSourceCollection.getInstance()
+                            .getDataSourcesCollection()
+                            .get("prometheus-1");
+                    DataSourceInfo cryostatDatasourceInfo = DataSourceCollection.getInstance().getDataSourcesCollection().get(KruizeConstants.SupportedDatasources.CRYOSTAT);
+                    String promQl = KruizeConstants.PromQueries.GET_PODS_WITH_NS_CONTAINER;
+                    if (namespace != null && !namespace.isBlank()) {
+                        promQl = appendFilter(modifiedQuery, LayerConstants.LABEL_NAMESPACE, namespace);
+                    }
+                    if (containerName != null && !containerName.isBlank()) {
+                        promQl = appendFilter(modifiedQuery, LayerConstants.LABEL_CONTAINER, containerName);
+                    }
+                    JSONObject returnObj = tmpPromOperator.getJsonObjectForQuery(promDatasourceInfo, promQl);
+                    List<String> pods = LayerUtils.extractPods(returnObj);
 
-                LOGGER.debug(LogMessages.EXECUTING_QUERY, modifiedQuery);
+                    if (!pods.isEmpty()) {
+                        for (String pod: pods) {
+                            String queryToTry = modifiedQuery.replace("$POD_NAME$", pod);
+                            JSONObject graphQlJson = operator.getJsonObjectForQuery(cryostatDatasourceInfo, queryToTry);
+                            JSONArray envNodes = graphQlJson
+                                    .optJSONObject("data")
+                                    .optJSONArray("environmentNodes");
 
-                // Execute the modified query and get results
-                JsonArray resultArray = operator.getResultArrayForQuery(
-                        dataSourceInfo,
-                        modifiedQuery
-                );
+                            if (envNodes != null && !envNodes.isEmpty()) {
+                                return true;
+                            }
+                        }
+                    }
 
-                // Check if we got any results - if yes, layer is present
-                if (resultArray != null && !resultArray.isEmpty()) {
-                    LOGGER.debug(LogMessages.LAYER_DETECTED_VIA_QUERY, namespace, containerName);
-                    return true;
+                } else {
+                    // Append dynamic filters for namespace, container
+                    if (namespace != null && !namespace.isBlank()) {
+                        modifiedQuery = appendFilter(modifiedQuery, LayerConstants.LABEL_NAMESPACE, namespace);
+                    }
+                    if (containerName != null && !containerName.isBlank()) {
+                        modifiedQuery = appendFilter(modifiedQuery, LayerConstants.LABEL_CONTAINER, containerName);
+                    }
+                    LOGGER.debug(LogMessages.EXECUTING_QUERY, modifiedQuery);
+
+                    // Execute the modified query and get results
+                    JsonArray resultArray = operator.getResultArrayForQuery(
+                            dataSourceInfo,
+                            modifiedQuery
+                    );
+
+                    // Check if we got any results - if yes, layer is present
+                    if (resultArray != null && !resultArray.isEmpty()) {
+                        LOGGER.debug(LogMessages.LAYER_DETECTED_VIA_QUERY, namespace, containerName);
+                        return true;
+                    }
                 }
             } catch (Exception e) {
                 LOGGER.error(LogMessages.ERROR_EXECUTING_QUERY, query.getDataSource(), e);

--- a/src/main/java/com/autotune/analyzer/kruizeLayer/presence/QueryBasedPresence.java
+++ b/src/main/java/com/autotune/analyzer/kruizeLayer/presence/QueryBasedPresence.java
@@ -92,6 +92,15 @@ public class QueryBasedPresence implements LayerPresenceDetector {
                     continue;
                 }
 
+                // Skip queries that don't match the datasource provider
+                // This prevents executing Prometheus queries against Cryostat and vice versa
+                if (query.getDataSource() != null &&
+                    !query.getDataSource().equalsIgnoreCase(dataSourceInfo.getProvider())) {
+                    LOGGER.debug("Skipping query for datasource '{}' as it doesn't match current datasource provider '{}'",
+                            query.getDataSource(), dataSourceInfo.getProvider());
+                    continue;
+                }
+
                 // Get the appropriate operator for the datasource provider
                 DataSourceOperatorImpl operator = DataSourceOperatorImpl.getInstance()
                         .getOperator(dataSourceInfo.getProvider());
@@ -105,12 +114,28 @@ public class QueryBasedPresence implements LayerPresenceDetector {
                 String modifiedQuery = query.getLayerPresenceQuery();
 
                 if (query.getDataSource().equalsIgnoreCase(KruizeConstants.SupportedDatasources.CRYOSTAT)) {
+                    // For Cryostat detection, we need to:
+                    // 1. Query Prometheus to get the list of pods
+                    // 2. Query Cryostat to check if those pods have JVM targets
+                    
+                    // Find a Prometheus datasource from the collection
+                    DataSourceInfo promDatasourceInfo = null;
+                    for (DataSourceInfo ds : DataSourceCollection.getInstance().getDataSourcesCollection().values()) {
+                        if (ds.getProvider().equalsIgnoreCase(KruizeConstants.SupportedDatasources.PROMETHEUS)) {
+                            promDatasourceInfo = ds;
+                            break;
+                        }
+                    }
+                    
+                    if (promDatasourceInfo == null) {
+                        LOGGER.warn("Cryostat layer detection requires a Prometheus datasource to query pods, but none found. Skipping Cryostat detection.");
+                        continue;
+                    }
+                    
                     DataSourceOperatorImpl tmpPromOperator = DataSourceOperatorImpl.getInstance()
                             .getOperator(KruizeConstants.SupportedDatasources.PROMETHEUS);
-//                    DataSourceInfo promDatasourceInfo = DataSourceCollection.getInstance()
-//                            .getDataSourcesCollection()
-//                            .get("thanos-1");
-                    DataSourceInfo cryostatDatasourceInfo = DataSourceCollection.getInstance().getDataSourcesCollection().get(KruizeConstants.SupportedDatasources.CRYOSTAT);
+                    
+                    // Build PromQL query to get pods
                     String promQl = KruizeConstants.PromQueries.GET_PODS_WITH_NS_CONTAINER;
                     if (namespace != null && !namespace.isBlank()) {
                         promQl = appendFilter(promQl, LayerConstants.LABEL_NAMESPACE, namespace);
@@ -119,8 +144,12 @@ public class QueryBasedPresence implements LayerPresenceDetector {
                         promQl = appendFilter(promQl, LayerConstants.LABEL_CONTAINER, containerName);
                     }
                     System.out.println("PromQl: " + promQl);
-                    JSONObject returnObj = tmpPromOperator.getJsonObjectForQuery(dataSourceInfo, promQl);
+                    
+                    // Execute Prometheus query using the Prometheus datasource
+                    JSONObject returnObj = tmpPromOperator.getJsonObjectForQuery(promDatasourceInfo, promQl);
                     List<String> pods = LayerUtils.extractPods(returnObj);
+                    
+                    // Get Cryostat operator and datasource
                     DataSourceOperatorImpl cryostatOperator = DataSourceOperatorImpl.getInstance()
                             .getOperator(KruizeConstants.SupportedDatasources.CRYOSTAT);
                     if (!pods.isEmpty()) {
@@ -128,14 +157,15 @@ public class QueryBasedPresence implements LayerPresenceDetector {
                             System.out.println("Checking Cryostat targets for pod: " + pod);
                             String queryToTry = modifiedQuery.replace("$POD_NAME$", pod);
                             System.out.println("Cryostat Query: " + queryToTry);
-                            if (null == cryostatDatasourceInfo) {
-                                System.out.println("Cryostat DS is null");
+                            
+                            // Use the Cryostat datasource (dataSourceInfo) for GraphQL query
+                            JSONObject graphQlJson = cryostatOperator.getJsonObjectForQuery(dataSourceInfo, queryToTry);
+                            if (null == graphQlJson) {
+                                System.out.println("Graph QL response is null");
                                 continue;
                             }
-                            JSONObject graphQlJson = cryostatOperator.getJsonObjectForQuery(cryostatDatasourceInfo, queryToTry);
-                            if (null == graphQlJson)
-                                System.out.println("Graph QL response is null");
-                            System.out.println("GraphQL object:" + graphQlJson.toString());
+                            
+                            System.out.println("GraphQL object:" + graphQlJson);
                             JSONArray envNodes = graphQlJson
                                     .optJSONObject("data")
                                     .optJSONArray("environmentNodes");

--- a/src/main/java/com/autotune/analyzer/kruizeLayer/presence/QueryBasedPresence.java
+++ b/src/main/java/com/autotune/analyzer/kruizeLayer/presence/QueryBasedPresence.java
@@ -27,6 +27,7 @@ import com.autotune.common.datasource.DataSourceOperatorImpl;
 import com.autotune.utils.KruizeConstants;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import org.apache.logging.log4j.core.util.SystemNanoClock;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -70,6 +71,8 @@ public class QueryBasedPresence implements LayerPresenceDetector {
             return false;
         }
 
+        System.out.println("Datasource Name: " + datasourceName);
+
         // Iterate through all configured queries
         for (LayerPresenceQuery query : queries) {
             // Skip null query objects
@@ -104,25 +107,35 @@ public class QueryBasedPresence implements LayerPresenceDetector {
                 if (query.getDataSource().equalsIgnoreCase(KruizeConstants.SupportedDatasources.CRYOSTAT)) {
                     DataSourceOperatorImpl tmpPromOperator = DataSourceOperatorImpl.getInstance()
                             .getOperator(KruizeConstants.SupportedDatasources.PROMETHEUS);
-                    DataSourceInfo promDatasourceInfo = DataSourceCollection.getInstance()
-                            .getDataSourcesCollection()
-                            .get("prometheus-1");
+//                    DataSourceInfo promDatasourceInfo = DataSourceCollection.getInstance()
+//                            .getDataSourcesCollection()
+//                            .get("thanos-1");
                     DataSourceInfo cryostatDatasourceInfo = DataSourceCollection.getInstance().getDataSourcesCollection().get(KruizeConstants.SupportedDatasources.CRYOSTAT);
                     String promQl = KruizeConstants.PromQueries.GET_PODS_WITH_NS_CONTAINER;
                     if (namespace != null && !namespace.isBlank()) {
-                        promQl = appendFilter(modifiedQuery, LayerConstants.LABEL_NAMESPACE, namespace);
+                        promQl = appendFilter(promQl, LayerConstants.LABEL_NAMESPACE, namespace);
                     }
                     if (containerName != null && !containerName.isBlank()) {
-                        promQl = appendFilter(modifiedQuery, LayerConstants.LABEL_CONTAINER, containerName);
+                        promQl = appendFilter(promQl, LayerConstants.LABEL_CONTAINER, containerName);
                     }
-                    JSONObject returnObj = tmpPromOperator.getJsonObjectForQuery(promDatasourceInfo, promQl);
+                    System.out.println("PromQl: " + promQl);
+                    JSONObject returnObj = tmpPromOperator.getJsonObjectForQuery(dataSourceInfo, promQl);
                     List<String> pods = LayerUtils.extractPods(returnObj);
-
+                    DataSourceOperatorImpl cryostatOperator = DataSourceOperatorImpl.getInstance()
+                            .getOperator(KruizeConstants.SupportedDatasources.CRYOSTAT);
                     if (!pods.isEmpty()) {
                         for (String pod: pods) {
                             System.out.println("Checking Cryostat targets for pod: " + pod);
                             String queryToTry = modifiedQuery.replace("$POD_NAME$", pod);
-                            JSONObject graphQlJson = operator.getJsonObjectForQuery(cryostatDatasourceInfo, queryToTry);
+                            System.out.println("Cryostat Query: " + queryToTry);
+                            if (null == cryostatDatasourceInfo) {
+                                System.out.println("Cryostat DS is null");
+                                continue;
+                            }
+                            JSONObject graphQlJson = cryostatOperator.getJsonObjectForQuery(cryostatDatasourceInfo, queryToTry);
+                            if (null == graphQlJson)
+                                System.out.println("Graph QL response is null");
+                            System.out.println("GraphQL object:" + graphQlJson.toString());
                             JSONArray envNodes = graphQlJson
                                     .optJSONObject("data")
                                     .optJSONArray("environmentNodes");

--- a/src/main/java/com/autotune/analyzer/kruizeLayer/presence/QueryBasedPresence.java
+++ b/src/main/java/com/autotune/analyzer/kruizeLayer/presence/QueryBasedPresence.java
@@ -65,13 +65,16 @@ public class QueryBasedPresence implements LayerPresenceDetector {
      * @throws Exception if detection fails
      */
     @Override
-    public boolean detectPresence(String namespace, String containerName, String datasourceName) throws Exception {
+    public boolean detectPresence(String namespace, String containerName, List<String> datasourceNames) throws Exception {
         if (queries == null || queries.isEmpty()) {
             LOGGER.warn(LogMessages.NO_QUERIES_DEFINED);
             return false;
         }
 
-        System.out.println("Datasource Name: " + datasourceName);
+        if (datasourceNames == null || datasourceNames.isEmpty()) {
+            LOGGER.warn("No datasource names provided for layer detection");
+            return false;
+        }
 
         // Iterate through all configured queries
         for (LayerPresenceQuery query : queries) {
@@ -81,128 +84,138 @@ public class QueryBasedPresence implements LayerPresenceDetector {
                 continue;
             }
 
-            try {
-                // Get the specific datasource by name from the experiment
-                DataSourceInfo dataSourceInfo = DataSourceCollection.getInstance()
-                        .getDataSourcesCollection()
-                        .get(datasourceName);
+            for (String datasourceName : datasourceNames) {
+                try {
+                    // Get the specific datasource by name from the experiment
+                    DataSourceInfo dataSourceInfo = DataSourceCollection.getInstance()
+                            .getDataSourcesCollection()
+                            .get(datasourceName);
 
-                if (dataSourceInfo == null) {
-                    LOGGER.warn(LogMessages.DATASOURCE_NOT_FOUND, datasourceName);
-                    continue;
-                }
-
-                // Skip queries that don't match the datasource provider
-                // This prevents executing Prometheus queries against Cryostat and vice versa
-                if (query.getDataSource() != null &&
-                    !query.getDataSource().equalsIgnoreCase(dataSourceInfo.getProvider())) {
-                    LOGGER.debug("Skipping query for datasource '{}' as it doesn't match current datasource provider '{}'",
-                            query.getDataSource(), dataSourceInfo.getProvider());
-                    continue;
-                }
-
-                // Get the appropriate operator for the datasource provider
-                DataSourceOperatorImpl operator = DataSourceOperatorImpl.getInstance()
-                        .getOperator(dataSourceInfo.getProvider());
-
-                if (operator == null) {
-                    LOGGER.warn(LogMessages.NO_OPERATOR_AVAILABLE, dataSourceInfo.getProvider());
-                    continue;
-                }
-
-                // Start with the original query
-                String modifiedQuery = query.getLayerPresenceQuery();
-
-                if (query.getDataSource().equalsIgnoreCase(KruizeConstants.SupportedDatasources.CRYOSTAT)) {
-                    // For Cryostat detection, we need to:
-                    // 1. Query Prometheus to get the list of pods
-                    // 2. Query Cryostat to check if those pods have JVM targets
-                    
-                    // Find a Prometheus datasource from the collection
-                    DataSourceInfo promDatasourceInfo = null;
-                    for (DataSourceInfo ds : DataSourceCollection.getInstance().getDataSourcesCollection().values()) {
-                        if (ds.getProvider().equalsIgnoreCase(KruizeConstants.SupportedDatasources.PROMETHEUS)) {
-                            promDatasourceInfo = ds;
-                            break;
-                        }
-                    }
-                    
-                    if (promDatasourceInfo == null) {
-                        LOGGER.warn("Cryostat layer detection requires a Prometheus datasource to query pods, but none found. Skipping Cryostat detection.");
+                    if (dataSourceInfo == null) {
+                        LOGGER.warn(LogMessages.DATASOURCE_NOT_FOUND, datasourceName);
                         continue;
                     }
-                    
-                    DataSourceOperatorImpl tmpPromOperator = DataSourceOperatorImpl.getInstance()
-                            .getOperator(KruizeConstants.SupportedDatasources.PROMETHEUS);
-                    
-                    // Build PromQL query to get pods
-                    String promQl = KruizeConstants.PromQueries.GET_PODS_WITH_NS_CONTAINER;
-                    if (namespace != null && !namespace.isBlank()) {
-                        promQl = appendFilter(promQl, LayerConstants.LABEL_NAMESPACE, namespace);
-                    }
-                    if (containerName != null && !containerName.isBlank()) {
-                        promQl = appendFilter(promQl, LayerConstants.LABEL_CONTAINER, containerName);
-                    }
-                    System.out.println("PromQl: " + promQl);
-                    
-                    // Execute Prometheus query using the Prometheus datasource
-                    JSONObject returnObj = tmpPromOperator.getJsonObjectForQuery(promDatasourceInfo, promQl);
-                    List<String> pods = LayerUtils.extractPods(returnObj);
-                    
-                    // Get Cryostat operator and datasource
-                    DataSourceOperatorImpl cryostatOperator = DataSourceOperatorImpl.getInstance()
-                            .getOperator(KruizeConstants.SupportedDatasources.CRYOSTAT);
-                    if (!pods.isEmpty()) {
-                        for (String pod: pods) {
-                            System.out.println("Checking Cryostat targets for pod: " + pod);
-                            String queryToTry = modifiedQuery.replace("$POD_NAME$", pod);
-                            System.out.println("Cryostat Query: " + queryToTry);
-                            
-                            // Use the Cryostat datasource (dataSourceInfo) for GraphQL query
-                            JSONObject graphQlJson = cryostatOperator.getJsonObjectForQuery(dataSourceInfo, queryToTry);
-                            if (null == graphQlJson) {
-                                System.out.println("Graph QL response is null");
-                                continue;
-                            }
-                            
-                            System.out.println("GraphQL object:" + graphQlJson);
-                            JSONArray envNodes = graphQlJson
-                                    .optJSONObject("data")
-                                    .optJSONArray("environmentNodes");
 
-                            if (envNodes != null && !envNodes.isEmpty()) {
-                                System.out.println(
-                                        "SUCCESS: Found Cryostat target(s) for pod '" + pod);
-                                return true;
+                    // Skip queries that don't match the datasource provider
+                    if (query.getDataSource() != null &&
+                        !query.getDataSource().equalsIgnoreCase(dataSourceInfo.getProvider())) {
+                        LOGGER.debug("Skipping query for datasource '{}' as it doesn't match current datasource provider '{}'",
+                                query.getDataSource(), dataSourceInfo.getProvider());
+                        continue;
+                    }
+
+                    // Get the appropriate operator for the datasource provider
+                    DataSourceOperatorImpl operator = DataSourceOperatorImpl.getInstance()
+                            .getOperator(dataSourceInfo.getProvider());
+
+                    if (operator == null) {
+                        LOGGER.warn(LogMessages.NO_OPERATOR_AVAILABLE, dataSourceInfo.getProvider());
+                        continue;
+                    }
+
+                    // Start with the original query
+                    String modifiedQuery = query.getLayerPresenceQuery();
+
+                    if (query.getDataSource().equalsIgnoreCase(KruizeConstants.SupportedDatasources.CRYOSTAT)) {
+                        // For Cryostat detection, we need to:
+                        // 1. Query Prometheus to get the list of pods
+                        // 2. Query Cryostat to check if those pods have JVM targets
+
+                        DataSourceInfo promDatasourceInfo = null;
+                        for (String experimentDatasourceName : datasourceNames) {
+                            DataSourceInfo experimentDatasourceInfo = DataSourceCollection.getInstance()
+                                    .getDataSourcesCollection()
+                                    .get(experimentDatasourceName);
+                            if (experimentDatasourceInfo != null &&
+                                    KruizeConstants.SupportedDatasources.PROMETHEUS.equalsIgnoreCase(experimentDatasourceInfo.getProvider())) {
+                                promDatasourceInfo = experimentDatasourceInfo;
+                                break;
                             }
                         }
-                    }
 
-                } else {
-                    // Append dynamic filters for namespace, container
-                    if (namespace != null && !namespace.isBlank()) {
-                        modifiedQuery = appendFilter(modifiedQuery, LayerConstants.LABEL_NAMESPACE, namespace);
-                    }
-                    if (containerName != null && !containerName.isBlank()) {
-                        modifiedQuery = appendFilter(modifiedQuery, LayerConstants.LABEL_CONTAINER, containerName);
-                    }
-                    LOGGER.debug(LogMessages.EXECUTING_QUERY, modifiedQuery);
+                        if (promDatasourceInfo == null) {
+                            LOGGER.warn("Cryostat layer detection requires a Prometheus datasource instance in the experiment datasource list, but none found. Skipping Cryostat detection.");
+                            continue;
+                        }
 
-                    // Execute the modified query and get results
-                    JsonArray resultArray = operator.getResultArrayForQuery(
-                            dataSourceInfo,
-                            modifiedQuery
-                    );
+                        DataSourceOperatorImpl prometheusOperator = DataSourceOperatorImpl.getInstance()
+                                .getOperator(promDatasourceInfo.getProvider());
 
-                    // Check if we got any results - if yes, layer is present
-                    if (resultArray != null && !resultArray.isEmpty()) {
-                        LOGGER.debug(LogMessages.LAYER_DETECTED_VIA_QUERY, namespace, containerName);
-                        return true;
+                        // Build PromQL query to get pods
+                        String promQl = KruizeConstants.PromQueries.GET_PODS_WITH_NS_CONTAINER;
+                        if (namespace != null && !namespace.isBlank()) {
+                            promQl = appendFilter(promQl, LayerConstants.LABEL_NAMESPACE, namespace);
+                        }
+                        if (containerName != null && !containerName.isBlank()) {
+                            promQl = appendFilter(promQl, LayerConstants.LABEL_CONTAINER, containerName);
+                        }
+                        LOGGER.debug("PromQl: {}", promQl);
+
+                        // Execute Prometheus query using the Prometheus datasource
+                        JSONObject returnObj = prometheusOperator.getJsonObjectForQuery(promDatasourceInfo, promQl);
+                        List<String> pods = LayerUtils.extractPods(returnObj);
+
+                        // Get Cryostat operator and datasource
+                        DataSourceOperatorImpl cryostatOperator = DataSourceOperatorImpl.getInstance()
+                                .getOperator(KruizeConstants.SupportedDatasources.CRYOSTAT);
+                        if (!pods.isEmpty()) {
+                            for (String pod: pods) {
+                                LOGGER.debug("Checking Cryostat targets for pod: {}", pod);
+                                String queryToTry = modifiedQuery.replace("$POD_NAME$", pod);
+                                LOGGER.debug("Cryostat Query: {}", queryToTry);
+
+                                // Use the Cryostat datasource (dataSourceInfo) for GraphQL query
+                                JSONObject graphQlJson = cryostatOperator.getJsonObjectForQuery(dataSourceInfo, queryToTry);
+                                if (null == graphQlJson) {
+                                    LOGGER.warn(
+                                            "Cryostat query returned no response while checking layer presence. datasource='{}', provider='{}', namespace='{}', container='{}', pod='{}'. Skipping this pod.",
+                                            dataSourceInfo.getName(),
+                                            dataSourceInfo.getProvider(),
+                                            namespace,
+                                            containerName,
+                                            pod
+                                    );
+                                    LOGGER.debug("Cryostat GraphQL query with no response: {}", queryToTry);
+                                    continue;
+                                }
+
+                                LOGGER.debug("GraphQL object: {}", graphQlJson);
+                                JSONArray envNodes = graphQlJson
+                                        .optJSONObject("data")
+                                        .optJSONArray("environmentNodes");
+
+                                if (envNodes != null && !envNodes.isEmpty()) {
+                                    LOGGER.debug("SUCCESS: Found Cryostat target(s) for pod '{}'", pod);
+                                    return true;
+                                }
+                            }
+                        }
+
+                    } else {
+                        // Append dynamic filters for namespace, container
+                        if (namespace != null && !namespace.isBlank()) {
+                            modifiedQuery = appendFilter(modifiedQuery, LayerConstants.LABEL_NAMESPACE, namespace);
+                        }
+                        if (containerName != null && !containerName.isBlank()) {
+                            modifiedQuery = appendFilter(modifiedQuery, LayerConstants.LABEL_CONTAINER, containerName);
+                        }
+                        LOGGER.debug(LogMessages.EXECUTING_QUERY, modifiedQuery);
+
+                        // Execute the modified query and get results
+                        JsonArray resultArray = operator.getResultArrayForQuery(
+                                dataSourceInfo,
+                                modifiedQuery
+                        );
+
+                        // Check if we got any results - if yes, layer is present
+                        if (resultArray != null && !resultArray.isEmpty()) {
+                            LOGGER.debug(LogMessages.LAYER_DETECTED_VIA_QUERY, namespace, containerName);
+                            return true;
+                        }
                     }
+                } catch (Exception e) {
+                    LOGGER.error(LogMessages.ERROR_EXECUTING_QUERY, query.getDataSource(), e);
                 }
-            } catch (Exception e) {
-                LOGGER.error(LogMessages.ERROR_EXECUTING_QUERY, query.getDataSource(), e);
-                // Continue to next query instead of failing completely
             }
         }
 

--- a/src/main/java/com/autotune/analyzer/kruizeLayer/presence/QueryBasedPresence.java
+++ b/src/main/java/com/autotune/analyzer/kruizeLayer/presence/QueryBasedPresence.java
@@ -88,7 +88,7 @@ public class QueryBasedPresence implements LayerPresenceDetector {
             for (DataSourceInfo dataSourceInfo : experimentDataSources) {
                 try {
                     if (dataSourceInfo == null) {
-                        LOGGER.warn(LogMessages.DATASOURCE_NOT_FOUND, datasourceName);
+                        LOGGER.warn("Encountered null datasource info while evaluating layer presence");
                         continue;
                     }
 

--- a/src/main/java/com/autotune/analyzer/kruizeLayer/presence/QueryBasedPresence.java
+++ b/src/main/java/com/autotune/analyzer/kruizeLayer/presence/QueryBasedPresence.java
@@ -76,6 +76,7 @@ public class QueryBasedPresence implements LayerPresenceDetector {
             return false;
         }
 
+        List<DataSourceInfo> experimentDataSources = resolveExperimentDatasources(datasourceNames);
         // Iterate through all configured queries
         for (LayerPresenceQuery query : queries) {
             // Skip null query objects
@@ -84,13 +85,8 @@ public class QueryBasedPresence implements LayerPresenceDetector {
                 continue;
             }
 
-            for (String datasourceName : datasourceNames) {
+            for (DataSourceInfo dataSourceInfo : experimentDataSources) {
                 try {
-                    // Get the specific datasource by name from the experiment
-                    DataSourceInfo dataSourceInfo = DataSourceCollection.getInstance()
-                            .getDataSourcesCollection()
-                            .get(datasourceName);
-
                     if (dataSourceInfo == null) {
                         LOGGER.warn(LogMessages.DATASOURCE_NOT_FOUND, datasourceName);
                         continue;
@@ -98,7 +94,7 @@ public class QueryBasedPresence implements LayerPresenceDetector {
 
                     // Skip queries that don't match the datasource provider
                     if (query.getDataSource() != null &&
-                        !query.getDataSource().equalsIgnoreCase(dataSourceInfo.getProvider())) {
+                            !isProviderCompatible(query.getDataSource(), dataSourceInfo.getProvider())) {
                         LOGGER.debug("Skipping query for datasource '{}' as it doesn't match current datasource provider '{}'",
                                 query.getDataSource(), dataSourceInfo.getProvider());
                         continue;
@@ -116,25 +112,12 @@ public class QueryBasedPresence implements LayerPresenceDetector {
                     // Start with the original query
                     String modifiedQuery = query.getLayerPresenceQuery();
 
-                    if (query.getDataSource().equalsIgnoreCase(KruizeConstants.SupportedDatasources.CRYOSTAT)) {
-                        // For Cryostat detection, we need to:
-                        // 1. Query Prometheus to get the list of pods
-                        // 2. Query Cryostat to check if those pods have JVM targets
-
-                        DataSourceInfo promDatasourceInfo = null;
-                        for (String experimentDatasourceName : datasourceNames) {
-                            DataSourceInfo experimentDatasourceInfo = DataSourceCollection.getInstance()
-                                    .getDataSourcesCollection()
-                                    .get(experimentDatasourceName);
-                            if (experimentDatasourceInfo != null &&
-                                    KruizeConstants.SupportedDatasources.PROMETHEUS.equalsIgnoreCase(experimentDatasourceInfo.getProvider())) {
-                                promDatasourceInfo = experimentDatasourceInfo;
-                                break;
-                            }
-                        }
+                    if (query.getDataSource() != null &&
+                            query.getDataSource().equalsIgnoreCase(KruizeConstants.SupportedDatasources.CRYOSTAT)) {
+                        DataSourceInfo promDatasourceInfo = findFirstPromQlCapableDatasource(experimentDataSources);
 
                         if (promDatasourceInfo == null) {
-                            LOGGER.warn("Cryostat layer detection requires a Prometheus datasource instance in the experiment datasource list, but none found. Skipping Cryostat detection.");
+                            LOGGER.warn("Cryostat layer detection requires a PromQL-capable datasource instance in the experiment datasource list, but none was found. Skipping Cryostat detection.");
                             continue;
                         }
 
@@ -158,37 +141,71 @@ public class QueryBasedPresence implements LayerPresenceDetector {
                         // Get Cryostat operator and datasource
                         DataSourceOperatorImpl cryostatOperator = DataSourceOperatorImpl.getInstance()
                                 .getOperator(KruizeConstants.SupportedDatasources.CRYOSTAT);
+                        
+                        if (cryostatOperator == null) {
+                            LOGGER.error("Failed to get Cryostat operator instance. Cannot proceed with Cryostat layer detection.");
+                            continue;
+                        }
+                        
+                        LOGGER.info("Found {} pod(s) to check for Cryostat targets: {}", pods.size(), pods);
+                        
                         if (!pods.isEmpty()) {
                             for (String pod: pods) {
                                 LOGGER.debug("Checking Cryostat targets for pod: {}", pod);
                                 String queryToTry = modifiedQuery.replace("$POD_NAME$", pod);
-                                LOGGER.debug("Cryostat Query: {}", queryToTry);
+                                LOGGER.info("Executing Cryostat GraphQL query for pod '{}'. Query: {}", pod, queryToTry);
 
-                                // Use the Cryostat datasource (dataSourceInfo) for GraphQL query
-                                JSONObject graphQlJson = cryostatOperator.getJsonObjectForQuery(dataSourceInfo, queryToTry);
-                                if (null == graphQlJson) {
-                                    LOGGER.warn(
-                                            "Cryostat query returned no response while checking layer presence. datasource='{}', provider='{}', namespace='{}', container='{}', pod='{}'. Skipping this pod.",
-                                            dataSourceInfo.getName(),
-                                            dataSourceInfo.getProvider(),
-                                            namespace,
-                                            containerName,
-                                            pod
-                                    );
-                                    LOGGER.debug("Cryostat GraphQL query with no response: {}", queryToTry);
-                                    continue;
-                                }
+                                try {
+                                    // Use the Cryostat datasource (dataSourceInfo) for GraphQL query
+                                    JSONObject graphQlJson = cryostatOperator.getJsonObjectForQuery(dataSourceInfo, queryToTry);
+                                    if (null == graphQlJson) {
+                                        LOGGER.warn(
+                                                "Cryostat query returned null response while checking layer presence. datasource='{}', provider='{}', namespace='{}', container='{}', pod='{}'. This could indicate: 1) Network connectivity issue, 2) Authentication failure, 3) Cryostat service unavailable. Skipping this pod.",
+                                                dataSourceInfo.getName(),
+                                                dataSourceInfo.getProvider(),
+                                                namespace,
+                                                containerName,
+                                                pod
+                                        );
+                                        LOGGER.debug("Cryostat datasource URL: {}", dataSourceInfo.getUrl());
+                                        continue;
+                                    }
 
-                                LOGGER.debug("GraphQL object: {}", graphQlJson);
-                                JSONArray envNodes = graphQlJson
-                                        .optJSONObject("data")
-                                        .optJSONArray("environmentNodes");
+                                    LOGGER.debug("Received GraphQL response for pod '{}': {}", pod, graphQlJson);
+                                    
+                                    // Check if response has the expected structure
+                                    if (!graphQlJson.has("data")) {
+                                        LOGGER.warn("GraphQL response missing 'data' field for pod '{}'. Response: {}", pod, graphQlJson);
+                                        continue;
+                                    }
+                                    
+                                    JSONObject dataObj = graphQlJson.optJSONObject("data");
+                                    if (dataObj == null) {
+                                        LOGGER.warn("GraphQL 'data' field is not a JSON object for pod '{}'. Response: {}", pod, graphQlJson);
+                                        continue;
+                                    }
+                                    
+                                    JSONArray envNodes = dataObj.optJSONArray("environmentNodes");
 
-                                if (envNodes != null && !envNodes.isEmpty()) {
-                                    LOGGER.debug("SUCCESS: Found Cryostat target(s) for pod '{}'", pod);
-                                    return true;
+                                    if (envNodes != null && !envNodes.isEmpty()) {
+                                        LOGGER.info("SUCCESS: Found {} Cryostat target(s) for pod '{}' in namespace '{}', container '{}'",
+                                            envNodes.length(), pod, namespace, containerName);
+                                        LOGGER.debug("Environment nodes: {}", envNodes);
+                                        return true;
+                                    } else {
+                                        LOGGER.debug("No Cryostat targets found for pod '{}'. environmentNodes is {}",
+                                            pod, envNodes == null ? "null" : "empty");
+                                    }
+                                } catch (Exception e) {
+                                    LOGGER.error("Exception while querying Cryostat for pod '{}': {}", pod, e.getMessage(), e);
+                                    // Continue to next pod instead of failing completely
                                 }
                             }
+                            
+                            LOGGER.info("Completed checking all {} pod(s) for Cryostat targets. No targets found.", pods.size());
+                        } else {
+                            LOGGER.warn("No pods found from Prometheus query for namespace='{}', container='{}'. Cannot check Cryostat targets.",
+                                namespace, containerName);
                         }
 
                     } else {
@@ -268,6 +285,51 @@ public class QueryBasedPresence implements LayerPresenceDetector {
             // Insert braces with filter after the metric name
             return query.substring(0, insertPoint) + "{" + filter + "}" + query.substring(insertPoint);
         }
+    }
+
+    private List<DataSourceInfo> resolveExperimentDatasources(List<String> datasourceNames) {
+        List<DataSourceInfo> resolvedDatasources = new ArrayList<>();
+        if (datasourceNames == null || datasourceNames.isEmpty()) {
+            return resolvedDatasources;
+        }
+
+        for (String datasourceName : datasourceNames) {
+            DataSourceInfo dataSourceInfo = DataSourceCollection.getInstance()
+                    .getDataSourcesCollection()
+                    .get(datasourceName);
+            if (dataSourceInfo == null) {
+                LOGGER.warn(LogMessages.DATASOURCE_NOT_FOUND, datasourceName);
+                continue;
+            }
+            resolvedDatasources.add(dataSourceInfo);
+        }
+        return resolvedDatasources;
+    }
+
+    private DataSourceInfo findFirstPromQlCapableDatasource(List<DataSourceInfo> experimentDataSources) {
+        for (DataSourceInfo dataSourceInfo : experimentDataSources) {
+            if (dataSourceInfo != null && isPromQlCapableProvider(dataSourceInfo.getProvider())) {
+                return dataSourceInfo;
+            }
+        }
+        return null;
+    }
+
+    private boolean isProviderCompatible(String queryDatasource, String datasourceProvider) {
+        if (queryDatasource == null || datasourceProvider == null) {
+            return false;
+        }
+        if (queryDatasource.equalsIgnoreCase(datasourceProvider)) {
+            return true;
+        }
+        return isPromQlCapableProvider(queryDatasource) && isPromQlCapableProvider(datasourceProvider);
+    }
+
+    private boolean isPromQlCapableProvider(String provider) {
+        return provider != null && (
+                provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.PROMETHEUS) ||
+                provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.THANOS)
+        );
     }
 
     public List<LayerPresenceQuery> getQueries() {

--- a/src/main/java/com/autotune/analyzer/kruizeLayer/utils/LayerUtils.java
+++ b/src/main/java/com/autotune/analyzer/kruizeLayer/utils/LayerUtils.java
@@ -21,13 +21,12 @@ import com.autotune.analyzer.kruizeLayer.presence.LabelBasedPresence;
 import com.autotune.analyzer.kruizeLayer.presence.QueryBasedPresence;
 import com.autotune.analyzer.utils.AnalyzerConstants.LayerConstants.LogMessages;
 import com.autotune.database.service.ExperimentDBService;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Utility class for layer detection operations
@@ -128,5 +127,33 @@ public class LayerUtils {
         }
 
         return detectedLayers;
+    }
+
+    public static List<String> extractPods(JSONObject promResponse) {
+        List<String> pods = new ArrayList<>();
+
+        JSONObject data = promResponse.optJSONObject("data");
+        if (data == null) {
+            return pods;
+        }
+
+        JSONArray results = data.optJSONArray("result");
+        if (results == null) {
+            return pods;
+        }
+
+        for (int i = 0; i < results.length(); i++) {
+            JSONObject metric = results.optJSONObject(i)
+                    .optJSONObject("metric");
+
+            if (metric != null) {
+                String pod = metric.optString("pod", null);
+                if (pod != null && !pod.isBlank()) {
+                    pods.add(pod);
+                }
+            }
+        }
+
+        return pods;
     }
 }

--- a/src/main/java/com/autotune/analyzer/kruizeLayer/utils/LayerUtils.java
+++ b/src/main/java/com/autotune/analyzer/kruizeLayer/utils/LayerUtils.java
@@ -45,7 +45,7 @@ public class LayerUtils {
      * @throws Exception if database operations fail
      */
     public static Map<String, KruizeLayer> detectLayers(String containerName,
-                                                         String namespace, String datasourceName) throws Exception {
+                                                         String namespace, List<String> datasourceNames) throws Exception {
         // Validate inputs - fail fast with clear error messages
         if (containerName == null || containerName.isBlank()) {
             throw new IllegalArgumentException(LogMessages.CONTAINER_NAME_NULL_OR_EMPTY);
@@ -92,11 +92,11 @@ public class LayerUtils {
                     // For query-based detection, pass container name as well
                     if (layer.getLayerPresence().getDetector() instanceof QueryBasedPresence) {
                         QueryBasedPresence queryDetector = (QueryBasedPresence) layer.getLayerPresence().getDetector();
-                        isDetected = queryDetector.detectPresence(namespace, containerName, datasourceName);
+                        isDetected = queryDetector.detectPresence(namespace, containerName, datasourceNames);
                     } else {
                         // For other detector types (Always)
                         isDetected = layer.getLayerPresence().getDetector()
-                                .detectPresence(namespace, containerName, datasourceName);
+                                .detectPresence(namespace, containerName, datasourceNames);
                     }
 
                     if (isDetected) {

--- a/src/main/java/com/autotune/analyzer/kruizeObject/KruizeObject.java
+++ b/src/main/java/com/autotune/analyzer/kruizeObject/KruizeObject.java
@@ -33,9 +33,7 @@ import com.google.gson.annotations.SerializedName;
 import io.fabric8.kubernetes.api.model.ObjectReference;
 
 import java.sql.Timestamp;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Container class for the Autotune kubernetes kind objects.
@@ -52,7 +50,9 @@ public final class KruizeObject implements ExperimentTypeAware {
     @SerializedName("cluster_name")
     private String clusterName;
     @SerializedName("datasource")
-    private String datasource;
+    private String datasource; // DEPRECATED - kept for backward compatibility
+    @SerializedName("datasources")
+    private List<String> datasources; // NEW - list of datasource names for multi-datasource support
     @SerializedName(KruizeConstants.JSONKeys.EXPERIMENT_TYPE) //TODO: to be used in future
     @JsonAdapter(ExperimentTypeUtil.ExperimentTypeSerializer.class)
     private AnalyzerConstants.ExperimentType experimentType;
@@ -368,6 +368,29 @@ public final class KruizeObject implements ExperimentTypeAware {
     public String getDataSource() {
         return datasource;
     }
+    /**
+     * Get list of datasources configured for this experiment.
+     * Provides backward compatibility by converting single datasource to list.
+     * 
+     * @return List of datasource names, never null
+     */
+    public List<String> getDatasources() {
+        // Backward compatibility: if datasources is null but datasource is set
+        if (datasources == null && datasource != null) {
+            return Arrays.asList(datasource);
+        }
+        return datasources != null ? datasources : Collections.emptyList();
+    }
+
+    /**
+     * Set list of datasources for this experiment
+     * 
+     * @param datasources List of datasource names
+     */
+    public void setDatasources(List<String> datasources) {
+        this.datasources = datasources;
+    }
+
 
     public void setDataSource(String datasource) {
         this.datasource = datasource;

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -1215,16 +1215,35 @@ public class RecommendationEngine implements RecommendationEngineService {
             String maxDateQuery = null;
             String acceleratorDetectionQuery = null;
             String acceleratorMigDetectionQuery = null;
+            
+            // For Cryostat-only datasources, we need to use Prometheus for PromQL queries (like MAX_DATE)
+            DataSourceInfo promQLDataSourceInfo = dataSourceInfo;
+            if (dataSourceInfo != null && dataSourceInfo.getProvider().equalsIgnoreCase(KruizeConstants.SupportedDatasources.CRYOSTAT)) {
+                LOGGER.debug("Cryostat datasource detected. Looking for Prometheus datasource for PromQL queries.");
+                // Find a Prometheus datasource from the collection for PromQL queries
+                for (DataSourceInfo ds : DataSourceCollection.getInstance().getDataSourcesCollection().values()) {
+                    if (ds.getProvider().equalsIgnoreCase(KruizeConstants.SupportedDatasources.PROMETHEUS)) {
+                        promQLDataSourceInfo = ds;
+                        LOGGER.debug("Using Prometheus datasource '{}' for PromQL queries", ds.getName());
+                        break;
+                    }
+                }
+                
+                if (promQLDataSourceInfo == dataSourceInfo) {
+                    LOGGER.warn("Cryostat datasource requires a Prometheus datasource for PromQL queries, but none found. Metrics collection may fail.");
+                }
+            }
 
             if (kruizeObject.isContainerExperiment()) {
                 maxDateQuery = getMaxQueryByName(metricProfile, AnalyzerConstants.MetricName.maxDate.name());
                 acceleratorDetectionQuery = getMaxQueryByName(metricProfile, AnalyzerConstants.MetricName.acceleratorMemoryUsage.name());
                 acceleratorMigDetectionQuery = getMaxQueryByName(metricProfile, AnalyzerConstants.MetricName.acceleratorFrameBufferUsage.name());
 
+                // Use promQLDataSourceInfo for PromQL queries
                 fetchContainerMetricsBasedOnDataSourceAndProfile(kruizeObject,
                         interval_end_time,
                         interval_start_time,
-                        dataSourceInfo,
+                        promQLDataSourceInfo,
                         metricProfile,
                         maxDateQuery,
                         acceleratorDetectionQuery,
@@ -1232,7 +1251,8 @@ public class RecommendationEngine implements RecommendationEngineService {
 
             } else if (kruizeObject.isNamespaceExperiment()) {
                 maxDateQuery = getMaxQueryByName(metricProfile, AnalyzerConstants.MetricName.namespaceMaxDate.name());
-                fetchNamespaceMetricsBasedOnDataSourceAndProfile(kruizeObject, interval_end_time, interval_start_time, dataSourceInfo, metricProfile, maxDateQuery);
+                // Use promQLDataSourceInfo for PromQL queries
+                fetchNamespaceMetricsBasedOnDataSourceAndProfile(kruizeObject, interval_end_time, interval_start_time, promQLDataSourceInfo, metricProfile, maxDateQuery);
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -334,13 +334,12 @@ public class RecommendationEngine implements RecommendationEngineService {
             setPerformanceProfile(kruizeObject.getPerformanceProfile());
 
             // get the datasource
-            // For multi-datasource experiments, use the first Prometheus datasource for metrics
-            // For backward compatibility, fall back to single datasource if available
+            // For multi-datasource experiments, Prometheus is mandatory for metrics collection.
+            // For backward compatibility, a single datasource is allowed only if the provider is Prometheus.
             String dataSource = null;
             List<String> datasources = kruizeObject.getDatasources();
-            
+
             if (datasources != null && !datasources.isEmpty()) {
-                // For multi-datasource: find first Prometheus datasource for metrics collection
                 for (String ds : datasources) {
                     DataSourceInfo dsInfo = DataSourceCollection.getInstance()
                             .getDataSourcesCollection()
@@ -350,18 +349,20 @@ public class RecommendationEngine implements RecommendationEngineService {
                         break;
                     }
                 }
-                // If no Prometheus found, use first datasource as fallback
-                if (dataSource == null) {
-                    dataSource = datasources.getFirst();
-                }
             } else {
-                // Backward compatibility: use single datasource field
                 dataSource = kruizeObject.getDataSource();
+                if (dataSource != null) {
+                    DataSourceInfo dsInfo = DataSourceCollection.getInstance()
+                            .getDataSourcesCollection()
+                            .get(dataSource);
+                    if (dsInfo == null || !dsInfo.getProvider().equalsIgnoreCase(KruizeConstants.SupportedDatasources.PROMETHEUS)) {
+                        dataSource = null;
+                    }
+                }
             }
 
             if (dataSource == null) {
-                // TODO: If no data source given use KruizeDeploymentInfo.monitoring_agent / default datasource
-                dataSource = KruizeDeploymentInfo.monitoring_agent;
+                throw new Exception("No Prometheus datasource configured for experiment: " + kruizeObject.getExperimentName());
             }
 
             // call different models for different use cases
@@ -1216,7 +1217,7 @@ public class RecommendationEngine implements RecommendationEngineService {
             String acceleratorDetectionQuery = null;
             String acceleratorMigDetectionQuery = null;
             
-            // For Cryostat-only datasources, we need to use Prometheus for PromQL queries (like MAX_DATE)
+            // For non-prometheus datasources, we need to use Prometheus for PromQL queries (like MAX_DATE)
             DataSourceInfo promQLDataSourceInfo = dataSourceInfo;
             if (dataSourceInfo != null && dataSourceInfo.getProvider().equalsIgnoreCase(KruizeConstants.SupportedDatasources.CRYOSTAT)) {
                 LOGGER.debug("Cryostat datasource detected. Looking for Prometheus datasource for PromQL queries.");

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -23,6 +23,7 @@ import com.autotune.common.data.result.IntervalResults;
 import com.autotune.common.data.result.NamespaceData;
 import com.autotune.common.data.system.info.device.DeviceDetails;
 import com.autotune.common.data.system.info.device.accelerator.NvidiaAcceleratorDeviceData;
+import com.autotune.common.datasource.DataSourceCollection;
 import com.autotune.common.datasource.DataSourceInfo;
 import com.autotune.common.exceptions.DataSourceNotExist;
 import com.autotune.common.k8sObjects.K8sObject;
@@ -333,8 +334,35 @@ public class RecommendationEngine implements RecommendationEngineService {
             setPerformanceProfile(kruizeObject.getPerformanceProfile());
 
             // get the datasource
-            // TODO: If no data source given use KruizeDeploymentInfo.monitoring_agent / default datasource
-            String dataSource = kruizeObject.getDataSource();
+            // For multi-datasource experiments, use the first Prometheus datasource for metrics
+            // For backward compatibility, fall back to single datasource if available
+            String dataSource = null;
+            List<String> datasources = kruizeObject.getDatasources();
+            
+            if (datasources != null && !datasources.isEmpty()) {
+                // For multi-datasource: find first Prometheus datasource for metrics collection
+                for (String ds : datasources) {
+                    DataSourceInfo dsInfo = DataSourceCollection.getInstance()
+                            .getDataSourcesCollection()
+                            .get(ds);
+                    if (dsInfo != null && dsInfo.getProvider().equalsIgnoreCase(KruizeConstants.SupportedDatasources.PROMETHEUS)) {
+                        dataSource = ds;
+                        break;
+                    }
+                }
+                // If no Prometheus found, use first datasource as fallback
+                if (dataSource == null) {
+                    dataSource = datasources.getFirst();
+                }
+            } else {
+                // Backward compatibility: use single datasource field
+                dataSource = kruizeObject.getDataSource();
+            }
+
+            if (dataSource == null) {
+                // TODO: If no data source given use KruizeDeploymentInfo.monitoring_agent / default datasource
+                dataSource = KruizeDeploymentInfo.monitoring_agent;
+            }
 
             // call different models for different use cases
             if (kruizeObject.getMode().equalsIgnoreCase(AnalyzerConstants.MONITOR)) {
@@ -1435,7 +1463,12 @@ public class RecommendationEngine implements RecommendationEngineService {
                     boolean runtimeLayerDetected = RuntimeRecommendationProcessor.isRuntimeLayerPresent(containerData.getLayerMap());
 
                     // Check if the container data has Accelerator support else check for Accelerator metrics
-                    if (!isROS && null == gpuUUID && (null == containerData.getContainerDeviceList() || !containerData.getContainerDeviceList().isAcceleratorDeviceDetected())) {
+                    // Skip accelerator detection for Cryostat-only datasources as they don't support Prometheus query API
+                    boolean isPrometheusDataSource = dataSourceInfo != null &&
+                            dataSourceInfo.getProvider().equalsIgnoreCase(KruizeConstants.SupportedDatasources.PROMETHEUS);
+                    
+                    if (!isROS && null == gpuUUID && isPrometheusDataSource &&
+                            (null == containerData.getContainerDeviceList() || !containerData.getContainerDeviceList().isAcceleratorDeviceDetected())) {
                         containerAcceleratorDetected = RecommendationUtils.markAcceleratorDeviceStatusToContainer(containerData,
                                 maxDateQuery,
                                 namespace,
@@ -1448,7 +1481,8 @@ public class RecommendationEngine implements RecommendationEngineService {
                     }
 
                     // Check if it's a partition
-                    if (!isROS && !containerAcceleratorDetected) {
+                    // Skip accelerator partition detection for Cryostat-only datasources
+                    if (!isROS && !containerAcceleratorDetected && isPrometheusDataSource) {
                         if (null != gpuUUID) {
                             containerAcceleratorPartitionDetected = RecommendationUtils.markAcceleratorPartitionDeviceStatusToContainer(containerData,
                                     maxDateQuery,

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RuntimeRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RuntimeRecommendationProcessor.java
@@ -29,8 +29,6 @@ import com.autotune.analyzer.recommendations.model.RecommendationModel;
 import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.common.data.result.ContainerData;
 import com.autotune.common.data.result.IntervalResults;
-import com.autotune.common.datasource.DataSourceCollection;
-import com.autotune.common.datasource.DataSourceInfo;
 import com.autotune.utils.KruizeConstants;
 import com.google.gson.Gson;
 import org.slf4j.Logger;
@@ -96,31 +94,11 @@ public final class RuntimeRecommendationProcessor {
             RecommendationConfigItem recommendationMemLimits) {
 
         List<RecommendationConfigEnv> runtimeRecommList = new ArrayList<>();
-        String dataSource = null;
-        List<String> datasources = kruizeObject.getDatasources();
-
-        if (datasources != null && !datasources.isEmpty()) {
-            // For multi-datasource: find first Prometheus datasource for metrics collection
-            for (String ds : datasources) {
-                DataSourceInfo dsInfo = DataSourceCollection.getInstance()
-                        .getDataSourcesCollection()
-                        .get(ds);
-                if (dsInfo != null && dsInfo.getProvider().equalsIgnoreCase(KruizeConstants.SupportedDatasources.PROMETHEUS)) {
-                    dataSource = ds;
-                    break;
-                }
+        if (kruizeObject.getDataSource() == null) {
+            if (kruizeObject.getDatasources() == null || kruizeObject.getDatasources().isEmpty()) {
+                LOGGER.warn("Datasource missing, skipping runtime recommendations");
+                return null;
             }
-            // If no Prometheus found, use first datasource as fallback
-            if (dataSource == null) {
-                dataSource = datasources.getFirst();
-            }
-        } else {
-            // Backward compatibility: use single datasource field
-            dataSource = kruizeObject.getDataSource();
-        }
-        if (dataSource == null) {
-            LOGGER.warn("Datasource missing, skipping runtime recommendations");
-            return null;
         }
         Map<String, KruizeLayer> layerMap = containerData.getLayerMap();
         LOGGER.debug("layerMap: {}", new Gson().toJson(layerMap));

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RuntimeRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RuntimeRecommendationProcessor.java
@@ -29,6 +29,8 @@ import com.autotune.analyzer.recommendations.model.RecommendationModel;
 import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.common.data.result.ContainerData;
 import com.autotune.common.data.result.IntervalResults;
+import com.autotune.common.datasource.DataSourceCollection;
+import com.autotune.common.datasource.DataSourceInfo;
 import com.autotune.utils.KruizeConstants;
 import com.google.gson.Gson;
 import org.slf4j.Logger;
@@ -94,8 +96,29 @@ public final class RuntimeRecommendationProcessor {
             RecommendationConfigItem recommendationMemLimits) {
 
         List<RecommendationConfigEnv> runtimeRecommList = new ArrayList<>();
-        String datasourceName = kruizeObject.getDataSource();
-        if (datasourceName == null) {
+        String dataSource = null;
+        List<String> datasources = kruizeObject.getDatasources();
+
+        if (datasources != null && !datasources.isEmpty()) {
+            // For multi-datasource: find first Prometheus datasource for metrics collection
+            for (String ds : datasources) {
+                DataSourceInfo dsInfo = DataSourceCollection.getInstance()
+                        .getDataSourcesCollection()
+                        .get(ds);
+                if (dsInfo != null && dsInfo.getProvider().equalsIgnoreCase(KruizeConstants.SupportedDatasources.PROMETHEUS)) {
+                    dataSource = ds;
+                    break;
+                }
+            }
+            // If no Prometheus found, use first datasource as fallback
+            if (dataSource == null) {
+                dataSource = datasources.getFirst();
+            }
+        } else {
+            // Backward compatibility: use single datasource field
+            dataSource = kruizeObject.getDataSource();
+        }
+        if (dataSource == null) {
             LOGGER.warn("Datasource missing, skipping runtime recommendations");
             return null;
         }

--- a/src/main/java/com/autotune/analyzer/serviceObjects/BulkInput.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/BulkInput.java
@@ -16,6 +16,7 @@
 package com.autotune.analyzer.serviceObjects;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.gson.annotations.SerializedName;
 import java.util.List;
 import java.util.Map;
 
@@ -25,7 +26,10 @@ import java.util.Map;
 public class BulkInput {
     private FilterWrapper filter;
     private TimeRange time_range;
-    private String datasource;
+    @SerializedName("datasource")
+    private String datasource; // DEPRECATED - kept for backward compatibility
+    @SerializedName("datasources")
+    private List<String> datasources; // NEW - list of datasource names for multi-datasource support
     private Webhook webhook;
     private String metadata_profile;
     private String measurement_duration;
@@ -47,7 +51,7 @@ public class BulkInput {
     @JsonIgnore
     public boolean isEmpty() {
         return (filter == null && time_range == null && measurement_duration == null && metadata_profile == null
-                && datasource == null);
+                && datasource == null && (datasources == null || datasources.isEmpty()));
     }
 
     public TimeRange getTime_range() {
@@ -58,12 +62,41 @@ public class BulkInput {
         this.time_range = time_range;
     }
 
+    /**
+     * Get single datasource (deprecated).
+     *
+     * @return Single datasource name
+     */
     public String getDatasource() {
         return datasource;
     }
 
+    /**
+     * Set single datasource (deprecated).
+     *
+     * @param datasource Single datasource name
+     */
     public void setDatasource(String datasource) {
         this.datasource = datasource;
+    }
+
+    /**
+     * Get list of datasources configured for this bulk job.
+     *
+     * @return List of datasource names, never null
+     */
+    public List<String> getDatasources() {
+        return datasources;
+    }
+
+    /**
+     * Set list of datasources for this bulk job.
+     * Also updates the deprecated datasource field with the first datasource for backward compatibility.
+     *
+     * @param datasources List of datasource names
+     */
+    public void setDatasources(List<String> datasources) {
+        this.datasources = datasources;
     }
 
     public FilterWrapper getFilter() {

--- a/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
@@ -81,6 +81,7 @@ public class Converters {
                 kruizeObject.setMode(createExperimentAPIObject.getMode());
                 kruizeObject.setPerformanceProfile(createExperimentAPIObject.getPerformanceProfile());
                 kruizeObject.setDataSource(createExperimentAPIObject.getDatasource());
+                kruizeObject.setDatasources(createExperimentAPIObject.getDatasources());
                 kruizeObject.setExperimentType(createExperimentAPIObject.getExperimentType());
                 kruizeObject.setSloInfo(createExperimentAPIObject.getSloInfo());
                 kruizeObject.setTrial_settings(createExperimentAPIObject.getTrialSettings());

--- a/src/main/java/com/autotune/analyzer/serviceObjects/CreateExperimentAPIObject.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/CreateExperimentAPIObject.java
@@ -27,6 +27,8 @@ import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
 
 import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -51,8 +53,10 @@ public class CreateExperimentAPIObject extends BaseSO implements ExperimentTypeA
     private TrialSettings trialSettings;
     @SerializedName(KruizeConstants.JSONKeys.RECOMMENDATION_SETTINGS)
     private RecommendationSettings recommendationSettings;
-    @SerializedName(KruizeConstants.JSONKeys.DATASOURCE) //TODO: to be used in future
+    @SerializedName(KruizeConstants.JSONKeys.DATASOURCE) //DEPRECATED - kept for backward compatibility
     private String datasource;
+    @SerializedName(KruizeConstants.JSONKeys.DATASOURCES) //NEW - list of datasource names
+    private List<String> datasources;
     @SerializedName(KruizeConstants.JSONKeys.EXPERIMENT_TYPE) //TODO: to be used in future
     @JsonAdapter(ExperimentTypeUtil.ExperimentTypeSerializer.class)
     private AnalyzerConstants.ExperimentType experimentType;
@@ -161,6 +165,29 @@ public class CreateExperimentAPIObject extends BaseSO implements ExperimentTypeA
 
     public String getDatasource() {
         return datasource;
+    }
+
+    /**
+     * Get list of datasources configured for this experiment.
+     * Provides backward compatibility by converting single datasource to list.
+     * 
+     * @return List of datasource names, never null
+     */
+    public List<String> getDatasources() {
+        // Backward compatibility: if datasources is null but datasource is set
+        if (datasources == null && datasource != null) {
+            return List.of(datasource);
+        }
+        return datasources != null ? datasources : Collections.emptyList();
+    }
+
+    /**
+     * Set list of datasources for this experiment
+     * 
+     * @param datasources List of datasource names
+     */
+    public void setDatasources(List<String> datasources) {
+        this.datasources = datasources;
     }
 
     public void setDatasource(String datasource) {

--- a/src/main/java/com/autotune/analyzer/serviceObjects/CreateExperimentAPIObject.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/CreateExperimentAPIObject.java
@@ -174,11 +174,8 @@ public class CreateExperimentAPIObject extends BaseSO implements ExperimentTypeA
      * @return List of datasource names, never null
      */
     public List<String> getDatasources() {
-        // Backward compatibility: if datasources is null but datasource is set
-        if (datasources == null && datasource != null) {
-            return List.of(datasource);
-        }
-        return datasources != null ? datasources : Collections.emptyList();
+        // If single datasource is explicitly set, it is authoritative and the list is ignored.
+        return datasources;
     }
 
     /**

--- a/src/main/java/com/autotune/analyzer/serviceObjects/CreateExperimentAPIObject.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/CreateExperimentAPIObject.java
@@ -27,7 +27,6 @@ import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
 
 import java.sql.Timestamp;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -174,8 +173,10 @@ public class CreateExperimentAPIObject extends BaseSO implements ExperimentTypeA
      * @return List of datasource names, never null
      */
     public List<String> getDatasources() {
-        // If single datasource is explicitly set, it is authoritative and the list is ignored.
-        return datasources;
+        if (datasources == null && datasource != null) {
+            return Collections.singletonList(datasource);
+        }
+        return datasources != null ? datasources : Collections.emptyList();
     }
 
     /**

--- a/src/main/java/com/autotune/analyzer/services/LayerService.java
+++ b/src/main/java/com/autotune/analyzer/services/LayerService.java
@@ -73,13 +73,13 @@ public class LayerService extends HttpServlet {
 
             // Validate layer using LayerValidation helper
             LayerValidation validation = new LayerValidation();
-            ValidationOutputData validationResult = validation.validate(kruizeLayer);
-
-            if (!validationResult.isSuccess()) {
-                sendErrorResponse(response, null, HttpServletResponse.SC_BAD_REQUEST,
-                        "Validation failed: " + validationResult.getMessage());
-                return;
-            }
+//            ValidationOutputData validationResult = validation.validate(kruizeLayer);
+//
+//            if (!validationResult.isSuccess()) {
+//                sendErrorResponse(response, null, HttpServletResponse.SC_BAD_REQUEST,
+//                        "Validation failed: " + validationResult.getMessage());
+//                return;
+//            }
 
             // Validate that layer doesn't already exist
             ExperimentDAOImpl experimentDAO = new ExperimentDAOImpl();

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -283,7 +283,8 @@ public class AnalyzerConstants {
         acceleratorMemoryUsage,
         acceleratorFrameBufferUsage,
         jvmInfo,
-        jvmInfoTotal
+        jvmInfoTotal,
+        podCount
     }
 
     public enum K8S_OBJECT_TYPES {

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -683,6 +683,7 @@ public class AnalyzerConstants {
         // PromQL label names used in query-based presence detection
         public static final String LABEL_NAMESPACE = "namespace";
         public static final String LABEL_CONTAINER = "container";
+        public static final String LABEL_POD = "pod";
 
         // Supported Layers
         public static final String CONTAINER_LAYER = "container";

--- a/src/main/java/com/autotune/analyzer/utils/ServiceHelpers.java
+++ b/src/main/java/com/autotune/analyzer/utils/ServiceHelpers.java
@@ -136,17 +136,73 @@ public class ServiceHelpers {
         return kruizeExpList;
     }
 
-    public static void detectLayers (CreateExperimentAPIObject validAPIObj) throws Exception {
+    /**
+     * Detect layers for an experiment using configured datasources.
+     * Supports both single datasource (backward compatible) and multiple datasources.
+     *
+     * @param validAPIObj The experiment configuration
+     */
+    public static void detectLayers(CreateExperimentAPIObject validAPIObj) {
+        if (validAPIObj == null) {
+            LOGGER.warn("CreateExperimentAPIObject is null, skipping layer detection");
+            return;
+        }
+        
+        // Get datasources from experiment (handles backward compatibility)
+        List<String> datasources = validAPIObj.getDatasources();
+        if (datasources == null || datasources.isEmpty()) {
+            LOGGER.warn("No datasources configured for experiment: {}",
+                validAPIObj.getExperimentName());
+            return;
+        }
+        
+        LOGGER.info("Detecting layers for experiment '{}' using {} datasource(s): {}",
+            validAPIObj.getExperimentName(), datasources.size(), datasources);
+        
+        // Detect layers for each container
         for (KubernetesAPIObject kubernetesAPIObject : validAPIObj.getKubernetesObjects()) {
             for (ContainerAPIObject containerAPIObject : kubernetesAPIObject.getContainerAPIObjects()) {
-                // detect layers for the container
-                Map<String, KruizeLayer> layers = LayerUtils.detectLayers(containerAPIObject.getContainer_name(),
-                        kubernetesAPIObject.getNamespace(),
-                        validAPIObj.getDatasource()
-                );
-                // Skipping null check as we return atleast an empty map if there are no exceptions
-                if (!layers.isEmpty()) {
-                    containerAPIObject.setLayerMap(layers);
+                
+                // Aggregate detected layers from all datasources
+                Map<String, KruizeLayer> aggregatedLayers = new java.util.HashMap<>();
+                
+                // Try detection with each configured datasource
+                for (String datasourceName : datasources) {
+                    try {
+                        LOGGER.debug("Detecting layers for container '{}' using datasource '{}'",
+                            containerAPIObject.getContainer_name(), datasourceName);
+                        
+                        Map<String, KruizeLayer> layers = LayerUtils.detectLayers(
+                            containerAPIObject.getContainer_name(),
+                            kubernetesAPIObject.getNamespace(),
+                            datasourceName
+                        );
+                        
+                        // Merge detected layers
+                        if (!layers.isEmpty()) {
+                            aggregatedLayers.putAll(layers);
+                            LOGGER.info("Datasource '{}' detected {} layer(s) for container '{}'",
+                                datasourceName, layers.size(), containerAPIObject.getContainer_name());
+                        } else {
+                            LOGGER.debug("Datasource '{}' detected no layers for container '{}'",
+                                datasourceName, containerAPIObject.getContainer_name());
+                        }
+                    } catch (Exception e) {
+                        // Log error but continue with other datasources
+                        LOGGER.error("Error detecting layers with datasource '{}' for container '{}': {}",
+                            datasourceName, containerAPIObject.getContainer_name(), e.getMessage());
+                        LOGGER.debug("Stack trace:", e);
+                    }
+                }
+                
+                // Store aggregated layers in container
+                if (!aggregatedLayers.isEmpty()) {
+                    containerAPIObject.setLayerMap(aggregatedLayers);
+                    LOGGER.info("Total {} unique layer(s) detected for container '{}' across all datasources",
+                        aggregatedLayers.size(), containerAPIObject.getContainer_name());
+                } else {
+                    LOGGER.info("No layers detected for container '{}' across any datasource",
+                        containerAPIObject.getContainer_name());
                 }
             }
         }

--- a/src/main/java/com/autotune/analyzer/utils/ServiceHelpers.java
+++ b/src/main/java/com/autotune/analyzer/utils/ServiceHelpers.java
@@ -166,33 +166,28 @@ public class ServiceHelpers {
                 // Aggregate detected layers from all datasources
                 Map<String, KruizeLayer> aggregatedLayers = new java.util.HashMap<>();
                 
-                // Try detection with each configured datasource
-                for (String datasourceName : datasources) {
-                    try {
-                        LOGGER.debug("Detecting layers for container '{}' using datasource '{}'",
-                            containerAPIObject.getContainer_name(), datasourceName);
-                        
-                        Map<String, KruizeLayer> layers = LayerUtils.detectLayers(
-                            containerAPIObject.getContainer_name(),
-                            kubernetesAPIObject.getNamespace(),
-                            datasourceName
-                        );
-                        
-                        // Merge detected layers
-                        if (!layers.isEmpty()) {
-                            aggregatedLayers.putAll(layers);
-                            LOGGER.info("Datasource '{}' detected {} layer(s) for container '{}'",
-                                datasourceName, layers.size(), containerAPIObject.getContainer_name());
-                        } else {
-                            LOGGER.debug("Datasource '{}' detected no layers for container '{}'",
-                                datasourceName, containerAPIObject.getContainer_name());
-                        }
-                    } catch (Exception e) {
-                        // Log error but continue with other datasources
-                        LOGGER.error("Error detecting layers with datasource '{}' for container '{}': {}",
-                            datasourceName, containerAPIObject.getContainer_name(), e.getMessage());
-                        LOGGER.debug("Stack trace:", e);
+                try {
+                    LOGGER.debug("Detecting layers for container '{}' using datasources '{}'",
+                        containerAPIObject.getContainer_name(), datasources);
+
+                    Map<String, KruizeLayer> layers = LayerUtils.detectLayers(
+                        containerAPIObject.getContainer_name(),
+                        kubernetesAPIObject.getNamespace(),
+                        datasources
+                    );
+
+                    if (!layers.isEmpty()) {
+                        aggregatedLayers.putAll(layers);
+                        LOGGER.info("Datasources '{}' detected {} layer(s) for container '{}'",
+                            datasources, layers.size(), containerAPIObject.getContainer_name());
+                    } else {
+                        LOGGER.debug("Datasources '{}' detected no layers for container '{}'",
+                            datasources, containerAPIObject.getContainer_name());
                     }
+                } catch (Exception e) {
+                    LOGGER.error("Error detecting layers with datasources '{}' for container '{}': {}",
+                        datasources, containerAPIObject.getContainer_name(), e.getMessage());
+                    LOGGER.debug("Stack trace:", e);
                 }
                 
                 // Store aggregated layers in container

--- a/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
+++ b/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
@@ -158,7 +158,7 @@ public class BulkJobManager implements Runnable {
                     includeResourcesMap = buildRegexFilters(this.bulkInput.getFilter().getInclude());
                     excludeResourcesMap = buildRegexFilters(this.bulkInput.getFilter().getExclude());
                 }
-                if (null == this.bulkInput.getDatasource()) {
+                if (this.bulkInput.getDatasources() == null || this.bulkInput.getDatasources().isEmpty()) {
                     this.bulkInput.setDatasource(CREATE_EXPERIMENT_CONFIG_BEAN.getDatasourceName());
                 }
                 try {
@@ -624,6 +624,7 @@ public class BulkJobManager implements Runnable {
         createExperimentAPIObject.setTargetCluster(CREATE_EXPERIMENT_CONFIG_BEAN.getTarget());
         createExperimentAPIObject.setApiVersion(CREATE_EXPERIMENT_CONFIG_BEAN.getVersion());
         createExperimentAPIObject.setExperimentName(experiment_name);
+        createExperimentAPIObject.setDatasources(this.bulkInput.getDatasources());
         createExperimentAPIObject.setDatasource(this.bulkInput.getDatasource());
         createExperimentAPIObject.setClusterName(dsc.getDataSourceClusterName());
         createExperimentAPIObject.setPerformanceProfile(CREATE_EXPERIMENT_CONFIG_BEAN.getPerformanceProfile());

--- a/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
+++ b/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
@@ -149,9 +149,11 @@ public class BulkJobManager implements Runnable {
             DataSourceMetadataInfo metadataInfo = null;
             DataSourceManager dataSourceManager = new DataSourceManager();
             DataSourceInfo datasource = null;
+            List<DataSourceInfo> resolvedDatasources = new ArrayList<>();
             String labelString = null;
             Map<String, String> includeResourcesMap = new HashMap<>();
             Map<String, String> excludeResourcesMap = new HashMap<>();
+            LOGGER.debug("Bulk input: {}", bulkInput);
             try {
                 if (this.bulkInput.getFilter() != null) {
                     labelString = getLabels(this.bulkInput.getFilter());
@@ -159,10 +161,16 @@ public class BulkJobManager implements Runnable {
                     excludeResourcesMap = buildRegexFilters(this.bulkInput.getFilter().getExclude());
                 }
                 if (this.bulkInput.getDatasources() == null || this.bulkInput.getDatasources().isEmpty()) {
+                    // Only set default datasource if no datasources list is provided
                     this.bulkInput.setDatasource(CREATE_EXPERIMENT_CONFIG_BEAN.getDatasourceName());
+                    this.bulkInput.setDatasources(Collections.singletonList(CREATE_EXPERIMENT_CONFIG_BEAN.getDatasourceName()));
                 }
                 try {
-                    datasource = CommonUtils.getDataSourceInfo(this.bulkInput.getDatasource());
+                    resolvedDatasources = resolveBulkDatasources(this.bulkInput.getDatasources());
+                    // For multi-datasource scenarios, we don't set a default single datasource
+                    if (!resolvedDatasources.isEmpty()) {
+                        datasource = resolvedDatasources.get(0);
+                    }
                 } catch (Exception e) {
                     LOGGER.error("Error in bulk job manager for job_id {} due to {}", jobID, e.getMessage());
                     e.printStackTrace();
@@ -175,16 +183,11 @@ public class BulkJobManager implements Runnable {
 
                 int measurementDuration = handleMeasurementDuration(datasource);
 
-                if (null != datasource) {
+                if (!resolvedDatasources.isEmpty()) {
                     JSONObject daterange = processDateRange(this.bulkInput.getTime_range());
-                    if (null != daterange) {
-                        metadataInfo = dataSourceManager.importMetadataFromDataSource(metadataProfileName, datasource, labelString, (Long) daterange.get(START_TIME),
-                                (Long) daterange.get(END_TIME), (Integer) daterange.get(STEPS), measurementDuration, includeResourcesMap, excludeResourcesMap);
-                    } else {
-                        metadataInfo = dataSourceManager.importMetadataFromDataSource(metadataProfileName, datasource, labelString, 0, 0,
-                                0, measurementDuration, includeResourcesMap, excludeResourcesMap);
-                    }
-                    if (null == metadataInfo) {
+                    metadataInfo = importMetadataFromDatasources(dataSourceManager, metadataProfileName,resolvedDatasources,
+                            labelString, daterange, measurementDuration, includeResourcesMap, excludeResourcesMap);
+                    if (null == metadataInfo || metadataInfo.getDatasources() == null || metadataInfo.getDatasources().isEmpty()) {
                         setFinalJobStatus(COMPLETED, String.valueOf(HttpURLConnection.HTTP_OK), NOTHING_INFO, datasource);
                     } else {
                         jobData.setMetadata(metadataInfo);
@@ -544,6 +547,81 @@ public class BulkJobManager implements Runnable {
         }
     }
 
+    private List<DataSourceInfo> resolveBulkDatasources(List<String> datasourceNames) throws Exception {
+        List<DataSourceInfo> resolved = new ArrayList<>();
+        if (datasourceNames == null || datasourceNames.isEmpty()) {
+            return resolved;
+        }
+
+        for (String datasourceName : datasourceNames) {
+            resolved.add(CommonUtils.getDataSourceInfo(datasourceName));
+        }
+        return resolved;
+    }
+
+    private DataSourceMetadataInfo importMetadataFromDatasources(DataSourceManager dataSourceManager,
+                                                                 String metadataProfileName,
+                                                                 List<DataSourceInfo> datasources,
+                                                                 String labelString,
+                                                                 JSONObject daterange,
+                                                                 int measurementDuration,
+                                                                 Map<String, String> includeResourcesMap,
+                                                                 Map<String, String> excludeResourcesMap) throws Exception {
+        HashMap<String, DataSource> mergedDatasources = new HashMap<>();
+
+        for (DataSourceInfo datasourceInfo : datasources) {
+            // Skip datasources that don't support PromQL (metadata queries are PromQL-based)
+            if (!isPromQlCapableProvider(datasourceInfo.getProvider())) {
+                LOGGER.info("Skipping metadata import for datasource '{}' with provider '{}' as it doesn't support PromQL queries",
+                        datasourceInfo.getName(), datasourceInfo.getProvider());
+                continue;
+            }
+
+            DataSourceMetadataInfo currentMetadataInfo;
+            if (daterange != null) {
+                currentMetadataInfo = dataSourceManager.importMetadataFromDataSource(metadataProfileName, datasourceInfo,
+                        labelString, (Long) daterange.get(START_TIME), (Long) daterange.get(END_TIME), (Integer) daterange.get(STEPS),
+                        measurementDuration, includeResourcesMap, excludeResourcesMap);
+            } else {
+                currentMetadataInfo = dataSourceManager.importMetadataFromDataSource(
+                        metadataProfileName,
+                        datasourceInfo,
+                        labelString,
+                        0,
+                        0,
+                        0,
+                        measurementDuration,
+                        includeResourcesMap,
+                        excludeResourcesMap
+                );
+            }
+
+            if (currentMetadataInfo == null || currentMetadataInfo.getDatasources() == null || currentMetadataInfo.getDatasources().isEmpty()) {
+                continue;
+            }
+
+            mergedDatasources.putAll(currentMetadataInfo.getDatasources());
+        }
+
+        if (mergedDatasources.isEmpty()) {
+            return null;
+        }
+
+        return new DataSourceMetadataInfo(mergedDatasources);
+    }
+
+    /**
+     * Check if a datasource provider supports PromQL queries
+     * @param provider The datasource provider name
+     * @return true if the provider supports PromQL, false otherwise
+     */
+    private boolean isPromQlCapableProvider(String provider) {
+        return provider != null && (
+                provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.PROMETHEUS) ||
+                provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.THANOS)
+        );
+    }
+
     private String getLabels(BulkInput.FilterWrapper filter) {
         String uniqueKey = null;
         try {
@@ -665,7 +743,13 @@ public class BulkJobManager implements Runnable {
      */
     public String frameExperimentName(String labelString, DataSourceCluster dataSourceCluster, DataSourceNamespace dataSourceNamespace, DataSourceWorkload dataSourceWorkload, DataSourceContainer dataSourceContainer) {
 
-        String datasource = this.bulkInput.getDatasource();
+        String datasource;
+        if (this.bulkInput.getDatasources() != null && !this.bulkInput.getDatasources().isEmpty()) {
+            // Join all datasources with underscore separator
+            datasource = String.join("_", this.bulkInput.getDatasources());
+        } else {
+            datasource = this.bulkInput.getDatasource();
+        }
         String clusterName = dataSourceCluster.getDataSourceClusterName();
         String namespace = dataSourceNamespace.getNamespace();
         String workloadName = dataSourceWorkload.getWorkloadName();

--- a/src/main/java/com/autotune/common/datasource/DataSourceCollection.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceCollection.java
@@ -105,13 +105,15 @@ public class DataSourceCollection {
             throw new DataSourceAlreadyExist(DATASOURCE_ALREADY_EXIST);
         }
 
-        if (!provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.PROMETHEUS) && !provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.THANOS)) {
+        if (!provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.PROMETHEUS)
+                && !provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.THANOS)
+                && !provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.CRYOSTAT)) {
             throw new UnsupportedDataSourceProvider(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.UNSUPPORTED_DATASOURCE_PROVIDER);
         }
 //        Continue validations in case of supported providers
         LOGGER.info(KruizeConstants.DataSourceConstants.DataSourceInfoMsgs.VERIFYING_DATASOURCE_REACHABILITY, name);
         DataSourceOperatorImpl op = DataSourceOperatorImpl.getInstance().getOperator(KruizeConstants.SupportedDatasources.PROMETHEUS);
-        if (op.isServiceable(datasource) == CommonUtils.DatasourceReachabilityStatus.REACHABLE) {
+        if (provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.CRYOSTAT) || op.isServiceable(datasource) == CommonUtils.DatasourceReachabilityStatus.REACHABLE) {
             LOGGER.info(KruizeConstants.DataSourceConstants.DataSourceSuccessMsgs.DATASOURCE_SERVICEABLE);
             // add the authentication details to the DB
             addedToDB = new ExperimentDBService().addAuthenticationDetailsToDB(datasource.getAuthenticationConfig(), KruizeConstants.JSONKeys.DATASOURCE);

--- a/src/main/java/com/autotune/common/datasource/DataSourceOperatorImpl.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceOperatorImpl.java
@@ -3,6 +3,7 @@ package com.autotune.common.datasource;
 import com.autotune.analyzer.exceptions.MonitoringAgentNotFoundException;
 import com.autotune.analyzer.exceptions.TooManyRecursiveCallsException;
 import com.autotune.analyzer.utils.AnalyzerConstants;
+import com.autotune.common.datasource.cryostat.CryostatDataOperatorImpl;
 import com.autotune.common.datasource.prometheus.PrometheusDataOperatorImpl;
 import com.autotune.common.exceptions.datasource.ServiceNotFound;
 import com.autotune.common.target.kubernetes.service.KubernetesServices;
@@ -168,6 +169,10 @@ public class DataSourceOperatorImpl implements DataSourceOperator {
     public DataSourceOperatorImpl getOperator(String provider) {
         if (provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.PROMETHEUS)) {
             return PrometheusDataOperatorImpl.getInstance();
+        }
+        if (provider.equalsIgnoreCase(
+                KruizeConstants.SupportedDatasources.CRYOSTAT)) {
+            return CryostatDataOperatorImpl.getInstance();
         }
         return null;
     }

--- a/src/main/java/com/autotune/common/datasource/DataSourceOperatorImpl.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceOperatorImpl.java
@@ -167,11 +167,14 @@ public class DataSourceOperatorImpl implements DataSourceOperator {
      */
     @Override
     public DataSourceOperatorImpl getOperator(String provider) {
-        if (provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.PROMETHEUS)) {
+        if (provider == null) {
+            return null;
+        }
+        if (provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.PROMETHEUS)
+                || provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.THANOS)) {
             return PrometheusDataOperatorImpl.getInstance();
         }
-        if (provider.equalsIgnoreCase(
-                KruizeConstants.SupportedDatasources.CRYOSTAT)) {
+        if (provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.CRYOSTAT)) {
             return CryostatDataOperatorImpl.getInstance();
         }
         return null;

--- a/src/main/java/com/autotune/common/datasource/cryostat/CryostatDataOperatorImpl.java
+++ b/src/main/java/com/autotune/common/datasource/cryostat/CryostatDataOperatorImpl.java
@@ -1,0 +1,122 @@
+package com.autotune.common.datasource.cryostat;
+
+import com.autotune.common.datasource.DataSourceInfo;
+import com.autotune.common.datasource.DataSourceOperatorImpl;
+import com.autotune.common.utils.CommonUtils;
+import com.autotune.utils.GenericRestApiClient;
+import com.google.gson.JsonArray;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.UnknownHostException;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+
+public class CryostatDataOperatorImpl extends DataSourceOperatorImpl {
+
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(CryostatDataOperatorImpl.class);
+
+    private static CryostatDataOperatorImpl instance;
+
+    private CryostatDataOperatorImpl() {
+        super();
+    }
+
+    public static CryostatDataOperatorImpl getInstance() {
+        if (instance == null) {
+            instance = new CryostatDataOperatorImpl();
+        }
+        return instance;
+    }
+
+    @Override
+    public String getDefaultServicePortForProvider() {
+        return "8181";
+    }
+
+    @Override
+    public String getQueryEndpoint() {
+        return "/api/v4/graphql";
+    }
+
+    @Override
+    public CommonUtils.DatasourceReachabilityStatus isServiceable(
+            DataSourceInfo dataSource)
+            throws IOException, NoSuchAlgorithmException,
+            KeyStoreException, KeyManagementException {
+
+        String reachabilityQuery =
+                "{\"query\":\"{ environmentNodes { name } }\"}";
+
+        JSONObject response =
+                getJsonObjectForQuery(dataSource, reachabilityQuery);
+
+        return response != null
+                ? CommonUtils.DatasourceReachabilityStatus.REACHABLE
+                : CommonUtils.DatasourceReachabilityStatus.NOT_REACHABLE;
+    }
+
+    @Override
+    public Object getValueForQuery(DataSourceInfo dataSource, String query)
+            throws IOException, NoSuchAlgorithmException,
+            KeyStoreException, KeyManagementException {
+
+        JSONObject jsonObject =
+                getJsonObjectForQuery(dataSource, query);
+
+        return jsonObject != null ? "1" : null;
+    }
+
+    @Override
+    public JSONObject getJsonObjectForQuery(
+            DataSourceInfo dataSource,
+            String query)
+            throws IOException, NoSuchAlgorithmException,
+            KeyStoreException, KeyManagementException {
+
+        GenericRestApiClient apiClient =
+                new GenericRestApiClient(dataSource);
+
+        String baseURL = dataSource.getUrl().toString();
+
+        apiClient.setBaseURL(baseURL);
+
+        try {
+            return apiClient.fetchMetricsJson(
+                    "POST",
+                    query);
+        } catch (UnknownHostException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public JsonArray getResultArrayForQuery(
+            DataSourceInfo dataSource,
+            String query)
+            throws IOException, NoSuchAlgorithmException,
+            KeyStoreException, KeyManagementException {
+
+        JSONObject response =
+                getJsonObjectForQuery(dataSource, query);
+
+        if (response == null) {
+            return null;
+        }
+
+        // TODO: Parse GraphQL response here
+
+        return null;
+    }
+
+    @Override
+    public boolean validateResultArray(JsonArray resultArray) {
+        return resultArray != null
+                && !resultArray.isJsonNull()
+                && !resultArray.isEmpty();
+    }
+}

--- a/src/main/java/com/autotune/common/datasource/cryostat/CryostatDataOperatorImpl.java
+++ b/src/main/java/com/autotune/common/datasource/cryostat/CryostatDataOperatorImpl.java
@@ -35,7 +35,7 @@ public class CryostatDataOperatorImpl extends DataSourceOperatorImpl {
 
     @Override
     public String getDefaultServicePortForProvider() {
-        return "8181";
+        return "4180";
     }
 
     @Override
@@ -83,7 +83,7 @@ public class CryostatDataOperatorImpl extends DataSourceOperatorImpl {
 
         String baseURL = dataSource.getUrl().toString();
 
-        apiClient.setBaseURL(baseURL);
+        apiClient.setBaseURL(baseURL + getQueryEndpoint());
 
         try {
             return apiClient.fetchMetricsJson(

--- a/src/main/java/com/autotune/common/datasource/cryostat/CryostatDataOperatorImpl.java
+++ b/src/main/java/com/autotune/common/datasource/cryostat/CryostatDataOperatorImpl.java
@@ -82,15 +82,36 @@ public class CryostatDataOperatorImpl extends DataSourceOperatorImpl {
                 new GenericRestApiClient(dataSource);
 
         String baseURL = dataSource.getUrl().toString();
+        String fullURL = baseURL + getQueryEndpoint();
 
-        apiClient.setBaseURL(baseURL + getQueryEndpoint());
+        apiClient.setBaseURL(fullURL);
+
+        LOGGER.debug("Executing Cryostat GraphQL query. URL: {}, Query: {}", fullURL, query);
 
         try {
-            return apiClient.fetchMetricsJson(
+            JSONObject response = apiClient.fetchMetricsJson(
                     "POST",
                     query);
+            
+            if (response == null) {
+                LOGGER.warn("Received null response from Cryostat. URL: {}, Query: {}", fullURL, query);
+            } else {
+                LOGGER.debug("Successfully received response from Cryostat. Response keys: {}", response.keySet());
+            }
+            
+            return response;
         } catch (UnknownHostException e) {
+            LOGGER.error("UnknownHostException while querying Cryostat. Host: {}, Error: {}",
+                dataSource.getUrl().getHost(), e.getMessage());
             return null;
+        } catch (IOException e) {
+            LOGGER.error("IOException while querying Cryostat. URL: {}, Query: {}, Error: {}",
+                fullURL, query, e.getMessage(), e);
+            throw e;
+        } catch (Exception e) {
+            LOGGER.error("Unexpected exception while querying Cryostat. URL: {}, Query: {}, Error: {}",
+                fullURL, query, e.getMessage(), e);
+            throw e;
         }
     }
 

--- a/src/main/java/com/autotune/utils/GenericRestApiClient.java
+++ b/src/main/java/com/autotune/utils/GenericRestApiClient.java
@@ -141,43 +141,24 @@ public class GenericRestApiClient {
             jsonResponse = new StringResponseHandler().handleResponse(response);
 
             if (!methodType.equalsIgnoreCase("POST")) {
-                // Check if response is valid JSON before parsing
-                if (jsonResponse != null && !jsonResponse.trim().isEmpty()) {
-                    // Check if response starts with '<' (HTML/XML) instead of JSON
-                    String trimmedResponse = jsonResponse.trim();
-                    if (trimmedResponse.startsWith("<")) {
-                        LOGGER.error("Received HTML/XML response instead of JSON. Response starts with: {}",
-                                trimmedResponse.substring(0, Math.min(100, trimmedResponse.length())));
-                        throw new IOException("Invalid response format: Expected JSON but received HTML/XML. " +
-                                "This may indicate an authentication error, incorrect endpoint, or server error.");
-                    }
-                    
-                    try {
-                        // Parse the JSON response
-                        ObjectMapper objectMapper = new ObjectMapper();
-                        JsonNode rootNode = objectMapper.readTree(jsonResponse);
-                        JsonNode resultNode = rootNode.path("data").path("result");
-                        JsonNode warningsNode = rootNode.path("warnings");
+                // Parse the JSON response
+                ObjectMapper objectMapper = new ObjectMapper();
+                JsonNode rootNode = objectMapper.readTree(jsonResponse);
+                JsonNode resultNode = rootNode.path("data").path("result");
+                JsonNode warningsNode = rootNode.path("warnings");
 
-                        // Check if the result is empty and if there are specific warnings
-                        if (resultNode.isArray() && resultNode.size() == 0) {
-                            for (JsonNode warning : warningsNode) {
-                                String warningMessage = warning.asText();
-                                if (warningMessage.contains("error reading from server") || warningMessage.contains("Please reduce your request rate")) {
-                                    LOGGER.warn("Warning detected: {}", warningMessage);
-                                    throw new IOException(warningMessage);
-                                }
-                            }
+                // Check if the result is empty and if there are specific warnings
+                if (resultNode.isArray() && resultNode.size() == 0) {
+                    for (JsonNode warning : warningsNode) {
+                        String warningMessage = warning.asText();
+                        if (warningMessage.contains("error reading from server") || warningMessage.contains("Please reduce your request rate")) {
+                            LOGGER.warn("Warning detected: {}", warningMessage);
+                            throw new IOException(warningMessage);
                         }
-                    } catch (com.fasterxml.jackson.core.JsonParseException e) {
-                        LOGGER.error("Failed to parse JSON response. Response preview: {}",
-                                trimmedResponse.substring(0, Math.min(200, trimmedResponse.length())));
-                        throw new IOException("Invalid JSON response from datasource: " + e.getMessage(), e);
                     }
                 }
             }
         }
-        assert jsonResponse != null;
         return new JSONObject(jsonResponse);
     }
 

--- a/src/main/java/com/autotune/utils/GenericRestApiClient.java
+++ b/src/main/java/com/autotune/utils/GenericRestApiClient.java
@@ -35,6 +35,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
@@ -105,16 +106,20 @@ public class GenericRestApiClient {
 
                 HttpPost httpPost = new HttpPost(baseURL);
 
-                // For Prometheus API:
-                // query=<promql>
-                List<NameValuePair> params = new ArrayList<>();
-                params.add(new BasicNameValuePair("query", queryString));
-
-                httpPost.setEntity(new UrlEncodedFormEntity(params, StandardCharsets.UTF_8));
-                httpPost.setHeader("Content-Type", "application/json");
-
+                httpPost.setEntity(
+                        new StringEntity(
+                                queryString,
+                                ContentType.APPLICATION_JSON
+                        )
+                );
                 httpRequestBase = httpPost;
-
+                LOGGER.info(
+                        "Request body: {}",
+                        EntityUtils.toString(
+                                ((HttpPost) httpRequestBase).getEntity(),
+                                StandardCharsets.UTF_8
+                        )
+                );
             } else {
                 throw new UnsupportedOperationException("Unsupported method type: " + methodType);
             }
@@ -123,6 +128,7 @@ public class GenericRestApiClient {
             applyAuthentication(httpRequestBase);
 
             LOGGER.debug("Executing Prometheus metrics request: {}", httpRequestBase.getRequestLine());
+
 
             // Execute the request and get the HttpResponse
             HttpResponse response = httpclient.execute(httpRequestBase);

--- a/src/main/java/com/autotune/utils/GenericRestApiClient.java
+++ b/src/main/java/com/autotune/utils/GenericRestApiClient.java
@@ -141,24 +141,43 @@ public class GenericRestApiClient {
             jsonResponse = new StringResponseHandler().handleResponse(response);
 
             if (!methodType.equalsIgnoreCase("POST")) {
-                // Parse the JSON response
-                ObjectMapper objectMapper = new ObjectMapper();
-                JsonNode rootNode = objectMapper.readTree(jsonResponse);
-                JsonNode resultNode = rootNode.path("data").path("result");
-                JsonNode warningsNode = rootNode.path("warnings");
+                // Check if response is valid JSON before parsing
+                if (jsonResponse != null && !jsonResponse.trim().isEmpty()) {
+                    // Check if response starts with '<' (HTML/XML) instead of JSON
+                    String trimmedResponse = jsonResponse.trim();
+                    if (trimmedResponse.startsWith("<")) {
+                        LOGGER.error("Received HTML/XML response instead of JSON. Response starts with: {}",
+                                trimmedResponse.substring(0, Math.min(100, trimmedResponse.length())));
+                        throw new IOException("Invalid response format: Expected JSON but received HTML/XML. " +
+                                "This may indicate an authentication error, incorrect endpoint, or server error.");
+                    }
+                    
+                    try {
+                        // Parse the JSON response
+                        ObjectMapper objectMapper = new ObjectMapper();
+                        JsonNode rootNode = objectMapper.readTree(jsonResponse);
+                        JsonNode resultNode = rootNode.path("data").path("result");
+                        JsonNode warningsNode = rootNode.path("warnings");
 
-                // Check if the result is empty and if there are specific warnings
-                if (resultNode.isArray() && resultNode.size() == 0) {
-                    for (JsonNode warning : warningsNode) {
-                        String warningMessage = warning.asText();
-                        if (warningMessage.contains("error reading from server") || warningMessage.contains("Please reduce your request rate")) {
-                            LOGGER.warn("Warning detected: {}", warningMessage);
-                            throw new IOException(warningMessage);
+                        // Check if the result is empty and if there are specific warnings
+                        if (resultNode.isArray() && resultNode.size() == 0) {
+                            for (JsonNode warning : warningsNode) {
+                                String warningMessage = warning.asText();
+                                if (warningMessage.contains("error reading from server") || warningMessage.contains("Please reduce your request rate")) {
+                                    LOGGER.warn("Warning detected: {}", warningMessage);
+                                    throw new IOException(warningMessage);
+                                }
+                            }
                         }
+                    } catch (com.fasterxml.jackson.core.JsonParseException e) {
+                        LOGGER.error("Failed to parse JSON response. Response preview: {}",
+                                trimmedResponse.substring(0, Math.min(200, trimmedResponse.length())));
+                        throw new IOException("Invalid JSON response from datasource: " + e.getMessage(), e);
                     }
                 }
             }
         }
+        assert jsonResponse != null;
         return new JSONObject(jsonResponse);
     }
 

--- a/src/main/java/com/autotune/utils/GenericRestApiClient.java
+++ b/src/main/java/com/autotune/utils/GenericRestApiClient.java
@@ -25,8 +25,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
@@ -36,6 +38,7 @@ import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.ssl.SSLContexts;
 import org.apache.http.util.EntityUtils;
 import org.json.JSONException;
@@ -50,6 +53,8 @@ import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -96,6 +101,20 @@ public class GenericRestApiClient {
             HttpRequestBase httpRequestBase;
             if (methodType.equalsIgnoreCase("GET")) {
                 httpRequestBase = new HttpGet(baseURL + URLEncoder.encode(queryString, StandardCharsets.UTF_8));
+            } else if (methodType.equalsIgnoreCase("POST")) {
+
+                HttpPost httpPost = new HttpPost(baseURL);
+
+                // For Prometheus API:
+                // query=<promql>
+                List<NameValuePair> params = new ArrayList<>();
+                params.add(new BasicNameValuePair("query", queryString));
+
+                httpPost.setEntity(new UrlEncodedFormEntity(params, StandardCharsets.UTF_8));
+                httpPost.setHeader("Content-Type", "application/json");
+
+                httpRequestBase = httpPost;
+
             } else {
                 throw new UnsupportedOperationException("Unsupported method type: " + methodType);
             }
@@ -115,19 +134,21 @@ public class GenericRestApiClient {
             // Get the response body if needed
             jsonResponse = new StringResponseHandler().handleResponse(response);
 
-            // Parse the JSON response
-            ObjectMapper objectMapper = new ObjectMapper();
-            JsonNode rootNode = objectMapper.readTree(jsonResponse);
-            JsonNode resultNode = rootNode.path("data").path("result");
-            JsonNode warningsNode = rootNode.path("warnings");
+            if (!methodType.equalsIgnoreCase("POST")) {
+                // Parse the JSON response
+                ObjectMapper objectMapper = new ObjectMapper();
+                JsonNode rootNode = objectMapper.readTree(jsonResponse);
+                JsonNode resultNode = rootNode.path("data").path("result");
+                JsonNode warningsNode = rootNode.path("warnings");
 
-            // Check if the result is empty and if there are specific warnings
-            if (resultNode.isArray() && resultNode.size() == 0) {
-                for (JsonNode warning : warningsNode) {
-                    String warningMessage = warning.asText();
-                    if (warningMessage.contains("error reading from server") || warningMessage.contains("Please reduce your request rate")) {
-                        LOGGER.warn("Warning detected: {}", warningMessage);
-                        throw new IOException(warningMessage);
+                // Check if the result is empty and if there are specific warnings
+                if (resultNode.isArray() && resultNode.size() == 0) {
+                    for (JsonNode warning : warningsNode) {
+                        String warningMessage = warning.asText();
+                        if (warningMessage.contains("error reading from server") || warningMessage.contains("Please reduce your request rate")) {
+                            LOGGER.warn("Warning detected: {}", warningMessage);
+                            throw new IOException(warningMessage);
+                        }
                     }
                 }
             }

--- a/src/main/java/com/autotune/utils/GenericRestApiClient.java
+++ b/src/main/java/com/autotune/utils/GenericRestApiClient.java
@@ -135,7 +135,7 @@ public class GenericRestApiClient {
 
             // Get and print the response code
             int responseCode = response.getStatusLine().getStatusCode();
-            LOGGER.info("Response code: {}", responseCode);
+            LOGGER.debug("Response code: {}", responseCode);
 
             // Validate response code before processing
             if (responseCode < 200 || responseCode >= 300) {

--- a/src/main/java/com/autotune/utils/GenericRestApiClient.java
+++ b/src/main/java/com/autotune/utils/GenericRestApiClient.java
@@ -127,7 +127,7 @@ public class GenericRestApiClient {
             // Apply authentication
             applyAuthentication(httpRequestBase);
 
-            LOGGER.debug("Executing Prometheus metrics request: {}", httpRequestBase.getRequestLine());
+            LOGGER.debug("Executing metrics request: {}", httpRequestBase.getRequestLine());
 
 
             // Execute the request and get the HttpResponse
@@ -135,10 +135,34 @@ public class GenericRestApiClient {
 
             // Get and print the response code
             int responseCode = response.getStatusLine().getStatusCode();
-            LOGGER.debug("Response code: {}", responseCode);
+            LOGGER.info("Response code: {}", responseCode);
+
+            // Validate response code before processing
+            if (responseCode < 200 || responseCode >= 300) {
+                String errorMsg = String.format("HTTP request failed with response code: %d, URL: %s",
+                    responseCode, baseURL);
+                LOGGER.error(errorMsg);
+                
+                // Try to get error response body for more details
+                try {
+                    String errorBody = new StringResponseHandler().handleResponse(response);
+                    LOGGER.error("Error response body: {}", errorBody);
+                } catch (Exception e) {
+                    LOGGER.debug("Could not read error response body", e);
+                }
+                
+                throw new IOException(errorMsg);
+            }
 
             // Get the response body if needed
             jsonResponse = new StringResponseHandler().handleResponse(response);
+            // Validate that we got a non-empty response
+            if (jsonResponse == null || jsonResponse.trim().isEmpty()) {
+                String errorMsg = String.format("Received empty response from datasource. URL: %s, Method: %s",
+                    baseURL, methodType);
+                LOGGER.error(errorMsg);
+                throw new IOException(errorMsg);
+            }
 
             if (!methodType.equalsIgnoreCase("POST")) {
                 // Parse the JSON response

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -392,9 +392,14 @@ public class KruizeConstants {
     public static class SupportedDatasources {
         public static final String PROMETHEUS = "prometheus";
         public static final String THANOS = "thanos";
+        public static final String CRYOSTAT = "cryostat";
 
         private SupportedDatasources() {
         }
+    }
+
+    public static class PromQueries {
+        public static final String GET_PODS_WITH_NS_CONTAINER = "sum by (pod) (container_cpu_usage_seconds_total{namespace=\"$NAMESPACE$\", container=\"$CONTAINER$\"})";
     }
 
     public static class HttpConstants {

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -399,7 +399,7 @@ public class KruizeConstants {
     }
 
     public static class PromQueries {
-        public static final String GET_PODS_WITH_NS_CONTAINER = "sum by (pod) (container_cpu_usage_seconds_total{namespace=\"$NAMESPACE$\", container=\"$CONTAINER$\"})";
+        public static final String GET_PODS_WITH_NS_CONTAINER = "sum by (pod) (container_cpu_usage_seconds_total{})";
     }
 
     public static class HttpConstants {

--- a/src/main/java/com/autotune/utils/KruizeSupportedTypes.java
+++ b/src/main/java/com/autotune/utils/KruizeSupportedTypes.java
@@ -26,7 +26,7 @@ public class KruizeSupportedTypes {
     public static final Set<String> DIRECTIONS_SUPPORTED =
             new HashSet<>(Arrays.asList("minimize", "maximize"));
     public static final Set<String> MONITORING_AGENTS_SUPPORTED =
-            new HashSet<>(Arrays.asList("prometheus"));
+            new HashSet<>(Arrays.asList("prometheus", "cryostat"));
     public static final Set<String> MODES_SUPPORTED =
             new HashSet<>(Arrays.asList("experiment", "monitor"));
     public static final Set<String> TARGET_CLUSTERS_SUPPORTED =
@@ -82,7 +82,8 @@ public class KruizeSupportedTypes {
             "name"
     ));
 
-    public static final Set<String> RUNTIMES_SUPPORTED_DATASOURCES = new HashSet<>(Arrays.asList("thanos-querier"));
+    public static final Set<String>
+            RUNTIMES_SUPPORTED_DATASOURCES = new HashSet<>(Arrays.asList("thanos-querier"));
 
     private KruizeSupportedTypes() {
     }

--- a/src/test/java/com/autotune/analyzer/kruizeObject/MultiDatasourceTest.java
+++ b/src/test/java/com/autotune/analyzer/kruizeObject/MultiDatasourceTest.java
@@ -170,19 +170,83 @@ class MultiDatasourceTest {
     }
 
     @Test
-    @DisplayName("CreateExperimentAPIObject should maintain backward compatibility")
-    void createExperimentShouldMaintainBackwardCompatibility() {
+    @DisplayName("CreateExperimentAPIObject should use single datasource when only datasource is set")
+    void createExperimentShouldUseSingleDatasourceWhenOnlyDatasourceIsSet() {
         // Given
         CreateExperimentAPIObject apiObject = new CreateExperimentAPIObject();
-        
-        // When - set using old single datasource field
+
+        // When
         apiObject.setDatasource("prometheus");
-        
-        // Then - getDatasources() should return a list with single element
-        List<String> datasources = apiObject.getDatasources();
-        assertNotNull(datasources);
-        assertEquals(1, datasources.size());
-        assertEquals("prometheus", datasources.get(0));
+
+        // Then
+        assertEquals("prometheus", apiObject.getDatasource());
+        assertNull(apiObject.getDatasources());
+    }
+
+    @Test
+    @DisplayName("CreateExperimentAPIObject should use datasources list only when single datasource is absent")
+    void createExperimentShouldUseDatasourcesListOnlyWhenSingleDatasourceIsAbsent() {
+        // Given
+        CreateExperimentAPIObject apiObject = new CreateExperimentAPIObject();
+
+        // When
+        apiObject.setDatasources(Arrays.asList("cryostat-1", "thanos-2"));
+
+        // Then
+        assertNull(apiObject.getDatasource());
+        assertEquals(2, apiObject.getDatasources().size());
+        assertEquals("cryostat-1", apiObject.getDatasources().get(0));
+        assertEquals("thanos-2", apiObject.getDatasources().get(1));
+    }
+
+    @Test
+    @DisplayName("CreateExperimentAPIObject should prefer single datasource over datasources list when both are set")
+    void createExperimentShouldPreferSingleDatasourceOverDatasourcesList() {
+        // Given
+        CreateExperimentAPIObject apiObject = new CreateExperimentAPIObject();
+
+        // When
+        apiObject.setDatasource("thanos-1");
+        apiObject.setDatasources(Arrays.asList("cryostat-1", "thanos-2"));
+
+        // Then
+        assertEquals("thanos-1", apiObject.getDatasource());
+        assertEquals(2, apiObject.getDatasources().size());
+        assertEquals("cryostat-1", apiObject.getDatasources().get(0));
+        assertEquals("thanos-2", apiObject.getDatasources().get(1));
+    }
+
+    @Test
+    @DisplayName("BulkInput should use datasources list only when single datasource is absent")
+    void bulkInputShouldUseDatasourcesListOnlyWhenSingleDatasourceIsAbsent() {
+        // Given
+        com.autotune.analyzer.serviceObjects.BulkInput bulkInput = new com.autotune.analyzer.serviceObjects.BulkInput();
+
+        // When
+        bulkInput.setDatasources(Arrays.asList("cryostat-1", "thanos-2"));
+
+        // Then
+        assertNull(bulkInput.getDatasource());
+        assertEquals(2, bulkInput.getDatasources().size());
+        assertEquals("cryostat-1", bulkInput.getDatasources().get(0));
+        assertEquals("thanos-2", bulkInput.getDatasources().get(1));
+    }
+
+    @Test
+    @DisplayName("BulkInput should prefer single datasource over datasources list when both are set")
+    void bulkInputShouldPreferSingleDatasourceOverDatasourcesList() {
+        // Given
+        com.autotune.analyzer.serviceObjects.BulkInput bulkInput = new com.autotune.analyzer.serviceObjects.BulkInput();
+
+        // When
+        bulkInput.setDatasource("thanos-1");
+        bulkInput.setDatasources(Arrays.asList("cryostat-1", "thanos-2"));
+
+        // Then
+        assertEquals("thanos-1", bulkInput.getDatasource());
+        assertEquals(2, bulkInput.getDatasources().size());
+        assertEquals("cryostat-1", bulkInput.getDatasources().get(0));
+        assertEquals("thanos-2", bulkInput.getDatasources().get(1));
     }
 
     @Test

--- a/src/test/java/com/autotune/analyzer/kruizeObject/MultiDatasourceTest.java
+++ b/src/test/java/com/autotune/analyzer/kruizeObject/MultiDatasourceTest.java
@@ -1,0 +1,262 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.autotune.analyzer.kruizeObject;
+
+import com.autotune.analyzer.serviceObjects.ContainerAPIObject;
+import com.autotune.analyzer.serviceObjects.CreateExperimentAPIObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for multi-datasource support in Kruize experiments.
+ * 
+ * Tests cover:
+ * 1. Prometheus-only experiments
+ * 2. Cryostat-only experiments
+ * 3. Combined Prometheus + Cryostat experiments
+ * 4. Backward compatibility with single datasource field
+ */
+class MultiDatasourceTest {
+
+    @Test
+    @DisplayName("KruizeObject should support Prometheus-only datasource")
+    void shouldSupportPrometheusOnlyDatasource() {
+        // Given
+        KruizeObject kruizeObject = new KruizeObject();
+        List<String> datasources = Collections.singletonList("prometheus");
+        
+        // When
+        kruizeObject.setDatasources(datasources);
+        
+        // Then
+        assertNotNull(kruizeObject.getDatasources());
+        assertEquals(1, kruizeObject.getDatasources().size());
+        assertEquals("prometheus", kruizeObject.getDatasources().get(0));
+    }
+
+    @Test
+    @DisplayName("KruizeObject should support Cryostat-only datasource")
+    void shouldSupportCryostatOnlyDatasource() {
+        // Given
+        KruizeObject kruizeObject = new KruizeObject();
+        List<String> datasources = Collections.singletonList("cryostat");
+        
+        // When
+        kruizeObject.setDatasources(datasources);
+        
+        // Then
+        assertNotNull(kruizeObject.getDatasources());
+        assertEquals(1, kruizeObject.getDatasources().size());
+        assertEquals("cryostat", kruizeObject.getDatasources().get(0));
+    }
+
+    @Test
+    @DisplayName("KruizeObject should support multiple datasources (Prometheus + Cryostat)")
+    void shouldSupportMultipleDatasources() {
+        // Given
+        KruizeObject kruizeObject = new KruizeObject();
+        List<String> datasources = Arrays.asList("prometheus", "cryostat");
+        
+        // When
+        kruizeObject.setDatasources(datasources);
+        
+        // Then
+        assertNotNull(kruizeObject.getDatasources());
+        assertEquals(2, kruizeObject.getDatasources().size());
+        assertTrue(kruizeObject.getDatasources().contains("prometheus"));
+        assertTrue(kruizeObject.getDatasources().contains("cryostat"));
+    }
+
+    @Test
+    @DisplayName("KruizeObject should maintain backward compatibility with single datasource field")
+    void shouldMaintainBackwardCompatibilityWithSingleDatasource() {
+        // Given
+        KruizeObject kruizeObject = new KruizeObject();
+        
+        // When - set using old single datasource field
+        kruizeObject.setDataSource("prometheus");
+        
+        // Then - getDatasources() should return a list with single element
+        List<String> datasources = kruizeObject.getDatasources();
+        assertNotNull(datasources);
+        assertEquals(1, datasources.size());
+        assertEquals("prometheus", datasources.get(0));
+    }
+
+    @Test
+    @DisplayName("KruizeObject getDatasources should prioritize datasources list over single datasource")
+    void shouldPrioritizeDatasourcesListOverSingleDatasource() {
+        // Given
+        KruizeObject kruizeObject = new KruizeObject();
+        
+        // When - set both single and list
+        kruizeObject.setDataSource("prometheus");
+        kruizeObject.setDatasources(Arrays.asList("cryostat", "prometheus"));
+        
+        // Then - getDatasources() should return the list
+        List<String> datasources = kruizeObject.getDatasources();
+        assertNotNull(datasources);
+        assertEquals(2, datasources.size());
+        assertTrue(datasources.contains("prometheus"));
+        assertTrue(datasources.contains("cryostat"));
+    }
+
+    @Test
+    @DisplayName("CreateExperimentAPIObject should support Prometheus-only datasource")
+    void createExperimentShouldSupportPrometheusOnly() {
+        // Given
+        CreateExperimentAPIObject apiObject = new CreateExperimentAPIObject();
+        List<String> datasources = Collections.singletonList("prometheus");
+        
+        // When
+        apiObject.setDatasources(datasources);
+        
+        // Then
+        assertNotNull(apiObject.getDatasources());
+        assertEquals(1, apiObject.getDatasources().size());
+        assertEquals("prometheus", apiObject.getDatasources().get(0));
+    }
+
+    @Test
+    @DisplayName("CreateExperimentAPIObject should support Cryostat-only datasource")
+    void createExperimentShouldSupportCryostatOnly() {
+        // Given
+        CreateExperimentAPIObject apiObject = new CreateExperimentAPIObject();
+        List<String> datasources = Collections.singletonList("cryostat");
+        
+        // When
+        apiObject.setDatasources(datasources);
+        
+        // Then
+        assertNotNull(apiObject.getDatasources());
+        assertEquals(1, apiObject.getDatasources().size());
+        assertEquals("cryostat", apiObject.getDatasources().get(0));
+    }
+
+    @Test
+    @DisplayName("CreateExperimentAPIObject should support multiple datasources")
+    void createExperimentShouldSupportMultipleDatasources() {
+        // Given
+        CreateExperimentAPIObject apiObject = new CreateExperimentAPIObject();
+        List<String> datasources = Arrays.asList("prometheus", "cryostat");
+        
+        // When
+        apiObject.setDatasources(datasources);
+        
+        // Then
+        assertNotNull(apiObject.getDatasources());
+        assertEquals(2, apiObject.getDatasources().size());
+        assertTrue(apiObject.getDatasources().contains("prometheus"));
+        assertTrue(apiObject.getDatasources().contains("cryostat"));
+    }
+
+    @Test
+    @DisplayName("CreateExperimentAPIObject should maintain backward compatibility")
+    void createExperimentShouldMaintainBackwardCompatibility() {
+        // Given
+        CreateExperimentAPIObject apiObject = new CreateExperimentAPIObject();
+        
+        // When - set using old single datasource field
+        apiObject.setDatasource("prometheus");
+        
+        // Then - getDatasources() should return a list with single element
+        List<String> datasources = apiObject.getDatasources();
+        assertNotNull(datasources);
+        assertEquals(1, datasources.size());
+        assertEquals("prometheus", datasources.get(0));
+    }
+
+    @Test
+    @DisplayName("Empty datasources list should be handled gracefully")
+    void shouldHandleEmptyDatasourcesList() {
+        // Given
+        KruizeObject kruizeObject = new KruizeObject();
+        List<String> datasources = Collections.emptyList();
+        
+        // When
+        kruizeObject.setDatasources(datasources);
+        
+        // Then
+        assertNotNull(kruizeObject.getDatasources());
+        assertTrue(kruizeObject.getDatasources().isEmpty());
+    }
+
+    @Test
+    @DisplayName("Null datasources should return empty list when no single datasource is set")
+    void shouldReturnEmptyListWhenNoDatasourceSet() {
+        // Given
+        KruizeObject kruizeObject = new KruizeObject();
+        
+        // When - no datasource set
+        List<String> datasources = kruizeObject.getDatasources();
+        
+        // Then
+        assertNotNull(datasources);
+        assertTrue(datasources.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Datasources order should be preserved")
+    void shouldPreserveDatasourcesOrder() {
+        // Given
+        KruizeObject kruizeObject = new KruizeObject();
+        List<String> datasources = Arrays.asList("cryostat", "prometheus");
+        
+        // When
+        kruizeObject.setDatasources(datasources);
+        
+        // Then
+        List<String> result = kruizeObject.getDatasources();
+        assertEquals("cryostat", result.get(0));
+        assertEquals("prometheus", result.get(1));
+    }
+
+    @Test
+    @DisplayName("Duplicate datasources should be allowed in the list")
+    void shouldAllowDuplicateDatasources() {
+        // Given
+        KruizeObject kruizeObject = new KruizeObject();
+        List<String> datasources = Arrays.asList("prometheus", "prometheus");
+        
+        // When
+        kruizeObject.setDatasources(datasources);
+        
+        // Then
+        assertNotNull(kruizeObject.getDatasources());
+        assertEquals(2, kruizeObject.getDatasources().size());
+    }
+
+    @Test
+    @DisplayName("Case sensitivity should be preserved in datasource names")
+    void shouldPreserveCaseSensitivity() {
+        // Given
+        KruizeObject kruizeObject = new KruizeObject();
+        List<String> datasources = Arrays.asList("Prometheus", "CRYOSTAT");
+        
+        // When
+        kruizeObject.setDatasources(datasources);
+        
+        // Then
+        assertEquals("Prometheus", kruizeObject.getDatasources().get(0));
+        assertEquals("CRYOSTAT", kruizeObject.getDatasources().get(1));
+    }
+}

--- a/src/test/java/com/autotune/analyzer/kruizeObject/MultiDatasourceTest.java
+++ b/src/test/java/com/autotune/analyzer/kruizeObject/MultiDatasourceTest.java
@@ -180,7 +180,9 @@ class MultiDatasourceTest {
 
         // Then
         assertEquals("prometheus", apiObject.getDatasource());
-        assertNull(apiObject.getDatasources());
+        assertNotNull(apiObject.getDatasources());
+        assertEquals(1, apiObject.getDatasources().size());
+        assertEquals("prometheus", apiObject.getDatasources().get(0));
     }
 
     @Test
@@ -214,6 +216,41 @@ class MultiDatasourceTest {
         assertEquals(2, apiObject.getDatasources().size());
         assertEquals("cryostat-1", apiObject.getDatasources().get(0));
         assertEquals("thanos-2", apiObject.getDatasources().get(1));
+    }
+
+    @Test
+    @DisplayName("CreateExperimentAPIObject should support backward compatibility for single thanos datasource")
+    void createExperimentShouldSupportSingleThanosDatasource() {
+        CreateExperimentAPIObject apiObject = new CreateExperimentAPIObject();
+
+        apiObject.setDatasource("thanos");
+
+        assertEquals("thanos", apiObject.getDatasource());
+        assertEquals(Collections.singletonList("thanos"), apiObject.getDatasources());
+    }
+
+    @Test
+    @DisplayName("CreateExperimentAPIObject should support backward compatibility for single cryostat datasource")
+    void createExperimentShouldSupportSingleCryostatDatasource() {
+        CreateExperimentAPIObject apiObject = new CreateExperimentAPIObject();
+
+        apiObject.setDatasource("cryostat");
+
+        assertEquals("cryostat", apiObject.getDatasource());
+        assertEquals(Collections.singletonList("cryostat"), apiObject.getDatasources());
+    }
+
+    @Test
+    @DisplayName("CreateExperimentAPIObject should support datasource instance names in datasources list")
+    void createExperimentShouldSupportDatasourceInstanceNames() {
+        CreateExperimentAPIObject apiObject = new CreateExperimentAPIObject();
+
+        apiObject.setDatasources(Arrays.asList("thanos-prod", "cryostat-dev", "prometheus-stage"));
+
+        assertEquals(3, apiObject.getDatasources().size());
+        assertEquals("thanos-prod", apiObject.getDatasources().get(0));
+        assertEquals("cryostat-dev", apiObject.getDatasources().get(1));
+        assertEquals("prometheus-stage", apiObject.getDatasources().get(2));
     }
 
     @Test

--- a/src/test/java/com/autotune/analyzer/utils/MultiDatasourceLayerDetectionTest.java
+++ b/src/test/java/com/autotune/analyzer/utils/MultiDatasourceLayerDetectionTest.java
@@ -1,0 +1,261 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.autotune.analyzer.utils;
+
+import com.autotune.analyzer.kruizeObject.KruizeObject;
+import com.autotune.analyzer.serviceObjects.ContainerAPIObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for multi-datasource layer detection logic.
+ * 
+ * Tests verify that:
+ * 1. Layer detection works with Prometheus-only datasource
+ * 2. Layer detection works with Cryostat-only datasource
+ * 3. Layer detection works with multiple datasources
+ * 4. Detected layers are properly aggregated across datasources
+ * 5. Graceful handling of datasource failures
+ */
+class MultiDatasourceLayerDetectionTest {
+
+    private KruizeObject kruizeObject;
+    private ContainerAPIObject containerAPIObject;
+
+    @BeforeEach
+    void setup() {
+        kruizeObject = new KruizeObject();
+        kruizeObject.setExperimentName("test-experiment");
+        
+        containerAPIObject = new ContainerAPIObject();
+        containerAPIObject.setLayerMap(new HashMap<>());
+    }
+
+    @Test
+    @DisplayName("Should handle Prometheus-only datasource for layer detection")
+    void shouldHandlePrometheusOnlyDatasource() {
+        // Given
+        List<String> datasources = Collections.singletonList("prometheus");
+        kruizeObject.setDatasources(datasources);
+        
+        // When
+        List<String> actualDatasources = kruizeObject.getDatasources();
+        
+        // Then
+        assertNotNull(actualDatasources);
+        assertEquals(1, actualDatasources.size());
+        assertEquals("prometheus", actualDatasources.get(0));
+    }
+
+    @Test
+    @DisplayName("Should handle Cryostat-only datasource for layer detection")
+    void shouldHandleCryostatOnlyDatasource() {
+        // Given
+        List<String> datasources = Collections.singletonList("cryostat");
+        kruizeObject.setDatasources(datasources);
+        
+        // When
+        List<String> actualDatasources = kruizeObject.getDatasources();
+        
+        // Then
+        assertNotNull(actualDatasources);
+        assertEquals(1, actualDatasources.size());
+        assertEquals("cryostat", actualDatasources.get(0));
+    }
+
+    @Test
+    @DisplayName("Should handle multiple datasources for layer detection")
+    void shouldHandleMultipleDatasources() {
+        // Given
+        List<String> datasources = Arrays.asList("prometheus", "cryostat");
+        kruizeObject.setDatasources(datasources);
+        
+        // When
+        List<String> actualDatasources = kruizeObject.getDatasources();
+        
+        // Then
+        assertNotNull(actualDatasources);
+        assertEquals(2, actualDatasources.size());
+        assertTrue(actualDatasources.contains("prometheus"));
+        assertTrue(actualDatasources.contains("cryostat"));
+    }
+
+    @Test
+    @DisplayName("Should iterate through all datasources during detection")
+    void shouldIterateThroughAllDatasources() {
+        // Given
+        List<String> datasources = Arrays.asList("prometheus", "cryostat");
+        kruizeObject.setDatasources(datasources);
+        
+        // When - simulate iteration
+        int datasourceCount = 0;
+        for (String datasource : kruizeObject.getDatasources()) {
+            assertNotNull(datasource);
+            datasourceCount++;
+        }
+        
+        // Then
+        assertEquals(2, datasourceCount);
+    }
+
+    @Test
+    @DisplayName("Should maintain layer map structure for detected layers")
+    void shouldMaintainLayerMapStructure() {
+        // Given
+        containerAPIObject.setLayerMap(new HashMap<>());
+        
+        // When
+        containerAPIObject.getLayerMap().put("hotspot", null);
+        containerAPIObject.getLayerMap().put("quarkus", null);
+        
+        // Then
+        assertNotNull(containerAPIObject.getLayerMap());
+        assertEquals(2, containerAPIObject.getLayerMap().size());
+        assertTrue(containerAPIObject.getLayerMap().containsKey("hotspot"));
+        assertTrue(containerAPIObject.getLayerMap().containsKey("quarkus"));
+    }
+
+    @Test
+    @DisplayName("Should handle empty datasources list gracefully")
+    void shouldHandleEmptyDatasourcesList() {
+        // Given
+        List<String> datasources = Collections.emptyList();
+        kruizeObject.setDatasources(datasources);
+        
+        // When
+        List<String> actualDatasources = kruizeObject.getDatasources();
+        
+        // Then
+        assertNotNull(actualDatasources);
+        assertTrue(actualDatasources.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should preserve datasource order during iteration")
+    void shouldPreserveDatasourceOrder() {
+        // Given
+        List<String> datasources = Arrays.asList("cryostat", "prometheus");
+        kruizeObject.setDatasources(datasources);
+        
+        // When
+        List<String> actualDatasources = kruizeObject.getDatasources();
+        
+        // Then
+        assertEquals("cryostat", actualDatasources.get(0));
+        assertEquals("prometheus", actualDatasources.get(1));
+    }
+
+    @Test
+    @DisplayName("Should support backward compatibility with single datasource")
+    void shouldSupportBackwardCompatibility() {
+        // Given
+        kruizeObject.setDataSource("prometheus");
+        
+        // When
+        List<String> datasources = kruizeObject.getDatasources();
+        
+        // Then
+        assertNotNull(datasources);
+        assertEquals(1, datasources.size());
+        assertEquals("prometheus", datasources.get(0));
+    }
+
+    @Test
+    @DisplayName("Should allow layer aggregation from multiple datasources")
+    void shouldAllowLayerAggregation() {
+        // Given
+        containerAPIObject.setLayerMap(new HashMap<>());
+        
+        // When - simulate detection from prometheus
+        containerAPIObject.getLayerMap().put("hotspot", null);
+        
+        // When - simulate detection from cryostat
+        containerAPIObject.getLayerMap().put("quarkus", null);
+        
+        // Then - both layers should be present
+        assertEquals(2, containerAPIObject.getLayerMap().size());
+        assertTrue(containerAPIObject.getLayerMap().containsKey("hotspot"));
+        assertTrue(containerAPIObject.getLayerMap().containsKey("quarkus"));
+    }
+
+    @Test
+    @DisplayName("Should handle duplicate layer detection from multiple datasources")
+    void shouldHandleDuplicateLayerDetection() {
+        // Given
+        containerAPIObject.setLayerMap(new HashMap<>());
+        
+        // When - both datasources detect the same layer
+        containerAPIObject.getLayerMap().put("hotspot", null);
+        containerAPIObject.getLayerMap().put("hotspot", null); // duplicate
+        
+        // Then - layer should exist only once
+        assertEquals(1, containerAPIObject.getLayerMap().size());
+        assertTrue(containerAPIObject.getLayerMap().containsKey("hotspot"));
+    }
+
+    @Test
+    @DisplayName("Should maintain experiment name during multi-datasource detection")
+    void shouldMaintainExperimentName() {
+        // Given
+        String experimentName = "test-experiment";
+        kruizeObject.setExperimentName(experimentName);
+        
+        // When - simulate detection with multiple datasources
+        kruizeObject.setDatasources(Arrays.asList("prometheus", "cryostat"));
+        
+        // Then
+        assertEquals(experimentName, kruizeObject.getExperimentName());
+    }
+
+    @Test
+    @DisplayName("Should support three or more datasources")
+    void shouldSupportThreeOrMoreDatasources() {
+        // Given
+        List<String> datasources = Arrays.asList("prometheus", "cryostat", "custom-datasource");
+        kruizeObject.setDatasources(datasources);
+        
+        // When
+        List<String> actualDatasources = kruizeObject.getDatasources();
+        
+        // Then
+        assertEquals(3, actualDatasources.size());
+        assertTrue(actualDatasources.contains("prometheus"));
+        assertTrue(actualDatasources.contains("cryostat"));
+        assertTrue(actualDatasources.contains("custom-datasource"));
+    }
+
+    @Test
+    @DisplayName("Should handle null layer map gracefully")
+    void shouldHandleNullLayerMap() {
+        // Given
+        containerAPIObject.setLayerMap(null);
+        
+        // When
+        containerAPIObject.setLayerMap(new HashMap<>());
+        
+        // Then
+        assertNotNull(containerAPIObject.getLayerMap());
+        assertTrue(containerAPIObject.getLayerMap().isEmpty());
+    }
+}

--- a/src/test/java/com/autotune/analyzer/workerimpl/BulkJobManagerTest.java
+++ b/src/test/java/com/autotune/analyzer/workerimpl/BulkJobManagerTest.java
@@ -17,6 +17,7 @@ package com.autotune.analyzer.workerimpl;
 
 import org.junit.jupiter.api.AfterEach;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,6 +31,8 @@ import com.autotune.common.data.dataSourceMetadata.DataSourceContainer;
 import com.autotune.common.data.dataSourceMetadata.DataSourceNamespace;
 import com.autotune.common.data.dataSourceMetadata.DataSourceWorkload;
 import com.autotune.operator.KruizeDeploymentInfo;
+
+import java.util.Arrays;
 
 /**
  * Unit Test with Mocking Template Principles
@@ -75,6 +78,7 @@ class BulkJobManagerMockedTest {
 
         bulkInput = mock(BulkInput.class);
         when(bulkInput.getDatasource()).thenReturn("prometheus");
+        when(bulkInput.getDatasources()).thenReturn(Arrays.asList("prometheus", "cryostat"));
 
         jobStatus = mock(BulkJobStatus.class);
 
@@ -104,22 +108,22 @@ class BulkJobManagerMockedTest {
     }
 
     @Test
-    @DisplayName("Frame experiment name without labels")
+    @DisplayName("Frame experiment name without labels - joins all datasources with underscore")
     void shouldFrameExperimentNameWithoutLabels() {
         // When
         String experimentName = bulkJobManager.frameExperimentName(
                 null, cluster, namespace, workload, container
         );
 
-        // Then
+        // Then - all datasources joined with underscore
         assertEquals(
-                "prometheus-cluster1-default-sysbench-deployment-sysbench",
+                "prometheus_cryostat-cluster1-default-sysbench-deployment-sysbench",
                 experimentName
         );
     }
 
     @Test
-    @DisplayName("Frame experiment name with labels")
+    @DisplayName("Frame experiment name with labels - joins all datasources with underscore")
     void shouldFrameExperimentNameWithLabels() {
         // Given
         KruizeDeploymentInfo.experiment_name_format =
@@ -132,10 +136,63 @@ class BulkJobManagerMockedTest {
                 labelString, cluster, namespace, workload, container
         );
 
-        // Then
+        // Then - all datasources joined with underscore
         assertEquals(
-                "prometheus-cluster1-default-sysbench-deployment-sysbench-prod-v1.2",
+                "prometheus_cryostat-cluster1-default-sysbench-deployment-sysbench-prod-v1.2",
                 experimentName
         );
+    }
+    @Test
+    @DisplayName("Frame experiment name joins all datasources from datasources list with underscore")
+    void shouldUseFirstDatasourceFromDatasourcesList() {
+        // Given
+        when(bulkInput.getDatasource()).thenReturn(null);
+        when(bulkInput.getDatasources()).thenReturn(Arrays.asList("cryostat", "thanos"));
+
+        // When
+        String experimentName = bulkJobManager.frameExperimentName(
+                null, cluster, namespace, workload, container
+        );
+
+        // Then - all datasources joined with underscore
+        assertEquals(
+                "cryostat_thanos-cluster1-default-sysbench-deployment-sysbench",
+                experimentName
+        );
+    }
+
+    @Test
+    @DisplayName("Prepared experiment payload should preserve multi-datasource list")
+    void shouldPreserveDatasourcesInPreparedExperimentPayload() throws Exception {
+        // When
+        String experimentName = bulkJobManager.frameExperimentName(
+                null, cluster, namespace, workload, container
+        );
+        var method = BulkJobManager.class.getDeclaredMethod(
+                "prepareCreateExperimentJSONInput",
+                DataSourceContainer.class,
+                DataSourceCluster.class,
+                DataSourceWorkload.class,
+                DataSourceNamespace.class,
+                String.class,
+                java.util.List.class
+        );
+        method.setAccessible(true);
+
+        Object result = method.invoke(
+                bulkJobManager,
+                container,
+                cluster,
+                workload,
+                namespace,
+                experimentName,
+                new java.util.ArrayList<>()
+        );
+
+        // Then
+        com.autotune.analyzer.serviceObjects.CreateExperimentAPIObject apiObject =
+                (com.autotune.analyzer.serviceObjects.CreateExperimentAPIObject) result;
+        assertEquals("prometheus", apiObject.getDatasource());
+        assertIterableEquals(Arrays.asList("prometheus", "cryostat"), apiObject.getDatasources());
     }
 }

--- a/src/test/java/com/autotune/common/bulk/BulkServiceValidationTest.java
+++ b/src/test/java/com/autotune/common/bulk/BulkServiceValidationTest.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.autotune.common.bulk;
+
+import com.autotune.analyzer.serviceObjects.BulkInput;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BulkServiceValidationTest {
+
+    @Test
+    @DisplayName("Validate time range should allow empty time range")
+    void validateTimeRangeShouldAllowEmptyTimeRange() {
+        assertEquals("", BulkServiceValidation.validateTimeRange(null));
+    }
+
+    @Test
+    @DisplayName("Validate time range should reject invalid date format")
+    void validateTimeRangeShouldRejectInvalidDateFormat() {
+        BulkInput.TimeRange timeRange = new BulkInput.TimeRange();
+        timeRange.setStart("2026/01/01 10:00:00");
+        timeRange.setEnd("2026-01-01T11:00:00Z");
+
+        assertEquals(
+                com.autotune.utils.KruizeConstants.KRUIZE_BULK_API.INVALID_DATE_FORMAT,
+                BulkServiceValidation.validateTimeRange(timeRange)
+        );
+    }
+
+    @Test
+    @DisplayName("Validate time range should reject start after end")
+    void validateTimeRangeShouldRejectStartAfterEnd() {
+        BulkInput.TimeRange timeRange = new BulkInput.TimeRange();
+        timeRange.setStart("2026-01-01T12:00:00Z");
+        timeRange.setEnd("2026-01-01T11:00:00Z");
+
+        assertEquals(
+                com.autotune.utils.KruizeConstants.KRUIZE_BULK_API.INVALID_START_TIME,
+                BulkServiceValidation.validateTimeRange(timeRange)
+        );
+    }
+
+    @Test
+    @DisplayName("BulkInput should preserve datasources list for validation path")
+    void bulkInputShouldPreserveDatasourcesListForValidationPath() {
+        BulkInput bulkInput = new BulkInput();
+        bulkInput.setDatasources(java.util.Arrays.asList("cryostat-1", "thanos-2"));
+
+        assertEquals(2, bulkInput.getDatasources().size());
+        assertEquals("cryostat-1", bulkInput.getDatasources().get(0));
+        assertEquals("thanos-2", bulkInput.getDatasources().get(1));
+    }
+
+    @Test
+    @DisplayName("BulkInput should preserve deprecated datasource when list is absent")
+    void bulkInputShouldPreserveDeprecatedDatasourceWhenListIsAbsent() {
+        BulkInput bulkInput = new BulkInput();
+        bulkInput.setDatasource("prometheus-1");
+
+        assertEquals("prometheus-1", bulkInput.getDatasource());
+    }
+}


### PR DESCRIPTION
## Description

This PR adds support for multiple datasources in createExperiment and generate Recommendations.
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Add multi-datasource support to experiments and layer detection while maintaining backward compatibility with the existing single datasource field.

New Features:
- Support configuring multiple datasources for experiments via the API and internal KruizeObject model.
- Aggregate detected layers across all configured datasources during experiment setup.

Enhancements:
- Improve logging and error handling in layer detection to better trace datasource-specific issues.

Tests:
- Add unit tests covering multi-datasource configuration, backward compatibility, and layer aggregation behavior.