### PR TITLE
PR #1: Add database schema, core models, and validation utility for cluster support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ __pycache__/
 
 # macOS specific files
 .DS_Store
+
+# Maven build directory
+target/

--- a/migrations/lm/v111__add_cluster_to_datasources.sql
+++ b/migrations/lm/v111__add_cluster_to_datasources.sql
@@ -1,0 +1,8 @@
+ALTER TABLE kruize_datasources
+ADD COLUMN IF NOT EXISTS clusters JSONB;
+
+-- Add comment for documentation
+COMMENT ON COLUMN kruize_datasources.clusters IS 'JSON array of cluster names associated with this datasource, e.g. ["cluster-1","cluster-2"]';
+
+-- Note: No default value is set to maintain backward compatibility
+-- Existing datasources will have NULL clusters, which is handled gracefully in the application code

--- a/src/main/java/com/autotune/common/datasource/DataSourceInfo.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceInfo.java
@@ -155,11 +155,15 @@ public class DataSourceInfo {
     }
 
     /**
-     * Returns the list of cluster names associated with this datasource
-     * @return List of cluster names, empty list if no clusters defined
+     * Returns the list of cluster names associated with this datasource.
+     * The {@code clusters} field is final and set once at construction time;
+     * all callers only read the list, so returning the same reference is safe
+     * and avoids allocating a new list on every call.
+     *
+     * @return list of cluster names; empty list if no clusters were provided
      */
     public List<String> getClusters() {
-        return new ArrayList<>(clusters);
+        return clusters;
     }
 
     @Override

--- a/src/main/java/com/autotune/common/datasource/DataSourceInfo.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceInfo.java
@@ -17,6 +17,8 @@ package com.autotune.common.datasource;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.common.auth.AuthenticationConfig;
@@ -41,10 +43,15 @@ public class DataSourceInfo {
     private final String namespace;
     private final URL url;
     private AuthenticationConfig authenticationConfig;
+    private final List<String> clusters;
 
     private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(DataSourceInfo.class);
 
     public DataSourceInfo(String name, String provider, String serviceName, String namespace, URL url, AuthenticationConfig authConfig) {
+        this(name, provider, serviceName, namespace, url, authConfig, null);
+    }
+
+    public DataSourceInfo(String name, String provider, String serviceName, String namespace, URL url, AuthenticationConfig authConfig, List<String> clusters) {
         this.name = name;
         this.provider = provider;
         if (null == url) {
@@ -55,6 +62,7 @@ public class DataSourceInfo {
         this.serviceName = serviceName;
         this.namespace = namespace;
         this.authenticationConfig = authConfig;
+        this.clusters = (clusters != null) ? new ArrayList<>(clusters) : new ArrayList<>();
     }
 
     /**
@@ -146,6 +154,14 @@ public class DataSourceInfo {
         LOGGER.debug("Authentication details for datasource {} have been updated.", this.name);
     }
 
+    /**
+     * Returns the list of cluster names associated with this datasource
+     * @return List of cluster names, empty list if no clusters defined
+     */
+    public List<String> getClusters() {
+        return new ArrayList<>(clusters);
+    }
+
     @Override
     public String toString() {
         return "DataSourceInfo{" +
@@ -154,6 +170,7 @@ public class DataSourceInfo {
                 ", serviceName='" + serviceName + '\'' +
                 ", namespace='" + namespace + '\'' +
                 ", url=" + url +
+                ", clusters=" + clusters +
                 '}';
     }
 }

--- a/src/main/java/com/autotune/database/table/KruizeDataSourceEntry.java
+++ b/src/main/java/com/autotune/database/table/KruizeDataSourceEntry.java
@@ -16,7 +16,13 @@
 
 package com.autotune.database.table;
 
+import com.autotune.utils.Utils;
+import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.persistence.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.List;
 
 /**
  * This is a Java class named KruizeDataSourceEntry annotated with JPA annotations.
@@ -42,6 +48,12 @@ public class KruizeDataSourceEntry {
     private String serviceName;
     private String namespace;
     private String url;
+
+    /** JSONB array of cluster names, e.g. {@code ["cluster-a","cluster-b"]}. */
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private JsonNode clusters;
+
     @ManyToOne(cascade = CascadeType.PERSIST) // Cascade PERSIST to auto-save authentication entry
     @JoinColumn(name = "authentication_id", nullable = false) // Foreign key column in the datasource table
     private KruizeAuthenticationEntry kruizeAuthenticationEntry;
@@ -100,5 +112,23 @@ public class KruizeDataSourceEntry {
 
     public void setUrl(String url) {
         this.url = url;
+    }
+
+    public JsonNode getClusters() {
+        return clusters;
+    }
+
+    public void setClusters(JsonNode clusters) {
+        this.clusters = clusters;
+    }
+
+    /**
+     * Returns the clusters JSONB column parsed into a {@code List<String>}.
+     * Delegates to {@link Utils#parseClusterList(JsonNode)}.
+     *
+     * @return list of cluster names; empty list if the column is null or malformed
+     */
+    public List<String> getClusterList() {
+        return Utils.parseClusterList(clusters);
     }
 }

--- a/src/main/java/com/autotune/utils/Utils.java
+++ b/src/main/java/com/autotune/utils/Utils.java
@@ -288,7 +288,7 @@ public class Utils {
             return new ArrayList<>();
         }
         // LinkedHashSet preserves insertion order while eliminating duplicates
-        Set<String> seen = new LinkedHashSet<>();
+        Set<String> clusters = new LinkedHashSet<>();
         for (JsonNode node : clustersNode) {
             if (node == null || !node.isTextual()) {
                 LOGGER.warn("Skipping non-textual cluster entry: {}", node);
@@ -303,10 +303,10 @@ public class Utils {
                 LOGGER.warn("Skipping cluster name '{}': exceeds max length of {} characters", name, MAX_CLUSTER_NAME_LENGTH);
                 continue;
             }
-            if (!seen.add(name)) {
+            if (!clusters.add(name)) {
                 LOGGER.warn("Skipping duplicate cluster name: '{}'", name);
             }
         }
-        return new ArrayList<>(seen);
+        return new ArrayList<>(clusters);
     }
 }

--- a/src/main/java/com/autotune/utils/Utils.java
+++ b/src/main/java/com/autotune/utils/Utils.java
@@ -276,12 +276,17 @@ public class Utils {
      * @return list of valid cluster-name strings, never {@code null}
      */
     public static List<String> parseClusterList(JsonNode clustersNode) {
-        if (clustersNode == null || !clustersNode.isArray()) {
+        if (clustersNode == null) {
+            LOGGER.warn("clusters JSONB node is null, returning empty list");
+            return new ArrayList<>();
+        }
+        if (!clustersNode.isArray()) {
+            LOGGER.warn("clusters JSONB node is not an array (was: {}), returning empty list", clustersNode.getNodeType());
             return new ArrayList<>();
         }
         List<String> result = new ArrayList<>();
         for (JsonNode node : clustersNode) {
-            if (!node.isTextual()) {
+            if (node == null || !node.isTextual()) {
                 LOGGER.warn("Skipping non-textual cluster entry: {}", node);
                 continue;
             }

--- a/src/main/java/com/autotune/utils/Utils.java
+++ b/src/main/java/com/autotune/utils/Utils.java
@@ -24,6 +24,7 @@ import com.autotune.analyzer.utils.GsonUTCDateAdapter;
 import com.autotune.common.data.metrics.MetricMetadata;
 import com.autotune.common.data.result.ContainerData;
 import com.autotune.common.data.system.info.device.DeviceDetails;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.gson.ExclusionStrategy;
 import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
@@ -39,7 +40,9 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 /**
  * Contains methods that are of general utility in the codebase
@@ -252,5 +255,47 @@ public class Utils {
                 return null;
             }
         }
+    }
+
+    // Maximum length for a single cluster name (mirrors DNS subdomain limit)
+    private static final int MAX_CLUSTER_NAME_LENGTH = 253;
+
+    /**
+     * Parses a JSONB-backed JsonNode (expected to be a JSON array of strings) into a
+     * {@code List<String>}.
+     * <p>
+     * Each element is validated before inclusion:
+     * <ul>
+     *   <li>Must be a non-null textual node</li>
+     *   <li>Cannot be blank after trimming</li>
+     *   <li>Cannot exceed {@value MAX_CLUSTER_NAME_LENGTH} characters</li>
+     * </ul>
+     * Invalid entries are logged and skipped; the method never returns {@code null}.
+     *
+     * @param clustersNode the JsonNode stored in the {@code clusters} JSONB column
+     * @return list of valid cluster-name strings, never {@code null}
+     */
+    public static List<String> parseClusterList(JsonNode clustersNode) {
+        if (clustersNode == null || !clustersNode.isArray()) {
+            return new ArrayList<>();
+        }
+        List<String> result = new ArrayList<>();
+        for (JsonNode node : clustersNode) {
+            if (!node.isTextual()) {
+                LOGGER.warn("Skipping non-textual cluster entry: {}", node);
+                continue;
+            }
+            String name = node.asText().trim();
+            if (name.isEmpty()) {
+                LOGGER.warn("Skipping blank cluster name entry");
+                continue;
+            }
+            if (name.length() > MAX_CLUSTER_NAME_LENGTH) {
+                LOGGER.warn("Skipping cluster name '{}': exceeds max length of {} characters", name, MAX_CLUSTER_NAME_LENGTH);
+                continue;
+            }
+            result.add(name);
+        }
+        return result;
     }
 }

--- a/src/main/java/com/autotune/utils/Utils.java
+++ b/src/main/java/com/autotune/utils/Utils.java
@@ -42,7 +42,9 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Contains methods that are of general utility in the codebase
@@ -269,11 +271,12 @@ public class Utils {
      *   <li>Must be a non-null textual node</li>
      *   <li>Cannot be blank after trimming</li>
      *   <li>Cannot exceed {@value MAX_CLUSTER_NAME_LENGTH} characters</li>
+     *   <li>Must not be a duplicate (case-sensitive; first occurrence is kept)</li>
      * </ul>
-     * Invalid entries are logged and skipped; the method never returns {@code null}.
+     * Invalid or duplicate entries are logged and skipped; the method never returns {@code null}.
      *
      * @param clustersNode the JsonNode stored in the {@code clusters} JSONB column
-     * @return list of valid cluster-name strings, never {@code null}
+     * @return list of valid, deduplicated cluster-name strings, never {@code null}
      */
     public static List<String> parseClusterList(JsonNode clustersNode) {
         if (clustersNode == null) {
@@ -284,7 +287,8 @@ public class Utils {
             LOGGER.warn("clusters JSONB node is not an array (was: {}), returning empty list", clustersNode.getNodeType());
             return new ArrayList<>();
         }
-        List<String> result = new ArrayList<>();
+        // LinkedHashSet preserves insertion order while eliminating duplicates
+        Set<String> seen = new LinkedHashSet<>();
         for (JsonNode node : clustersNode) {
             if (node == null || !node.isTextual()) {
                 LOGGER.warn("Skipping non-textual cluster entry: {}", node);
@@ -299,8 +303,10 @@ public class Utils {
                 LOGGER.warn("Skipping cluster name '{}': exceeds max length of {} characters", name, MAX_CLUSTER_NAME_LENGTH);
                 continue;
             }
-            result.add(name);
+            if (!seen.add(name)) {
+                LOGGER.warn("Skipping duplicate cluster name: '{}'", name);
+            }
         }
-        return result;
+        return new ArrayList<>(seen);
     }
 }


### PR DESCRIPTION
## Description

This PR adds the foundational infrastructure for cluster name support in Kruize, including database schema, JPA entities, data models, and validation utilities.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Summary by Sourcery

Add foundational support for associating data sources with validated cluster names across the application and database.

New Features:
- Allow datasources to store and expose associated cluster names via the domain model and public API.
- Introduce centralized utilities for validating and parsing cluster names according to DNS-1123 rules.

Enhancements:
- Extend datasource information handling to include cluster metadata while preserving backward compatibility.

Chores:
- Add a database migration to persist cluster name associations on the kruize_datasources table.