### PR TITLE
[BULK-PROFILE]-3: Add Bulk Profile service object

### DIFF
--- a/src/main/java/com/autotune/analyzer/serviceObjects/BulkConfig.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/BulkConfig.java
@@ -24,12 +24,12 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Service object representing a Bulk Profile configuration.
+ * Service object representing an Optimiser Bulk Configuration.
  * Aligned with CreateExperiment API structure for consistency.
  */
-public class BulkProfile {
-    @JsonProperty("profile_name")
-    private String profileName;
+public class BulkConfig {
+    @JsonProperty("config_name")
+    private String configName;
 
     @JsonProperty("cluster_name")
     private String clusterName;
@@ -46,7 +46,7 @@ public class BulkProfile {
     @JsonProperty("metadata_profile")
     private String metadataProfile;
 
-    @JsonProperty("performanceProfile")
+    @JsonProperty("performance_profile")
     private String performanceProfile;
 
     @JsonProperty("trial_settings")
@@ -66,15 +66,15 @@ public class BulkProfile {
     @JsonProperty("updated_at")
     private Instant updatedAt;
 
-    public BulkProfile() {
+    public BulkConfig() {
     }
 
-    public String getProfileName() {
-        return profileName;
+    public String getConfigName() {
+        return configName;
     }
 
-    public void setProfileName(String profileName) {
-        this.profileName = profileName;
+    public void setConfigName(String configName) {
+        this.configName = configName;
     }
 
     public String getClusterName() {
@@ -190,7 +190,7 @@ public class BulkProfile {
     }
 
     /**
-     * Trial settings for the bulk profile (matches CreateExperiment structure)
+     * Trial settings for the optimiser bulk config (matches CreateExperiment structure)
      */
     public static class TrialSettings {
         @JsonProperty("measurement_duration")
@@ -213,7 +213,7 @@ public class BulkProfile {
     }
 
     /**
-     * Recommendation settings for the bulk profile
+     * Recommendation settings for the optimiser bulk config
      */
     public static class RecommendationSettings {
         private String scheduling;

--- a/src/main/java/com/autotune/analyzer/serviceObjects/BulkConfig.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/BulkConfig.java
@@ -216,10 +216,13 @@ public class BulkConfig {
      * Recommendation settings for the optimiser bulk config
      */
     public static class RecommendationSettings {
+        @JsonProperty("scheduling")
         private String scheduling;
 
+        @JsonProperty("terms")
         private List<String> terms = new ArrayList<>();
 
+        @JsonProperty("models")
         private List<String> models = new ArrayList<>();
 
         public RecommendationSettings() {

--- a/src/main/java/com/autotune/analyzer/serviceObjects/BulkConfig.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/BulkConfig.java
@@ -34,10 +34,13 @@ public class BulkConfig {
     @JsonProperty("cluster_name")
     private String clusterName;
 
+    @JsonProperty("datasources")
     private List<String> datasources = new ArrayList<>();
 
+    @JsonProperty("namespaces")
     private List<String> namespaces = new ArrayList<>();
 
+    @JsonProperty("labels")
     private Map<String, String> labels = new HashMap<>();
 
     @JsonProperty("experiment_types")
@@ -58,6 +61,7 @@ public class BulkConfig {
     @JsonProperty("webhook_url")
     private String webhookUrl;
 
+    @JsonProperty("enabled")
     private Boolean enabled = true;
 
     @JsonProperty("created_at")
@@ -194,21 +198,21 @@ public class BulkConfig {
      */
     public static class TrialSettings {
         @JsonProperty("measurement_duration")
-        private String measurementDuration;
+        private String measurementDurationMinutes;
 
         public TrialSettings() {
         }
 
-        public TrialSettings(String measurementDuration) {
-            this.measurementDuration = measurementDuration;
+        public TrialSettings(String measurementDurationMinutes) {
+            this.measurementDurationMinutes = measurementDurationMinutes;
         }
 
-        public String getMeasurementDuration() {
-            return measurementDuration;
+        public String getMeasurementDurationMinutes() {
+            return measurementDurationMinutes;
         }
 
-        public void setMeasurementDuration(String measurementDuration) {
-            this.measurementDuration = measurementDuration;
+        public void setMeasurementDurationMinutes(String measurementDurationMinutes) {
+            this.measurementDurationMinutes = measurementDurationMinutes;
         }
     }
 

--- a/src/main/java/com/autotune/analyzer/serviceObjects/BulkProfile.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/BulkProfile.java
@@ -1,0 +1,263 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.autotune.analyzer.serviceObjects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class BulkProfile {
+    @JsonProperty("profile_name")
+    private String profileName;
+
+    private String description;
+
+    private List<Cluster> clusters = new ArrayList<>();
+
+    @JsonProperty("recommendation_settings")
+    private RecommendationSettings recommendationSettings;
+
+    private Boolean enabled = true;
+
+    @JsonProperty("webhook_url")
+    private String webhookUrl;
+
+    @JsonProperty("created_at")
+    private Instant createdAt;
+
+    @JsonProperty("updated_at")
+    private Instant updatedAt;
+
+    public BulkProfile() {
+    }
+
+    public BulkProfile(String profileName, String description, List<Cluster> clusters,
+                       RecommendationSettings recommendationSettings, boolean enabled, String webhookUrl) {
+        this.profileName = profileName;
+        this.description = description;
+        this.clusters = clusters;
+        this.recommendationSettings = recommendationSettings;
+        this.enabled = enabled;
+        this.webhookUrl = webhookUrl;
+    }
+
+    public String getProfileName() {
+        return profileName;
+    }
+
+    public void setProfileName(String profileName) {
+        this.profileName = profileName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public List<Cluster> getClusters() {
+        return clusters;
+    }
+
+    public void setClusters(List<Cluster> clusters) {
+        this.clusters = clusters;
+    }
+
+    public RecommendationSettings getRecommendationSettings() {
+        return recommendationSettings;
+    }
+
+    public void setRecommendationSettings(RecommendationSettings recommendationSettings) {
+        this.recommendationSettings = recommendationSettings;
+    }
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getWebhookUrl() {
+        return webhookUrl;
+    }
+
+    public void setWebhookUrl(String webhookUrl) {
+        this.webhookUrl = webhookUrl;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    /**
+     * Cluster configuration within a bulk profile
+     */
+    public static class Cluster {
+
+        @JsonProperty("cluster_name")
+        private String clusterName;
+
+        private List<String> datasources = new ArrayList<>();
+
+        private List<String> namespaces = new ArrayList<>();
+
+        private Map<String, String> labels = new HashMap<>();
+
+        @JsonProperty("experiment_types")
+        private List<String> experimentTypes = new ArrayList<>();
+
+        @JsonProperty("metadata_profile")
+        private String metadataProfile;
+
+        public Cluster() {
+        }
+
+        public Cluster(String clusterName, List<String> datasources, List<String> namespaces,
+                       Map<String, String> labels, List<String> experimentTypes, String metadataProfile) {
+            this.clusterName = clusterName;
+            this.datasources = datasources;
+            this.namespaces = namespaces;
+            this.labels = labels;
+            this.experimentTypes = experimentTypes;
+            this.metadataProfile = metadataProfile;
+        }
+
+        public String getClusterName() {
+            return clusterName;
+        }
+
+        public void setClusterName(String clusterName) {
+            this.clusterName = clusterName;
+        }
+
+        public List<String> getDatasources() {
+            return datasources;
+        }
+
+        public void setDatasources(List<String> datasources) {
+            this.datasources = datasources;
+        }
+
+        public List<String> getNamespaces() {
+            return namespaces;
+        }
+
+        public void setNamespaces(List<String> namespaces) {
+            this.namespaces = namespaces;
+        }
+
+        public Map<String, String> getLabels() {
+            return labels;
+        }
+
+        public void setLabels(Map<String, String> labels) {
+            this.labels = labels;
+        }
+
+        public List<String> getExperimentTypes() {
+            return experimentTypes;
+        }
+
+        public void setExperimentTypes(List<String> experimentTypes) {
+            this.experimentTypes = experimentTypes;
+        }
+
+        public String getMetadataProfile() {
+            return metadataProfile;
+        }
+
+        public void setMetadataProfile(String metadataProfile) {
+            this.metadataProfile = metadataProfile;
+        }
+    }
+
+    /**
+     * Recommendation settings for the bulk profile
+     */
+    public static class RecommendationSettings {
+
+        private String scheduling;
+
+        private List<String> terms = new ArrayList<>();
+
+        private List<String> models = new ArrayList<>();
+
+        @JsonProperty("measurement_duration")
+        private String measurementDuration;
+
+        public RecommendationSettings() {
+        }
+
+        public RecommendationSettings(String scheduling, List<String> terms, List<String> models, String measurementDuration) {
+            this.scheduling = scheduling;
+            this.terms = terms;
+            this.models = models;
+            this.measurementDuration = measurementDuration;
+        }
+
+        public String getScheduling() {
+            return scheduling;
+        }
+
+        public void setScheduling(String scheduling) {
+            this.scheduling = scheduling;
+        }
+
+        public List<String> getTerms() {
+            return terms;
+        }
+
+        public void setTerms(List<String> terms) {
+            this.terms = terms;
+        }
+
+        public List<String> getModels() {
+            return models;
+        }
+
+        public void setModels(List<String> models) {
+            this.models = models;
+        }
+
+        public String getMeasurementDuration() {
+            return measurementDuration;
+        }
+
+        public void setMeasurementDuration(String measurementDuration) {
+            this.measurementDuration = measurementDuration;
+        }
+    }
+}

--- a/src/main/java/com/autotune/analyzer/serviceObjects/BulkProfile.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/BulkProfile.java
@@ -79,6 +79,8 @@ public class BulkProfile {
     }
 
     public void setClusters(List<Cluster> clusters) {
+        if (null == clusters)
+            clusters = new ArrayList<>();
         this.clusters = clusters;
     }
 

--- a/src/main/java/com/autotune/analyzer/serviceObjects/BulkProfile.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/BulkProfile.java
@@ -23,21 +23,42 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Service object representing a Bulk Profile configuration.
+ * Aligned with CreateExperiment API structure for consistency.
+ */
 public class BulkProfile {
     @JsonProperty("profile_name")
     private String profileName;
 
-    private String description;
+    @JsonProperty("cluster_name")
+    private String clusterName;
 
-    private List<Cluster> clusters = new ArrayList<>();
+    private List<String> datasources = new ArrayList<>();
+
+    private List<String> namespaces = new ArrayList<>();
+
+    private Map<String, String> labels = new HashMap<>();
+
+    @JsonProperty("experiment_types")
+    private List<String> experimentTypes = new ArrayList<>();
+
+    @JsonProperty("metadata_profile")
+    private String metadataProfile;
+
+    @JsonProperty("performanceProfile")
+    private String performanceProfile;
+
+    @JsonProperty("trial_settings")
+    private TrialSettings trialSettings;
 
     @JsonProperty("recommendation_settings")
     private RecommendationSettings recommendationSettings;
 
-    private Boolean enabled = true;
-
     @JsonProperty("webhook_url")
     private String webhookUrl;
+
+    private Boolean enabled = true;
 
     @JsonProperty("created_at")
     private Instant createdAt;
@@ -48,16 +69,6 @@ public class BulkProfile {
     public BulkProfile() {
     }
 
-    public BulkProfile(String profileName, String description, List<Cluster> clusters,
-                       RecommendationSettings recommendationSettings, boolean enabled, String webhookUrl) {
-        this.profileName = profileName;
-        this.description = description;
-        this.clusters = clusters;
-        this.recommendationSettings = recommendationSettings;
-        this.enabled = enabled;
-        this.webhookUrl = webhookUrl;
-    }
-
     public String getProfileName() {
         return profileName;
     }
@@ -66,22 +77,76 @@ public class BulkProfile {
         this.profileName = profileName;
     }
 
-    public String getDescription() {
-        return description;
+    public String getClusterName() {
+        return clusterName;
     }
 
-    public void setDescription(String description) {
-        this.description = description;
+    public void setClusterName(String clusterName) {
+        this.clusterName = clusterName;
     }
 
-    public List<Cluster> getClusters() {
-        return clusters;
+    public List<String> getDatasources() {
+        return datasources;
     }
 
-    public void setClusters(List<Cluster> clusters) {
-        if (null == clusters)
-            clusters = new ArrayList<>();
-        this.clusters = clusters;
+    public void setDatasources(List<String> datasources) {
+        if (null == datasources)
+            datasources = new ArrayList<>();
+        this.datasources = datasources;
+    }
+
+    public List<String> getNamespaces() {
+        return namespaces;
+    }
+
+    public void setNamespaces(List<String> namespaces) {
+        if (null == namespaces)
+            namespaces = new ArrayList<>();
+        this.namespaces = namespaces;
+    }
+
+    public Map<String, String> getLabels() {
+        return labels;
+    }
+
+    public void setLabels(Map<String, String> labels) {
+        if (null == labels)
+            labels = new HashMap<>();
+        this.labels = labels;
+    }
+
+    public List<String> getExperimentTypes() {
+        return experimentTypes;
+    }
+
+    public void setExperimentTypes(List<String> experimentTypes) {
+        if (null == experimentTypes)
+            experimentTypes = new ArrayList<>();
+        this.experimentTypes = experimentTypes;
+    }
+
+    public String getMetadataProfile() {
+        return metadataProfile;
+    }
+
+    public void setMetadataProfile(String metadataProfile) {
+        this.metadataProfile = metadataProfile;
+    }
+
+    public String getPerformanceProfile() {
+        return performanceProfile;
+    }
+
+    public void setPerformanceProfile(String performanceProfile) {
+        this.performanceProfile = performanceProfile;
+    }
+
+    public TrialSettings getTrialSettings() {
+        return trialSettings;
+    }
+
+    public void setTrialSettings(TrialSettings trialSettings) {
+        this.trialSettings = trialSettings;
     }
 
     public RecommendationSettings getRecommendationSettings() {
@@ -92,20 +157,20 @@ public class BulkProfile {
         this.recommendationSettings = recommendationSettings;
     }
 
-    public Boolean getEnabled() {
-        return enabled;
-    }
-
-    public void setEnabled(Boolean enabled) {
-        this.enabled = enabled;
-    }
-
     public String getWebhookUrl() {
         return webhookUrl;
     }
 
     public void setWebhookUrl(String webhookUrl) {
         this.webhookUrl = webhookUrl;
+    }
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
     }
 
     public Instant getCreatedAt() {
@@ -125,84 +190,25 @@ public class BulkProfile {
     }
 
     /**
-     * Cluster configuration within a bulk profile
+     * Trial settings for the bulk profile (matches CreateExperiment structure)
      */
-    public static class Cluster {
+    public static class TrialSettings {
+        @JsonProperty("measurement_duration")
+        private String measurementDuration;
 
-        @JsonProperty("cluster_name")
-        private String clusterName;
-
-        private List<String> datasources = new ArrayList<>();
-
-        private List<String> namespaces = new ArrayList<>();
-
-        private Map<String, String> labels = new HashMap<>();
-
-        @JsonProperty("experiment_types")
-        private List<String> experimentTypes = new ArrayList<>();
-
-        @JsonProperty("metadata_profile")
-        private String metadataProfile;
-
-        public Cluster() {
+        public TrialSettings() {
         }
 
-        public Cluster(String clusterName, List<String> datasources, List<String> namespaces,
-                       Map<String, String> labels, List<String> experimentTypes, String metadataProfile) {
-            this.clusterName = clusterName;
-            this.datasources = datasources;
-            this.namespaces = namespaces;
-            this.labels = labels;
-            this.experimentTypes = experimentTypes;
-            this.metadataProfile = metadataProfile;
+        public TrialSettings(String measurementDuration) {
+            this.measurementDuration = measurementDuration;
         }
 
-        public String getClusterName() {
-            return clusterName;
+        public String getMeasurementDuration() {
+            return measurementDuration;
         }
 
-        public void setClusterName(String clusterName) {
-            this.clusterName = clusterName;
-        }
-
-        public List<String> getDatasources() {
-            return datasources;
-        }
-
-        public void setDatasources(List<String> datasources) {
-            this.datasources = datasources;
-        }
-
-        public List<String> getNamespaces() {
-            return namespaces;
-        }
-
-        public void setNamespaces(List<String> namespaces) {
-            this.namespaces = namespaces;
-        }
-
-        public Map<String, String> getLabels() {
-            return labels;
-        }
-
-        public void setLabels(Map<String, String> labels) {
-            this.labels = labels;
-        }
-
-        public List<String> getExperimentTypes() {
-            return experimentTypes;
-        }
-
-        public void setExperimentTypes(List<String> experimentTypes) {
-            this.experimentTypes = experimentTypes;
-        }
-
-        public String getMetadataProfile() {
-            return metadataProfile;
-        }
-
-        public void setMetadataProfile(String metadataProfile) {
-            this.metadataProfile = metadataProfile;
+        public void setMeasurementDuration(String measurementDuration) {
+            this.measurementDuration = measurementDuration;
         }
     }
 
@@ -210,24 +216,19 @@ public class BulkProfile {
      * Recommendation settings for the bulk profile
      */
     public static class RecommendationSettings {
-
         private String scheduling;
 
         private List<String> terms = new ArrayList<>();
 
         private List<String> models = new ArrayList<>();
 
-        @JsonProperty("measurement_duration")
-        private String measurementDuration;
-
         public RecommendationSettings() {
         }
 
-        public RecommendationSettings(String scheduling, List<String> terms, List<String> models, String measurementDuration) {
+        public RecommendationSettings(String scheduling, List<String> terms, List<String> models) {
             this.scheduling = scheduling;
             this.terms = terms;
             this.models = models;
-            this.measurementDuration = measurementDuration;
         }
 
         public String getScheduling() {
@@ -243,6 +244,8 @@ public class BulkProfile {
         }
 
         public void setTerms(List<String> terms) {
+            if (null == terms)
+                terms = new ArrayList<>();
             this.terms = terms;
         }
 
@@ -251,15 +254,9 @@ public class BulkProfile {
         }
 
         public void setModels(List<String> models) {
+            if (null == models)
+                models = new ArrayList<>();
             this.models = models;
-        }
-
-        public String getMeasurementDuration() {
-            return measurementDuration;
-        }
-
-        public void setMeasurementDuration(String measurementDuration) {
-            this.measurementDuration = measurementDuration;
         }
     }
 }

--- a/src/main/java/com/autotune/database/table/lm/KruizeBulkConfigEntry.java
+++ b/src/main/java/com/autotune/database/table/lm/KruizeBulkConfigEntry.java
@@ -70,7 +70,7 @@ public class KruizeBulkConfigEntry {
     @Column(name = "recommendation_settings", columnDefinition = "jsonb", nullable = false)
     private JsonNode recommendationSettings;
 
-    @Column(name = "webhook_url", columnDefinition = "VARCHAR(500)", nullable = false)
+    @Column(name = "webhook_url", columnDefinition = "VARCHAR(500)")
     private String webhookUrl;
 
     @Column(name = "enabled", nullable = false)


### PR DESCRIPTION
## Description

This PR is built on top of #1979 

#1979 needs to be merged before merging this PR

Fixes #1977 

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Introduce data model and persistence entity for optimiser bulk configuration aligned with existing experiment APIs.

New Features:
- Add BulkConfig service object representing optimiser bulk configuration, including trial and recommendation settings.
- Add KruizeBulkConfigEntry JPA entity to store bulk configuration in the database using JSON fields for complex attributes.