### PR TITLE
[PR-4] Add config and type updates for multi-datasource support

### DIFF
--- a/manifests/autotune/layers/hotspot-micrometer-config.json
+++ b/manifests/autotune/layers/hotspot-micrometer-config.json
@@ -37,6 +37,11 @@
         "datasource": "prometheus",
         "query": "jvm_memory_used_bytes{area=\"heap\",id=~\"Old.+\"}",
         "key": "pod"
+      },
+      {
+        "datasource": "cryostat",
+        "query": "{\"query\":\"{ environmentNodes(filter:{ nodeTypes:[\\\"Pod\\\"] name:\\\"$POD_NAME$\\\" }) { name descendantTargets { name target { alias id jvmId } } } }\"}",
+        "key": "pod"
       }
     ]
   },

--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -262,9 +262,44 @@ data:
                 "tokenFilePath": "/var/run/secrets/kubernetes.io/serviceaccount/token"
               }
           }
+        },
+        {
+          "name": "cryostat",
+          "provider": "cryostat",
+          "serviceName": "",
+          "namespace": "",
+          "url": "https://cryostat.cryostat.svc.cluster.local:4180",
+          "authentication": {
+            "type": "bearer",
+            "credentials": {
+              "tokenFilePath": "/var/run/secrets/kubernetes.io/serviceaccount/token"
+            }
+          }
         }
       ]
     }
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cryostat-access-role
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kruize-cryostat-access
+subjects:
+  - kind: ServiceAccount
+    name: kruize-sa
+    namespace: openshift-tuning
+roleRef:
+  kind: ClusterRole
+  name: cryostat-access-role
+  apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -614,3 +649,15 @@ spec:
         - name: nginx-config-volume
           configMap:
             name: nginx-config
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: kruize-route
+  namespace: openshift-tuning
+spec:
+  to:
+    kind: Service
+    name: kruize
+  port:
+    targetPort: kruize-port

--- a/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
+++ b/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
@@ -175,8 +175,9 @@ public class ExperimentValidation {
                         // check if the provided datasource name(s) exist
                         List<String> datasources = kruizeObject.getDatasources();
                         if (datasources != null && !datasources.isEmpty()) {
+                            Map<String, DataSourceInfo> dataSourcesCollection = DataSourceCollection.getInstance().getDataSourcesCollection();
                             for (String datasourceName : datasources) {
-                                DataSourceInfo dataSourceInfo = DataSourceCollection.getInstance().getDataSourcesCollection().get(datasourceName);
+                                DataSourceInfo dataSourceInfo = dataSourcesCollection.get(datasourceName);
                                 if (dataSourceInfo != null) {
                                     LOGGER.debug("DataSource {} exists", datasourceName);
                                 } else {

--- a/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
+++ b/src/main/java/com/autotune/analyzer/experiment/ExperimentValidation.java
@@ -172,12 +172,22 @@ public class ExperimentValidation {
                             validationOutputData.setErrorCode(HttpServletResponse.SC_BAD_REQUEST);
                             proceed = false;
                         }
-                        // check if the provided datasource name exists
-                        DataSourceInfo dataSourceInfo = DataSourceCollection.getInstance().getDataSourcesCollection().get(kruizeObject.getDataSource());
-                        if (dataSourceInfo != null) {
-                            LOGGER.debug("DataSource {} exists", kruizeObject.getDataSource());
+                        // check if the provided datasource name(s) exist
+                        List<String> datasources = kruizeObject.getDatasources();
+                        if (datasources != null && !datasources.isEmpty()) {
+                            for (String datasourceName : datasources) {
+                                DataSourceInfo dataSourceInfo = DataSourceCollection.getInstance().getDataSourcesCollection().get(datasourceName);
+                                if (dataSourceInfo != null) {
+                                    LOGGER.debug("DataSource {} exists", datasourceName);
+                                } else {
+                                    errorMsg = String.format(AnalyzerErrorConstants.APIErrors.ListDataSourcesAPI.INVALID_DATASOURCE_NAME_MSG, datasourceName);
+                                    validationOutputData.setErrorCode(HttpServletResponse.SC_BAD_REQUEST);
+                                    proceed = false;
+                                    break;
+                                }
+                            }
                         } else {
-                            errorMsg = String.format(AnalyzerErrorConstants.APIErrors.ListDataSourcesAPI.INVALID_DATASOURCE_NAME_MSG, kruizeObject.getDataSource());
+                            errorMsg = KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.NO_DATASOURCE_SERVICEABLE;
                             validationOutputData.setErrorCode(HttpServletResponse.SC_BAD_REQUEST);
                             proceed = false;
                         }
@@ -401,7 +411,8 @@ public class ExperimentValidation {
                         }
                     }
                 } else if (expObj.getExperiment_usecase_type().isLocal_monitoring()) {
-                    if (null == expObj.getDataSource()) {
+                    // Check both single datasource and datasources list
+                    if (null == expObj.getDataSource() && (null == expObj.getDatasources() || expObj.getDatasources().isEmpty())) {
                         errorMsg = errorMsg.concat(String.format(LOCAL_MONITORING_DATASOURCE_MANDATORY, expObj.getExperimentName()));
                         missingLocalDatasource = true;
                     }

--- a/src/main/java/com/autotune/analyzer/kruizeLayer/presence/LabelBasedPresence.java
+++ b/src/main/java/com/autotune/analyzer/kruizeLayer/presence/LabelBasedPresence.java
@@ -43,7 +43,7 @@ public class LabelBasedPresence implements LayerPresenceDetector {
     }
 
     @Override
-    public boolean detectPresence(String namespace, String containerName, String datasourceName) throws Exception {
+    public boolean detectPresence(String namespace, String containerName, List<String> datasourceNames) throws Exception {
         // TODO: Implement label-based presence detection
         throw new UnsupportedOperationException("Label-based presence detection not yet implemented");
     }

--- a/src/main/java/com/autotune/analyzer/kruizeLayer/presence/LayerPresenceDetector.java
+++ b/src/main/java/com/autotune/analyzer/kruizeLayer/presence/LayerPresenceDetector.java
@@ -17,6 +17,7 @@
 package com.autotune.analyzer.kruizeLayer.presence;
 
 import com.autotune.analyzer.utils.AnalyzerConstants.LayerConstants.PresenceType;
+import java.util.List;
 
 /**
  * Interface for different layer presence detection strategies
@@ -33,11 +34,11 @@ public interface LayerPresenceDetector {
      * Detect if the layer is present in the given namespace and container
      * @param namespace The Kubernetes namespace to check
      * @param containerName The container name to check (optional, can be null)
-     * @param datasourceName The datasource name to use for detection
+     * @param datasourceNames The datasource names configured for the experiment
      * @return true if the layer is detected, false otherwise
      * @throws Exception if detection fails due to connectivity or other issues
      */
-    boolean detectPresence(String namespace, String containerName, String datasourceName) throws Exception;
+    boolean detectPresence(String namespace, String containerName, List<String> datasourceNames) throws Exception;
 
 
 }

--- a/src/main/java/com/autotune/analyzer/kruizeLayer/presence/PresenceAlways.java
+++ b/src/main/java/com/autotune/analyzer/kruizeLayer/presence/PresenceAlways.java
@@ -17,6 +17,7 @@
 package com.autotune.analyzer.kruizeLayer.presence;
 
 import com.autotune.analyzer.utils.AnalyzerConstants.LayerConstants.PresenceType;
+import java.util.List;
 
 /**
  * Implementation for layers that are always present
@@ -31,7 +32,7 @@ public class PresenceAlways implements LayerPresenceDetector {
     }
 
     @Override
-    public boolean detectPresence(String namespace, String containerName, String datasourceName) throws Exception {
+    public boolean detectPresence(String namespace, String containerName, List<String> datasourceNames) throws Exception {
         // Layers with ALWAYS presence type are always detected
         return true;
     }

--- a/src/main/java/com/autotune/analyzer/kruizeLayer/presence/QueryBasedPresence.java
+++ b/src/main/java/com/autotune/analyzer/kruizeLayer/presence/QueryBasedPresence.java
@@ -114,7 +114,7 @@ public class QueryBasedPresence implements LayerPresenceDetector {
                     // Start with the original query
                     String modifiedQuery = query.getLayerPresenceQuery();
 
-                    if (query.getDataSource().equalsIgnoreCase(KruizeConstants.SupportedDatasources.CRYOSTAT)) {
+                    if (KruizeConstants.SupportedDatasources.CRYOSTAT.equalsIgnoreCase(query.getDataSource())) {
                         // For Cryostat detection, we need to:
                         // 1. Query Prometheus to get the list of pods
                         // 2. Query Cryostat to check if those pods have JVM targets
@@ -138,6 +138,14 @@ public class QueryBasedPresence implements LayerPresenceDetector {
 
                         DataSourceOperatorImpl prometheusOperator = DataSourceOperatorImpl.getInstance()
                                 .getOperator(promDatasourceInfo.getProvider());
+                        if (prometheusOperator == null) {
+                            LOGGER.warn(
+                                    "No datasource operator found for provider='{}' while performing Cryostat layer detection. " +
+                                            "Skipping detection for datasource='{}'.", promDatasourceInfo.getProvider(),
+                                    promDatasourceInfo.getName()
+                            );
+                            continue;
+                        }
 
                         // Build PromQL query to get pods
                         String promQl = KruizeConstants.PromQueries.GET_PODS_WITH_NS_CONTAINER;
@@ -156,6 +164,14 @@ public class QueryBasedPresence implements LayerPresenceDetector {
                         // Get Cryostat operator and datasource
                         DataSourceOperatorImpl cryostatOperator = DataSourceOperatorImpl.getInstance()
                                 .getOperator(KruizeConstants.SupportedDatasources.CRYOSTAT);
+                        if (cryostatOperator == null) {
+                            LOGGER.warn(
+                                    "No datasource operator found for provider='{}' while performing Cryostat layer detection. " +
+                                            "Skipping detection for datasource='{}'.", KruizeConstants.SupportedDatasources.CRYOSTAT,
+                                    dataSourceInfo.getName()
+                            );
+                            continue;
+                        }
                         if (!pods.isEmpty()) {
                             for (String pod: pods) {
                                 LOGGER.debug("Checking Cryostat targets for pod: {}", pod);

--- a/src/main/java/com/autotune/analyzer/kruizeLayer/presence/QueryBasedPresence.java
+++ b/src/main/java/com/autotune/analyzer/kruizeLayer/presence/QueryBasedPresence.java
@@ -17,13 +17,17 @@
 package com.autotune.analyzer.kruizeLayer.presence;
 
 import com.autotune.analyzer.kruizeLayer.LayerPresenceQuery;
+import com.autotune.analyzer.kruizeLayer.utils.LayerUtils;
 import com.autotune.analyzer.utils.AnalyzerConstants.LayerConstants;
 import com.autotune.analyzer.utils.AnalyzerConstants.LayerConstants.LogMessages;
 import com.autotune.analyzer.utils.AnalyzerConstants.LayerConstants.PresenceType;
 import com.autotune.common.datasource.DataSourceCollection;
 import com.autotune.common.datasource.DataSourceInfo;
 import com.autotune.common.datasource.DataSourceOperatorImpl;
+import com.autotune.utils.KruizeConstants;
 import com.google.gson.JsonArray;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,9 +63,14 @@ public class QueryBasedPresence implements LayerPresenceDetector {
      * @throws Exception if detection fails
      */
     @Override
-    public boolean detectPresence(String namespace, String containerName, String datasourceName) throws Exception {
+    public boolean detectPresence(String namespace, String containerName, List<String> datasourceNames) throws Exception {
         if (queries == null || queries.isEmpty()) {
             LOGGER.warn(LogMessages.NO_QUERIES_DEFINED);
+            return false;
+        }
+
+        if (datasourceNames == null || datasourceNames.isEmpty()) {
+            LOGGER.warn("No datasource names provided for layer detection");
             return false;
         }
 
@@ -73,53 +82,138 @@ public class QueryBasedPresence implements LayerPresenceDetector {
                 continue;
             }
 
-            try {
-                // Get the specific datasource by name from the experiment
-                DataSourceInfo dataSourceInfo = DataSourceCollection.getInstance()
-                        .getDataSourcesCollection()
-                        .get(datasourceName);
+            for (String datasourceName : datasourceNames) {
+                try {
+                    // Get the specific datasource by name from the experiment
+                    DataSourceInfo dataSourceInfo = DataSourceCollection.getInstance()
+                            .getDataSourcesCollection()
+                            .get(datasourceName);
 
-                if (dataSourceInfo == null) {
-                    LOGGER.warn(LogMessages.DATASOURCE_NOT_FOUND, datasourceName);
-                    continue;
+                    if (dataSourceInfo == null) {
+                        LOGGER.warn(LogMessages.DATASOURCE_NOT_FOUND, datasourceName);
+                        continue;
+                    }
+
+                    // Skip queries that don't match the datasource provider
+                    if (query.getDataSource() != null &&
+                        !query.getDataSource().equalsIgnoreCase(dataSourceInfo.getProvider())) {
+                        LOGGER.debug("Skipping query for datasource '{}' as it doesn't match current datasource provider '{}'",
+                                query.getDataSource(), dataSourceInfo.getProvider());
+                        continue;
+                    }
+
+                    // Get the appropriate operator for the datasource provider
+                    DataSourceOperatorImpl operator = DataSourceOperatorImpl.getInstance()
+                            .getOperator(dataSourceInfo.getProvider());
+
+                    if (operator == null) {
+                        LOGGER.warn(LogMessages.NO_OPERATOR_AVAILABLE, dataSourceInfo.getProvider());
+                        continue;
+                    }
+
+                    // Start with the original query
+                    String modifiedQuery = query.getLayerPresenceQuery();
+
+                    if (query.getDataSource().equalsIgnoreCase(KruizeConstants.SupportedDatasources.CRYOSTAT)) {
+                        // For Cryostat detection, we need to:
+                        // 1. Query Prometheus to get the list of pods
+                        // 2. Query Cryostat to check if those pods have JVM targets
+
+                        DataSourceInfo promDatasourceInfo = null;
+                        for (String experimentDatasourceName : datasourceNames) {
+                            DataSourceInfo experimentDatasourceInfo = DataSourceCollection.getInstance()
+                                    .getDataSourcesCollection()
+                                    .get(experimentDatasourceName);
+                            if (experimentDatasourceInfo != null &&
+                                    KruizeConstants.SupportedDatasources.PROMETHEUS.equalsIgnoreCase(experimentDatasourceInfo.getProvider())) {
+                                promDatasourceInfo = experimentDatasourceInfo;
+                                break;
+                            }
+                        }
+
+                        if (promDatasourceInfo == null) {
+                            LOGGER.warn("Cryostat layer detection requires a Prometheus datasource instance in the experiment datasource list, but none found. Skipping Cryostat detection.");
+                            continue;
+                        }
+
+                        DataSourceOperatorImpl prometheusOperator = DataSourceOperatorImpl.getInstance()
+                                .getOperator(promDatasourceInfo.getProvider());
+
+                        // Build PromQL query to get pods
+                        String promQl = KruizeConstants.PromQueries.GET_PODS_WITH_NS_CONTAINER;
+                        if (namespace != null && !namespace.isBlank()) {
+                            promQl = appendFilter(promQl, LayerConstants.LABEL_NAMESPACE, namespace);
+                        }
+                        if (containerName != null && !containerName.isBlank()) {
+                            promQl = appendFilter(promQl, LayerConstants.LABEL_CONTAINER, containerName);
+                        }
+                        LOGGER.debug("PromQl: {}", promQl);
+
+                        // Execute Prometheus query using the Prometheus datasource
+                        JSONObject returnObj = prometheusOperator.getJsonObjectForQuery(promDatasourceInfo, promQl);
+                        List<String> pods = LayerUtils.extractPods(returnObj);
+
+                        // Get Cryostat operator and datasource
+                        DataSourceOperatorImpl cryostatOperator = DataSourceOperatorImpl.getInstance()
+                                .getOperator(KruizeConstants.SupportedDatasources.CRYOSTAT);
+                        if (!pods.isEmpty()) {
+                            for (String pod: pods) {
+                                LOGGER.debug("Checking Cryostat targets for pod: {}", pod);
+                                String queryToTry = modifiedQuery.replace("$POD_NAME$", pod);
+                                LOGGER.debug("Cryostat Query: {}", queryToTry);
+
+                                // Use the Cryostat datasource (dataSourceInfo) for GraphQL query
+                                JSONObject graphQlJson = cryostatOperator.getJsonObjectForQuery(dataSourceInfo, queryToTry);
+                                if (null == graphQlJson) {
+                                    LOGGER.warn(
+                                            "Cryostat query returned no response while checking layer presence. datasource='{}', provider='{}', namespace='{}', container='{}', pod='{}'. Skipping this pod.",
+                                            dataSourceInfo.getName(),
+                                            dataSourceInfo.getProvider(),
+                                            namespace,
+                                            containerName,
+                                            pod
+                                    );
+                                    LOGGER.debug("Cryostat GraphQL query with no response: {}", queryToTry);
+                                    continue;
+                                }
+
+                                LOGGER.debug("GraphQL object: {}", graphQlJson);
+                                JSONArray envNodes = graphQlJson
+                                        .optJSONObject("data")
+                                        .optJSONArray("environmentNodes");
+
+                                if (envNodes != null && !envNodes.isEmpty()) {
+                                    LOGGER.debug("SUCCESS: Found Cryostat target(s) for pod '{}'", pod);
+                                    return true;
+                                }
+                            }
+                        }
+
+                    } else {
+                        // Append dynamic filters for namespace, container
+                        if (namespace != null && !namespace.isBlank()) {
+                            modifiedQuery = appendFilter(modifiedQuery, LayerConstants.LABEL_NAMESPACE, namespace);
+                        }
+                        if (containerName != null && !containerName.isBlank()) {
+                            modifiedQuery = appendFilter(modifiedQuery, LayerConstants.LABEL_CONTAINER, containerName);
+                        }
+                        LOGGER.debug(LogMessages.EXECUTING_QUERY, modifiedQuery);
+
+                        // Execute the modified query and get results
+                        JsonArray resultArray = operator.getResultArrayForQuery(
+                                dataSourceInfo,
+                                modifiedQuery
+                        );
+
+                        // Check if we got any results - if yes, layer is present
+                        if (resultArray != null && !resultArray.isEmpty()) {
+                            LOGGER.debug(LogMessages.LAYER_DETECTED_VIA_QUERY, namespace, containerName);
+                            return true;
+                        }
+                    }
+                } catch (Exception e) {
+                    LOGGER.error(LogMessages.ERROR_EXECUTING_QUERY, query.getDataSource(), e);
                 }
-
-                // Get the appropriate operator for the datasource provider
-                DataSourceOperatorImpl operator = DataSourceOperatorImpl.getInstance()
-                        .getOperator(dataSourceInfo.getProvider());
-
-                if (operator == null) {
-                    LOGGER.warn(LogMessages.NO_OPERATOR_AVAILABLE, dataSourceInfo.getProvider());
-                    continue;
-                }
-
-                // Start with the original query
-                String modifiedQuery = query.getLayerPresenceQuery();
-
-                // Append dynamic filters for namespace, container
-                if (namespace != null && !namespace.isBlank()) {
-                    modifiedQuery = appendFilter(modifiedQuery, LayerConstants.LABEL_NAMESPACE, namespace);
-                }
-                if (containerName != null && !containerName.isBlank()) {
-                    modifiedQuery = appendFilter(modifiedQuery, LayerConstants.LABEL_CONTAINER, containerName);
-                }
-
-                LOGGER.debug(LogMessages.EXECUTING_QUERY, modifiedQuery);
-
-                // Execute the modified query and get results
-                JsonArray resultArray = operator.getResultArrayForQuery(
-                        dataSourceInfo,
-                        modifiedQuery
-                );
-
-                // Check if we got any results - if yes, layer is present
-                if (resultArray != null && !resultArray.isEmpty()) {
-                    LOGGER.debug(LogMessages.LAYER_DETECTED_VIA_QUERY, namespace, containerName);
-                    return true;
-                }
-            } catch (Exception e) {
-                LOGGER.error(LogMessages.ERROR_EXECUTING_QUERY, query.getDataSource(), e);
-                // Continue to next query instead of failing completely
             }
         }
 

--- a/src/main/java/com/autotune/analyzer/kruizeLayer/utils/LayerUtils.java
+++ b/src/main/java/com/autotune/analyzer/kruizeLayer/utils/LayerUtils.java
@@ -132,6 +132,10 @@ public class LayerUtils {
     public static List<String> extractPods(JSONObject promResponse) {
         List<String> pods = new ArrayList<>();
 
+        if (promResponse == null) {
+            return pods;
+        }
+
         JSONObject data = promResponse.optJSONObject("data");
         if (data == null) {
             return pods;
@@ -143,9 +147,12 @@ public class LayerUtils {
         }
 
         for (int i = 0; i < results.length(); i++) {
-            JSONObject metric = results.optJSONObject(i)
-                    .optJSONObject("metric");
+            JSONObject result = results.optJSONObject(i);
+            if (result == null) {
+                continue;
+            }
 
+            JSONObject metric = result.optJSONObject("metric");
             if (metric != null) {
                 String pod = metric.optString("pod", null);
                 if (pod != null && !pod.isBlank()) {

--- a/src/main/java/com/autotune/analyzer/kruizeLayer/utils/LayerUtils.java
+++ b/src/main/java/com/autotune/analyzer/kruizeLayer/utils/LayerUtils.java
@@ -21,13 +21,12 @@ import com.autotune.analyzer.kruizeLayer.presence.LabelBasedPresence;
 import com.autotune.analyzer.kruizeLayer.presence.QueryBasedPresence;
 import com.autotune.analyzer.utils.AnalyzerConstants.LayerConstants.LogMessages;
 import com.autotune.database.service.ExperimentDBService;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Utility class for layer detection operations
@@ -46,7 +45,7 @@ public class LayerUtils {
      * @throws Exception if database operations fail
      */
     public static Map<String, KruizeLayer> detectLayers(String containerName,
-                                                         String namespace, String datasourceName) throws Exception {
+                                                         String namespace, List<String> datasourceNames) throws Exception {
         // Validate inputs - fail fast with clear error messages
         if (containerName == null || containerName.isBlank()) {
             throw new IllegalArgumentException(LogMessages.CONTAINER_NAME_NULL_OR_EMPTY);
@@ -93,11 +92,11 @@ public class LayerUtils {
                     // For query-based detection, pass container name as well
                     if (layer.getLayerPresence().getDetector() instanceof QueryBasedPresence) {
                         QueryBasedPresence queryDetector = (QueryBasedPresence) layer.getLayerPresence().getDetector();
-                        isDetected = queryDetector.detectPresence(namespace, containerName, datasourceName);
+                        isDetected = queryDetector.detectPresence(namespace, containerName, datasourceNames);
                     } else {
                         // For other detector types (Always)
                         isDetected = layer.getLayerPresence().getDetector()
-                                .detectPresence(namespace, containerName, datasourceName);
+                                .detectPresence(namespace, containerName, datasourceNames);
                     }
 
                     if (isDetected) {
@@ -128,5 +127,33 @@ public class LayerUtils {
         }
 
         return detectedLayers;
+    }
+
+    public static List<String> extractPods(JSONObject promResponse) {
+        List<String> pods = new ArrayList<>();
+
+        JSONObject data = promResponse.optJSONObject("data");
+        if (data == null) {
+            return pods;
+        }
+
+        JSONArray results = data.optJSONArray("result");
+        if (results == null) {
+            return pods;
+        }
+
+        for (int i = 0; i < results.length(); i++) {
+            JSONObject metric = results.optJSONObject(i)
+                    .optJSONObject("metric");
+
+            if (metric != null) {
+                String pod = metric.optString("pod", null);
+                if (pod != null && !pod.isBlank()) {
+                    pods.add(pod);
+                }
+            }
+        }
+
+        return pods;
     }
 }

--- a/src/main/java/com/autotune/analyzer/kruizeObject/KruizeObject.java
+++ b/src/main/java/com/autotune/analyzer/kruizeObject/KruizeObject.java
@@ -33,9 +33,7 @@ import com.google.gson.annotations.SerializedName;
 import io.fabric8.kubernetes.api.model.ObjectReference;
 
 import java.sql.Timestamp;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Container class for the Autotune kubernetes kind objects.
@@ -52,7 +50,9 @@ public final class KruizeObject implements ExperimentTypeAware {
     @SerializedName("cluster_name")
     private String clusterName;
     @SerializedName("datasource")
-    private String datasource;
+    private String datasource; // DEPRECATED - kept for backward compatibility
+    @SerializedName("datasources")
+    private List<String> datasources; // NEW - list of datasource names for multi-datasource support
     @SerializedName(KruizeConstants.JSONKeys.EXPERIMENT_TYPE) //TODO: to be used in future
     @JsonAdapter(ExperimentTypeUtil.ExperimentTypeSerializer.class)
     private AnalyzerConstants.ExperimentType experimentType;
@@ -368,6 +368,29 @@ public final class KruizeObject implements ExperimentTypeAware {
     public String getDataSource() {
         return datasource;
     }
+    /**
+     * Get list of datasources configured for this experiment.
+     * Provides backward compatibility by converting single datasource to list.
+     * 
+     * @return List of datasource names, never null
+     */
+    public List<String> getDatasources() {
+        // Backward compatibility: if datasources is null but datasource is set
+        if (datasources == null && datasource != null) {
+            return Arrays.asList(datasource);
+        }
+        return datasources != null ? datasources : Collections.emptyList();
+    }
+
+    /**
+     * Set list of datasources for this experiment
+     * 
+     * @param datasources List of datasource names
+     */
+    public void setDatasources(List<String> datasources) {
+        this.datasources = datasources;
+    }
+
 
     public void setDataSource(String datasource) {
         this.datasource = datasource;

--- a/src/main/java/com/autotune/analyzer/kruizeObject/KruizeObject.java
+++ b/src/main/java/com/autotune/analyzer/kruizeObject/KruizeObject.java
@@ -383,17 +383,36 @@ public final class KruizeObject implements ExperimentTypeAware {
     }
 
     /**
-     * Set list of datasources for this experiment
-     * 
+     * Set list of datasources for this experiment.
+     * Also updates the deprecated datasource field with the first datasource for backward compatibility.
+     *
      * @param datasources List of datasource names
      */
     public void setDatasources(List<String> datasources) {
         this.datasources = datasources;
+        // Maintain backward compatibility: sync deprecated datasource field
+        if (datasources != null && !datasources.isEmpty()) {
+            this.datasource = datasources.getFirst();
+        } else {
+            this.datasource = null;
+        }
     }
 
 
+    /**
+     * Set single datasource for this experiment (deprecated).
+     * Also updates the datasources list to maintain consistency.
+     *
+     * @param datasource Single datasource name
+     */
     public void setDataSource(String datasource) {
         this.datasource = datasource;
+        // Maintain consistency: sync datasources list
+        if (datasource != null) {
+            this.datasources = List.of(datasource);
+        } else {
+            this.datasources = null;
+        }
     }
 
     public AnalyzerConstants.ExperimentType getExperimentType() {

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -23,6 +23,7 @@ import com.autotune.common.data.result.IntervalResults;
 import com.autotune.common.data.result.NamespaceData;
 import com.autotune.common.data.system.info.device.DeviceDetails;
 import com.autotune.common.data.system.info.device.accelerator.NvidiaAcceleratorDeviceData;
+import com.autotune.common.datasource.DataSourceCollection;
 import com.autotune.common.datasource.DataSourceInfo;
 import com.autotune.common.exceptions.DataSourceNotExist;
 import com.autotune.common.k8sObjects.K8sObject;
@@ -333,8 +334,36 @@ public class RecommendationEngine implements RecommendationEngineService {
             setPerformanceProfile(kruizeObject.getPerformanceProfile());
 
             // get the datasource
-            // TODO: If no data source given use KruizeDeploymentInfo.monitoring_agent / default datasource
-            String dataSource = kruizeObject.getDataSource();
+            // For multi-datasource experiments, Prometheus is mandatory for metrics collection.
+            // For backward compatibility, a single datasource is allowed only if the provider is Prometheus.
+            String dataSource = null;
+            List<String> datasources = kruizeObject.getDatasources();
+
+            if (datasources != null && !datasources.isEmpty()) {
+                for (String ds : datasources) {
+                    DataSourceInfo dsInfo = DataSourceCollection.getInstance()
+                            .getDataSourcesCollection()
+                            .get(ds);
+                    if (dsInfo != null && dsInfo.getProvider().equalsIgnoreCase(KruizeConstants.SupportedDatasources.PROMETHEUS)) {
+                        dataSource = ds;
+                        break;
+                    }
+                }
+            } else {
+                dataSource = kruizeObject.getDataSource();
+                if (dataSource != null) {
+                    DataSourceInfo dsInfo = DataSourceCollection.getInstance()
+                            .getDataSourcesCollection()
+                            .get(dataSource);
+                    if (dsInfo == null || !dsInfo.getProvider().equalsIgnoreCase(KruizeConstants.SupportedDatasources.PROMETHEUS)) {
+                        dataSource = null;
+                    }
+                }
+            }
+
+            if (dataSource == null) {
+                throw new Exception("No Prometheus datasource configured for experiment: " + kruizeObject.getExperimentName());
+            }
 
             // call different models for different use cases
             if (kruizeObject.getMode().equalsIgnoreCase(AnalyzerConstants.MONITOR)) {
@@ -1187,16 +1216,35 @@ public class RecommendationEngine implements RecommendationEngineService {
             String maxDateQuery = null;
             String acceleratorDetectionQuery = null;
             String acceleratorMigDetectionQuery = null;
+            
+            // For non-prometheus datasources, we need to use Prometheus for PromQL queries (like MAX_DATE)
+            DataSourceInfo promQLDataSourceInfo = dataSourceInfo;
+            if (dataSourceInfo != null && dataSourceInfo.getProvider().equalsIgnoreCase(KruizeConstants.SupportedDatasources.CRYOSTAT)) {
+                LOGGER.debug("Cryostat datasource detected. Looking for Prometheus datasource for PromQL queries.");
+                // Find a Prometheus datasource from the collection for PromQL queries
+                for (DataSourceInfo ds : DataSourceCollection.getInstance().getDataSourcesCollection().values()) {
+                    if (ds.getProvider().equalsIgnoreCase(KruizeConstants.SupportedDatasources.PROMETHEUS)) {
+                        promQLDataSourceInfo = ds;
+                        LOGGER.debug("Using Prometheus datasource '{}' for PromQL queries", ds.getName());
+                        break;
+                    }
+                }
+                
+                if (promQLDataSourceInfo == dataSourceInfo) {
+                    LOGGER.warn("Cryostat datasource requires a Prometheus datasource for PromQL queries, but none found. Metrics collection may fail.");
+                }
+            }
 
             if (kruizeObject.isContainerExperiment()) {
                 maxDateQuery = getMaxQueryByName(metricProfile, AnalyzerConstants.MetricName.maxDate.name());
                 acceleratorDetectionQuery = getMaxQueryByName(metricProfile, AnalyzerConstants.MetricName.acceleratorMemoryUsage.name());
                 acceleratorMigDetectionQuery = getMaxQueryByName(metricProfile, AnalyzerConstants.MetricName.acceleratorFrameBufferUsage.name());
 
+                // Use promQLDataSourceInfo for PromQL queries
                 fetchContainerMetricsBasedOnDataSourceAndProfile(kruizeObject,
                         interval_end_time,
                         interval_start_time,
-                        dataSourceInfo,
+                        promQLDataSourceInfo,
                         metricProfile,
                         maxDateQuery,
                         acceleratorDetectionQuery,
@@ -1204,7 +1252,8 @@ public class RecommendationEngine implements RecommendationEngineService {
 
             } else if (kruizeObject.isNamespaceExperiment()) {
                 maxDateQuery = getMaxQueryByName(metricProfile, AnalyzerConstants.MetricName.namespaceMaxDate.name());
-                fetchNamespaceMetricsBasedOnDataSourceAndProfile(kruizeObject, interval_end_time, interval_start_time, dataSourceInfo, metricProfile, maxDateQuery);
+                // Use promQLDataSourceInfo for PromQL queries
+                fetchNamespaceMetricsBasedOnDataSourceAndProfile(kruizeObject, interval_end_time, interval_start_time, promQLDataSourceInfo, metricProfile, maxDateQuery);
             }
         } catch (Exception e) {
             e.printStackTrace();
@@ -1435,7 +1484,12 @@ public class RecommendationEngine implements RecommendationEngineService {
                     boolean runtimeLayerDetected = RuntimeRecommendationProcessor.isRuntimeLayerPresent(containerData.getLayerMap());
 
                     // Check if the container data has Accelerator support else check for Accelerator metrics
-                    if (!isROS && null == gpuUUID && (null == containerData.getContainerDeviceList() || !containerData.getContainerDeviceList().isAcceleratorDeviceDetected())) {
+                    // Skip accelerator detection for Cryostat-only datasources as they don't support Prometheus query API
+                    boolean isPrometheusDataSource = dataSourceInfo != null &&
+                            dataSourceInfo.getProvider().equalsIgnoreCase(KruizeConstants.SupportedDatasources.PROMETHEUS);
+                    
+                    if (!isROS && null == gpuUUID && isPrometheusDataSource &&
+                            (null == containerData.getContainerDeviceList() || !containerData.getContainerDeviceList().isAcceleratorDeviceDetected())) {
                         containerAcceleratorDetected = RecommendationUtils.markAcceleratorDeviceStatusToContainer(containerData,
                                 maxDateQuery,
                                 namespace,
@@ -1448,7 +1502,8 @@ public class RecommendationEngine implements RecommendationEngineService {
                     }
 
                     // Check if it's a partition
-                    if (!isROS && !containerAcceleratorDetected) {
+                    // Skip accelerator partition detection for Cryostat-only datasources
+                    if (!isROS && !containerAcceleratorDetected && isPrometheusDataSource) {
                         if (null != gpuUUID) {
                             containerAcceleratorPartitionDetected = RecommendationUtils.markAcceleratorPartitionDeviceStatusToContainer(containerData,
                                     maxDateQuery,

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RuntimeRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RuntimeRecommendationProcessor.java
@@ -94,10 +94,11 @@ public final class RuntimeRecommendationProcessor {
             RecommendationConfigItem recommendationMemLimits) {
 
         List<RecommendationConfigEnv> runtimeRecommList = new ArrayList<>();
-        String datasourceName = kruizeObject.getDataSource();
-        if (datasourceName == null) {
-            LOGGER.warn("Datasource missing, skipping runtime recommendations");
-            return null;
+        if (kruizeObject.getDataSource() == null) {
+            if (kruizeObject.getDatasources() == null || kruizeObject.getDatasources().isEmpty()) {
+                LOGGER.warn("Datasource missing, skipping runtime recommendations");
+                return null;
+            }
         }
         Map<String, KruizeLayer> layerMap = containerData.getLayerMap();
         LOGGER.debug("layerMap: {}", new Gson().toJson(layerMap));

--- a/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/Converters.java
@@ -81,6 +81,7 @@ public class Converters {
                 kruizeObject.setMode(createExperimentAPIObject.getMode());
                 kruizeObject.setPerformanceProfile(createExperimentAPIObject.getPerformanceProfile());
                 kruizeObject.setDataSource(createExperimentAPIObject.getDatasource());
+                kruizeObject.setDatasources(createExperimentAPIObject.getDatasources());
                 kruizeObject.setExperimentType(createExperimentAPIObject.getExperimentType());
                 kruizeObject.setSloInfo(createExperimentAPIObject.getSloInfo());
                 kruizeObject.setTrial_settings(createExperimentAPIObject.getTrialSettings());

--- a/src/main/java/com/autotune/analyzer/serviceObjects/CreateExperimentAPIObject.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/CreateExperimentAPIObject.java
@@ -27,6 +27,7 @@ import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
 
 import java.sql.Timestamp;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -51,8 +52,10 @@ public class CreateExperimentAPIObject extends BaseSO implements ExperimentTypeA
     private TrialSettings trialSettings;
     @SerializedName(KruizeConstants.JSONKeys.RECOMMENDATION_SETTINGS)
     private RecommendationSettings recommendationSettings;
-    @SerializedName(KruizeConstants.JSONKeys.DATASOURCE) //TODO: to be used in future
+    @SerializedName(KruizeConstants.JSONKeys.DATASOURCE) //DEPRECATED - kept for backward compatibility
     private String datasource;
+    @SerializedName(KruizeConstants.JSONKeys.DATASOURCES) //NEW - list of datasource names
+    private List<String> datasources;
     @SerializedName(KruizeConstants.JSONKeys.EXPERIMENT_TYPE) //TODO: to be used in future
     @JsonAdapter(ExperimentTypeUtil.ExperimentTypeSerializer.class)
     private AnalyzerConstants.ExperimentType experimentType;
@@ -161,6 +164,29 @@ public class CreateExperimentAPIObject extends BaseSO implements ExperimentTypeA
 
     public String getDatasource() {
         return datasource;
+    }
+
+    /**
+     * Get list of datasources configured for this experiment.
+     * Provides backward compatibility by converting single datasource to list.
+     *
+     * @return List of datasource names, never null
+     */
+    public List<String> getDatasources() {
+        // Backward compatibility: if datasources is null but datasource is set
+        if (datasources == null && datasource != null) {
+            return List.of(datasource);
+        }
+        return datasources != null ? datasources : Collections.emptyList();
+    }
+
+    /**
+     * Set list of datasources for this experiment
+     *
+     * @param datasources List of datasource names
+     */
+    public void setDatasources(List<String> datasources) {
+        this.datasources = datasources;
     }
 
     public void setDatasource(String datasource) {

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -684,6 +684,7 @@ public class AnalyzerConstants {
         // PromQL label names used in query-based presence detection
         public static final String LABEL_NAMESPACE = "namespace";
         public static final String LABEL_CONTAINER = "container";
+        public static final String LABEL_POD = "pod";
 
         // Supported Layers
         public static final String CONTAINER_LAYER = "container";

--- a/src/main/java/com/autotune/analyzer/utils/ServiceHelpers.java
+++ b/src/main/java/com/autotune/analyzer/utils/ServiceHelpers.java
@@ -136,17 +136,68 @@ public class ServiceHelpers {
         return kruizeExpList;
     }
 
-    public static void detectLayers (CreateExperimentAPIObject validAPIObj) throws Exception {
+    /**
+     * Detect layers for an experiment using configured datasources.
+     * Supports both single datasource (backward compatible) and multiple datasources.
+     *
+     * @param validAPIObj The experiment configuration
+     */
+    public static void detectLayers(CreateExperimentAPIObject validAPIObj) {
+        if (validAPIObj == null) {
+            LOGGER.warn("CreateExperimentAPIObject is null, skipping layer detection");
+            return;
+        }
+
+        // Get datasources from experiment (handles backward compatibility)
+        List<String> datasources = validAPIObj.getDatasources();
+        if (datasources == null || datasources.isEmpty()) {
+            LOGGER.warn("No datasources configured for experiment: {}",
+                    validAPIObj.getExperimentName());
+            return;
+        }
+
+        LOGGER.info("Detecting layers for experiment '{}' using {} datasource(s): {}",
+                validAPIObj.getExperimentName(), datasources.size(), datasources);
+
+        // Detect layers for each container
         for (KubernetesAPIObject kubernetesAPIObject : validAPIObj.getKubernetesObjects()) {
             for (ContainerAPIObject containerAPIObject : kubernetesAPIObject.getContainerAPIObjects()) {
-                // detect layers for the container
-                Map<String, KruizeLayer> layers = LayerUtils.detectLayers(containerAPIObject.getContainer_name(),
-                        kubernetesAPIObject.getNamespace(),
-                        validAPIObj.getDatasource()
-                );
-                // Skipping null check as we return atleast an empty map if there are no exceptions
-                if (!layers.isEmpty()) {
-                    containerAPIObject.setLayerMap(layers);
+
+                // Aggregate detected layers from all datasources
+                Map<String, KruizeLayer> aggregatedLayers = new java.util.HashMap<>();
+
+                try {
+                    LOGGER.debug("Detecting layers for container '{}' using datasources '{}'",
+                            containerAPIObject.getContainer_name(), datasources);
+
+                    Map<String, KruizeLayer> layers = LayerUtils.detectLayers(
+                            containerAPIObject.getContainer_name(),
+                            kubernetesAPIObject.getNamespace(),
+                            datasources
+                    );
+
+                    if (!layers.isEmpty()) {
+                        aggregatedLayers.putAll(layers);
+                        LOGGER.info("Datasources '{}' detected {} layer(s) for container '{}'",
+                                datasources, layers.size(), containerAPIObject.getContainer_name());
+                    } else {
+                        LOGGER.debug("Datasources '{}' detected no layers for container '{}'",
+                                datasources, containerAPIObject.getContainer_name());
+                    }
+                } catch (Exception e) {
+                    LOGGER.error("Error detecting layers with datasources '{}' for container '{}': {}",
+                            datasources, containerAPIObject.getContainer_name(), e.getMessage());
+                    LOGGER.debug("Stack trace:", e);
+                }
+
+                // Store aggregated layers in container
+                if (!aggregatedLayers.isEmpty()) {
+                    containerAPIObject.setLayerMap(aggregatedLayers);
+                    LOGGER.info("Total {} unique layer(s) detected for container '{}' across all datasources",
+                            aggregatedLayers.size(), containerAPIObject.getContainer_name());
+                } else {
+                    LOGGER.info("No layers detected for container '{}' across any datasource",
+                            containerAPIObject.getContainer_name());
                 }
             }
         }

--- a/src/main/java/com/autotune/common/datasource/DataSourceCollection.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceCollection.java
@@ -22,6 +22,7 @@ import com.autotune.common.utils.CommonUtils;
 import com.autotune.database.service.ExperimentDBService;
 import com.autotune.operator.KruizeDeploymentInfo;
 import com.autotune.utils.KruizeConstants;
+import com.autotune.utils.KruizeSupportedTypes;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -105,7 +106,7 @@ public class DataSourceCollection {
             throw new DataSourceAlreadyExist(DATASOURCE_ALREADY_EXIST);
         }
 
-        if (!provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.PROMETHEUS) && !provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.THANOS)) {
+        if (!KruizeSupportedTypes.DATASOURCES_SUPPORTED.contains(provider)) {
             throw new UnsupportedDataSourceProvider(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.UNSUPPORTED_DATASOURCE_PROVIDER);
         }
 //        Continue validations in case of supported providers

--- a/src/main/java/com/autotune/common/datasource/DataSourceCollection.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceCollection.java
@@ -38,6 +38,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 
 import static com.autotune.utils.KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.*;
 import static com.autotune.utils.KruizeConstants.DataSourceConstants.DataSourceSuccessMsgs.*;
@@ -106,7 +107,7 @@ public class DataSourceCollection {
             throw new DataSourceAlreadyExist(DATASOURCE_ALREADY_EXIST);
         }
 
-        if (!KruizeSupportedTypes.DATASOURCES_SUPPORTED.contains(provider)) {
+        if (!KruizeSupportedTypes.DATASOURCES_SUPPORTED.contains(provider.toLowerCase(Locale.ROOT))) {
             throw new UnsupportedDataSourceProvider(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.UNSUPPORTED_DATASOURCE_PROVIDER);
         }
 //        Continue validations in case of supported providers

--- a/src/main/java/com/autotune/common/datasource/DataSourceOperatorImpl.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceOperatorImpl.java
@@ -3,6 +3,7 @@ package com.autotune.common.datasource;
 import com.autotune.analyzer.exceptions.MonitoringAgentNotFoundException;
 import com.autotune.analyzer.exceptions.TooManyRecursiveCallsException;
 import com.autotune.analyzer.utils.AnalyzerConstants;
+import com.autotune.common.datasource.cryostat.CryostatDataOperatorImpl;
 import com.autotune.common.datasource.prometheus.PrometheusDataOperatorImpl;
 import com.autotune.common.exceptions.datasource.ServiceNotFound;
 import com.autotune.common.target.kubernetes.service.KubernetesServices;
@@ -27,6 +28,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class DataSourceOperatorImpl implements DataSourceOperator {
 
@@ -161,15 +163,18 @@ public class DataSourceOperatorImpl implements DataSourceOperator {
     /**
      * Returns the instance of specific operator class based on provider type
      *
-     * @param provider String containg the name of provider
+     * @param provider String containing the name of provider
      * @return instance of specific operator
      */
     @Override
     public DataSourceOperatorImpl getOperator(String provider) {
-        if (provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.PROMETHEUS)) {
-            return PrometheusDataOperatorImpl.getInstance();
-        }
-        return null;
+        return switch (provider.toLowerCase()) {
+            case KruizeConstants.SupportedDatasources.PROMETHEUS ->
+                    PrometheusDataOperatorImpl.getInstance();
+            case KruizeConstants.SupportedDatasources.CRYOSTAT ->
+                    CryostatDataOperatorImpl.getInstance();
+            default -> null;
+        };
     }
 
     /**

--- a/src/main/java/com/autotune/common/datasource/cryostat/CryostatDataOperatorImpl.java
+++ b/src/main/java/com/autotune/common/datasource/cryostat/CryostatDataOperatorImpl.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package com.autotune.common.datasource.cryostat;
+
+import com.autotune.common.datasource.DataSourceInfo;
+import com.autotune.common.datasource.DataSourceOperatorImpl;
+import com.autotune.common.utils.CommonUtils;
+import com.autotune.utils.GenericRestApiClient;
+import com.google.gson.JsonArray;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.net.UnknownHostException;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+
+public class CryostatDataOperatorImpl extends DataSourceOperatorImpl {
+
+    private static CryostatDataOperatorImpl instance;
+
+    private CryostatDataOperatorImpl() {
+        super();
+    }
+
+    public static CryostatDataOperatorImpl getInstance() {
+        if (instance == null) {
+            instance = new CryostatDataOperatorImpl();
+        }
+        return instance;
+    }
+
+    @Override
+    public String getDefaultServicePortForProvider() {
+        return "4180";
+    }
+
+    @Override
+    public String getQueryEndpoint() {
+        return "/api/v4/graphql";
+    }
+
+    @Override
+    public CommonUtils.DatasourceReachabilityStatus isServiceable(DataSourceInfo dataSource) throws IOException,
+            NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
+
+        String reachabilityQuery = "{\"query\":\"{ environmentNodes { name } }\"}";
+        JSONObject response = getJsonObjectForQuery(dataSource, reachabilityQuery);
+
+        return response != null ? CommonUtils.DatasourceReachabilityStatus.REACHABLE
+                : CommonUtils.DatasourceReachabilityStatus.NOT_REACHABLE;
+    }
+
+    @Override
+    public Object getValueForQuery(DataSourceInfo dataSource, String query) throws IOException, NoSuchAlgorithmException,
+            KeyStoreException, KeyManagementException {
+
+        JSONObject jsonObject = getJsonObjectForQuery(dataSource, query);
+        return jsonObject != null ? "1" : null;
+    }
+
+    @Override
+    public JSONObject getJsonObjectForQuery(DataSourceInfo dataSource, String query) throws IOException, NoSuchAlgorithmException,
+            KeyStoreException, KeyManagementException {
+
+        GenericRestApiClient apiClient = new GenericRestApiClient(dataSource);
+        String baseURL = dataSource.getUrl().toString();
+        apiClient.setBaseURL(baseURL + getQueryEndpoint());
+
+        try {
+            return apiClient.fetchMetricsJson("POST", query);
+        } catch (UnknownHostException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public JsonArray getResultArrayForQuery(DataSourceInfo dataSource, String query) throws IOException, NoSuchAlgorithmException,
+            KeyStoreException, KeyManagementException {
+
+        JSONObject response = getJsonObjectForQuery(dataSource, query);
+        if (response == null) {
+            return null;
+        }
+
+        // TODO: Parse GraphQL response here
+
+        return null;
+    }
+
+    @Override
+    public boolean validateResultArray(JsonArray resultArray) {
+        return resultArray != null && !resultArray.isJsonNull() && !resultArray.isEmpty();
+    }
+}

--- a/src/main/java/com/autotune/utils/GenericRestApiClient.java
+++ b/src/main/java/com/autotune/utils/GenericRestApiClient.java
@@ -98,23 +98,10 @@ public class GenericRestApiClient {
             if (methodType.equalsIgnoreCase("GET")) {
                 httpRequestBase = new HttpGet(baseURL + URLEncoder.encode(queryString, StandardCharsets.UTF_8));
             } else if (methodType.equalsIgnoreCase("POST")) {
-
                 HttpPost httpPost = new HttpPost(baseURL);
-
-                httpPost.setEntity(
-                        new StringEntity(
-                                queryString,
-                                ContentType.APPLICATION_JSON
-                        )
-                );
+                httpPost.setEntity(new StringEntity(queryString, ContentType.APPLICATION_JSON));
                 httpRequestBase = httpPost;
-                LOGGER.info(
-                        "Request body: {}",
-                        EntityUtils.toString(
-                                ((HttpPost) httpRequestBase).getEntity(),
-                                StandardCharsets.UTF_8
-                        )
-                );
+                LOGGER.debug("Request body: {}", EntityUtils.toString(((HttpPost) httpRequestBase).getEntity(), StandardCharsets.UTF_8));
             } else {
                 throw new UnsupportedOperationException("Unsupported method type: " + methodType);
             }
@@ -154,8 +141,7 @@ public class GenericRestApiClient {
             }
         }
         if (jsonResponse == null || jsonResponse.isBlank()) {
-            LOGGER.warn("Received null or empty JSON response");
-            return new JSONObject();
+            throw new IOException("Received null or empty JSON response");
         }
         return new JSONObject(jsonResponse);
     }

--- a/src/main/java/com/autotune/utils/GenericRestApiClient.java
+++ b/src/main/java/com/autotune/utils/GenericRestApiClient.java
@@ -33,6 +33,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
@@ -96,6 +97,24 @@ public class GenericRestApiClient {
             HttpRequestBase httpRequestBase;
             if (methodType.equalsIgnoreCase("GET")) {
                 httpRequestBase = new HttpGet(baseURL + URLEncoder.encode(queryString, StandardCharsets.UTF_8));
+            } else if (methodType.equalsIgnoreCase("POST")) {
+
+                HttpPost httpPost = new HttpPost(baseURL);
+
+                httpPost.setEntity(
+                        new StringEntity(
+                                queryString,
+                                ContentType.APPLICATION_JSON
+                        )
+                );
+                httpRequestBase = httpPost;
+                LOGGER.info(
+                        "Request body: {}",
+                        EntityUtils.toString(
+                                ((HttpPost) httpRequestBase).getEntity(),
+                                StandardCharsets.UTF_8
+                        )
+                );
             } else {
                 throw new UnsupportedOperationException("Unsupported method type: " + methodType);
             }
@@ -115,22 +134,28 @@ public class GenericRestApiClient {
             // Get the response body if needed
             jsonResponse = new StringResponseHandler().handleResponse(response);
 
-            // Parse the JSON response
-            ObjectMapper objectMapper = new ObjectMapper();
-            JsonNode rootNode = objectMapper.readTree(jsonResponse);
-            JsonNode resultNode = rootNode.path("data").path("result");
-            JsonNode warningsNode = rootNode.path("warnings");
+            if (!methodType.equalsIgnoreCase("POST")) {
+                // Parse the JSON response
+                ObjectMapper objectMapper = new ObjectMapper();
+                JsonNode rootNode = objectMapper.readTree(jsonResponse);
+                JsonNode resultNode = rootNode.path("data").path("result");
+                JsonNode warningsNode = rootNode.path("warnings");
 
-            // Check if the result is empty and if there are specific warnings
-            if (resultNode.isArray() && resultNode.size() == 0) {
-                for (JsonNode warning : warningsNode) {
-                    String warningMessage = warning.asText();
-                    if (warningMessage.contains("error reading from server") || warningMessage.contains("Please reduce your request rate")) {
-                        LOGGER.warn("Warning detected: {}", warningMessage);
-                        throw new IOException(warningMessage);
+                // Check if the result is empty and if there are specific warnings
+                if (resultNode.isArray() && resultNode.isEmpty()) {
+                    for (JsonNode warning : warningsNode) {
+                        String warningMessage = warning.asText();
+                        if (warningMessage.contains("error reading from server") || warningMessage.contains("Please reduce your request rate")) {
+                            LOGGER.warn("Warning detected: {}", warningMessage);
+                            throw new IOException(warningMessage);
+                        }
                     }
                 }
             }
+        }
+        if (jsonResponse == null || jsonResponse.isBlank()) {
+            LOGGER.warn("Received null or empty JSON response");
+            return new JSONObject();
         }
         return new JSONObject(jsonResponse);
     }

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -395,6 +395,7 @@ public class KruizeConstants {
     public static class SupportedDatasources {
         public static final String PROMETHEUS = "prometheus";
         public static final String THANOS = "thanos";
+        public static final String CRYOSTAT = "cryostat";
 
         private SupportedDatasources() {
         }

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -401,6 +401,10 @@ public class KruizeConstants {
         }
     }
 
+    public static class PromQueries {
+        public static final String GET_PODS_WITH_NS_CONTAINER = "sum by (pod) (container_cpu_usage_seconds_total{})";
+    }
+
     public static class HttpConstants {
         private HttpConstants() {
         }

--- a/src/main/java/com/autotune/utils/KruizeSupportedTypes.java
+++ b/src/main/java/com/autotune/utils/KruizeSupportedTypes.java
@@ -84,6 +84,8 @@ public class KruizeSupportedTypes {
 
     public static final Set<String> RUNTIMES_SUPPORTED_DATASOURCES = new HashSet<>(Arrays.asList("thanos-querier"));
 
+    public static final Set<String> DATASOURCES_SUPPORTED = new HashSet<>(Arrays.asList("prometheus", "thanos", "cryostat"));
+
     private KruizeSupportedTypes() {
     }
 }

--- a/src/main/java/com/autotune/utils/KruizeSupportedTypes.java
+++ b/src/main/java/com/autotune/utils/KruizeSupportedTypes.java
@@ -26,7 +26,7 @@ public class KruizeSupportedTypes {
     public static final Set<String> DIRECTIONS_SUPPORTED =
             new HashSet<>(Arrays.asList("minimize", "maximize"));
     public static final Set<String> MONITORING_AGENTS_SUPPORTED =
-            new HashSet<>(Arrays.asList("prometheus"));
+            new HashSet<>(Arrays.asList("prometheus", "cryostat"));
     public static final Set<String> MODES_SUPPORTED =
             new HashSet<>(Arrays.asList("experiment", "monitor"));
     public static final Set<String> TARGET_CLUSTERS_SUPPORTED =
@@ -82,7 +82,7 @@ public class KruizeSupportedTypes {
             "name"
     ));
 
-    public static final Set<String> RUNTIMES_SUPPORTED_DATASOURCES = new HashSet<>(Arrays.asList("thanos-querier"));
+    public static final Set<String> RUNTIMES_SUPPORTED_DATASOURCES = new HashSet<>(Arrays.asList("thanos-querier", "cryostat"));
 
     public static final Set<String> DATASOURCES_SUPPORTED = new HashSet<>(Arrays.asList("prometheus", "thanos", "cryostat"));
 


### PR DESCRIPTION
## Description

Adds supporting configuration and deployment updates required for the multi-datasource layer detection flow and related runtime setup.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Enable multi-datasource experiments and integrate Cryostat-based runtime layer detection with the required deployment configuration.

New Features:
- Support configuring experiments with multiple datasources while retaining compatibility with the existing single-datasource format.
- Add Cryostat datasource integration for runtime layer detection alongside Prometheus-based pod discovery.
- Add Kubernetes deployment configuration for Cryostat access, permissions, and an OpenShift route.

Bug Fixes:
- Ensure experiment validation rejects missing or unknown configured datasources and requires Prometheus for metrics collection.
- Prevent accelerator metric and partition detection from running against Cryostat-only datasource configurations.

Enhancements:
- Update layer presence detection and recommendation processing to operate across configured datasource lists and use Prometheus for PromQL queries when needed.
- Extend datasource provider and operator support to include Cryostat and HTTP POST JSON queries.

Deployment:
- Configure the CRC OpenShift installation with Cryostat datasource access, service-account permissions, and an exposed Kruize route.

Chores:
- Add shared pod extraction and datasource constants for multi-datasource layer detection.