### PR TITLE
[feat:podCount] replace variation map with Config

### DIFF
--- a/src/main/java/com/autotune/analyzer/recommendations/Recommendation.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/Recommendation.java
@@ -41,7 +41,7 @@ public class Recommendation {
     @SerializedName(KruizeConstants.JSONKeys.CONFIG)
     private HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> config;
     @SerializedName(KruizeConstants.JSONKeys.VARIATION)
-    private HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> variation;
+    private Config variation;
     @SerializedName(KruizeConstants.JSONKeys.NOTIFICATIONS)
     private HashMap<Integer, RecommendationNotification> notifications;
 
@@ -119,11 +119,11 @@ public class Recommendation {
         this.config = config;
     }
 
-    public HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> getVariation() {
+    public Config getVariation() {
         return variation;
     }
 
-    public void setVariation(HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> variation) {
+    public void setVariation(Config variation) {
         this.variation = variation;
     }
 

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/RecommendationEngine.java
@@ -809,7 +809,7 @@ public class RecommendationEngine implements RecommendationEngineService {
         }
 
         // Create variation map
-        HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> variation = new HashMap<>();
+        Config variation = new Config();
         // Create a new map for storing variation in requests
         HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem> requestsVariationMap = new HashMap<>();
 
@@ -1093,18 +1093,16 @@ public class RecommendationEngine implements RecommendationEngineService {
 
         // Set Request variation map
         if (!requestsVariationMap.isEmpty()) {
-            variation.put(AnalyzerConstants.ResourceSetting.requests, requestsVariationMap);
+            variation.setRequests(requestsVariationMap);
         }
 
         // Set Limits variation map
         if (!limitsVariationMap.isEmpty()) {
-            variation.put(AnalyzerConstants.ResourceSetting.limits, limitsVariationMap);
+            variation.setLimits(limitsVariationMap);
         }
 
-        // Set Variation Map
-        if (!variation.isEmpty()) {
-            recommendationModel.setVariation(variation);
-        }
+        // Set Variation
+        recommendationModel.setVariation(variation);
 
         return isSuccess;
     }

--- a/src/main/java/com/autotune/analyzer/recommendations/objects/MappedRecommendationForModel.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/objects/MappedRecommendationForModel.java
@@ -15,7 +15,7 @@ public class MappedRecommendationForModel {
         this.podsCount = 0;
         this.confidence_level = 0.0;
         this.config = new Config();
-        this.variation = new HashMap<>();
+        this.variation = new Config();
         this.notificationHashMap = new HashMap<>();
     }
 
@@ -26,7 +26,7 @@ public class MappedRecommendationForModel {
     @SerializedName(KruizeConstants.JSONKeys.CONFIG)
     private Config config;
     @SerializedName(KruizeConstants.JSONKeys.VARIATION)
-    private HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> variation;
+    private Config variation;
 
     @SerializedName(KruizeConstants.JSONKeys.NOTIFICATIONS)
     private HashMap<Integer, RecommendationNotification> notificationHashMap;
@@ -55,11 +55,11 @@ public class MappedRecommendationForModel {
         this.config = config;
     }
 
-    public HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> getVariation() {
+    public Config getVariation() {
         return variation;
     }
 
-    public void setVariation(HashMap<AnalyzerConstants.ResourceSetting, HashMap<AnalyzerConstants.RecommendationItem, RecommendationConfigItem>> variation) {
+    public void setVariation(Config variation) {
         this.variation = variation;
     }
 


### PR DESCRIPTION
## Description

Please describe the issue or feature and the summary of changes made to fix this. 

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Replace recommendation variation maps with the Config object to align variation handling with existing configuration structures.

Enhancements:
- Update recommendation and mapped recommendation models to use Config for variation instead of nested HashMaps.
- Simplify recommendation engine variation construction to work with the Config-based representation.