### PR TITLE
Update remaining tests with new API param

### DIFF
--- a/tests/scripts/local_monitoring_tests/bulk_stress_test/bulk_stress_test.sh
+++ b/tests/scripts/local_monitoring_tests/bulk_stress_test/bulk_stress_test.sh
@@ -16,6 +16,8 @@
 #
 ### Script to run bulk stress test with Kruize in local monitoring mode ##
 #
+# Usage: ./bulk_stress_test.sh [--api-version=v1|legacy]
+#
 
 CURRENT_DIR="$(dirname "$(realpath "$0")")"
 KRUIZE_REPO_PATH="${CURRENT_DIR}/../../../.."
@@ -47,7 +49,12 @@ function usage() {
 	echo
 	echo "Usage: [-i Kruize image] [-w No. of workers (default - 5)] [-t interval hours (default - 2)] [-s End date of tsdb block (default - current date & time)]"
 	echo "[-d no. of days of metrics usage data (default - 15)] [-a kruize replicas (default - 3)][-r <resultsdir path>] [--skipsetup skip kruize setup]"
-	echo "[ -z to test with prometheus datasource] [--test Specify the test to be run (default - time_range)] [--url Datasource url (default - ${ds_url}]"
+	echo "[ -z to test with prometheus datasource] [--test Specify the test to be run (default - time_range)] [--url Datasource url (default - ${ds_url}] [--api-version=v1|legacy]"
+	echo
+	echo "API Version Parameter:"
+	echo "  --api-version=v1      Use NEW v1 API (/kruize/api/v1/recommendations)"
+	echo "  --api-version=legacy  Use OLD/LEGACY APIs (/updateRecommendations, /generateRecommendations)"
+	echo "  Default: legacy (if no parameter specified)"
 	exit 1
 }
 
@@ -95,11 +102,17 @@ function kruize_local_thanos_patch() {
 }
 
 
-while getopts r:i:w:d:s:t:a:zh:-: gopts
+while getopts r:i:w:d:s:t:a:zh-: gopts
 do
 	case ${gopts} in
 	-)
 		case "${OPTARG}" in
+			api-version=*)
+				api_version=${OPTARG#*=}
+				;;
+			skipsetup)
+				skip_setup=1
+				;;
 			test=*)
 				test=${OPTARG#*=}
 				;;
@@ -144,6 +157,28 @@ do
 		;;
 	esac
 done
+
+# Set the API version environment variable if specified
+if [ -n "${api_version}" ]; then
+	case "${api_version}" in
+		v1|V1)
+			export USE_NEW_RECOMMENDATION_API=true
+			echo "Using NEW API (v1): /kruize/api/v1/recommendations"
+			;;
+		legacy|LEGACY|old|OLD)
+			export USE_NEW_RECOMMENDATION_API=false
+			echo "Using OLD/LEGACY APIs: /updateRecommendations, /generateRecommendations"
+			;;
+		*)
+			echo "Error: Invalid API version '${api_version}'. Valid values are: v1, legacy"
+			exit -1
+			;;
+	esac
+else
+	# Default to old/legacy API if no parameter specified
+	export USE_NEW_RECOMMENDATION_API=false
+	echo "Using default OLD/LEGACY APIs: /updateRecommendations, /generateRecommendations"
+fi
 
 start_time=$(get_date)
 LOG_DIR="${RESULTS_DIR}/bulk-stress-test-$(date +%Y%m%d%H%M)"

--- a/tests/scripts/remote_monitoring_tests/db_migration_test/db_migration_test.sh
+++ b/tests/scripts/remote_monitoring_tests/db_migration_test/db_migration_test.sh
@@ -16,6 +16,8 @@
 #
 ### Script to run DB migration test with Kruize in remote monitoring mode ##
 #
+# Usage: ./db_migration_test.sh [--api-version=v1|legacy]
+#
 
 # This test does the following:
 # Deploys the previous release of kruize that is specified and uploads results for 50 exps / 15 days
@@ -54,13 +56,29 @@ kruize_image_current="quay.io/kruize/autotune_operator:0.0.20.1_rm"
 
 function usage() {
 	echo
-	echo "Usage: [-i Kruize image previous release] [-j kruize image current release] [-u No. of experiments (default - 5000)] [-d No. of days of results (default - 15)] [-n No. of clients (default - 20)] [-m results duration interval in mins, (default - 15)] [-t interval hours (default - 6)] [-s Initial start date (default - 2023-01-10T00:00:00.000Z)] [-q query db interval in mins, (default - 10)] [-r <resultsdir path>]"
+	echo "Usage: [-i Kruize image previous release] [-j kruize image current release] [-u No. of experiments (default - 5000)] [-d No. of days of results (default - 15)] [-n No. of clients (default - 20)] [-m results duration interval in mins, (default - 15)] [-t interval hours (default - 6)] [-s Initial start date (default - 2023-01-10T00:00:00.000Z)] [-q query db interval in mins, (default - 10)] [-r <resultsdir path>] [--api-version=v1|legacy]"
+	echo
+	echo "API Version Parameter:"
+	echo "  --api-version=v1      Use NEW v1 API (/kruize/api/v1/recommendations)"
+	echo "  --api-version=legacy  Use OLD/LEGACY APIs (/updateRecommendations, /generateRecommendations)"
+	echo "  Default: legacy (if no parameter specified)"
 	exit -1
 }
 
-while getopts r:i:j:u:d:t:n:m:s:f:q:h gopts
+while getopts r:i:j:u:d:t:n:m:s:f:q:h-: gopts
 do
 	case ${gopts} in
+	-)
+		case "${OPTARG}" in
+			api-version=*)
+				api_version=${OPTARG#*=}
+				;;
+			*)
+				echo "Error: Invalid option --${OPTARG}"
+				usage
+				;;
+		esac
+		;;
 	r)
 		RESULTS_DIR="${OPTARG}"		
 		;;
@@ -100,6 +118,28 @@ do
 	esac
 done
 
+# Set the API version environment variable if specified
+if [ -n "${api_version}" ]; then
+	case "${api_version}" in
+		v1|V1)
+			export USE_NEW_RECOMMENDATION_API=true
+			echo "Using NEW API (v1): /kruize/api/v1/recommendations"
+			;;
+		legacy|LEGACY|old|OLD)
+			export USE_NEW_RECOMMENDATION_API=false
+			echo "Using OLD/LEGACY APIs: /updateRecommendations, /generateRecommendations"
+			;;
+		*)
+			echo "Error: Invalid API version '${api_version}'. Valid values are: v1, legacy"
+			exit -1
+			;;
+	esac
+else
+	# Default to old/legacy API if no parameter specified
+	export USE_NEW_RECOMMENDATION_API=false
+	echo "Using default OLD/LEGACY APIs: /updateRecommendations, /generateRecommendations"
+fi
+
 start_time=$(get_date)
 
 
@@ -114,9 +154,17 @@ LOG="${LOG_DIR}/db-migration-test.log"
 pushd ${SCALE_TEST} > /dev/null
 	echo ""
 	echo "Run scalability test to load 50 exps / 15 days data and update Recommendations with ${kruize_image_prev}"
-	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a migration"
-	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a "migration"
-popd > /dev/null 
+	
+	# Determine API version parameter
+	if [ "${USE_NEW_RECOMMENDATION_API}" = "true" ]; then
+		API_VERSION_PARAM="--api-version=v1"
+	else
+		API_VERSION_PARAM="--api-version=legacy"
+	fi
+	
+	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a migration ${API_VERSION_PARAM}"
+	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a "migration" ${API_VERSION_PARAM}
+popd > /dev/null
 	echo ""
 
 total_results_count=$((${num_exps} * ${num_clients} * ${num_days_of_res} * 96))
@@ -141,8 +189,8 @@ pushd ${SCALE_TEST} > /dev/null
 	restore_db=true
 	num_days_of_res=1
 
-	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -l ${restore_db} -f ${db_backup_file} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a migration"
-	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -l ${restore_db} -f ${db_backup_file} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a "migration"
+	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -l ${restore_db} -f ${db_backup_file} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a migration ${API_VERSION_PARAM}"
+	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -l ${restore_db} -f ${db_backup_file} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a "migration" ${API_VERSION_PARAM}
 
 	echo | tee -a ${LOG}
 	echo ""

--- a/tests/scripts/remote_monitoring_tests/db_migration_test/db_migration_test_without_postgres_restart.sh
+++ b/tests/scripts/remote_monitoring_tests/db_migration_test/db_migration_test_without_postgres_restart.sh
@@ -16,6 +16,8 @@
 #
 ### Script to run DB migration test with Kruize in remote monitoring mode ##
 #
+# Usage: ./db_migration_test_without_postgres_restart.sh [--api-version=v1|legacy]
+#
 
 # This test does the following:
 # Deploys the previous release of kruize that is specified and uploads results for 50 exps / 15 days
@@ -55,13 +57,29 @@ hours=6
 
 function usage() {
 	echo
-	echo "Usage: [-i Kruize image previous release] [-j kruize image current release] [-u No. of experiments (default - 5000)] [-d No. of days of results (default - 15)] [-n No. of clients (default - 20)] [-m results duration interval in mins, (default - 15)] [-t interval hours (default - 6)] [-s Initial start date (default - 2023-01-10T00:00:00.000Z)] [-q query db interval in mins, (default - 10)] [-r <resultsdir path>]"
+	echo "Usage: [-i Kruize image previous release] [-j kruize image current release] [-u No. of experiments (default - 5000)] [-d No. of days of results (default - 15)] [-n No. of clients (default - 20)] [-m results duration interval in mins, (default - 15)] [-t interval hours (default - 6)] [-s Initial start date (default - 2023-01-10T00:00:00.000Z)] [-q query db interval in mins, (default - 10)] [-r <resultsdir path>] [--api-version=v1|legacy]"
+	echo
+	echo "API Version Parameter:"
+	echo "  --api-version=v1      Use NEW v1 API (/kruize/api/v1/recommendations)"
+	echo "  --api-version=legacy  Use OLD/LEGACY APIs (/updateRecommendations, /generateRecommendations)"
+	echo "  Default: legacy (if no parameter specified)"
 	exit -1
 }
 
-while getopts r:i:j:u:d:t:n:m:s:f:q:h gopts
+while getopts r:i:j:u:d:t:n:m:s:f:q:h-: gopts
 do
 	case ${gopts} in
+	-)
+		case "${OPTARG}" in
+			api-version=*)
+				api_version=${OPTARG#*=}
+				;;
+			*)
+				echo "Error: Invalid option --${OPTARG}"
+				usage
+				;;
+		esac
+		;;
 	r)
 		RESULTS_DIR="${OPTARG}"		
 		;;
@@ -101,6 +119,28 @@ do
 	esac
 done
 
+# Set the API version environment variable if specified
+if [ -n "${api_version}" ]; then
+	case "${api_version}" in
+		v1|V1)
+			export USE_NEW_RECOMMENDATION_API=true
+			echo "Using NEW API (v1): /kruize/api/v1/recommendations"
+			;;
+		legacy|LEGACY|old|OLD)
+			export USE_NEW_RECOMMENDATION_API=false
+			echo "Using OLD/LEGACY APIs: /updateRecommendations, /generateRecommendations"
+			;;
+		*)
+			echo "Error: Invalid API version '${api_version}'. Valid values are: v1, legacy"
+			exit -1
+			;;
+	esac
+else
+	# Default to old/legacy API if no parameter specified
+	export USE_NEW_RECOMMENDATION_API=false
+	echo "Using default OLD/LEGACY APIs: /updateRecommendations, /generateRecommendations"
+fi
+
 start_time=$(get_date)
 LOG_DIR="${RESULTS_DIR}/db-migration-test-without-kruize-db-restart-$(date +%Y%m%d%H%M)"
 mkdir -p ${LOG_DIR}
@@ -111,9 +151,17 @@ LOG="${LOG_DIR}/db-migration-test-without-kruize-db-restart.log"
 pushd ${SCALE_TEST} > /dev/null
 	echo ""
 	echo "Run scalability test to load 50 exps / 15 days data and update Recommendations with ${kruize_image_prev}"
-	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a migration"
-	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a "migration"
-popd > /dev/null 
+	
+	# Determine API version parameter
+	if [ "${USE_NEW_RECOMMENDATION_API}" = "true" ]; then
+		API_VERSION_PARAM="--api-version=v1"
+	else
+		API_VERSION_PARAM="--api-version=legacy"
+	fi
+	
+	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a migration ${API_VERSION_PARAM}"
+	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a "migration" ${API_VERSION_PARAM}
+popd > /dev/null
 	echo ""
 
 sleep 20
@@ -145,8 +193,8 @@ pushd ${SCALE_TEST} > /dev/null
 
 	num_days_of_res=1
 
-	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -b ${kruize_setup} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a migration"
-	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -b ${kruize_setup} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a "migration"
+	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -b ${kruize_setup} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a migration ${API_VERSION_PARAM}"
+	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -b ${kruize_setup} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a "migration" ${API_VERSION_PARAM}
 
 	echo | tee -a ${LOG}
 	echo ""

--- a/tests/scripts/remote_monitoring_tests/fault_tolerant_tests/remote_monitoring_fault_tolerant_tests.sh
+++ b/tests/scripts/remote_monitoring_tests/fault_tolerant_tests/remote_monitoring_fault_tolerant_tests.sh
@@ -16,6 +16,8 @@
 #
 ### Script to run fault tolerant tests with Kruize in remote monitoring mode ##
 #
+# Usage: ./remote_monitoring_fault_tolerant_tests.sh [--api-version=v1|legacy]
+#
 
 CURRENT_DIR="$(dirname "$(realpath "$0")")"
 KRUIZE_REPO_PATH="${CURRENT_DIR}/../../../.."
@@ -39,7 +41,12 @@ num_exps=1
 
 function usage() {
 	echo
-	echo "Usage: -c cluster_tyep[minikube|openshift] [-i Kruize image] [-u No. of experiments (default - 1)] [ -d no. of iterations to test restart (default - 2)] [-r <resultsdir path>]"
+	echo "Usage: -c cluster_tyep[minikube|openshift] [-i Kruize image] [-u No. of experiments (default - 1)] [ -d no. of iterations to test restart (default - 2)] [-r <resultsdir path>] [--api-version=v1|legacy]"
+	echo
+	echo "API Version Parameter:"
+	echo "  --api-version=v1      Use NEW v1 API (/kruize/api/v1/recommendations)"
+	echo "  --api-version=legacy  Use OLD/LEGACY APIs (/updateRecommendations, /generateRecommendations)"
+	echo "  Default: legacy (if no parameter specified)"
 	exit -1
 }
 
@@ -54,9 +61,20 @@ function get_kruize_pod_log() {
 	kubectl logs -f ${kruize_pod} -n ${NAMESPACE} > ${log} 2>&1 &
 }
 
-while getopts c:r:i:u:d:t:h gopts
+while getopts c:r:i:u:d:t:h-: gopts
 do
 	case ${gopts} in
+	-)
+		case "${OPTARG}" in
+			api-version=*)
+				api_version=${OPTARG#*=}
+				;;
+			*)
+				echo "Error: Invalid option --${OPTARG}"
+				usage
+				;;
+		esac
+		;;
 	c)
 		CLUSTER_TYPE=${OPTARG}
 		;;
@@ -80,6 +98,28 @@ done
 
 if [ -z "${CLUSTER_TYPE}" ]; then
 	usage
+fi
+
+# Set the API version environment variable if specified
+if [ -n "${api_version}" ]; then
+	case "${api_version}" in
+		v1|V1)
+			export USE_NEW_RECOMMENDATION_API=true
+			echo "Using NEW API (v1): /kruize/api/v1/recommendations"
+			;;
+		legacy|LEGACY|old|OLD)
+			export USE_NEW_RECOMMENDATION_API=false
+			echo "Using OLD/LEGACY APIs: /updateRecommendations, /generateRecommendations"
+			;;
+		*)
+			echo "Error: Invalid API version '${api_version}'. Valid values are: v1, legacy"
+			exit -1
+			;;
+	esac
+else
+	# Default to old/legacy API if no parameter specified
+	export USE_NEW_RECOMMENDATION_API=false
+	echo "Using default OLD/LEGACY APIs: /updateRecommendations, /generateRecommendations"
 fi
 
 start_time=$(get_date)

--- a/tests/scripts/remote_monitoring_tests/perf_profile_migration_test/perf_profile_migration_test.sh
+++ b/tests/scripts/remote_monitoring_tests/perf_profile_migration_test/perf_profile_migration_test.sh
@@ -16,6 +16,8 @@
 #
 ### Script to run DB migration test with Kruize in remote monitoring mode ##
 #
+# Usage: ./perf_profile_migration_test.sh [--api-version=v1|legacy]
+#
 
 # This test does the following:
 # Deploys the previous release of kruize that is specified and uploads results for 10 exps / 15 days
@@ -51,13 +53,29 @@ kruize_image_current="quay.io/kruize/autotune_operator:0.7"
 
 function usage() {
 	echo
-	echo "Usage: [-i Kruize image previous release] [-j kruize image current release] [-u No. of experiments (default - 10)] [-d No. of days of results (default - 15)] [-n No. of clients (default - 10)] [-m results duration interval in mins, (default - 15)] [-t interval hours (default - 6)] [-s Initial start date (default - 2025-10-01T00:00:00.000Z)] [-q query db interval in mins, (default - 10)] [-r <resultsdir path>]"
+	echo "Usage: [-i Kruize image previous release] [-j kruize image current release] [-u No. of experiments (default - 10)] [-d No. of days of results (default - 15)] [-n No. of clients (default - 10)] [-m results duration interval in mins, (default - 15)] [-t interval hours (default - 6)] [-s Initial start date (default - 2025-10-01T00:00:00.000Z)] [-q query db interval in mins, (default - 10)] [-r <resultsdir path>] [--api-version=v1|legacy]"
+	echo
+	echo "API Version Parameter:"
+	echo "  --api-version=v1      Use NEW v1 API (/kruize/api/v1/recommendations)"
+	echo "  --api-version=legacy  Use OLD/LEGACY APIs (/updateRecommendations, /generateRecommendations)"
+	echo "  Default: legacy (if no parameter specified)"
 	exit -1
 }
 
-while getopts r:i:j:u:d:t:n:m:s:q:h gopts
+while getopts r:i:j:u:d:t:n:m:s:q:h-: gopts
 do
 	case ${gopts} in
+	-)
+		case "${OPTARG}" in
+			api-version=*)
+				api_version=${OPTARG#*=}
+				;;
+			*)
+				echo "Error: Invalid option --${OPTARG}"
+				usage
+				;;
+		esac
+		;;
 	r)
 		RESULTS_DIR="${OPTARG}"		
 		;;
@@ -94,6 +112,28 @@ do
 	esac
 done
 
+# Set the API version environment variable if specified
+if [ -n "${api_version}" ]; then
+	case "${api_version}" in
+		v1|V1)
+			export USE_NEW_RECOMMENDATION_API=true
+			echo "Using NEW API (v1): /kruize/api/v1/recommendations"
+			;;
+		legacy|LEGACY|old|OLD)
+			export USE_NEW_RECOMMENDATION_API=false
+			echo "Using OLD/LEGACY APIs: /updateRecommendations, /generateRecommendations"
+			;;
+		*)
+			echo "Error: Invalid API version '${api_version}'. Valid values are: v1, legacy"
+			exit -1
+			;;
+	esac
+else
+	# Default to old/legacy API if no parameter specified
+	export USE_NEW_RECOMMENDATION_API=false
+	echo "Using default OLD/LEGACY APIs: /updateRecommendations, /generateRecommendations"
+fi
+
 start_time=$(get_date)
 LOG_DIR="${RESULTS_DIR}/perf-profile-migration-test-$(date +%Y%m%d%H%M)"
 mkdir -p ${LOG_DIR}
@@ -104,8 +144,16 @@ total_results_count=0
 # Run scalability test to load 10 exps / 15 days data and update Recommendations with previous release
 echo ""
 echo "Run scalability test to load 10 exps / 15 days data and update Recommendations with ${kruize_image_prev}"
-echo "./run_test.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_10_15days -e ${total_results_count}"
-./run_test.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_10_15days -e ${total_results_count}
+
+# Determine API version parameter
+if [ "${USE_NEW_RECOMMENDATION_API}" = "true" ]; then
+	API_VERSION_PARAM="--api-version=v1"
+else
+	API_VERSION_PARAM="--api-version=legacy"
+fi
+
+echo "./run_test.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_10_15days -e ${total_results_count} ${API_VERSION_PARAM}"
+./run_test.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_10_15days -e ${total_results_count} ${API_VERSION_PARAM}
 echo ""
 
 sleep 20
@@ -136,8 +184,8 @@ kruize_setup=false
 total_results_count=$((${num_exps} * ${num_clients} * ${num_days_of_res} * 96))
 num_days_of_res=1
 
-echo "./run_test.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -b ${kruize_setup} -r ${LOG_DIR}/test_logs_10_16days -e ${total_results_count}"
-./run_test.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -b ${kruize_setup} -r ${LOG_DIR}/test_logs_10_16days -e ${total_results_count}
+echo "./run_test.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -b ${kruize_setup} -r ${LOG_DIR}/test_logs_10_16days -e ${total_results_count} ${API_VERSION_PARAM}"
+./run_test.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -b ${kruize_setup} -r ${LOG_DIR}/test_logs_10_16days -e ${total_results_count} ${API_VERSION_PARAM}
 
 echo | tee -a ${LOG}
 echo ""

--- a/tests/scripts/remote_monitoring_tests/stress_test/remote_monitoring_stress_test.sh
+++ b/tests/scripts/remote_monitoring_tests/stress_test/remote_monitoring_stress_test.sh
@@ -16,6 +16,8 @@
 #
 ### Script to run stress test with Kruize in remote monitoring mode ##
 #
+# Usage: ./remote_monitoring_stress_test.sh [--api-version=v1|legacy]
+#
 
 CURRENT_DIR="$(dirname "$(realpath "$0")")"
 KRUIZE_REPO_PATH="${CURRENT_DIR}/../../../.."
@@ -48,7 +50,12 @@ jmx_file="jmx/kruize_remote_monitoring_stress.jmx"
 
 function usage() {
 	echo
-	echo "Usage: -c cluster_type [minikube|openshift] [-i Kruize image] [-u users] [-e No. of results] [-d ramp up time in seconds] [-r <resultsdir path> ] [-t TIMEOUT for metrics script] [-b Experiment type [container|namespace] default - container]"
+	echo "Usage: -c cluster_type [minikube|openshift] [-i Kruize image] [-u users] [-e No. of results] [-d ramp up time in seconds] [-r <resultsdir path> ] [-t TIMEOUT for metrics script] [-b Experiment type [container|namespace] default - container] [--api-version=v1|legacy]"
+	echo
+	echo "API Version Parameter:"
+	echo "  --api-version=v1      Use NEW v1 API (/kruize/api/v1/recommendations)"
+	echo "  --api-version=legacy  Use OLD/LEGACY APIs (/updateRecommendations, /generateRecommendations)"
+	echo "  Default: legacy (if no parameter specified)"
 	exit -1
 }
 
@@ -78,9 +85,20 @@ function jmeter_setup() {
 	export PATH=${JMETER_HOME}/bin:${PATH}
 }
 
-while getopts c:r:i:u:d:t:e:b: gopts
+while getopts c:r:i:u:d:t:e:b:-: gopts
 do
 	case ${gopts} in
+	-)
+		case "${OPTARG}" in
+			api-version=*)
+				api_version=${OPTARG#*=}
+				;;
+			*)
+				echo "Error: Invalid option --${OPTARG}"
+				usage
+				;;
+		esac
+		;;
 	c)
 		CLUSTER_TYPE=${OPTARG}
 		;;
@@ -110,6 +128,28 @@ done
 
 if [ -z "${CLUSTER_TYPE}" ]; then
 	usage
+fi
+
+# Set the API version environment variable if specified
+if [ -n "${api_version}" ]; then
+	case "${api_version}" in
+		v1|V1)
+			export USE_NEW_RECOMMENDATION_API=true
+			echo "Using NEW API (v1): /kruize/api/v1/recommendations"
+			;;
+		legacy|LEGACY|old|OLD)
+			export USE_NEW_RECOMMENDATION_API=false
+			echo "Using OLD/LEGACY APIs: /updateRecommendations, /generateRecommendations"
+			;;
+		*)
+			echo "Error: Invalid API version '${api_version}'. Valid values are: v1, legacy"
+			exit -1
+			;;
+	esac
+else
+	# Default to old/legacy API if no parameter specified
+	export USE_NEW_RECOMMENDATION_API=false
+	echo "Using default OLD/LEGACY APIs: /updateRecommendations, /generateRecommendations"
 fi
 
 if [[ "${exp_type}" != "container" && "${exp_type}" != "namespace" ]]; then


### PR DESCRIPTION
## Description

This PR updates the remaining test with the new API param which we added as part of #1899 
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Add support across monitoring and migration test scripts to select between legacy and v1 recommendation APIs via a common parameter.

Enhancements:
- Introduce a unified --api-version flag in remote and local monitoring test scripts to toggle between legacy and v1 recommendation endpoints while defaulting to legacy when unspecified.
- Propagate the selected API version into underlying bulk and stress test runners using an environment variable and CLI argument for consistent behavior.