### PR TITLE
[PR - 0] Add cryostat operator instance and REST API changes

### DIFF
--- a/src/main/java/com/autotune/common/datasource/DataSourceCollection.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceCollection.java
@@ -22,6 +22,7 @@ import com.autotune.common.utils.CommonUtils;
 import com.autotune.database.service.ExperimentDBService;
 import com.autotune.operator.KruizeDeploymentInfo;
 import com.autotune.utils.KruizeConstants;
+import com.autotune.utils.KruizeSupportedTypes;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -105,7 +106,7 @@ public class DataSourceCollection {
             throw new DataSourceAlreadyExist(DATASOURCE_ALREADY_EXIST);
         }
 
-        if (!provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.PROMETHEUS) && !provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.THANOS)) {
+        if (!KruizeSupportedTypes.DATASOURCES_SUPPORTED.contains(provider)) {
             throw new UnsupportedDataSourceProvider(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.UNSUPPORTED_DATASOURCE_PROVIDER);
         }
 //        Continue validations in case of supported providers

--- a/src/main/java/com/autotune/common/datasource/DataSourceCollection.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceCollection.java
@@ -38,6 +38,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 
 import static com.autotune.utils.KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.*;
 import static com.autotune.utils.KruizeConstants.DataSourceConstants.DataSourceSuccessMsgs.*;
@@ -106,7 +107,7 @@ public class DataSourceCollection {
             throw new DataSourceAlreadyExist(DATASOURCE_ALREADY_EXIST);
         }
 
-        if (!KruizeSupportedTypes.DATASOURCES_SUPPORTED.contains(provider)) {
+        if (!KruizeSupportedTypes.DATASOURCES_SUPPORTED.contains(provider.toLowerCase(Locale.ROOT))) {
             throw new UnsupportedDataSourceProvider(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.UNSUPPORTED_DATASOURCE_PROVIDER);
         }
 //        Continue validations in case of supported providers

--- a/src/main/java/com/autotune/common/datasource/DataSourceOperatorImpl.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceOperatorImpl.java
@@ -3,6 +3,7 @@ package com.autotune.common.datasource;
 import com.autotune.analyzer.exceptions.MonitoringAgentNotFoundException;
 import com.autotune.analyzer.exceptions.TooManyRecursiveCallsException;
 import com.autotune.analyzer.utils.AnalyzerConstants;
+import com.autotune.common.datasource.cryostat.CryostatDataOperatorImpl;
 import com.autotune.common.datasource.prometheus.PrometheusDataOperatorImpl;
 import com.autotune.common.exceptions.datasource.ServiceNotFound;
 import com.autotune.common.target.kubernetes.service.KubernetesServices;
@@ -27,6 +28,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class DataSourceOperatorImpl implements DataSourceOperator {
 
@@ -161,15 +163,18 @@ public class DataSourceOperatorImpl implements DataSourceOperator {
     /**
      * Returns the instance of specific operator class based on provider type
      *
-     * @param provider String containg the name of provider
+     * @param provider String containing the name of provider
      * @return instance of specific operator
      */
     @Override
     public DataSourceOperatorImpl getOperator(String provider) {
-        if (provider.equalsIgnoreCase(KruizeConstants.SupportedDatasources.PROMETHEUS)) {
-            return PrometheusDataOperatorImpl.getInstance();
-        }
-        return null;
+        return switch (provider.toLowerCase()) {
+            case KruizeConstants.SupportedDatasources.PROMETHEUS ->
+                    PrometheusDataOperatorImpl.getInstance();
+            case KruizeConstants.SupportedDatasources.CRYOSTAT ->
+                    CryostatDataOperatorImpl.getInstance();
+            default -> null;
+        };
     }
 
     /**

--- a/src/main/java/com/autotune/common/datasource/cryostat/CryostatDataOperatorImpl.java
+++ b/src/main/java/com/autotune/common/datasource/cryostat/CryostatDataOperatorImpl.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package com.autotune.common.datasource.cryostat;
+
+import com.autotune.common.datasource.DataSourceInfo;
+import com.autotune.common.datasource.DataSourceOperatorImpl;
+import com.autotune.common.utils.CommonUtils;
+import com.autotune.utils.GenericRestApiClient;
+import com.google.gson.JsonArray;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.net.UnknownHostException;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+
+public class CryostatDataOperatorImpl extends DataSourceOperatorImpl {
+
+    private static CryostatDataOperatorImpl instance;
+
+    private CryostatDataOperatorImpl() {
+        super();
+    }
+
+    public static CryostatDataOperatorImpl getInstance() {
+        if (instance == null) {
+            instance = new CryostatDataOperatorImpl();
+        }
+        return instance;
+    }
+
+    @Override
+    public String getDefaultServicePortForProvider() {
+        return "4180";
+    }
+
+    @Override
+    public String getQueryEndpoint() {
+        return "/api/v4/graphql";
+    }
+
+    @Override
+    public CommonUtils.DatasourceReachabilityStatus isServiceable(DataSourceInfo dataSource) throws IOException,
+            NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
+
+        String reachabilityQuery = "{\"query\":\"{ environmentNodes { name } }\"}";
+        JSONObject response = getJsonObjectForQuery(dataSource, reachabilityQuery);
+
+        return response != null ? CommonUtils.DatasourceReachabilityStatus.REACHABLE
+                : CommonUtils.DatasourceReachabilityStatus.NOT_REACHABLE;
+    }
+
+    @Override
+    public Object getValueForQuery(DataSourceInfo dataSource, String query) throws IOException, NoSuchAlgorithmException,
+            KeyStoreException, KeyManagementException {
+
+        JSONObject jsonObject = getJsonObjectForQuery(dataSource, query);
+        return jsonObject != null ? "1" : null;
+    }
+
+    @Override
+    public JSONObject getJsonObjectForQuery(DataSourceInfo dataSource, String query) throws IOException, NoSuchAlgorithmException,
+            KeyStoreException, KeyManagementException {
+
+        GenericRestApiClient apiClient = new GenericRestApiClient(dataSource);
+        String baseURL = dataSource.getUrl().toString();
+        apiClient.setBaseURL(baseURL + getQueryEndpoint());
+
+        try {
+            return apiClient.fetchMetricsJson("POST", query);
+        } catch (UnknownHostException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public JsonArray getResultArrayForQuery(DataSourceInfo dataSource, String query) throws IOException, NoSuchAlgorithmException,
+            KeyStoreException, KeyManagementException {
+
+        JSONObject response = getJsonObjectForQuery(dataSource, query);
+        if (response == null) {
+            return null;
+        }
+
+        // TODO: Parse GraphQL response here
+
+        return null;
+    }
+
+    @Override
+    public boolean validateResultArray(JsonArray resultArray) {
+        return resultArray != null && !resultArray.isJsonNull() && !resultArray.isEmpty();
+    }
+}

--- a/src/main/java/com/autotune/utils/GenericRestApiClient.java
+++ b/src/main/java/com/autotune/utils/GenericRestApiClient.java
@@ -98,23 +98,10 @@ public class GenericRestApiClient {
             if (methodType.equalsIgnoreCase("GET")) {
                 httpRequestBase = new HttpGet(baseURL + URLEncoder.encode(queryString, StandardCharsets.UTF_8));
             } else if (methodType.equalsIgnoreCase("POST")) {
-
                 HttpPost httpPost = new HttpPost(baseURL);
-
-                httpPost.setEntity(
-                        new StringEntity(
-                                queryString,
-                                ContentType.APPLICATION_JSON
-                        )
-                );
+                httpPost.setEntity(new StringEntity(queryString, ContentType.APPLICATION_JSON));
                 httpRequestBase = httpPost;
-                LOGGER.info(
-                        "Request body: {}",
-                        EntityUtils.toString(
-                                ((HttpPost) httpRequestBase).getEntity(),
-                                StandardCharsets.UTF_8
-                        )
-                );
+                LOGGER.debug("Request body: {}", EntityUtils.toString(((HttpPost) httpRequestBase).getEntity(), StandardCharsets.UTF_8));
             } else {
                 throw new UnsupportedOperationException("Unsupported method type: " + methodType);
             }
@@ -154,8 +141,7 @@ public class GenericRestApiClient {
             }
         }
         if (jsonResponse == null || jsonResponse.isBlank()) {
-            LOGGER.warn("Received null or empty JSON response");
-            return new JSONObject();
+            throw new IOException("Received null or empty JSON response");
         }
         return new JSONObject(jsonResponse);
     }

--- a/src/main/java/com/autotune/utils/GenericRestApiClient.java
+++ b/src/main/java/com/autotune/utils/GenericRestApiClient.java
@@ -33,6 +33,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
@@ -96,6 +97,24 @@ public class GenericRestApiClient {
             HttpRequestBase httpRequestBase;
             if (methodType.equalsIgnoreCase("GET")) {
                 httpRequestBase = new HttpGet(baseURL + URLEncoder.encode(queryString, StandardCharsets.UTF_8));
+            } else if (methodType.equalsIgnoreCase("POST")) {
+
+                HttpPost httpPost = new HttpPost(baseURL);
+
+                httpPost.setEntity(
+                        new StringEntity(
+                                queryString,
+                                ContentType.APPLICATION_JSON
+                        )
+                );
+                httpRequestBase = httpPost;
+                LOGGER.info(
+                        "Request body: {}",
+                        EntityUtils.toString(
+                                ((HttpPost) httpRequestBase).getEntity(),
+                                StandardCharsets.UTF_8
+                        )
+                );
             } else {
                 throw new UnsupportedOperationException("Unsupported method type: " + methodType);
             }
@@ -115,22 +134,28 @@ public class GenericRestApiClient {
             // Get the response body if needed
             jsonResponse = new StringResponseHandler().handleResponse(response);
 
-            // Parse the JSON response
-            ObjectMapper objectMapper = new ObjectMapper();
-            JsonNode rootNode = objectMapper.readTree(jsonResponse);
-            JsonNode resultNode = rootNode.path("data").path("result");
-            JsonNode warningsNode = rootNode.path("warnings");
+            if (!methodType.equalsIgnoreCase("POST")) {
+                // Parse the JSON response
+                ObjectMapper objectMapper = new ObjectMapper();
+                JsonNode rootNode = objectMapper.readTree(jsonResponse);
+                JsonNode resultNode = rootNode.path("data").path("result");
+                JsonNode warningsNode = rootNode.path("warnings");
 
-            // Check if the result is empty and if there are specific warnings
-            if (resultNode.isArray() && resultNode.size() == 0) {
-                for (JsonNode warning : warningsNode) {
-                    String warningMessage = warning.asText();
-                    if (warningMessage.contains("error reading from server") || warningMessage.contains("Please reduce your request rate")) {
-                        LOGGER.warn("Warning detected: {}", warningMessage);
-                        throw new IOException(warningMessage);
+                // Check if the result is empty and if there are specific warnings
+                if (resultNode.isArray() && resultNode.isEmpty()) {
+                    for (JsonNode warning : warningsNode) {
+                        String warningMessage = warning.asText();
+                        if (warningMessage.contains("error reading from server") || warningMessage.contains("Please reduce your request rate")) {
+                            LOGGER.warn("Warning detected: {}", warningMessage);
+                            throw new IOException(warningMessage);
+                        }
                     }
                 }
             }
+        }
+        if (jsonResponse == null || jsonResponse.isBlank()) {
+            LOGGER.warn("Received null or empty JSON response");
+            return new JSONObject();
         }
         return new JSONObject(jsonResponse);
     }

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -395,6 +395,7 @@ public class KruizeConstants {
     public static class SupportedDatasources {
         public static final String PROMETHEUS = "prometheus";
         public static final String THANOS = "thanos";
+        public static final String CRYOSTAT = "cryostat";
 
         private SupportedDatasources() {
         }

--- a/src/main/java/com/autotune/utils/KruizeSupportedTypes.java
+++ b/src/main/java/com/autotune/utils/KruizeSupportedTypes.java
@@ -84,6 +84,8 @@ public class KruizeSupportedTypes {
 
     public static final Set<String> RUNTIMES_SUPPORTED_DATASOURCES = new HashSet<>(Arrays.asList("thanos-querier"));
 
+    public static final Set<String> DATASOURCES_SUPPORTED = new HashSet<>(Arrays.asList("prometheus", "thanos", "cryostat"));
+
     private KruizeSupportedTypes() {
     }
 }


### PR DESCRIPTION
## Description

This PR adds cryostat datasource client support and REST client handling needed for executing layer queries against cryostat-backed datasources.
Also, Updates datasource abstraction and shared constants/types needed to support multi-datasource layer query execution without including cryostat client-specific implementation changes.


Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Enable Cryostat-backed datasource queries through new datasource support and REST client capabilities.

New Features:
- Add Cryostat as a supported datasource with a dedicated operator for service checks and GraphQL query requests.
- Support POST requests in the generic REST client for JSON-based datasource queries.

Enhancements:
- Centralize supported datasource validation and operator selection across Prometheus, Thanos, and Cryostat.
- Improve REST response validation by rejecting null or empty responses while preserving datasource-specific response handling.