### PR TITLE
Revert "Ignore Deploymentconfig workloads for kruize monitoring"

### DIFF
--- a/design/MetadataProfileAPI.md
+++ b/design/MetadataProfileAPI.md
@@ -3,31 +3,6 @@
 This article describes how to add and retrieve Metadata Profiles with REST APIs using curl command. 
 Documentation still in progress stay tuned.
 
-## Supported and Unsupported Workload Types
-
-Kruize supports various Kubernetes workload types for monitoring and generating recommendations. However, certain workload types are not supported and are automatically filtered out during metadata import and query execution.
-
-### Supported Workload Types
-
-The following Kubernetes workload types are **supported** by Kruize:
-
-- **Deployment**
-- **StatefulSet**
-- **ReplicaSet**
-- **ReplicationController**
-- **DaemonSet**
-- **Job**
-
-### Unsupported Workload Types
-
-The following workload types are **not supported** by Kruize:
-
-- **DeploymentConfig** - OpenShift-specific deployment configuration (deprecated)
-
-The reason for excluding DeploymentConfig is that it is OpenShift-specific and has been deprecated from [Red Hat OpenShift v4.14](https://access.redhat.com/articles/7041372) onwards. OpenShift users are encouraged to migrate to standard Kubernetes Deployments.
-
----
-
 ## CreateMetadataProfile
 
 This is quick guide instructions to create metadata profile using input JSON as follows. For a more detailed guide,

--- a/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.json
+++ b/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.json
@@ -28,7 +28,7 @@
       "aggregation_functions": [
         {
           "function": "sum",
-          "query": "sum by (namespace, workload, workload_type) (avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!=\"\", $UNSUPPORTED_WORKLOAD_TYPES$ ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          "query": "sum by (namespace, workload, workload_type) (avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!=\"\" ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))"
         }
       ]
     },
@@ -40,7 +40,7 @@
       "aggregation_functions": [
         {
           "function": "sum",
-          "query": "sum by (container, image, workload, workload_type, namespace) (avg_over_time(kube_pod_container_info{container!=\"\" ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (pod, namespace) group_left(workload, workload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!=\"\", $UNSUPPORTED_WORKLOAD_TYPES$ ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          "query": "sum by (container, image, workload, workload_type, namespace) (avg_over_time(kube_pod_container_info{container!=\"\" ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (pod, namespace) group_left(workload, workload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!=\"\" ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))"
         }
       ]
     }

--- a/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.yaml
+++ b/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.yaml
@@ -21,7 +21,7 @@ query_variables:
   kubernetes_object: "container"
   aggregation_functions:
   - function: sum
-    query: 'sum by (namespace, workload, workload_type) (avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!="", $UNSUPPORTED_WORKLOAD_TYPES$ ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+    query: 'sum by (namespace, workload, workload_type) (avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!="" ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
 - name: containersForAdditionalLabel
   datasource: prometheus
@@ -29,4 +29,4 @@ query_variables:
   kubernetes_object: "container"
   aggregation_functions:
   - function: sum
-    query: 'sum by (container, image, workload, workload_type, namespace) (avg_over_time(kube_pod_container_info{container!="" ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (pod, namespace) group_left(workload, workload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!="", $UNSUPPORTED_WORKLOAD_TYPES$ ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+    query: 'sum by (container, image, workload, workload_type, namespace) (avg_over_time(kube_pod_container_info{container!="" ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (pod, namespace) group_left(workload, workload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!="" ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))'

--- a/manifests/autotune/metadata-profiles/cluster_metadata_local_monitoring.json
+++ b/manifests/autotune/metadata-profiles/cluster_metadata_local_monitoring.json
@@ -28,7 +28,7 @@
       "aggregation_functions": [
         {
           "function": "sum",
-	  "query": "sum by (namespace, workload, workload_type) (avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!=\"\", $UNSUPPORTED_WORKLOAD_TYPES$}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          "query": "sum by (namespace, workload, workload_type) (avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!=\"\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
         }
       ]
     },
@@ -40,7 +40,7 @@
       "aggregation_functions": [
         {
           "function": "sum",
-	  "query": "sum by (container, image, workload, workload_type, namespace) (avg_over_time(kube_pod_container_info{container!=\"\"}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (pod, namespace) group_left(workload, workload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!=\"\", $UNSUPPORTED_WORKLOAD_TYPES$}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          "query": "sum by (container, image, workload, workload_type, namespace) (avg_over_time(kube_pod_container_info{container!=\"\"}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (pod, namespace) group_left(workload, workload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!=\"\"}[$MEASUREMENT_DURATION_IN_MIN$m]))"
         }
       ]
     }

--- a/manifests/autotune/metadata-profiles/cluster_metadata_local_monitoring.yaml
+++ b/manifests/autotune/metadata-profiles/cluster_metadata_local_monitoring.yaml
@@ -21,7 +21,7 @@ query_variables:
   kubernetes_object: "container"
   aggregation_functions:
   - function: sum
-    query: 'sum by (namespace, workload, workload_type) (avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!="", $UNSUPPORTED_WORKLOAD_TYPES$}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+    query: 'sum by (namespace, workload, workload_type) (avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!=""}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
 - name: containersAcrossCluster
   datasource: prometheus
@@ -29,4 +29,4 @@ query_variables:
   kubernetes_object: "container"
   aggregation_functions:
   - function: sum
-    query: 'sum by (container, image, workload, workload_type, namespace) (avg_over_time(kube_pod_container_info{container!=""}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (pod, namespace) group_left(workload, workload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!="", $UNSUPPORTED_WORKLOAD_TYPES$}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+    query: 'sum by (container, image, workload, workload_type, namespace) (avg_over_time(kube_pod_container_info{container!=""}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (pod, namespace) group_left(workload, workload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!=""}[$MEASUREMENT_DURATION_IN_MIN$m]))'

--- a/src/main/java/com/autotune/analyzer/metadataProfiles/MetadataProfileValidation.java
+++ b/src/main/java/com/autotune/analyzer/metadataProfiles/MetadataProfileValidation.java
@@ -375,8 +375,7 @@ public class MetadataProfileValidation {
         DataSourceOperatorImpl op = DataSourceOperatorImpl.getInstance().getOperator(dataSourceInfo.getProvider());
 
         metricQuery = metricQuery.replace(AnalyzerConstants.MetadataProfileConstants.ADDITIONAL_LABEL, "")
-                .replace(AnalyzerConstants.MEASUREMENT_DURATION_IN_MIN_VARAIBLE, String.valueOf(AnalyzerConstants.DEFAULT_MEASUREMENT_DURATION_INT))
-                .replace(AnalyzerConstants.UNSUPPORTED_WORKLOAD_TYPES_VARIABLE, AnalyzerConstants.getUnsupportedWorkloadTypesFilter());
+                .replace(AnalyzerConstants.MEASUREMENT_DURATION_IN_MIN_VARAIBLE, String.valueOf(AnalyzerConstants.DEFAULT_MEASUREMENT_DURATION_INT));
 
         try {
             String metricIdentifier = MetadataProfileUtil.getMetricIdentifier(metricName);

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -16,7 +16,6 @@
 package com.autotune.analyzer.utils;
 
 import com.autotune.utils.KruizeConstants;
-import com.autotune.utils.Utils;
 
 import java.util.Map;
 import java.util.*;
@@ -72,7 +71,6 @@ public class AnalyzerConstants {
     public static final String MEASUREMENT_DURATION_IN_MIN_VARAIBLE = "$MEASUREMENT_DURATION_IN_MIN$";
     public static final String WORKLOAD_VARIABLE = "$WORKLOAD$";
     public static final String WORKLOAD_TYPE_VARIABLE = "$WORKLOAD_TYPE$";
-    public static final String UNSUPPORTED_WORKLOAD_TYPES_VARIABLE = "$UNSUPPORTED_WORKLOAD_TYPES$";
     public static final String API_VERSION = "apiVersion";
     public static final String KIND = "kind";
     public static final String RESOURCE_VERSION = "resourceVersion";
@@ -1119,35 +1117,5 @@ public class AnalyzerConstants {
 
             }
         }
-    }
-
-    /**
-     * Returns a PromQL filter string for unsupported workload types.
-     * This method generates a filter that excludes workload types not supported by Kruize.
-     * Currently, only DEPLOYMENT_CONFIG is unsupported.
-     * Uses case-insensitive regex matching to handle different naming conventions from various data sources.
-     *
-     * @return A string in the format 'workload_type!~"(?i)type1", workload_type!~"(?i)type2"'
-     *         or empty string if all types are supported
-     */
-    public static String getUnsupportedWorkloadTypesFilter() {
-        // List of unsupported K8S object types
-        List<K8S_OBJECT_TYPES> unsupportedTypes = Arrays.asList(
-            K8S_OBJECT_TYPES.DEPLOYMENT_CONFIG
-        );
-        
-        // Build the filter string with case-insensitive regex matching
-        StringBuilder filter = new StringBuilder();
-        for (K8S_OBJECT_TYPES type : unsupportedTypes) {
-            if (filter.length() > 0) {
-                filter.append(", ");
-            }
-            // Use regex with case-insensitive flag to match any case variation
-            // This handles: DeploymentConfig, deploymentConfig, deploymentconfig, etc.
-            String typeString = Utils.getAppropriateK8sObjectTypeString(type);
-            filter.append("workload_type!~").append("\"(?i)").append(typeString).append("\"");
-        }
-        
-        return filter.toString();
     }
 }

--- a/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
@@ -242,11 +242,6 @@ public class DataSourceMetadataOperator {
         workloadQuery = workloadQuery.replace(AnalyzerConstants.MEASUREMENT_DURATION_IN_MIN_VARAIBLE, Integer.toString(measurementDuration));
         containerQuery = containerQuery.replace(AnalyzerConstants.MEASUREMENT_DURATION_IN_MIN_VARAIBLE, Integer.toString(measurementDuration));
 
-        // Replace unsupported workload types variable with actual filter (only for workload and container queries)
-        String unsupportedWorkloadTypesFilter = AnalyzerConstants.getUnsupportedWorkloadTypesFilter();
-        workloadQuery = workloadQuery.replace(AnalyzerConstants.UNSUPPORTED_WORKLOAD_TYPES_VARIABLE, unsupportedWorkloadTypesFilter);
-        containerQuery = containerQuery.replace(AnalyzerConstants.UNSUPPORTED_WORKLOAD_TYPES_VARIABLE, unsupportedWorkloadTypesFilter);
-
         LOGGER.info("namespaceQuery: {}", namespaceQuery);
         LOGGER.info("workloadQuery: {}", workloadQuery);
         LOGGER.info("containerQuery: {}", containerQuery);


### PR DESCRIPTION
Reverts kruize/autotune#1924

## Summary by Sourcery

Revert the exclusion of DeploymentConfig workloads so they are again monitored and included in metadata processing.

Bug Fixes:
- Restore monitoring and metadata collection for DeploymentConfig workloads by removing the unsupported workload filter from queries and validation.

Documentation:
- Remove documentation describing DeploymentConfig as an unsupported workload type in metadata profile APIs.