### PR TITLE
[BULK-PROFILE]-2: Add KruizeBulkProfileEntry class

### DIFF
--- a/src/main/java/com/autotune/database/table/lm/KruizeBulkConfigEntry.java
+++ b/src/main/java/com/autotune/database/table/lm/KruizeBulkConfigEntry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2026 Red Hat, IBM Corporation and others.
+ * Copyright (c) 2026 IBM Corporation and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,12 @@
 package com.autotune.database.table.lm;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.sql.Timestamp;
 
@@ -35,8 +32,6 @@ import java.sql.Timestamp;
 @Entity
 @Table(name = "kruize_optimiser_bulk_config")
 public class KruizeBulkConfigEntry {
-    private static final Logger LOGGER = LoggerFactory.getLogger(KruizeBulkConfigEntry.class);
-    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     @Id
     @Column(name = "config_name", columnDefinition = "VARCHAR(255)")
@@ -206,7 +201,7 @@ public class KruizeBulkConfigEntry {
 
     @Override
     public String toString() {
-        return "KruizeBulkProfileEntry{" +
+        return "KruizeBulkConfigEntry{" +
                 "configName='" + configName + '\'' +
                 ", clusterName='" + clusterName + '\'' +
                 ", datasources=" + datasources +

--- a/src/main/java/com/autotune/database/table/lm/KruizeBulkConfigEntry.java
+++ b/src/main/java/com/autotune/database/table/lm/KruizeBulkConfigEntry.java
@@ -29,17 +29,17 @@ import org.slf4j.LoggerFactory;
 import java.sql.Timestamp;
 
 /**
- * Database entity to store Kruize bulk profile configurations.
+ * Database entity to store Kruize optimiser bulk configuration.
  * Aligned with CreateExperiment structure for consistency.
  */
 @Entity
-@Table(name = "kruize_bulk_profile")
-public class KruizeBulkProfileEntry {
-    private static final Logger LOGGER = LoggerFactory.getLogger(KruizeBulkProfileEntry.class);
+@Table(name = "kruize_optimiser_bulk_config")
+public class KruizeBulkConfigEntry {
+    private static final Logger LOGGER = LoggerFactory.getLogger(KruizeBulkConfigEntry.class);
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     @Id
-    @Column(name = "profile_name", columnDefinition = "VARCHAR(255)")
+    @Column(name = "config_name", columnDefinition = "VARCHAR(255)")
     private String profileName;
 
     @Column(name = "cluster_name", columnDefinition = "VARCHAR(255)", nullable = false)
@@ -88,7 +88,7 @@ public class KruizeBulkProfileEntry {
     private Timestamp updatedAt;
 
     // Default constructor
-    public KruizeBulkProfileEntry() {
+    public KruizeBulkConfigEntry() {
     }
 
     public String getProfileName() {

--- a/src/main/java/com/autotune/database/table/lm/KruizeBulkConfigEntry.java
+++ b/src/main/java/com/autotune/database/table/lm/KruizeBulkConfigEntry.java
@@ -73,7 +73,7 @@ public class KruizeBulkConfigEntry {
     @Column(name = "webhook_url", columnDefinition = "VARCHAR(500)")
     private String webhookUrl;
 
-    @Column(name = "enabled")
+    @Column(name = "enabled", nullable = false)
     private Boolean enabled;
 
     @Column(name = "created_at")

--- a/src/main/java/com/autotune/database/table/lm/KruizeBulkConfigEntry.java
+++ b/src/main/java/com/autotune/database/table/lm/KruizeBulkConfigEntry.java
@@ -56,7 +56,7 @@ public class KruizeBulkConfigEntry {
     @Column(name = "experiment_types", columnDefinition = "jsonb", nullable = false)
     private JsonNode experimentTypes;
 
-    @Column(name = "metadata_profile", columnDefinition = "VARCHAR(255)")
+    @Column(name = "metadata_profile", columnDefinition = "VARCHAR(255)", nullable = false)
     private String metadataProfile;
 
     @Column(name = "performance_profile", columnDefinition = "VARCHAR(255)", nullable = false)
@@ -70,7 +70,7 @@ public class KruizeBulkConfigEntry {
     @Column(name = "recommendation_settings", columnDefinition = "jsonb", nullable = false)
     private JsonNode recommendationSettings;
 
-    @Column(name = "webhook_url", columnDefinition = "VARCHAR(500)")
+    @Column(name = "webhook_url", columnDefinition = "VARCHAR(500)", nullable = false)
     private String webhookUrl;
 
     @Column(name = "enabled", nullable = false)

--- a/src/main/java/com/autotune/database/table/lm/KruizeBulkConfigEntry.java
+++ b/src/main/java/com/autotune/database/table/lm/KruizeBulkConfigEntry.java
@@ -95,8 +95,8 @@ public class KruizeBulkConfigEntry {
         return configName;
     }
 
-    public void setConfigName(String profileName) {
-        this.configName = profileName;
+    public void setConfigName(String configName) {
+        this.configName = configName;
     }
 
     public String getClusterName() {

--- a/src/main/java/com/autotune/database/table/lm/KruizeBulkConfigEntry.java
+++ b/src/main/java/com/autotune/database/table/lm/KruizeBulkConfigEntry.java
@@ -40,7 +40,7 @@ public class KruizeBulkConfigEntry {
 
     @Id
     @Column(name = "config_name", columnDefinition = "VARCHAR(255)")
-    private String profileName;
+    private String configName;
 
     @Column(name = "cluster_name", columnDefinition = "VARCHAR(255)", nullable = false)
     private String clusterName;
@@ -91,12 +91,12 @@ public class KruizeBulkConfigEntry {
     public KruizeBulkConfigEntry() {
     }
 
-    public String getProfileName() {
-        return profileName;
+    public String getConfigName() {
+        return configName;
     }
 
-    public void setProfileName(String profileName) {
-        this.profileName = profileName;
+    public void setConfigName(String profileName) {
+        this.configName = profileName;
     }
 
     public String getClusterName() {
@@ -207,7 +207,7 @@ public class KruizeBulkConfigEntry {
     @Override
     public String toString() {
         return "KruizeBulkProfileEntry{" +
-                "profileName='" + profileName + '\'' +
+                "configName='" + configName + '\'' +
                 ", clusterName='" + clusterName + '\'' +
                 ", datasources=" + datasources +
                 ", namespaces=" + namespaces +

--- a/src/main/java/com/autotune/database/table/lm/KruizeBulkProfileEntry.java
+++ b/src/main/java/com/autotune/database/table/lm/KruizeBulkProfileEntry.java
@@ -1,0 +1,150 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.autotune.database.table.lm;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Timestamp;
+
+/**
+ * Database entity to store Kruize bulk profile configurations.
+ * Bulk profiles define templates for automated bulk job creation with
+ * cluster configurations, recommendation settings, and scheduling.
+ */
+@Entity
+@Table(name = "kruize_bulk_profile")
+public class KruizeBulkProfileEntry {
+    private static final Logger LOGGER = LoggerFactory.getLogger(KruizeBulkProfileEntry.class);
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Id
+    @Column(name = "profile_name", columnDefinition = "VARCHAR(255)")
+    private String profileName;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "clusters", columnDefinition = "jsonb")
+    private JsonNode clusters;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "recommendation_settings", columnDefinition = "jsonb")
+    private JsonNode recommendationSettings;
+
+    @Column(name = "webhook_url", columnDefinition = "VARCHAR(500)")
+    private String webhookUrl;
+
+    @Column(name = "enabled")
+    private Boolean enabled;
+
+    @Column(name = "created_at")
+    private Timestamp createdAt;
+
+    @Column(name = "updated_at")
+    private Timestamp updatedAt;
+
+    // Default constructor
+    public KruizeBulkProfileEntry() {
+    }
+
+    // Constructor with all fields
+    public KruizeBulkProfileEntry(String profileName, JsonNode clusters, JsonNode recommendationSettings,
+                                  String webhookUrl, Boolean enabled, Timestamp createdAt, Timestamp updatedAt) {
+        this.profileName = profileName;
+        this.clusters = clusters;
+        this.recommendationSettings = recommendationSettings;
+        this.webhookUrl = webhookUrl;
+        this.enabled = enabled;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public String getProfileName() {
+        return profileName;
+    }
+
+    public void setProfileName(String profileName) {
+        this.profileName = profileName;
+    }
+
+    public JsonNode getClusters() {
+        return clusters;
+    }
+
+    public void setClusters(JsonNode clusters) {
+        this.clusters = clusters;
+    }
+
+    public JsonNode getRecommendationSettings() {
+        return recommendationSettings;
+    }
+
+    public void setRecommendationSettings(JsonNode recommendationSettings) {
+        this.recommendationSettings = recommendationSettings;
+    }
+
+    public String getWebhookUrl() {
+        return webhookUrl;
+    }
+
+    public void setWebhookUrl(String webhookUrl) {
+        this.webhookUrl = webhookUrl;
+    }
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public Timestamp getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Timestamp createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Timestamp getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Timestamp updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    @Override
+    public String toString() {
+        return "KruizeBulkProfileEntry{" +
+                "profileName='" + profileName + '\'' +
+                ", clusters=" + clusters +
+                ", recommendationSettings=" + recommendationSettings +
+                ", webhookUrl='" + webhookUrl + '\'' +
+                ", enabled=" + enabled +
+                ", createdAt=" + createdAt +
+                ", updatedAt=" + updatedAt +
+                '}';
+    }
+}

--- a/src/main/java/com/autotune/database/table/lm/KruizeBulkProfileEntry.java
+++ b/src/main/java/com/autotune/database/table/lm/KruizeBulkProfileEntry.java
@@ -44,7 +44,7 @@ public class KruizeBulkProfileEntry {
     private String profileName;
 
     @JdbcTypeCode(SqlTypes.JSON)
-    @Column(name = "clusters", columnDefinition = "jsonb")
+    @Column(name = "clusters", columnDefinition = "jsonb", nullable = false)
     private JsonNode clusters;
 
     @JdbcTypeCode(SqlTypes.JSON)

--- a/src/main/java/com/autotune/database/table/lm/KruizeBulkProfileEntry.java
+++ b/src/main/java/com/autotune/database/table/lm/KruizeBulkProfileEntry.java
@@ -30,8 +30,7 @@ import java.sql.Timestamp;
 
 /**
  * Database entity to store Kruize bulk profile configurations.
- * Bulk profiles define templates for automated bulk job creation with
- * cluster configurations, recommendation settings, and scheduling.
+ * Aligned with CreateExperiment structure for consistency.
  */
 @Entity
 @Table(name = "kruize_bulk_profile")
@@ -43,12 +42,37 @@ public class KruizeBulkProfileEntry {
     @Column(name = "profile_name", columnDefinition = "VARCHAR(255)")
     private String profileName;
 
-    @JdbcTypeCode(SqlTypes.JSON)
-    @Column(name = "clusters", columnDefinition = "jsonb", nullable = false)
-    private JsonNode clusters;
+    @Column(name = "cluster_name", columnDefinition = "VARCHAR(255)", nullable = false)
+    private String clusterName;
 
     @JdbcTypeCode(SqlTypes.JSON)
-    @Column(name = "recommendation_settings", columnDefinition = "jsonb")
+    @Column(name = "datasources", columnDefinition = "jsonb", nullable = false)
+    private JsonNode datasources;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "namespaces", columnDefinition = "jsonb", nullable = false)
+    private JsonNode namespaces;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "labels", columnDefinition = "jsonb")
+    private JsonNode labels;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "experiment_types", columnDefinition = "jsonb", nullable = false)
+    private JsonNode experimentTypes;
+
+    @Column(name = "metadata_profile", columnDefinition = "VARCHAR(255)")
+    private String metadataProfile;
+
+    @Column(name = "performance_profile", columnDefinition = "VARCHAR(255)", nullable = false)
+    private String performanceProfile;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "trial_settings", columnDefinition = "jsonb")
+    private JsonNode trialSettings;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "recommendation_settings", columnDefinition = "jsonb", nullable = false)
     private JsonNode recommendationSettings;
 
     @Column(name = "webhook_url", columnDefinition = "VARCHAR(500)")
@@ -67,18 +91,6 @@ public class KruizeBulkProfileEntry {
     public KruizeBulkProfileEntry() {
     }
 
-    // Constructor with all fields
-    public KruizeBulkProfileEntry(String profileName, JsonNode clusters, JsonNode recommendationSettings,
-                                  String webhookUrl, Boolean enabled, Timestamp createdAt, Timestamp updatedAt) {
-        this.profileName = profileName;
-        this.clusters = clusters;
-        this.recommendationSettings = recommendationSettings;
-        this.webhookUrl = webhookUrl;
-        this.enabled = enabled;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-    }
-
     public String getProfileName() {
         return profileName;
     }
@@ -87,12 +99,68 @@ public class KruizeBulkProfileEntry {
         this.profileName = profileName;
     }
 
-    public JsonNode getClusters() {
-        return clusters;
+    public String getClusterName() {
+        return clusterName;
     }
 
-    public void setClusters(JsonNode clusters) {
-        this.clusters = clusters;
+    public void setClusterName(String clusterName) {
+        this.clusterName = clusterName;
+    }
+
+    public JsonNode getDatasources() {
+        return datasources;
+    }
+
+    public void setDatasources(JsonNode datasources) {
+        this.datasources = datasources;
+    }
+
+    public JsonNode getNamespaces() {
+        return namespaces;
+    }
+
+    public void setNamespaces(JsonNode namespaces) {
+        this.namespaces = namespaces;
+    }
+
+    public JsonNode getLabels() {
+        return labels;
+    }
+
+    public void setLabels(JsonNode labels) {
+        this.labels = labels;
+    }
+
+    public JsonNode getExperimentTypes() {
+        return experimentTypes;
+    }
+
+    public void setExperimentTypes(JsonNode experimentTypes) {
+        this.experimentTypes = experimentTypes;
+    }
+
+    public String getMetadataProfile() {
+        return metadataProfile;
+    }
+
+    public void setMetadataProfile(String metadataProfile) {
+        this.metadataProfile = metadataProfile;
+    }
+
+    public String getPerformanceProfile() {
+        return performanceProfile;
+    }
+
+    public void setPerformanceProfile(String performanceProfile) {
+        this.performanceProfile = performanceProfile;
+    }
+
+    public JsonNode getTrialSettings() {
+        return trialSettings;
+    }
+
+    public void setTrialSettings(JsonNode trialSettings) {
+        this.trialSettings = trialSettings;
     }
 
     public JsonNode getRecommendationSettings() {
@@ -135,11 +203,19 @@ public class KruizeBulkProfileEntry {
         this.updatedAt = updatedAt;
     }
 
+
     @Override
     public String toString() {
         return "KruizeBulkProfileEntry{" +
                 "profileName='" + profileName + '\'' +
-                ", clusters=" + clusters +
+                ", clusterName='" + clusterName + '\'' +
+                ", datasources=" + datasources +
+                ", namespaces=" + namespaces +
+                ", labels=" + labels +
+                ", experimentTypes=" + experimentTypes +
+                ", metadataProfile='" + metadataProfile + '\'' +
+                ", performanceProfile='" + performanceProfile + '\'' +
+                ", trialSettings=" + trialSettings +
                 ", recommendationSettings=" + recommendationSettings +
                 ", webhookUrl='" + webhookUrl + '\'' +
                 ", enabled=" + enabled +


### PR DESCRIPTION
## Description

This PR is built on top of #1978 

#1978  needs to be merged before merging this

This PR adds the KruizeBulkProfileEntry class which matches the bulk profile table entry

Fixes #1977 

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

New Features:
- Add KruizeBulkConfigEntry JPA entity mapped to the kruize_optimiser_bulk_config table, including JSON-backed configuration fields and metadata columns for bulk optimiser configurations.