### PR TITLE
[BULK-PROFILE]-4: Add Converters in Bulk profile entry

### DIFF
--- a/migrations/lm/v112__create_optimizer_bulk_config_table.sql
+++ b/migrations/lm/v112__create_optimizer_bulk_config_table.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS kruize_optimiser_bulk_config (
+CREATE TABLE IF NOT EXISTS kruize_optimizer_bulk_config (
     config_name VARCHAR(255) PRIMARY KEY,
     cluster_name VARCHAR(255) NOT NULL,
     datasources JSONB NOT NULL,

--- a/src/main/java/com/autotune/database/table/lm/KruizeBulkConfigEntry.java
+++ b/src/main/java/com/autotune/database/table/lm/KruizeBulkConfigEntry.java
@@ -318,9 +318,16 @@ public class KruizeBulkConfigEntry {
 
     /**
      * Create an entity from a BulkConfig service object
-     * @throws RuntimeException if required fields are null or conversion fails
+     * @param config the BulkConfig object to convert
+     * @return KruizeBulkConfigEntry entity
+     * @throws IllegalArgumentException if config is null or required fields are null
+     * @throws RuntimeException if conversion fails
      */
     public static KruizeBulkConfigEntry fromBulkConfig(BulkConfig config) {
+        if (config == null) {
+            throw new IllegalArgumentException("BulkConfig cannot be null");
+        }
+        
         KruizeBulkConfigEntry entry = new KruizeBulkConfigEntry();
         entry.setConfigName(config.getConfigName());
         entry.setClusterName(config.getClusterName());

--- a/src/main/java/com/autotune/database/table/lm/KruizeBulkConfigEntry.java
+++ b/src/main/java/com/autotune/database/table/lm/KruizeBulkConfigEntry.java
@@ -35,11 +35,11 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Database entity to store Kruize optimiser bulk configuration.
+ * Database entity to store Kruize optimizer bulk configuration.
  * Aligned with CreateExperiment structure for consistency.
  */
 @Entity
-@Table(name = "kruize_optimiser_bulk_config")
+@Table(name = "kruize_optimizer_bulk_config")
 public class KruizeBulkConfigEntry {
     private static final Logger LOGGER = LoggerFactory.getLogger(KruizeBulkConfigEntry.class);
     private static final ObjectMapper objectMapper = new ObjectMapper();
@@ -211,41 +211,42 @@ public class KruizeBulkConfigEntry {
 
     /**
      * Convert this entity to a BulkConfig service object
+     * @throws RuntimeException if required fields are null or conversion fails
      */
     public BulkConfig toBulkConfig() {
         BulkConfig config = new BulkConfig();
         config.setConfigName(this.configName);
         config.setClusterName(this.clusterName);
         
-        // Convert JsonNode to List<String> for datasources
-        if (this.datasources != null) {
-            try {
-                List<String> datasourceList = objectMapper.convertValue(
-                    this.datasources,
-                    new TypeReference<List<String>>() {}
-                );
-                config.setDatasources(datasourceList);
-            } catch (Exception e) {
-                LOGGER.error("Error converting datasources: {}", e.getMessage());
-                config.setDatasources(new ArrayList<>());
-            }
+        // Required field: datasources
+        if (this.datasources == null) {
+            throw new IllegalStateException("Datasources cannot be null for config: " + configName);
+        }
+        try {
+            List<String> datasourceList = objectMapper.convertValue(
+                this.datasources,
+                new TypeReference<List<String>>() {}
+            );
+            config.setDatasources(datasourceList);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to convert datasources for config: " + configName, e);
         }
         
-        // Convert JsonNode to List<String> for namespaces
-        if (this.namespaces != null) {
-            try {
-                List<String> namespaceList = objectMapper.convertValue(
-                    this.namespaces,
-                    new TypeReference<List<String>>() {}
-                );
-                config.setNamespaces(namespaceList);
-            } catch (Exception e) {
-                LOGGER.error("Error converting namespaces: {}", e.getMessage());
-                config.setNamespaces(new ArrayList<>());
-            }
+        // Required field: namespaces
+        if (this.namespaces == null) {
+            throw new IllegalStateException("Namespaces cannot be null for config: " + configName);
+        }
+        try {
+            List<String> namespaceList = objectMapper.convertValue(
+                this.namespaces,
+                new TypeReference<List<String>>() {}
+            );
+            config.setNamespaces(namespaceList);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to convert namespaces for config: " + configName, e);
         }
         
-        // Convert JsonNode to Map<String, String> for labels
+        // Optional field: labels
         if (this.labels != null) {
             try {
                 Map<String, String> labelsMap = objectMapper.convertValue(
@@ -254,29 +255,28 @@ public class KruizeBulkConfigEntry {
                 );
                 config.setLabels(labelsMap);
             } catch (Exception e) {
-                LOGGER.error("Error converting labels: {}", e.getMessage());
-                config.setLabels(new HashMap<>());
+                throw new RuntimeException("Failed to convert labels for config: " + configName, e);
             }
         }
         
-        // Convert JsonNode to List<String> for experiment types
-        if (this.experimentTypes != null) {
-            try {
-                List<String> experimentTypeList = objectMapper.convertValue(
-                    this.experimentTypes,
-                    new TypeReference<List<String>>() {}
-                );
-                config.setExperimentTypes(experimentTypeList);
-            } catch (Exception e) {
-                LOGGER.error("Error converting experiment types: {}", e.getMessage());
-                config.setExperimentTypes(new ArrayList<>());
-            }
+        // Required field: experiment types
+        if (this.experimentTypes == null) {
+            throw new IllegalStateException("Experiment types cannot be null for config: " + configName);
+        }
+        try {
+            List<String> experimentTypeList = objectMapper.convertValue(
+                this.experimentTypes,
+                new TypeReference<List<String>>() {}
+            );
+            config.setExperimentTypes(experimentTypeList);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to convert experiment types for config: " + configName, e);
         }
         
         config.setMetadataProfile(this.metadataProfile);
         config.setPerformanceProfile(this.performanceProfile);
         
-        // Convert JsonNode to TrialSettings
+        // Optional field: trial settings
         if (this.trialSettings != null) {
             try {
                 BulkConfig.TrialSettings trialSettings = objectMapper.convertValue(
@@ -285,21 +285,22 @@ public class KruizeBulkConfigEntry {
                 );
                 config.setTrialSettings(trialSettings);
             } catch (Exception e) {
-                LOGGER.error("Error converting trial settings: {}", e.getMessage());
+                throw new RuntimeException("Failed to convert trial settings for config: " + configName, e);
             }
         }
         
-        // Convert JsonNode to RecommendationSettings
-        if (this.recommendationSettings != null) {
-            try {
-                BulkConfig.RecommendationSettings recSettings = objectMapper.convertValue(
-                    this.recommendationSettings,
-                    BulkConfig.RecommendationSettings.class
-                );
-                config.setRecommendationSettings(recSettings);
-            } catch (Exception e) {
-                LOGGER.error("Error converting recommendation settings: {}", e.getMessage());
-            }
+        // Required field: recommendation settings
+        if (this.recommendationSettings == null) {
+            throw new IllegalStateException("Recommendation settings cannot be null for config: " + configName);
+        }
+        try {
+            BulkConfig.RecommendationSettings recSettings = objectMapper.convertValue(
+                this.recommendationSettings,
+                BulkConfig.RecommendationSettings.class
+            );
+            config.setRecommendationSettings(recSettings);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to convert recommendation settings for config: " + configName, e);
         }
         
         config.setWebhookUrl(this.webhookUrl);
@@ -317,67 +318,72 @@ public class KruizeBulkConfigEntry {
 
     /**
      * Create an entity from a BulkConfig service object
+     * @throws RuntimeException if required fields are null or conversion fails
      */
     public static KruizeBulkConfigEntry fromBulkConfig(BulkConfig config) {
         KruizeBulkConfigEntry entry = new KruizeBulkConfigEntry();
         entry.setConfigName(config.getConfigName());
         entry.setClusterName(config.getClusterName());
         
-        // Convert List<String> to JsonNode for datasources
-        if (config.getDatasources() != null) {
-            try {
-                entry.setDatasources(objectMapper.valueToTree(config.getDatasources()));
-            } catch (Exception e) {
-                LOGGER.error("Error converting datasources: {}", e.getMessage());
-            }
+        // Required field: datasources
+        if (config.getDatasources() == null) {
+            throw new IllegalArgumentException("Datasources cannot be null for config: " + config.getConfigName());
+        }
+        try {
+            entry.setDatasources(objectMapper.valueToTree(config.getDatasources()));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to convert datasources for config: " + config.getConfigName(), e);
         }
         
-        // Convert List<String> to JsonNode for namespaces
-        if (config.getNamespaces() != null) {
-            try {
-                entry.setNamespaces(objectMapper.valueToTree(config.getNamespaces()));
-            } catch (Exception e) {
-                LOGGER.error("Error converting namespaces: {}", e.getMessage());
-            }
+        // Required field: namespaces
+        if (config.getNamespaces() == null) {
+            throw new IllegalArgumentException("Namespaces cannot be null for config: " + config.getConfigName());
+        }
+        try {
+            entry.setNamespaces(objectMapper.valueToTree(config.getNamespaces()));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to convert namespaces for config: " + config.getConfigName(), e);
         }
         
-        // Convert Map<String, String> to JsonNode for labels
+        // Optional field: labels
         if (config.getLabels() != null) {
             try {
                 entry.setLabels(objectMapper.valueToTree(config.getLabels()));
             } catch (Exception e) {
-                LOGGER.error("Error converting labels: {}", e.getMessage());
+                throw new RuntimeException("Failed to convert labels for config: " + config.getConfigName(), e);
             }
         }
         
-        // Convert List<String> to JsonNode for experiment types
-        if (config.getExperimentTypes() != null) {
-            try {
-                entry.setExperimentTypes(objectMapper.valueToTree(config.getExperimentTypes()));
-            } catch (Exception e) {
-                LOGGER.error("Error converting experiment types: {}", e.getMessage());
-            }
+        // Required field: experiment types
+        if (config.getExperimentTypes() == null) {
+            throw new IllegalArgumentException("Experiment types cannot be null for config: " + config.getConfigName());
+        }
+        try {
+            entry.setExperimentTypes(objectMapper.valueToTree(config.getExperimentTypes()));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to convert experiment types for config: " + config.getConfigName(), e);
         }
         
         entry.setMetadataProfile(config.getMetadataProfile());
         entry.setPerformanceProfile(config.getPerformanceProfile());
         
-        // Convert TrialSettings to JsonNode
+        // Optional field: trial settings
         if (config.getTrialSettings() != null) {
             try {
                 entry.setTrialSettings(objectMapper.valueToTree(config.getTrialSettings()));
             } catch (Exception e) {
-                LOGGER.error("Error converting trial settings: {}", e.getMessage());
+                throw new RuntimeException("Failed to convert trial settings for config: " + config.getConfigName(), e);
             }
         }
         
-        // Convert RecommendationSettings to JsonNode
-        if (config.getRecommendationSettings() != null) {
-            try {
-                entry.setRecommendationSettings(objectMapper.valueToTree(config.getRecommendationSettings()));
-            } catch (Exception e) {
-                LOGGER.error("Error converting recommendation settings: {}", e.getMessage());
-            }
+        // Required field: recommendation settings
+        if (config.getRecommendationSettings() == null) {
+            throw new IllegalArgumentException("Recommendation settings cannot be null for config: " + config.getConfigName());
+        }
+        try {
+            entry.setRecommendationSettings(objectMapper.valueToTree(config.getRecommendationSettings()));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to convert recommendation settings for config: " + config.getConfigName(), e);
         }
         
         entry.setWebhookUrl(config.getWebhookUrl());

--- a/src/main/java/com/autotune/database/table/lm/KruizeBulkConfigEntry.java
+++ b/src/main/java/com/autotune/database/table/lm/KruizeBulkConfigEntry.java
@@ -18,12 +18,15 @@ package com.autotune.database.table.lm;
 import com.autotune.analyzer.serviceObjects.BulkConfig;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -38,6 +41,8 @@ import java.util.Map;
 @Entity
 @Table(name = "kruize_optimiser_bulk_config")
 public class KruizeBulkConfigEntry {
+    private static final Logger LOGGER = LoggerFactory.getLogger(KruizeBulkConfigEntry.class);
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     @Id
     @Column(name = "config_name", columnDefinition = "VARCHAR(255)")

--- a/src/main/java/com/autotune/database/table/lm/KruizeBulkConfigEntry.java
+++ b/src/main/java/com/autotune/database/table/lm/KruizeBulkConfigEntry.java
@@ -67,7 +67,7 @@ public class KruizeBulkConfigEntry {
     @Column(name = "experiment_types", columnDefinition = "jsonb", nullable = false)
     private JsonNode experimentTypes;
 
-    @Column(name = "metadata_profile", columnDefinition = "VARCHAR(255)", nullable = false)
+    @Column(name = "metadata_profile", columnDefinition = "VARCHAR(255)")
     private String metadataProfile;
 
     @Column(name = "performance_profile", columnDefinition = "VARCHAR(255)", nullable = false)

--- a/src/main/java/com/autotune/database/table/lm/KruizeBulkConfigEntry.java
+++ b/src/main/java/com/autotune/database/table/lm/KruizeBulkConfigEntry.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package com.autotune.database.table.lm;
 
+import com.autotune.analyzer.serviceObjects.BulkConfig;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -24,6 +26,10 @@ import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
 import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Database entity to store Kruize optimiser bulk configuration.
@@ -198,6 +204,189 @@ public class KruizeBulkConfigEntry {
         this.updatedAt = updatedAt;
     }
 
+    /**
+     * Convert this entity to a BulkConfig service object
+     */
+    public BulkConfig toBulkConfig() {
+        BulkConfig config = new BulkConfig();
+        config.setConfigName(this.configName);
+        config.setClusterName(this.clusterName);
+        
+        // Convert JsonNode to List<String> for datasources
+        if (this.datasources != null) {
+            try {
+                List<String> datasourceList = objectMapper.convertValue(
+                    this.datasources,
+                    new TypeReference<List<String>>() {}
+                );
+                config.setDatasources(datasourceList);
+            } catch (Exception e) {
+                LOGGER.error("Error converting datasources: {}", e.getMessage());
+                config.setDatasources(new ArrayList<>());
+            }
+        }
+        
+        // Convert JsonNode to List<String> for namespaces
+        if (this.namespaces != null) {
+            try {
+                List<String> namespaceList = objectMapper.convertValue(
+                    this.namespaces,
+                    new TypeReference<List<String>>() {}
+                );
+                config.setNamespaces(namespaceList);
+            } catch (Exception e) {
+                LOGGER.error("Error converting namespaces: {}", e.getMessage());
+                config.setNamespaces(new ArrayList<>());
+            }
+        }
+        
+        // Convert JsonNode to Map<String, String> for labels
+        if (this.labels != null) {
+            try {
+                Map<String, String> labelsMap = objectMapper.convertValue(
+                    this.labels,
+                    new TypeReference<Map<String, String>>() {}
+                );
+                config.setLabels(labelsMap);
+            } catch (Exception e) {
+                LOGGER.error("Error converting labels: {}", e.getMessage());
+                config.setLabels(new HashMap<>());
+            }
+        }
+        
+        // Convert JsonNode to List<String> for experiment types
+        if (this.experimentTypes != null) {
+            try {
+                List<String> experimentTypeList = objectMapper.convertValue(
+                    this.experimentTypes,
+                    new TypeReference<List<String>>() {}
+                );
+                config.setExperimentTypes(experimentTypeList);
+            } catch (Exception e) {
+                LOGGER.error("Error converting experiment types: {}", e.getMessage());
+                config.setExperimentTypes(new ArrayList<>());
+            }
+        }
+        
+        config.setMetadataProfile(this.metadataProfile);
+        config.setPerformanceProfile(this.performanceProfile);
+        
+        // Convert JsonNode to TrialSettings
+        if (this.trialSettings != null) {
+            try {
+                BulkConfig.TrialSettings trialSettings = objectMapper.convertValue(
+                    this.trialSettings,
+                    BulkConfig.TrialSettings.class
+                );
+                config.setTrialSettings(trialSettings);
+            } catch (Exception e) {
+                LOGGER.error("Error converting trial settings: {}", e.getMessage());
+            }
+        }
+        
+        // Convert JsonNode to RecommendationSettings
+        if (this.recommendationSettings != null) {
+            try {
+                BulkConfig.RecommendationSettings recSettings = objectMapper.convertValue(
+                    this.recommendationSettings,
+                    BulkConfig.RecommendationSettings.class
+                );
+                config.setRecommendationSettings(recSettings);
+            } catch (Exception e) {
+                LOGGER.error("Error converting recommendation settings: {}", e.getMessage());
+            }
+        }
+        
+        config.setWebhookUrl(this.webhookUrl);
+        config.setEnabled(this.enabled);
+        
+        if (this.createdAt != null) {
+            config.setCreatedAt(this.createdAt.toInstant());
+        }
+        if (this.updatedAt != null) {
+            config.setUpdatedAt(this.updatedAt.toInstant());
+        }
+        
+        return config;
+    }
+
+    /**
+     * Create an entity from a BulkConfig service object
+     */
+    public static KruizeBulkConfigEntry fromBulkConfig(BulkConfig config) {
+        KruizeBulkConfigEntry entry = new KruizeBulkConfigEntry();
+        entry.setConfigName(config.getConfigName());
+        entry.setClusterName(config.getClusterName());
+        
+        // Convert List<String> to JsonNode for datasources
+        if (config.getDatasources() != null) {
+            try {
+                entry.setDatasources(objectMapper.valueToTree(config.getDatasources()));
+            } catch (Exception e) {
+                LOGGER.error("Error converting datasources: {}", e.getMessage());
+            }
+        }
+        
+        // Convert List<String> to JsonNode for namespaces
+        if (config.getNamespaces() != null) {
+            try {
+                entry.setNamespaces(objectMapper.valueToTree(config.getNamespaces()));
+            } catch (Exception e) {
+                LOGGER.error("Error converting namespaces: {}", e.getMessage());
+            }
+        }
+        
+        // Convert Map<String, String> to JsonNode for labels
+        if (config.getLabels() != null) {
+            try {
+                entry.setLabels(objectMapper.valueToTree(config.getLabels()));
+            } catch (Exception e) {
+                LOGGER.error("Error converting labels: {}", e.getMessage());
+            }
+        }
+        
+        // Convert List<String> to JsonNode for experiment types
+        if (config.getExperimentTypes() != null) {
+            try {
+                entry.setExperimentTypes(objectMapper.valueToTree(config.getExperimentTypes()));
+            } catch (Exception e) {
+                LOGGER.error("Error converting experiment types: {}", e.getMessage());
+            }
+        }
+        
+        entry.setMetadataProfile(config.getMetadataProfile());
+        entry.setPerformanceProfile(config.getPerformanceProfile());
+        
+        // Convert TrialSettings to JsonNode
+        if (config.getTrialSettings() != null) {
+            try {
+                entry.setTrialSettings(objectMapper.valueToTree(config.getTrialSettings()));
+            } catch (Exception e) {
+                LOGGER.error("Error converting trial settings: {}", e.getMessage());
+            }
+        }
+        
+        // Convert RecommendationSettings to JsonNode
+        if (config.getRecommendationSettings() != null) {
+            try {
+                entry.setRecommendationSettings(objectMapper.valueToTree(config.getRecommendationSettings()));
+            } catch (Exception e) {
+                LOGGER.error("Error converting recommendation settings: {}", e.getMessage());
+            }
+        }
+        
+        entry.setWebhookUrl(config.getWebhookUrl());
+        entry.setEnabled(config.getEnabled());
+        
+        if (config.getCreatedAt() != null) {
+            entry.setCreatedAt(Timestamp.from(config.getCreatedAt()));
+        }
+        if (config.getUpdatedAt() != null) {
+            entry.setUpdatedAt(Timestamp.from(config.getUpdatedAt()));
+        }
+        
+        return entry;
+    }
 
     @Override
     public String toString() {


### PR DESCRIPTION
## Description

This PR is built on top of #1980 

#1980 needs to be merged before merging this

Fixes #1977 

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Introduce bulk profile service object and persistence entity for storing automated bulk job configurations with associated database migration.

New Features:
- Add BulkProfile service object to represent bulk job profile configuration including clusters and recommendation settings.
- Persist bulk profile configurations via KruizeBulkProfileEntry JPA entity backed by JSONB columns.
- Create database migration to create kruize_bulk_profile table with metadata and enablement fields.