### PR TITLE
PR #2: Integrate cluster support into datasource layer

### DIFF
--- a/src/main/java/com/autotune/analyzer/adapters/DataSourceInfoAdapter.java
+++ b/src/main/java/com/autotune/analyzer/adapters/DataSourceInfoAdapter.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package com.autotune.analyzer.adapters;
+
+import com.autotune.common.datasource.DataSourceInfo;
+import com.autotune.utils.KruizeConstants;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import java.lang.reflect.Type;
+import java.util.List;
+
+/**
+ * Custom Gson serializer for DataSourceInfo to conditionally exclude empty clusters field.
+ * Uses constants from {@link KruizeConstants} for JSON key names so that serialization
+ * and deserialization (e.g., in DataSourceCollection) always use the same strings.
+ */
+public class DataSourceInfoAdapter implements JsonSerializer<DataSourceInfo> {
+
+    @Override
+    public JsonElement serialize(DataSourceInfo src, Type typeOfSrc, JsonSerializationContext context) {
+        JsonObject jsonObject = new JsonObject();
+
+        jsonObject.addProperty(KruizeConstants.DataSourceConstants.DATASOURCE_NAME, src.getName());
+        jsonObject.addProperty(KruizeConstants.DataSourceConstants.DATASOURCE_PROVIDER, src.getProvider());
+        jsonObject.addProperty(KruizeConstants.DataSourceConstants.DATASOURCE_SERVICE_NAME, src.getServiceName());
+        jsonObject.addProperty(KruizeConstants.DataSourceConstants.DATASOURCE_SERVICE_NAMESPACE, src.getNamespace());
+        jsonObject.addProperty(KruizeConstants.DataSourceConstants.DATASOURCE_URL,
+                src.getUrl() != null ? src.getUrl().toString() : null);
+
+        // Use the same "authentication" key as AuthenticationConstants and the design contract
+        if (src.getAuthenticationConfig() != null) {
+            jsonObject.add(KruizeConstants.AuthenticationConstants.AUTHENTICATION,
+                    context.serialize(src.getAuthenticationConfig()));
+        }
+
+        // Only add clusters field if the list is not empty
+        List<String> clusters = src.getClusters();
+        if (clusters != null && !clusters.isEmpty()) {
+            jsonObject.add(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.CLUSTERS,
+                    context.serialize(clusters));
+        }
+
+        return jsonObject;
+    }
+}

--- a/src/main/java/com/autotune/analyzer/services/ListDatasources.java
+++ b/src/main/java/com/autotune/analyzer/services/ListDatasources.java
@@ -16,6 +16,7 @@
 
 package com.autotune.analyzer.services;
 
+import com.autotune.analyzer.adapters.DataSourceInfoAdapter;
 import com.autotune.analyzer.adapters.DeviceDetailsAdapter;
 import com.autotune.analyzer.adapters.RecommendationItemAdapter;
 import com.autotune.analyzer.serviceObjects.ListDatasourcesAPIObject;
@@ -153,6 +154,7 @@ public class ListDatasources extends HttpServlet {
                 .registerTypeAdapter(Date.class, new GsonUTCDateAdapter())
                 .registerTypeAdapter(AnalyzerConstants.RecommendationItem.class, new RecommendationItemAdapter())
                 .registerTypeAdapter(DeviceDetails.class, new DeviceDetailsAdapter())
+                .registerTypeAdapter(DataSourceInfo.class, new DataSourceInfoAdapter())
                 .create();
     }
 

--- a/src/main/java/com/autotune/common/datasource/DataSourceCollection.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceCollection.java
@@ -200,6 +200,28 @@ public class DataSourceCollection {
                 String dataSourceURL = dataSourceObject.optString(KruizeConstants.DataSourceConstants.DATASOURCE_URL);
                 LOGGER.info(dataSourceURL);
                 AuthenticationConfig authConfig = getAuthenticationDetails(dataSourceObject, name);
+                
+                // Extract and validate clusters array if present
+                List<String> clusters = new ArrayList<>();
+                if (dataSourceObject.has(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.CLUSTERS)) {
+                    JSONArray clustersArray = dataSourceObject.optJSONArray(KruizeConstants.DataSourceConstants.DataSourceMetadataInfoJSONKeys.CLUSTERS);
+                    if (clustersArray != null) {
+                        for (int i = 0; i < clustersArray.length(); i++) {
+                            String clusterName = clustersArray.optString(i, null);
+                            if (clusterName == null) {
+                                LOGGER.warn("Null cluster name encountered for datasource '{}', index {}. Skipping entry.", name, i);
+                                continue;
+                            }
+                            String trimmedClusterName = clusterName.trim();
+                            if (trimmedClusterName.isEmpty()) {
+                                LOGGER.warn("Blank cluster name encountered for datasource '{}', index {}. Skipping entry.", name, i);
+                                continue;
+                            }
+                            clusters.add(trimmedClusterName);
+                        }
+                        LOGGER.debug("Valid clusters for datasource {}: count={}", name, clusters.size());
+                    }
+                }
 
                 // Validate input
                 if (!validateInput(name, provider, serviceName, dataSourceURL, namespace)) { //TODO: add validations for auth
@@ -212,7 +234,7 @@ public class DataSourceCollection {
                     if (!dataSourceURL.isBlank()) {
                         url = new URI(dataSourceURL).toURL();
                     }
-                    dataSourceInfo = new DataSourceInfo(name, provider, serviceName, namespace, url, authConfig);
+                    dataSourceInfo = new DataSourceInfo(name, provider, serviceName, namespace, url, authConfig, clusters);
 
                     // Attempt to add, addDataSource() returns corresponding exception if it fails. Increment the success count otherwise.
                     addDataSource(dataSourceInfo);

--- a/src/main/java/com/autotune/database/helper/DBHelpers.java
+++ b/src/main/java/com/autotune/database/helper/DBHelpers.java
@@ -79,6 +79,7 @@ import static com.autotune.utils.KruizeConstants.KRUIZE_BULK_API.JOB_ID;
  */
 public class DBHelpers {
     private static final Logger LOGGER = LoggerFactory.getLogger(DBHelpers.class);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
 
     private DBHelpers() {
@@ -1247,8 +1248,8 @@ public class DBHelpers {
                     }
                     // Convert List<String> clusters to JsonNode and store as JSONB
                     List<String> clusterList = dataSourceInfo.getClusters();
-                    if (!clusterList.isEmpty()) {
-                        kruizeDataSource.setClusters(new ObjectMapper().valueToTree(clusterList));
+                    if (clusterList != null && !clusterList.isEmpty()) {
+                        kruizeDataSource.setClusters(OBJECT_MAPPER.valueToTree(clusterList));
                     }
                 } catch (Exception e) {
                     kruizeDataSource = null;

--- a/src/main/java/com/autotune/database/helper/DBHelpers.java
+++ b/src/main/java/com/autotune/database/helper/DBHelpers.java
@@ -1202,12 +1202,15 @@ public class DBHelpers {
                                 LOGGER.error("GSON failed to convert the DB Json object in convertKruizeDataSourceToDataSourceObject");
                             }
                         }
+                        // Get cluster list from database entry
+                        List<String> clusterList = kruizeDataSource.getClusterList();
+                        
                         if (kruizeDataSource.getServiceName().isEmpty() && null != kruizeDataSource.getUrl()) {
                             dataSourceInfo = new DataSourceInfo(kruizeDataSource.getName(), kruizeDataSource
-                                    .getProvider(), null, null, new URL(kruizeDataSource.getUrl()), authConfig);
+                                    .getProvider(), null, null, new URL(kruizeDataSource.getUrl()), authConfig, clusterList);
                         } else {
                             dataSourceInfo = new DataSourceInfo(kruizeDataSource.getName(), kruizeDataSource
-                                    .getProvider(), kruizeDataSource.getServiceName(), kruizeDataSource.getNamespace(), null, authConfig);
+                                    .getProvider(), kruizeDataSource.getServiceName(), kruizeDataSource.getNamespace(), null, authConfig, clusterList);
                         }
                         dataSourceInfoList.add(dataSourceInfo);
                     } catch (Exception e) {
@@ -1238,7 +1241,15 @@ public class DBHelpers {
                     kruizeDataSource.setProvider(dataSourceInfo.getProvider());
                     kruizeDataSource.setServiceName(dataSourceInfo.getServiceName());
                     kruizeDataSource.setNamespace(dataSourceInfo.getNamespace());
-                    kruizeDataSource.setUrl(dataSourceInfo.getUrl().toString());
+                    // Only set URL if it's not null (service-based datasources have null URL)
+                    if (dataSourceInfo.getUrl() != null) {
+                        kruizeDataSource.setUrl(dataSourceInfo.getUrl().toString());
+                    }
+                    // Convert List<String> clusters to JsonNode and store as JSONB
+                    List<String> clusterList = dataSourceInfo.getClusters();
+                    if (!clusterList.isEmpty()) {
+                        kruizeDataSource.setClusters(new ObjectMapper().valueToTree(clusterList));
+                    }
                 } catch (Exception e) {
                     kruizeDataSource = null;
                     LOGGER.error("Error while converting DataSource Object to KruizeDataSource table due to {}", e.getMessage());


### PR DESCRIPTION
## Description

What This Enables:
✅ Loading datasources with clusters from config files
✅ Storing clusters in database (using PR #1's schema)
✅ Retrieving clusters from database
✅ Returning clusters in ListDatasources API response
✅ Validation of cluster names (using PR #1's utility)

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [x] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Add cluster-awareness to datasource configuration, persistence, and listing APIs.

New Features:
- Allow datasources to declare associated cluster names via configuration and store them in the database.
- Expose validated cluster lists for datasources through the ListDatasources API while omitting empty cluster data from responses.

Enhancements:
- Introduce utility helpers for validating, parsing, and formatting cluster name lists used across datasource and database layers.

Chores:
- Add a database migration to persist comma-separated cluster names for datasources in the kruize_datasources table.

## Summary by Sourcery

Add cluster awareness to datasources across configuration loading, database persistence, and listing APIs.

New Features:
- Support declaring and validating datasource clusters from configuration files and carrying them into DataSourceInfo objects.
- Persist datasource cluster lists in the database and hydrate them back into DataSourceInfo when reading from storage.
- Expose datasource cluster information via the ListDatasources API while omitting clusters when none are defined.

Enhancements:
- Introduce a custom Gson adapter for DataSourceInfo to control JSON serialization and keep cluster and authentication fields consistent.
- Guard database URL mapping to avoid writing null URLs for service-based datasources.