### PR TITLE
[feat:podCount] represent pod_count aggregation values as integer in listRecommendations API

### DIFF
--- a/src/main/java/com/autotune/analyzer/services/ListExperiments.java
+++ b/src/main/java/com/autotune/analyzer/services/ListExperiments.java
@@ -17,6 +17,7 @@
 package com.autotune.analyzer.services;
 
 import com.autotune.analyzer.adapters.DeviceDetailsAdapter;
+import com.autotune.analyzer.adapters.MetricAggregationInfoResultsIntSerializer;
 import com.autotune.analyzer.adapters.RecommendationItemAdapter;
 import com.autotune.analyzer.kruizeObject.KruizeObject;
 import com.autotune.analyzer.serviceObjects.*;
@@ -24,6 +25,7 @@ import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.analyzer.utils.AnalyzerErrorConstants;
 import com.autotune.analyzer.utils.GsonUTCDateAdapter;
 import com.autotune.common.data.metrics.Metric;
+import com.autotune.common.data.metrics.MetricAggregationInfoResults;
 import com.autotune.common.data.metrics.MetricResults;
 import com.autotune.common.data.result.ContainerData;
 import com.autotune.common.data.result.IntervalResults;
@@ -316,6 +318,7 @@ public class ListExperiments extends HttpServlet {
                 .registerTypeAdapter(Date.class, new GsonUTCDateAdapter())
                 .registerTypeAdapter(AnalyzerConstants.RecommendationItem.class, new RecommendationItemAdapter())
                 .registerTypeAdapter(DeviceDetails.class, new DeviceDetailsAdapter())
+                .registerTypeAdapter(MetricAggregationInfoResults.class, new MetricAggregationInfoResultsIntSerializer())
                 .setExclusionStrategies(new ExclusionStrategy() {
                     @Override
                     public boolean shouldSkipField(FieldAttributes f) {


### PR DESCRIPTION
## Description

This is related to current podCount feature. `metrics_info` section shows aggregation values of `pod_count` in recommendations. These recommendations are accessible by 3 APIs

/updateRecommendations
/generateRecommendations
/listRecommendations

In first 2 API endpoints, this is handled correctly. However, for /listRecommendations endpoint, custom serializer is not registered with gson object being used for generating API response. So, it defaults to the field datatype which is Double.

Before fix :
```
  "metrics_info": {
    "pod_count": {
      "avg": 7.0,
      "max": 7.0,
      "min": 7.0
    }
  },
```

After fix :
```
  "metrics_info": {
    "pod_count": {
      "avg": 7,
      "max": 7,
      "min": 7
    }
  },
```


Fixes # (issue)

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Bug Fixes:
- Fix pod_count metric aggregation values in listRecommendations responses being serialized as doubles instead of integers.