### PR TITLE
[feat:podCount] remove incompatible version check in tests

### DIFF
--- a/tests/scripts/helpers/utils.py
+++ b/tests/scripts/helpers/utils.py
@@ -659,7 +659,6 @@ def term_based_start_time(input_date_str, term):
 def validate_reco_json(create_exp_json, update_results_json, list_reco_json, expected_duration_in_hours=None,
                        test_name=None):
     # Validate experiment
-    assert create_exp_json["version"] == list_reco_json["version"]
     assert create_exp_json["experiment_name"] == list_reco_json["experiment_name"]
     assert create_exp_json["cluster_name"] == list_reco_json["cluster_name"]
     experiment_type = create_exp_json.get("experiment_type")
@@ -682,7 +681,6 @@ def validate_reco_json(create_exp_json, update_results_json, list_reco_json, exp
 
 def validate_local_monitoring_reco_json(create_exp_json, list_reco_json, expected_duration_in_hours=None, test_name=None):
     # Validate experiment
-    assert create_exp_json["version"] == list_reco_json["version"]
     assert create_exp_json["experiment_name"] == list_reco_json["experiment_name"]
     assert create_exp_json["cluster_name"] == list_reco_json["cluster_name"]
 


### PR DESCRIPTION
## Description

As part of current podCount PR, version for recommendation API response will be updated to "v3.0" as we are adding new attributes to recommendation response. This is applicable for below API endpoint that returns recommendations

1. /updateRecommendations
2. /generateRecommendations
3. /listRecommendations

However, version upgrade would fail existing checks as we are checking if version of experiment API is same as version of recommendation API. In reality, version of API can change independently and we should not expect all APIs be of same version. Unless we want to maintain that way, in which case, we need to bump up version of all APIs to v3.0.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Tests:
- Remove strict version equality checks between experiment and recommendation responses in recommendation validation helpers to allow independent API versioning.