### PR TITLE
PR #3: Add cluster_name support to Bulk API

### DIFF
--- a/src/main/java/com/autotune/analyzer/serviceObjects/BulkInput.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/BulkInput.java
@@ -30,6 +30,13 @@ public class BulkInput {
     private String metadata_profile;
     private String measurement_duration;
     private String requestId; //TODO: to be used for the Kafka consumer case to map requestID with jobID
+    
+    /**
+     * Cluster name to use for all experiments in this bulk job.
+     * If provided, overrides cluster name from datasource metadata.
+     * If not provided, cluster name from metadata will be used.
+     */
+    private String cluster_name;
 
     // Getters and Setters
 
@@ -47,7 +54,7 @@ public class BulkInput {
     @JsonIgnore
     public boolean isEmpty() {
         return (filter == null && time_range == null && measurement_duration == null && metadata_profile == null
-                && datasource == null);
+                && datasource == null && cluster_name == null);
     }
 
     public TimeRange getTime_range() {
@@ -89,6 +96,14 @@ public class BulkInput {
     public String getMeasurement_duration() {return measurement_duration;}
 
     public void setMeasurement_duration(String measurement_duration) {this.measurement_duration = measurement_duration;}
+
+    public String getCluster_name() {
+        return cluster_name;
+    }
+
+    public void setCluster_name(String cluster_name) {
+        this.cluster_name = cluster_name;
+    }
 
     // Nested class for FilterWrapper that contains 'exclude' and 'include'
     public static class FilterWrapper {

--- a/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
+++ b/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
@@ -513,6 +513,9 @@ public class BulkJobManager implements Runnable {
             for (DataSource ds : dataSourceCollection) {
                 HashMap<String, DataSourceCluster> clusterHashMap = ds.getClusters();
                 for (DataSourceCluster dsc : clusterHashMap.values()) {
+                    String clusterName = this.bulkInput.getCluster_name() != null
+                            ? this.bulkInput.getCluster_name()
+                            : dsc.getDataSourceClusterName();
                     HashMap<String, DataSourceNamespace> namespaceHashMap = dsc.getNamespaces();
                     for (DataSourceNamespace namespace : namespaceHashMap.values()) {
                         HashMap<String, DataSourceWorkload> dataSourceWorkloadHashMap = namespace.getWorkloads();
@@ -522,10 +525,10 @@ public class BulkJobManager implements Runnable {
                                 if (dataSourceContainerHashMap != null) {
                                     for (DataSourceContainer dc : dataSourceContainerHashMap.values()) {
                                         // Experiment name - dynamically constructed
-                                        String experiment_name = frameExperimentName(labelString, dsc, namespace, dsw, dc);
+                                        String experiment_name = frameExperimentName(labelString, clusterName, namespace, dsw, dc);
                                         // create JSON to be passed in the createExperimentAPI
                                         List<CreateExperimentAPIObject> createExperimentAPIObjectList = new ArrayList<>();
-                                        CreateExperimentAPIObject apiObject = prepareCreateExperimentJSONInput(dc, dsc, dsw, namespace,
+                                        CreateExperimentAPIObject apiObject = prepareCreateExperimentJSONInput(dc, clusterName, dsw, namespace,
                                                 experiment_name, createExperimentAPIObjectList);
                                         createExperimentAPIObjectMap.put(experiment_name, apiObject);
                                     }
@@ -609,14 +612,14 @@ public class BulkJobManager implements Runnable {
 
     /**
      * @param dc                         DataSourceContainer object to get the container details
-     * @param dsc                        DataSourceCluster object to get the cluster details
+     * @param clusterName                resolved cluster name (user override or data source cluster name)
      * @param dsw                        DataSourceWorkload object to get the workload details
      * @param namespace                  DataSourceNamespace object to get the namespace details
      * @param createExperimentAPIObjects
      * @return Json string to be sent to the createExperimentAPI for experiment creation
      * @throws JsonProcessingException
      */
-    private CreateExperimentAPIObject prepareCreateExperimentJSONInput(DataSourceContainer dc, DataSourceCluster dsc, DataSourceWorkload dsw,
+    private CreateExperimentAPIObject prepareCreateExperimentJSONInput(DataSourceContainer dc, String clusterName, DataSourceWorkload dsw,
                                                                        DataSourceNamespace namespace, String experiment_name, List<CreateExperimentAPIObject> createExperimentAPIObjects) throws IOException {
 
         CreateExperimentAPIObject createExperimentAPIObject = new CreateExperimentAPIObject();
@@ -625,9 +628,6 @@ public class BulkJobManager implements Runnable {
         createExperimentAPIObject.setApiVersion(CREATE_EXPERIMENT_CONFIG_BEAN.getVersion());
         createExperimentAPIObject.setExperimentName(experiment_name);
         createExperimentAPIObject.setDatasource(this.bulkInput.getDatasource());
-        String clusterName = this.bulkInput.getCluster_name() != null
-                ? this.bulkInput.getCluster_name()
-                : dsc.getDataSourceClusterName();
         createExperimentAPIObject.setClusterName(clusterName);
         createExperimentAPIObject.setPerformanceProfile(CREATE_EXPERIMENT_CONFIG_BEAN.getPerformanceProfile());
         createExperimentAPIObject.setMetadataProfile(CREATE_EXPERIMENT_CONFIG_BEAN.getMetadataProfile());
@@ -668,10 +668,9 @@ public class BulkJobManager implements Runnable {
      * @param dataSourceContainer
      * @return
      */
-    public String frameExperimentName(String labelString, DataSourceCluster dataSourceCluster, DataSourceNamespace dataSourceNamespace, DataSourceWorkload dataSourceWorkload, DataSourceContainer dataSourceContainer) {
+    public String frameExperimentName(String labelString, String clusterName, DataSourceNamespace dataSourceNamespace, DataSourceWorkload dataSourceWorkload, DataSourceContainer dataSourceContainer) {
 
         String datasource = this.bulkInput.getDatasource();
-        String clusterName = dataSourceCluster.getDataSourceClusterName();
         String namespace = dataSourceNamespace.getNamespace();
         String workloadName = dataSourceWorkload.getWorkloadName();
         String workloadType = dataSourceWorkload.getWorkloadType();

--- a/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
+++ b/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
@@ -625,7 +625,15 @@ public class BulkJobManager implements Runnable {
         createExperimentAPIObject.setApiVersion(CREATE_EXPERIMENT_CONFIG_BEAN.getVersion());
         createExperimentAPIObject.setExperimentName(experiment_name);
         createExperimentAPIObject.setDatasource(this.bulkInput.getDatasource());
-        createExperimentAPIObject.setClusterName(dsc.getDataSourceClusterName());
+        // Use cluster_name from bulk payload if provided (trimmed), otherwise use metadata cluster
+        String clusterName = dsc.getDataSourceClusterName(); // default to metadata cluster
+        if (this.bulkInput.getCluster_name() != null) {
+            String trimmedClusterName = this.bulkInput.getCluster_name().trim();
+            if (!trimmedClusterName.isEmpty()) {
+                clusterName = trimmedClusterName;
+            }
+        }
+        createExperimentAPIObject.setClusterName(clusterName);
         createExperimentAPIObject.setPerformanceProfile(CREATE_EXPERIMENT_CONFIG_BEAN.getPerformanceProfile());
         createExperimentAPIObject.setMetadataProfile(CREATE_EXPERIMENT_CONFIG_BEAN.getMetadataProfile());
         List<KubernetesAPIObject> kubernetesAPIObjectList = new ArrayList<>();
@@ -638,8 +646,11 @@ public class BulkJobManager implements Runnable {
         kubernetesAPIObject.setNamespace(namespace.getNamespace());
         kubernetesAPIObjectList.add(kubernetesAPIObject);
         createExperimentAPIObject.setKubernetesObjects(kubernetesAPIObjectList);
+        
+        // Create recommendation settings with threshold
         RecommendationSettings rs = new RecommendationSettings();
         rs.setThreshold(CREATE_EXPERIMENT_CONFIG_BEAN.getThreshold());
+        
         createExperimentAPIObject.setRecommendationSettings(rs);
         TrialSettings trialSettings = new TrialSettings();
         trialSettings.setMeasurement_durationMinutes(CREATE_EXPERIMENT_CONFIG_BEAN.getMeasurementDurationStr());

--- a/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
+++ b/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
@@ -625,14 +625,9 @@ public class BulkJobManager implements Runnable {
         createExperimentAPIObject.setApiVersion(CREATE_EXPERIMENT_CONFIG_BEAN.getVersion());
         createExperimentAPIObject.setExperimentName(experiment_name);
         createExperimentAPIObject.setDatasource(this.bulkInput.getDatasource());
-        // Use cluster_name from bulk payload if provided (trimmed), otherwise use metadata cluster
-        String clusterName = dsc.getDataSourceClusterName(); // default to metadata cluster
-        if (this.bulkInput.getCluster_name() != null) {
-            String trimmedClusterName = this.bulkInput.getCluster_name().trim();
-            if (!trimmedClusterName.isEmpty()) {
-                clusterName = trimmedClusterName;
-            }
-        }
+        String clusterName = this.bulkInput.getCluster_name() != null
+                ? this.bulkInput.getCluster_name()
+                : dsc.getDataSourceClusterName();
         createExperimentAPIObject.setClusterName(clusterName);
         createExperimentAPIObject.setPerformanceProfile(CREATE_EXPERIMENT_CONFIG_BEAN.getPerformanceProfile());
         createExperimentAPIObject.setMetadataProfile(CREATE_EXPERIMENT_CONFIG_BEAN.getMetadataProfile());

--- a/src/main/java/com/autotune/common/bulk/BulkServiceValidation.java
+++ b/src/main/java/com/autotune/common/bulk/BulkServiceValidation.java
@@ -68,9 +68,16 @@ public class BulkServiceValidation {
         validationOutputData = buildErrorOutput(validateTimeRange(payload.getTime_range()), jobID);
         if (validationOutputData != null) return validationOutputData;
 
-        // Validate cluster_name if provided
-        validationOutputData = buildErrorOutput(validateClusterName(payload.getCluster_name()), jobID);
-        if (validationOutputData != null) return validationOutputData;
+        // validateClusterName both validates and returns the normalized (trimmed) cluster name.
+        // Writing the result back onto the payload means all downstream callers (e.g. BulkJobManager)
+        // can use payload.getCluster_name() directly without repeating trim/empty checks.
+        String[] clusterNameError = new String[1];
+        String normalizedClusterName = validateClusterName(payload.getCluster_name(), clusterNameError);
+        if (clusterNameError[0] != null) {
+            return buildErrorOutput(clusterNameError[0], jobID);
+        }
+        // null means the field was not supplied (optional); a non-null trimmed value is written back.
+        payload.setCluster_name(normalizedClusterName);
 
         if (payload.getDatasource() != null) {
             validationOutputData = buildErrorOutput(validateDatasourceConnection(payload.getDatasource()), jobID);
@@ -173,25 +180,41 @@ public class BulkServiceValidation {
     }
 
     /**
-     * Validates the cluster_name field if provided.
-     * Null is valid since cluster_name is an optional field.
-     * Checks that the name is not blank and does not exceed 253 characters.
+     * Validates the {@code cluster_name} field and returns its normalized (trimmed) value.
      *
-     * @param clusterName the cluster name to validate (can be null for optional field)
-     * @return an error message if validation fails; otherwise an empty string
+     * <p>This method centralizes all trimming and length-checking logic so callers never
+     * need to repeat these operations:
+     * <ul>
+     *   <li>If {@code clusterName} is {@code null} (optional field not supplied), {@code null}
+     *       is returned and {@code errorOut[0]} is left as {@code null} — "not set" is valid.</li>
+     *   <li>If the trimmed value is blank, {@code null} is returned and {@code errorOut[0]}
+     *       is set to {@link KruizeConstants.KRUIZE_BULK_API#CLUSTER_NAME_EMPTY}.</li>
+     *   <li>If the trimmed value exceeds {@link KruizeConstants.KRUIZE_BULK_API#MAX_CLUSTER_NAME_LENGTH}
+     *       characters, {@code null} is returned and {@code errorOut[0]} is set to the
+     *       {@link KruizeConstants.KRUIZE_BULK_API#CLUSTER_NAME_TOO_LONG} message.</li>
+     *   <li>Otherwise the trimmed, valid value is returned and {@code errorOut[0]} remains {@code null}.</li>
+     * </ul>
+     *
+     * @param clusterName the raw cluster name from the request payload (may be null)
+     * @param errorOut    a single-element array used to surface the error message; {@code errorOut[0]}
+     *                    is {@code null} when validation succeeds
+     * @return the trimmed cluster name on success; {@code null} when not supplied or on validation failure
      */
-    public static String validateClusterName(String clusterName) {
+    public static String validateClusterName(String clusterName, String[] errorOut) {
         if (clusterName == null) {
-            return ""; // Optional field
+            return null; // Optional field — not supplied, no error
         }
         String trimmed = clusterName.trim();
         if (trimmed.isEmpty()) {
-            return "cluster_name cannot be an empty string";
+            errorOut[0] = KruizeConstants.KRUIZE_BULK_API.CLUSTER_NAME_EMPTY;
+            return null;
         }
-        if (trimmed.length() > 253) {
-            return String.format("cluster_name is too long (max 253 characters, got %d)", trimmed.length());
+        if (trimmed.length() > KruizeConstants.KRUIZE_BULK_API.MAX_CLUSTER_NAME_LENGTH) {
+            errorOut[0] = String.format(KruizeConstants.KRUIZE_BULK_API.CLUSTER_NAME_TOO_LONG,
+                    KruizeConstants.KRUIZE_BULK_API.MAX_CLUSTER_NAME_LENGTH, trimmed.length());
+            return null;
         }
-        return "";
+        return trimmed; // Normalized value
     }
 
 }

--- a/src/main/java/com/autotune/common/bulk/BulkServiceValidation.java
+++ b/src/main/java/com/autotune/common/bulk/BulkServiceValidation.java
@@ -68,6 +68,10 @@ public class BulkServiceValidation {
         validationOutputData = buildErrorOutput(validateTimeRange(payload.getTime_range()), jobID);
         if (validationOutputData != null) return validationOutputData;
 
+        // Validate cluster_name if provided
+        validationOutputData = buildErrorOutput(validateClusterName(payload.getCluster_name()), jobID);
+        if (validationOutputData != null) return validationOutputData;
+
         if (payload.getDatasource() != null) {
             validationOutputData = buildErrorOutput(validateDatasourceConnection(payload.getDatasource()), jobID);
         }
@@ -167,4 +171,27 @@ public class BulkServiceValidation {
         }
         return errorMessage;
     }
+
+    /**
+     * Validates the cluster_name field if provided.
+     * Null is valid since cluster_name is an optional field.
+     * Checks that the name is not blank and does not exceed 253 characters.
+     *
+     * @param clusterName the cluster name to validate (can be null for optional field)
+     * @return an error message if validation fails; otherwise an empty string
+     */
+    public static String validateClusterName(String clusterName) {
+        if (clusterName == null) {
+            return ""; // Optional field
+        }
+        String trimmed = clusterName.trim();
+        if (trimmed.isEmpty()) {
+            return "cluster_name cannot be an empty string";
+        }
+        if (trimmed.length() > 253) {
+            return String.format("cluster_name is too long (max 253 characters, got %d)", trimmed.length());
+        }
+        return "";
+    }
+
 }

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -974,6 +974,16 @@ public class KruizeConstants {
         public static final String INVALID_DATE_FORMAT = "Invalid date format. Must follow ISO 8601 format (YYYY-MM-DDTHH:mm:ss.sssZ)";
         public static final String TIME_RANGE_EXCEPTION = "Exception occurred while validating the time range";
 
+        // cluster_name validation
+        /**
+         * Maximum allowed length for a cluster_name value.
+         * 253 is the maximum length of a DNS subdomain as defined in RFC 1123,
+         * which Kubernetes adopts as the upper bound for cluster-scoped identifiers.
+         */
+        public static final int MAX_CLUSTER_NAME_LENGTH = 253;
+        public static final String CLUSTER_NAME_EMPTY = "cluster_name cannot be an empty string";
+        public static final String CLUSTER_NAME_TOO_LONG = "cluster_name is too long (max %d characters, got %d)";
+
 
 
         // TODO : Bulk API Create Experiments defaults

--- a/src/test/java/com/autotune/analyzer/workerimpl/BulkJobManagerTest.java
+++ b/src/test/java/com/autotune/analyzer/workerimpl/BulkJobManagerTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.when;
 
 import com.autotune.analyzer.serviceObjects.BulkInput;
 import com.autotune.analyzer.serviceObjects.BulkJobStatus;
-import com.autotune.common.data.dataSourceMetadata.DataSourceCluster;
 import com.autotune.common.data.dataSourceMetadata.DataSourceContainer;
 import com.autotune.common.data.dataSourceMetadata.DataSourceNamespace;
 import com.autotune.common.data.dataSourceMetadata.DataSourceWorkload;
@@ -60,7 +59,7 @@ class BulkJobManagerMockedTest {
     private BulkInput bulkInput;
     private BulkJobStatus jobStatus;
 
-    private DataSourceCluster cluster;
+    private String clusterName;
     private DataSourceNamespace namespace;
     private DataSourceWorkload workload;
     private DataSourceContainer container;
@@ -78,8 +77,7 @@ class BulkJobManagerMockedTest {
 
         jobStatus = mock(BulkJobStatus.class);
 
-        cluster = mock(DataSourceCluster.class);
-        when(cluster.getDataSourceClusterName()).thenReturn("cluster1");
+        clusterName = "cluster1";
 
         namespace = mock(DataSourceNamespace.class);
         when(namespace.getNamespace()).thenReturn("default");
@@ -108,7 +106,7 @@ class BulkJobManagerMockedTest {
     void shouldFrameExperimentNameWithoutLabels() {
         // When
         String experimentName = bulkJobManager.frameExperimentName(
-                null, cluster, namespace, workload, container
+                null, clusterName, namespace, workload, container
         );
 
         // Then
@@ -129,7 +127,7 @@ class BulkJobManagerMockedTest {
 
         // When
         String experimentName = bulkJobManager.frameExperimentName(
-                labelString, cluster, namespace, workload, container
+                labelString, clusterName, namespace, workload, container
         );
 
         // Then


### PR DESCRIPTION
## Description

What This Enables:
Users can specify a single cluster_name in bulk requests
All experiments in the bulk job will use this cluster name
Backward compatible: if not provided, uses existing datasource metadata behavior

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Add optional cluster_name support to bulk experiment requests and apply it across all experiments in a bulk job.

New Features:
- Allow bulk API requests to specify an optional cluster_name applied to all experiments in the job.

Enhancements:
- Validate the optional cluster_name field for non-empty value and maximum length and integrate it into bulk job creation flow.