### PR TITLE
[feat:podCount] add replicas to current config

### DIFF
--- a/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
@@ -119,10 +119,33 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
         String experimentName = engineService.getExperimentName();
         Timestamp intervalEndTime = engineService.getInterval_end_time();
 
+        Map<Timestamp, IntervalResults> filteredResultsMap = containerData.getResults();
+        IntervalResults lastDatapoint = filteredResultsMap.get(monitoringEndTime);
+
+        RecommendationConfigItem configItem = RecommendationUtils.getCurrentValue(lastDatapoint, AnalyzerConstants.MetricName.podCount, notifications);
+        if (configItem != null && configItem.getAmount() != null) {
+            // RecommendationUtils.getPodCount ensured that configItem.getAmount() is never 0. It can be 'null'.
+            int replicas = configItem.getAmount().intValue();
+            currentConfig.setReplicas(replicas);
+            LOGGER.debug("Current replicas for workload '{}' is {}", containerData.getContainer_name(), replicas);
+        }
+
         for (AnalyzerConstants.ResourceSetting resourceSetting : AnalyzerConstants.ResourceSetting.values()) {
             for (AnalyzerConstants.RecommendationItem recommendationItem : AnalyzerConstants.RecommendationItem.values()) {
-                RecommendationConfigItem configItem = RecommendationUtils.getCurrentValue(containerData.getResults(),
-                        monitoringEndTime, resourceSetting, recommendationItem, notifications);
+                AnalyzerConstants.MetricName metricName = null;
+                if (resourceSetting == AnalyzerConstants.ResourceSetting.requests) {
+                    if (recommendationItem == AnalyzerConstants.RecommendationItem.CPU)
+                        metricName = AnalyzerConstants.MetricName.cpuRequest;
+                    else if (recommendationItem == AnalyzerConstants.RecommendationItem.MEMORY)
+                        metricName = AnalyzerConstants.MetricName.memoryRequest;
+                } else if (resourceSetting == AnalyzerConstants.ResourceSetting.limits) {
+                    if (recommendationItem == AnalyzerConstants.RecommendationItem.CPU)
+                        metricName = AnalyzerConstants.MetricName.cpuLimit;
+                    else if (recommendationItem == AnalyzerConstants.RecommendationItem.MEMORY)
+                        metricName = AnalyzerConstants.MetricName.memoryLimit;
+                }
+
+                configItem = RecommendationUtils.getCurrentValue(lastDatapoint, metricName, notifications);
 
                 // Use base class validation method
                 if (!validateConfigItem(configItem, recommendationItem, notifications, LOGGER, experimentName, intervalEndTime)) {

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
@@ -124,7 +124,7 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
 
         RecommendationConfigItem configItem = RecommendationUtils.getCurrentValue(lastDatapoint, AnalyzerConstants.MetricName.podCount, notifications);
         if (configItem != null && configItem.getAmount() != null) {
-            // RecommendationUtils.getPodCount ensured that configItem.getAmount() is never 0. It can be 'null'.
+            // RecommendationUtils.getCurrentValue ensured that configItem.getAmount() is never 0. It can be 'null'.
             int replicas = (int) Math.ceil(configItem.getAmount());
             currentConfig.setReplicas(replicas);
             LOGGER.debug("Current replicas for workload '{}' is {}", containerData.getContainer_name(), replicas);
@@ -132,19 +132,8 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
 
         for (AnalyzerConstants.ResourceSetting resourceSetting : AnalyzerConstants.ResourceSetting.values()) {
             for (AnalyzerConstants.RecommendationItem recommendationItem : AnalyzerConstants.RecommendationItem.values()) {
-                AnalyzerConstants.MetricName metricName = null;
-                if (resourceSetting == AnalyzerConstants.ResourceSetting.requests) {
-                    if (recommendationItem == AnalyzerConstants.RecommendationItem.CPU)
-                        metricName = AnalyzerConstants.MetricName.cpuRequest;
-                    else if (recommendationItem == AnalyzerConstants.RecommendationItem.MEMORY)
-                        metricName = AnalyzerConstants.MetricName.memoryRequest;
-                } else if (resourceSetting == AnalyzerConstants.ResourceSetting.limits) {
-                    if (recommendationItem == AnalyzerConstants.RecommendationItem.CPU)
-                        metricName = AnalyzerConstants.MetricName.cpuLimit;
-                    else if (recommendationItem == AnalyzerConstants.RecommendationItem.MEMORY)
-                        metricName = AnalyzerConstants.MetricName.memoryLimit;
-                }
 
+                AnalyzerConstants.MetricName metricName = getMetricName(resourceSetting, recommendationItem);
                 configItem = RecommendationUtils.getCurrentValue(lastDatapoint, metricName, notifications);
 
                 // Use base class validation method
@@ -172,6 +161,22 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
             currentConfig.setLimits(currentLimitsMap);
         }
         return currentConfig;
+    }
+
+    private static AnalyzerConstants.MetricName getMetricName(AnalyzerConstants.ResourceSetting resourceSetting, AnalyzerConstants.RecommendationItem recommendationItem) {
+        AnalyzerConstants.MetricName metricName = null;
+        if (resourceSetting == AnalyzerConstants.ResourceSetting.requests) {
+            if (recommendationItem == AnalyzerConstants.RecommendationItem.CPU)
+                metricName = AnalyzerConstants.MetricName.cpuRequest;
+            else if (recommendationItem == AnalyzerConstants.RecommendationItem.MEMORY)
+                metricName = AnalyzerConstants.MetricName.memoryRequest;
+        } else if (resourceSetting == AnalyzerConstants.ResourceSetting.limits) {
+            if (recommendationItem == AnalyzerConstants.RecommendationItem.CPU)
+                metricName = AnalyzerConstants.MetricName.cpuLimit;
+            else if (recommendationItem == AnalyzerConstants.RecommendationItem.MEMORY)
+                metricName = AnalyzerConstants.MetricName.memoryLimit;
+        }
+        return metricName;
     }
 
     private boolean generateRecommendationsBasedOnTerms(ContainerData containerData, KruizeObject kruizeObject,

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
@@ -125,7 +125,7 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
         RecommendationConfigItem configItem = RecommendationUtils.getCurrentValue(lastDatapoint, AnalyzerConstants.MetricName.podCount, notifications);
         if (configItem != null && configItem.getAmount() != null) {
             // RecommendationUtils.getPodCount ensured that configItem.getAmount() is never 0. It can be 'null'.
-            int replicas = configItem.getAmount().intValue();
+            int replicas = (int) Math.ceil(configItem.getAmount());
             currentConfig.setReplicas(replicas);
             LOGGER.debug("Current replicas for workload '{}' is {}", containerData.getContainer_name(), replicas);
         }

--- a/src/main/java/com/autotune/analyzer/recommendations/utils/RecommendationUtils.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/utils/RecommendationUtils.java
@@ -63,7 +63,7 @@ public class RecommendationUtils {
         RecommendationConfigItem recommendationConfigItem = null;
         Double currentValue = null;
         String format = null;
-        if (null != metricName) {
+        if (currentDatapoint != null && null != metricName) {
             if (currentDatapoint.getMetricResultsMap().containsKey(metricName)) {
                 MetricResults metricResults = currentDatapoint.getMetricResultsMap().get(metricName);
                 MetricAggregationInfoResults metricAggregationInfoResults = metricResults.getAggregationInfoResult();
@@ -91,21 +91,26 @@ public class RecommendationUtils {
             }
 
             if (currentValue == null) {
-                //TODO: Add notification when we are unable to determine replicas for some reason.
-                if (notifications != null) {
-                    if (metricName == AnalyzerConstants.MetricName.cpuRequest)
-                        notifications.add(RecommendationConstants.RecommendationNotification.CRITICAL_CPU_REQUEST_NOT_SET);
-                    else if (metricName == AnalyzerConstants.MetricName.memoryRequest)
-                        notifications.add(RecommendationConstants.RecommendationNotification.CRITICAL_MEMORY_REQUEST_NOT_SET);
-                    else if (metricName == AnalyzerConstants.MetricName.cpuLimit)
-                        notifications.add(RecommendationConstants.RecommendationNotification.WARNING_CPU_LIMIT_NOT_SET);
-                    else if (metricName == AnalyzerConstants.MetricName.memoryLimit)
-                        notifications.add(RecommendationConstants.RecommendationNotification.CRITICAL_MEMORY_LIMIT_NOT_SET);
-                }
+                checkAndAddNotifications(metricName, notifications);
             }
             return new RecommendationConfigItem(currentValue, format);
         }
+        checkAndAddNotifications(metricName, notifications);
         return null;
+    }
+
+    //TODO: Add notification when we are unable to determine replicas for some reason.
+    private static void checkAndAddNotifications(AnalyzerConstants.MetricName metricName, ArrayList<RecommendationConstants.RecommendationNotification> notifications) {
+        if (notifications != null) {
+            if (metricName == AnalyzerConstants.MetricName.cpuRequest)
+                notifications.add(RecommendationConstants.RecommendationNotification.CRITICAL_CPU_REQUEST_NOT_SET);
+            else if (metricName == AnalyzerConstants.MetricName.memoryRequest)
+                notifications.add(RecommendationConstants.RecommendationNotification.CRITICAL_MEMORY_REQUEST_NOT_SET);
+            else if (metricName == AnalyzerConstants.MetricName.cpuLimit)
+                notifications.add(RecommendationConstants.RecommendationNotification.WARNING_CPU_LIMIT_NOT_SET);
+            else if (metricName == AnalyzerConstants.MetricName.memoryLimit)
+                notifications.add(RecommendationConstants.RecommendationNotification.CRITICAL_MEMORY_LIMIT_NOT_SET);
+        }
     }
 
     public static RecommendationConfigItem getCurrentValue(Map<Timestamp, IntervalResults> filteredResultsMap,

--- a/src/main/java/com/autotune/analyzer/services/ListExperiments.java
+++ b/src/main/java/com/autotune/analyzer/services/ListExperiments.java
@@ -17,7 +17,6 @@
 package com.autotune.analyzer.services;
 
 import com.autotune.analyzer.adapters.DeviceDetailsAdapter;
-import com.autotune.analyzer.adapters.MetricAggregationInfoResultsIntSerializer;
 import com.autotune.analyzer.adapters.RecommendationItemAdapter;
 import com.autotune.analyzer.kruizeObject.KruizeObject;
 import com.autotune.analyzer.serviceObjects.*;
@@ -25,7 +24,6 @@ import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.analyzer.utils.AnalyzerErrorConstants;
 import com.autotune.analyzer.utils.GsonUTCDateAdapter;
 import com.autotune.common.data.metrics.Metric;
-import com.autotune.common.data.metrics.MetricAggregationInfoResults;
 import com.autotune.common.data.metrics.MetricResults;
 import com.autotune.common.data.result.ContainerData;
 import com.autotune.common.data.result.IntervalResults;
@@ -318,7 +316,6 @@ public class ListExperiments extends HttpServlet {
                 .registerTypeAdapter(Date.class, new GsonUTCDateAdapter())
                 .registerTypeAdapter(AnalyzerConstants.RecommendationItem.class, new RecommendationItemAdapter())
                 .registerTypeAdapter(DeviceDetails.class, new DeviceDetailsAdapter())
-                .registerTypeAdapter(MetricAggregationInfoResults.class, new MetricAggregationInfoResultsIntSerializer())
                 .setExclusionStrategies(new ExclusionStrategy() {
                     @Override
                     public boolean shouldSkipField(FieldAttributes f) {

--- a/src/main/java/com/autotune/analyzer/services/ListRecommendations.java
+++ b/src/main/java/com/autotune/analyzer/services/ListRecommendations.java
@@ -17,6 +17,7 @@
 package com.autotune.analyzer.services;
 
 import com.autotune.analyzer.adapters.DeviceDetailsAdapter;
+import com.autotune.analyzer.adapters.MetricAggregationInfoResultsIntSerializer;
 import com.autotune.analyzer.adapters.RecommendationItemAdapter;
 import com.autotune.analyzer.exceptions.KruizeResponse;
 import com.autotune.analyzer.kruizeObject.KruizeObject;
@@ -27,6 +28,7 @@ import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.analyzer.utils.AnalyzerErrorConstants;
 import com.autotune.analyzer.utils.GsonUTCDateAdapter;
 import com.autotune.analyzer.utils.ServiceHelpers;
+import com.autotune.common.data.metrics.MetricAggregationInfoResults;
 import com.autotune.common.data.result.ContainerData;
 import com.autotune.common.data.system.info.device.DeviceDetails;
 import com.autotune.database.service.ExperimentDBService;
@@ -245,6 +247,7 @@ public class ListRecommendations extends HttpServlet {
                             .registerTypeAdapter(Date.class, new GsonUTCDateAdapter())
                             .registerTypeAdapter(AnalyzerConstants.RecommendationItem.class, new RecommendationItemAdapter())
                             .registerTypeAdapter(DeviceDetails.class, new DeviceDetailsAdapter())
+                            .registerTypeAdapter(MetricAggregationInfoResults.class, new MetricAggregationInfoResultsIntSerializer())
                             .setExclusionStrategies(strategy)
                             .create();
                     gsonStr = gsonObj.toJson(recommendationList);


### PR DESCRIPTION
## Description

This PR is related to current podCount feature. This PR contains changes to include `replicas` in current config.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Populate container current configuration from the latest metrics datapoint and improve handling of missing metric values.

New Features:
- Derive and set the current replica count from the podCount metric in the latest container results.

Bug Fixes:
- Prevent null-pointer issues by checking the latest metrics datapoint before accessing metric results and triggering notifications when values are missing.

Enhancements:
- Refactor notification handling for missing CPU and memory metrics into a shared helper and streamline metric selection when reading current resource settings.

## Summary by Sourcery

Populate container current configuration with replica counts and streamline how current metric values and notifications are derived from the latest datapoint.

New Features:
- Include current replica count in container configuration based on the latest podCount metric.

Bug Fixes:
- Avoid null-pointer issues when reading current metric values by checking for a valid datapoint before accessing metric results.

Enhancements:
- Refactor notification generation for missing CPU and memory metrics into a shared helper and reuse the latest datapoint when deriving current resource settings.
- Adjust Gson configuration so MetricAggregationInfoResults is serialized in the recommendations API rather than the experiments listing API.