### PR TITLE
PR #4: Add comprehensive tests for cluster name support

### DIFF
--- a/src/test/java/com/autotune/analyzer/workerimpl/BulkJobManagerPassthroughTest.java
+++ b/src/test/java/com/autotune/analyzer/workerimpl/BulkJobManagerPassthroughTest.java
@@ -93,60 +93,74 @@ class BulkJobManagerPassthroughTest {
     @DisplayName("Cluster Name Passthrough Tests")
     class ClusterNamePassthroughTests {
 
+        /**
+         * Mirrors the resolution logic in BulkJobManager.getExperimentMap():
+         *   clusterName = bulkInput.getCluster_name() != null
+         *       ? bulkInput.getCluster_name()
+         *       : dsc.getDataSourceClusterName();
+         */
+        private String resolveClusterName(String payloadCluster, String metadataCluster) {
+            return payloadCluster != null ? payloadCluster : metadataCluster;
+        }
+
         @Test
-        @DisplayName("Should return cluster name from bulk payload when provided")
-        void shouldReturnClusterNameFromBulkPayload() {
-            // Given
+        @DisplayName("Payload cluster name is used in experiment name when provided")
+        void payloadClusterNameAppearsInExperimentName() {
+            // Given – bulk payload supplies an explicit cluster name
             when(bulkInput.getCluster_name()).thenReturn("custom-cluster");
+            String resolved = resolveClusterName(bulkInput.getCluster_name(),
+                    cluster.getDataSourceClusterName());
 
-            // When
-            String clusterName = bulkInput.getCluster_name();
+            // When – frameExperimentName builds the name from the resolved cluster
+            String experimentName = bulkJobManager.frameExperimentName(
+                    null, resolved, namespace, workload, container
+            );
 
-            // Then
-            assertEquals("custom-cluster", clusterName,
-                    "Should return cluster name from bulk payload");
+            // Then – the payload cluster name, not the metadata cluster, appears in the result
+            assertEquals("prometheus-custom-cluster-default-test-app-deployment-app-container",
+                    experimentName,
+                    "Experiment name must embed the cluster name supplied in the bulk payload");
+            assertFalse(experimentName.contains("metadata-cluster"),
+                    "Metadata cluster name must not leak into the experiment name when payload overrides it");
         }
 
         @Test
-        @DisplayName("Should return null when bulk payload cluster is null")
-        void shouldReturnNullWhenBulkPayloadClusterIsNull() {
-            // Given
+        @DisplayName("Metadata cluster name is used in experiment name when payload cluster is null")
+        void metadataClusterNameUsedWhenPayloadClusterIsNull() {
+            // Given – no cluster in the payload → fall back to data-source metadata
             when(bulkInput.getCluster_name()).thenReturn(null);
+            String resolved = resolveClusterName(bulkInput.getCluster_name(),
+                    cluster.getDataSourceClusterName());
 
             // When
-            String clusterName = bulkInput.getCluster_name();
+            String experimentName = bulkJobManager.frameExperimentName(
+                    null, resolved, namespace, workload, container
+            );
 
             // Then
-            assertNull(clusterName,
-                    "Should return null when bulk payload cluster is null");
+            assertEquals("prometheus-metadata-cluster-default-test-app-deployment-app-container",
+                    experimentName,
+                    "Experiment name must fall back to the metadata cluster name when payload is null");
         }
 
         @Test
-        @DisplayName("Should return empty string when bulk payload cluster is empty")
-        void shouldReturnEmptyStringWhenBulkPayloadClusterIsEmpty() {
-            // Given
-            when(bulkInput.getCluster_name()).thenReturn("");
-
-            // When
-            String clusterName = bulkInput.getCluster_name();
-
-            // Then
-            assertEquals("", clusterName,
-                    "Should return empty string when bulk payload cluster is empty");
-        }
-
-        @Test
-        @DisplayName("Should handle cluster name with special characters")
-        void shouldHandleClusterNameWithSpecialCharacters() {
+        @DisplayName("Cluster name with dots and hyphens is preserved verbatim in experiment name")
+        void clusterNameWithSpecialCharactersPreservedInExperimentName() {
             // Given
             when(bulkInput.getCluster_name()).thenReturn("prod-cluster-01.us-east");
+            String resolved = resolveClusterName(bulkInput.getCluster_name(),
+                    cluster.getDataSourceClusterName());
 
             // When
-            String clusterName = bulkInput.getCluster_name();
+            String experimentName = bulkJobManager.frameExperimentName(
+                    null, resolved, namespace, workload, container
+            );
 
             // Then
-            assertEquals("prod-cluster-01.us-east", clusterName,
-                    "Should handle cluster name with special characters");
+            assertTrue(experimentName.contains("prod-cluster-01.us-east"),
+                    "Special characters in cluster name must be preserved in the experiment name");
+            assertEquals("prometheus-prod-cluster-01.us-east-default-test-app-deployment-app-container",
+                    experimentName);
         }
     }
 
@@ -155,29 +169,47 @@ class BulkJobManagerPassthroughTest {
     class ClusterNameUsageTests {
 
         @Test
-        @DisplayName("Should use cluster name from bulk payload in experiment name")
-        void shouldUseClusterNameFromBulkPayloadInExperimentName() {
-            // Given
+        @DisplayName("Payload cluster name overrides metadata cluster name in experiment name")
+        void payloadClusterNameOverridesMetadataCluster() {
+            // Given – a different cluster in the payload vs the metadata
             when(bulkInput.getCluster_name()).thenReturn("prod-cluster");
+            // Resolution matches BulkJobManager.getExperimentMap() logic
+            String resolved = bulkInput.getCluster_name() != null
+                    ? bulkInput.getCluster_name()
+                    : cluster.getDataSourceClusterName();
 
             // When
-            String clusterName = bulkInput.getCluster_name();
+            String experimentName = bulkJobManager.frameExperimentName(
+                    null, resolved, namespace, workload, container
+            );
 
             // Then
-            assertEquals("prod-cluster", clusterName, "Cluster name should match");
+            assertEquals("prometheus-prod-cluster-default-test-app-deployment-app-container",
+                    experimentName,
+                    "Payload cluster name must be reflected in the generated experiment name");
+            assertFalse(experimentName.contains("metadata-cluster"),
+                    "Metadata cluster name must not appear when payload overrides it");
         }
 
         @Test
-        @DisplayName("Should handle null cluster name (backward compatibility)")
-        void shouldHandleNullClusterName() {
-            // Given
+        @DisplayName("Null payload cluster name falls back to metadata cluster in experiment name")
+        void nullPayloadClusterFallsBackToMetadataCluster() {
+            // Given – null cluster name in payload
             when(bulkInput.getCluster_name()).thenReturn(null);
+            String resolved = bulkInput.getCluster_name() != null
+                    ? bulkInput.getCluster_name()
+                    : cluster.getDataSourceClusterName();   // "metadata-cluster"
 
             // When
-            String clusterName = bulkInput.getCluster_name();
+            String experimentName = bulkJobManager.frameExperimentName(
+                    null, resolved, namespace, workload, container
+            );
 
             // Then
-            assertNull(clusterName, "Cluster name should be null");
+            assertTrue(experimentName.contains("metadata-cluster"),
+                    "Metadata cluster name must be used in the experiment name when payload cluster is null");
+            assertEquals("prometheus-metadata-cluster-default-test-app-deployment-app-container",
+                    experimentName);
         }
     }
 
@@ -186,14 +218,19 @@ class BulkJobManagerPassthroughTest {
     class BackwardCompatibilityTests {
 
         @Test
-        @DisplayName("Should maintain existing behavior when cluster name not provided")
+        @DisplayName("Omitting cluster_name in payload still produces a valid experiment name from metadata")
         void shouldMaintainExistingBehaviorWhenClusterNameNotProvided() {
-            // Given - Old-style bulk input without cluster name
+            // Given – old-style bulk input without cluster_name; BulkJobManager falls back to the
+            // metadata cluster name (mirrors the getExperimentMap() resolution logic)
             when(bulkInput.getCluster_name()).thenReturn(null);
+            String resolved = bulkInput.getCluster_name() != null
+                    ? bulkInput.getCluster_name()
+                    : cluster.getDataSourceClusterName();   // "metadata-cluster"
 
-            // When
+            // When – the resolved name is passed through to frameExperimentName, exactly as
+            // BulkJobManager does
             String experimentName = bulkJobManager.frameExperimentName(
-                    null, cluster.getDataSourceClusterName(), namespace, workload, container
+                    null, resolved, namespace, workload, container
             );
 
             // Then
@@ -205,16 +242,25 @@ class BulkJobManagerPassthroughTest {
         }
 
         @Test
-        @DisplayName("Should not break existing experiments without cluster name")
-        void shouldNotBreakExistingExperimentsWithoutClusterName() {
-            // Given
-            when(bulkInput.getCluster_name()).thenReturn(null);
+        @DisplayName("Providing cluster_name in payload overrides metadata cluster in backward-compat scenario")
+        void clusterNamePayloadOverridesMetadataInBackwardCompatScenario() {
+            // Given – a new bulk payload that adds cluster_name alongside existing fields
+            when(bulkInput.getCluster_name()).thenReturn("override-cluster");
+            String resolved = bulkInput.getCluster_name() != null
+                    ? bulkInput.getCluster_name()
+                    : cluster.getDataSourceClusterName();
 
-            // When - Verify that BulkInput can be created without cluster name
-            boolean hasClusterName = bulkInput.getCluster_name() != null;
+            // When
+            String experimentName = bulkJobManager.frameExperimentName(
+                    null, resolved, namespace, workload, container
+            );
 
-            // Then
-            assertFalse(hasClusterName, "Should not have cluster name");
+            // Then – the override cluster name must win; metadata cluster must not appear
+            assertEquals("prometheus-override-cluster-default-test-app-deployment-app-container",
+                    experimentName,
+                    "Adding cluster_name to an existing payload must override the metadata cluster name");
+            assertFalse(experimentName.contains("metadata-cluster"),
+                    "Metadata cluster must not bleed into the name when payload provides an override");
         }
     }
 }

--- a/src/test/java/com/autotune/analyzer/workerimpl/BulkJobManagerPassthroughTest.java
+++ b/src/test/java/com/autotune/analyzer/workerimpl/BulkJobManagerPassthroughTest.java
@@ -1,0 +1,220 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.autotune.analyzer.workerimpl;
+
+import com.autotune.analyzer.kruizeObject.KruizeObject;
+import com.autotune.analyzer.kruizeObject.RecommendationSettings;
+import com.autotune.analyzer.serviceObjects.BulkInput;
+import com.autotune.analyzer.serviceObjects.BulkJobStatus;
+import com.autotune.common.data.dataSourceMetadata.DataSourceCluster;
+import com.autotune.common.data.dataSourceMetadata.DataSourceContainer;
+import com.autotune.common.data.dataSourceMetadata.DataSourceNamespace;
+import com.autotune.common.data.dataSourceMetadata.DataSourceWorkload;
+import com.autotune.operator.KruizeDeploymentInfo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for BulkJobManager cluster name passthrough logic.
+ *
+ * Tests verify that:
+ * 1. Cluster name from bulk payload is correctly passed to experiments
+ * 2. Backward compatibility is maintained when cluster name is not provided
+ */
+class BulkJobManagerPassthroughTest {
+
+    private BulkJobManager bulkJobManager;
+    private BulkInput bulkInput;
+    private BulkJobStatus jobStatus;
+    private DataSourceCluster cluster;
+    private DataSourceNamespace namespace;
+    private DataSourceWorkload workload;
+    private DataSourceContainer container;
+    private String originalExperimentNameFormat;
+
+    @BeforeEach
+    void setup() {
+        // Capture static/global state
+        originalExperimentNameFormat = KruizeDeploymentInfo.experiment_name_format;
+
+        bulkInput = mock(BulkInput.class);
+        when(bulkInput.getDatasource()).thenReturn("prometheus");
+
+        jobStatus = mock(BulkJobStatus.class);
+
+        cluster = mock(DataSourceCluster.class);
+        when(cluster.getDataSourceClusterName()).thenReturn("metadata-cluster");
+
+        namespace = mock(DataSourceNamespace.class);
+        when(namespace.getNamespace()).thenReturn("default");
+
+        workload = mock(DataSourceWorkload.class);
+        when(workload.getWorkloadName()).thenReturn("test-app");
+        when(workload.getWorkloadType()).thenReturn("deployment");
+
+        container = mock(DataSourceContainer.class);
+        when(container.getContainerName()).thenReturn("app-container");
+
+        KruizeDeploymentInfo.experiment_name_format =
+                "%datasource%-%clustername%-%namespace%-%workloadname%-%workloadtype%-%containername%";
+
+        bulkJobManager = new BulkJobManager("job-123", jobStatus, bulkInput);
+    }
+
+    @AfterEach
+    void tearDown() {
+        // Restore static/global state
+        KruizeDeploymentInfo.experiment_name_format = originalExperimentNameFormat;
+    }
+
+    @Nested
+    @DisplayName("Cluster Name Passthrough Tests")
+    class ClusterNamePassthroughTests {
+
+        @Test
+        @DisplayName("Should return cluster name from bulk payload when provided")
+        void shouldReturnClusterNameFromBulkPayload() {
+            // Given
+            when(bulkInput.getCluster_name()).thenReturn("custom-cluster");
+
+            // When
+            String clusterName = bulkInput.getCluster_name();
+
+            // Then
+            assertEquals("custom-cluster", clusterName,
+                    "Should return cluster name from bulk payload");
+        }
+
+        @Test
+        @DisplayName("Should return null when bulk payload cluster is null")
+        void shouldReturnNullWhenBulkPayloadClusterIsNull() {
+            // Given
+            when(bulkInput.getCluster_name()).thenReturn(null);
+
+            // When
+            String clusterName = bulkInput.getCluster_name();
+
+            // Then
+            assertNull(clusterName,
+                    "Should return null when bulk payload cluster is null");
+        }
+
+        @Test
+        @DisplayName("Should return empty string when bulk payload cluster is empty")
+        void shouldReturnEmptyStringWhenBulkPayloadClusterIsEmpty() {
+            // Given
+            when(bulkInput.getCluster_name()).thenReturn("");
+
+            // When
+            String clusterName = bulkInput.getCluster_name();
+
+            // Then
+            assertEquals("", clusterName,
+                    "Should return empty string when bulk payload cluster is empty");
+        }
+
+        @Test
+        @DisplayName("Should handle cluster name with special characters")
+        void shouldHandleClusterNameWithSpecialCharacters() {
+            // Given
+            when(bulkInput.getCluster_name()).thenReturn("prod-cluster-01.us-east");
+
+            // When
+            String clusterName = bulkInput.getCluster_name();
+
+            // Then
+            assertEquals("prod-cluster-01.us-east", clusterName,
+                    "Should handle cluster name with special characters");
+        }
+    }
+
+    @Nested
+    @DisplayName("Cluster Name Usage Tests")
+    class ClusterNameUsageTests {
+
+        @Test
+        @DisplayName("Should use cluster name from bulk payload in experiment name")
+        void shouldUseClusterNameFromBulkPayloadInExperimentName() {
+            // Given
+            when(bulkInput.getCluster_name()).thenReturn("prod-cluster");
+
+            // When
+            String clusterName = bulkInput.getCluster_name();
+
+            // Then
+            assertEquals("prod-cluster", clusterName, "Cluster name should match");
+        }
+
+        @Test
+        @DisplayName("Should handle null cluster name (backward compatibility)")
+        void shouldHandleNullClusterName() {
+            // Given
+            when(bulkInput.getCluster_name()).thenReturn(null);
+
+            // When
+            String clusterName = bulkInput.getCluster_name();
+
+            // Then
+            assertNull(clusterName, "Cluster name should be null");
+        }
+    }
+
+    @Nested
+    @DisplayName("Backward Compatibility Tests")
+    class BackwardCompatibilityTests {
+
+        @Test
+        @DisplayName("Should maintain existing behavior when cluster name not provided")
+        void shouldMaintainExistingBehaviorWhenClusterNameNotProvided() {
+            // Given - Old-style bulk input without cluster name
+            when(bulkInput.getCluster_name()).thenReturn(null);
+
+            // When
+            String experimentName = bulkJobManager.frameExperimentName(
+                    null, cluster.getDataSourceClusterName(), namespace, workload, container
+            );
+
+            // Then
+            assertTrue(experimentName.contains("metadata-cluster"),
+                    "Should use metadata cluster when bulk payload cluster is not provided");
+            assertEquals("prometheus-metadata-cluster-default-test-app-deployment-app-container",
+                    experimentName,
+                    "Experiment name should follow existing format");
+        }
+
+        @Test
+        @DisplayName("Should not break existing experiments without cluster name")
+        void shouldNotBreakExistingExperimentsWithoutClusterName() {
+            // Given
+            when(bulkInput.getCluster_name()).thenReturn(null);
+
+            // When - Verify that BulkInput can be created without cluster name
+            boolean hasClusterName = bulkInput.getCluster_name() != null;
+
+            // Then
+            assertFalse(hasClusterName, "Should not have cluster name");
+        }
+    }
+}

--- a/src/test/java/com/autotune/common/bulk/BulkServiceValidationTest.java
+++ b/src/test/java/com/autotune/common/bulk/BulkServiceValidationTest.java
@@ -1,0 +1,189 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.autotune.common.bulk;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for BulkServiceValidation class.
+ * Tests validation logic for cluster_name, model_settings, and term_settings fields.
+ * 
+ * Test Structure:
+ * - Nested test classes for each validation method
+ * - Positive and negative test cases
+ * - Edge cases and boundary conditions
+ */
+class BulkServiceValidationTest {
+
+    @Nested
+    @DisplayName("Cluster Name Validation Tests")
+    class ClusterNameValidationTests {
+
+        @Test
+        @DisplayName("Should accept null cluster name")
+        void shouldAcceptNullClusterName() {
+            // Given
+            String[] errorOut = new String[1];
+
+            // When
+            String result = BulkServiceValidation.validateClusterName(null, errorOut);
+
+            // Then
+            assertNull(result, "Null cluster name should return null (optional field, not supplied)");
+            assertNull(errorOut[0], "No error should be set for null cluster name");
+        }
+
+        @Test
+        @DisplayName("Should reject empty string cluster name")
+        void shouldRejectEmptyStringClusterName() {
+            // Given
+            String[] errorOut = new String[1];
+
+            // When
+            String result = BulkServiceValidation.validateClusterName("", errorOut);
+
+            // Then
+            assertNull(result, "Empty string should return null");
+            assertNotNull(errorOut[0], "Error should be set for empty cluster name");
+            assertTrue(errorOut[0].contains("cannot be an empty string"),
+                "Empty string should be rejected");
+        }
+
+        @Test
+        @DisplayName("Should accept valid lowercase cluster name")
+        void shouldAcceptValidLowercaseClusterName() {
+            // Given
+            String[] errorOut = new String[1];
+
+            // When
+            String result = BulkServiceValidation.validateClusterName("cluster-a", errorOut);
+
+            // Then
+            assertEquals("cluster-a", result, "Valid lowercase cluster name should be returned");
+            assertNull(errorOut[0], "No error should be set for valid cluster name");
+        }
+
+        @Test
+        @DisplayName("Should accept cluster name with dots")
+        void shouldAcceptClusterNameWithDots() {
+            // Given
+            String[] errorOut = new String[1];
+
+            // When
+            String result = BulkServiceValidation.validateClusterName("cluster.prod.us-east", errorOut);
+
+            // Then
+            assertEquals("cluster.prod.us-east", result, "Cluster name with dots should be accepted");
+            assertNull(errorOut[0], "No error should be set for valid cluster name");
+        }
+
+        @Test
+        @DisplayName("Should accept cluster name with numbers")
+        void shouldAcceptClusterNameWithNumbers() {
+            // Given
+            String[] errorOut = new String[1];
+
+            // When
+            String result = BulkServiceValidation.validateClusterName("cluster-123", errorOut);
+
+            // Then
+            assertEquals("cluster-123", result, "Cluster name with numbers should be accepted");
+            assertNull(errorOut[0], "No error should be set for valid cluster name");
+        }
+
+        @Test
+        @DisplayName("Should reject cluster name exceeding 253 characters")
+        void shouldRejectClusterNameExceeding253Characters() {
+            // Given - Create a 254 character string
+            String longName = "a".repeat(254);
+            String[] errorOut = new String[1];
+
+            // When
+            String result = BulkServiceValidation.validateClusterName(longName, errorOut);
+
+            // Then
+            assertNull(result, "Cluster name exceeding 253 characters should return null");
+            assertNotNull(errorOut[0], "Error should be set for too-long cluster name");
+            assertTrue(errorOut[0].contains("too long"),
+                "Cluster name exceeding 253 characters should be rejected");
+        }
+
+        @Test
+        @DisplayName("Should accept cluster name with exactly 253 characters")
+        void shouldAcceptClusterNameWith253Characters() {
+            // Given - Create a valid 253 character string
+            String maxLengthName = "a" + "-".repeat(251) + "b";
+            String[] errorOut = new String[1];
+
+            // When
+            String result = BulkServiceValidation.validateClusterName(maxLengthName, errorOut);
+
+            // Then
+            assertEquals(maxLengthName, result, "253 character cluster name should be accepted");
+            assertNull(errorOut[0], "No error should be set for 253-character cluster name");
+        }
+
+        @Test
+        @DisplayName("Should accept single character cluster name")
+        void shouldAcceptSingleCharacterClusterName() {
+            // Given
+            String[] errorOut = new String[1];
+
+            // When
+            String result = BulkServiceValidation.validateClusterName("a", errorOut);
+
+            // Then
+            assertEquals("a", result, "Single character cluster name should be accepted");
+            assertNull(errorOut[0], "No error should be set for valid cluster name");
+        }
+
+        @Test
+        @DisplayName("Should return trimmed cluster name when leading and trailing whitespace present")
+        void shouldAcceptClusterNameWithWhitespaceAfterTrimming() {
+            // Given
+            String[] errorOut = new String[1];
+
+            // When
+            String result = BulkServiceValidation.validateClusterName("  prod-cluster  ", errorOut);
+
+            // Then
+            assertEquals("prod-cluster", result, "Cluster name should be trimmed");
+            assertNull(errorOut[0], "No error should be set for valid cluster name after trimming");
+        }
+
+        @Test
+        @DisplayName("Should reject whitespace-only cluster name")
+        void shouldRejectWhitespaceOnlyClusterName() {
+            // Given
+            String[] errorOut = new String[1];
+
+            // When
+            String result = BulkServiceValidation.validateClusterName("   ", errorOut);
+
+            // Then
+            assertNull(result, "Whitespace-only cluster name should return null");
+            assertNotNull(errorOut[0], "Error should be set for whitespace-only cluster name");
+            assertTrue(errorOut[0].contains("cannot be an empty string"),
+                "Whitespace-only cluster name should be rejected as empty");
+        }
+    }
+
+
+}

--- a/src/test/java/com/autotune/database/table/KruizeDataSourceEntryTest.java
+++ b/src/test/java/com/autotune/database/table/KruizeDataSourceEntryTest.java
@@ -1,0 +1,198 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package com.autotune.database.table;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for KruizeDataSourceEntry cluster functionality.
+ * The clusters column is stored as JSONB (JsonNode array of strings).
+ */
+public class KruizeDataSourceEntryTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /** Helper: build a JsonNode array from varargs strings */
+    private static ArrayNode jsonArray(String... values) {
+        ArrayNode arr = MAPPER.createArrayNode();
+        for (String v : values) arr.add(v);
+        return arr;
+    }
+
+    @Test
+    @DisplayName("Set and get cluster list with multiple clusters")
+    public void testSetAndGetClusterList() {
+        KruizeDataSourceEntry entry = new KruizeDataSourceEntry();
+        entry.setClusters(jsonArray("default", "stage", "prod"));
+
+        List<String> result = entry.getClusterList();
+        assertEquals(3, result.size());
+        assertTrue(result.contains("default"));
+        assertTrue(result.contains("stage"));
+        assertTrue(result.contains("prod"));
+    }
+
+    @Test
+    @DisplayName("Set and get single cluster")
+    public void testSingleCluster() {
+        KruizeDataSourceEntry entry = new KruizeDataSourceEntry();
+        entry.setClusters(jsonArray("default"));
+
+        List<String> result = entry.getClusterList();
+        assertEquals(1, result.size());
+        assertEquals("default", result.get(0));
+    }
+
+    @Test
+    @DisplayName("Null clusters JsonNode returns empty list")
+    public void testNullClustersNode() {
+        KruizeDataSourceEntry entry = new KruizeDataSourceEntry();
+        entry.setClusters(null);
+
+        assertNull(entry.getClusters());
+        assertTrue(entry.getClusterList().isEmpty());
+    }
+
+    @Test
+    @DisplayName("Empty JsonNode array returns empty list")
+    public void testEmptyArrayNode() {
+        KruizeDataSourceEntry entry = new KruizeDataSourceEntry();
+        entry.setClusters(MAPPER.createArrayNode());
+
+        assertNotNull(entry.getClusters());
+        assertTrue(entry.getClusterList().isEmpty());
+    }
+
+    @Test
+    @DisplayName("getClusterList when clusters field is never set")
+    public void testGetClusterListWhenNeverSet() {
+        KruizeDataSourceEntry entry = new KruizeDataSourceEntry();
+
+        List<String> result = entry.getClusterList();
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Blank/whitespace-only elements are skipped by parseClusterList")
+    public void testBlankElementsAreSkipped() {
+        KruizeDataSourceEntry entry = new KruizeDataSourceEntry();
+        ArrayNode arr = MAPPER.createArrayNode();
+        arr.add("valid-cluster");
+        arr.add("  ");          // whitespace-only — should be skipped
+        arr.add("");            // empty string — should be skipped
+        arr.add("another-valid");
+        entry.setClusters(arr);
+
+        List<String> result = entry.getClusterList();
+        assertEquals(2, result.size());
+        assertTrue(result.contains("valid-cluster"));
+        assertTrue(result.contains("another-valid"));
+    }
+
+    @Test
+    @DisplayName("Names exceeding 253 characters are skipped by parseClusterList")
+    public void testTooLongNamesAreSkipped() {
+        KruizeDataSourceEntry entry = new KruizeDataSourceEntry();
+        String tooLong = "a".repeat(254);
+        String atLimit  = "a".repeat(253);
+        entry.setClusters(jsonArray("short-name", tooLong, atLimit));
+
+        List<String> result = entry.getClusterList();
+        assertEquals(2, result.size());
+        assertTrue(result.contains("short-name"));
+        assertTrue(result.contains(atLimit));
+        assertFalse(result.contains(tooLong));
+    }
+
+    @Test
+    @DisplayName("Mixed valid and invalid cluster names - only valid ones returned")
+    public void testMixedValidAndInvalid() {
+        KruizeDataSourceEntry entry = new KruizeDataSourceEntry();
+        String tooLong = "x".repeat(300);
+        ArrayNode arr = MAPPER.createArrayNode();
+        arr.add("cluster1");
+        arr.add("");
+        arr.add("cluster2");
+        arr.add("   ");
+        arr.add(tooLong);
+        arr.add("cluster3");
+        entry.setClusters(arr);
+
+        List<String> result = entry.getClusterList();
+        assertEquals(3, result.size());
+        assertEquals("cluster1", result.get(0));
+        assertEquals("cluster2", result.get(1));
+        assertEquals("cluster3", result.get(2));
+    }
+
+    @Test
+    @DisplayName("Cluster names with special characters are preserved")
+    public void testClustersWithSpecialCharacters() {
+        KruizeDataSourceEntry entry = new KruizeDataSourceEntry();
+        entry.setClusters(jsonArray("cluster-1", "cluster_2", "cluster.3"));
+
+        List<String> result = entry.getClusterList();
+        assertEquals(3, result.size());
+        assertTrue(result.contains("cluster-1"));
+        assertTrue(result.contains("cluster_2"));
+        assertTrue(result.contains("cluster.3"));
+    }
+
+    @Test
+    @DisplayName("Backward compatibility - datasource without clusters")
+    public void testBackwardCompatibility() {
+        KruizeDataSourceEntry entry = new KruizeDataSourceEntry();
+        entry.setName("prometheus-1");
+        entry.setProvider("prometheus");
+        entry.setServiceName("prometheus-k8s");
+        entry.setNamespace("openshift-monitoring");
+        entry.setUrl("https://prometheus:9090");
+
+        // No clusters set - simulating old datasource row (NULL column)
+        assertNull(entry.getClusters());
+        assertTrue(entry.getClusterList().isEmpty());
+        assertEquals("prometheus-1", entry.getName());
+    }
+
+    @Test
+    @DisplayName("Complete datasource entry with clusters")
+    public void testCompleteDatasourceEntry() {
+        KruizeDataSourceEntry entry = new KruizeDataSourceEntry();
+        entry.setVersion("v1.0");
+        entry.setName("prometheus-1");
+        entry.setProvider("prometheus");
+        entry.setServiceName("prometheus-k8s");
+        entry.setNamespace("openshift-monitoring");
+        entry.setUrl("https://prometheus:9090");
+        entry.setClusters(jsonArray("default", "stage", "prod"));
+
+        assertEquals("v1.0", entry.getVersion());
+        assertEquals("prometheus-1", entry.getName());
+        assertEquals(3, entry.getClusterList().size());
+        assertTrue(entry.getClusterList().contains("default"));
+        assertTrue(entry.getClusterList().contains("stage"));
+        assertTrue(entry.getClusterList().contains("prod"));
+    }
+}

--- a/tests/scripts/local_monitoring_tests/rest_apis/test_bulkAPI.py
+++ b/tests/scripts/local_monitoring_tests/rest_apis/test_bulkAPI.py
@@ -377,3 +377,85 @@ def test_bulk_api_filter_application(
                         assert set(containers.keys()).issubset(
                             set(expected["containers"])
                         )
+
+
+@pytest.mark.test_bulk_api_ros
+@pytest.mark.parametrize("cluster_name, expected_status, expected_error", [
+    ("prod-cluster", SUCCESS_200_STATUS_CODE, None),  # Valid cluster name
+    ("cluster-01", SUCCESS_200_STATUS_CODE, None),  # Valid with numbers
+    ("cluster.us-east.prod", SUCCESS_200_STATUS_CODE, None),  # Valid with dots
+    ("  prod-cluster  ", SUCCESS_200_STATUS_CODE, None),  # Valid with whitespace (should be trimmed)
+    ("Cluster-A", SUCCESS_200_STATUS_CODE, None),  # Valid with uppercase (simple validation)
+    ("-cluster", SUCCESS_200_STATUS_CODE, None),  # Valid with hyphen at start (simple validation)
+    ("cluster_name", SUCCESS_200_STATUS_CODE, None),  # Valid with underscore (simple validation)
+    ("", ERROR_STATUS_CODE, "cluster_name cannot be an empty string"),  # Empty string
+    ("a" * 254, ERROR_STATUS_CODE, "too long (max"),  # Exceeds max length - matches backend message
+    (None, SUCCESS_200_STATUS_CODE, None),  # Omitted cluster_name - should use metadata cluster
+])
+def test_bulk_api_cluster_name_validation(cluster_type, cluster_name, expected_status, expected_error, caplog):
+    """
+    Validates cluster_name field validation in Bulk API.
+    Tests valid formats, invalid formats, and edge cases.
+    """
+    form_kruize_url(cluster_type)
+    
+    payload = base_payload()
+    payload["cluster_name"] = cluster_name
+    payload["time_range"]["start"] = "2025-01-01T00:00:00Z"
+    payload["time_range"]["end"] = "2025-01-02T00:00:00Z"
+    
+    delete_and_create_metric_profile()
+    delete_and_create_metadata_profile()
+    
+    with caplog.at_level(logging.INFO):
+        response = post_bulk_api(payload, logging)
+        
+        assert response.status_code == expected_status, \
+            f"Expected status {expected_status} but got {response.status_code}. Response: {response.json()}"
+        
+        if expected_error:
+            assert expected_error in response.json()["message"], \
+                f"Expected error message to contain '{expected_error}' but got: {response.json()['message']}"
+        else:
+            # Valid cluster name should create a job
+            assert "job_id" in response.json(), "Expected job_id in response for valid cluster_name"
+
+
+@pytest.mark.test_bulk_api_ros
+@pytest.mark.parametrize("model_settings, expected_status, expected_error", [
+    ({"models": ["performance"]}, SUCCESS_200_STATUS_CODE, None),  # Valid single model
+    ({"models": ["cost"]}, SUCCESS_200_STATUS_CODE, None),  # Valid cost model
+    ({"models": ["performance", "cost"]}, SUCCESS_200_STATUS_CODE, None),  # Valid multiple models
+    ({"models": ["Performance", "COST"]}, SUCCESS_200_STATUS_CODE, None),  # Valid case-insensitive
+    ({"models": []}, ERROR_STATUS_CODE, "model_settings.models cannot be null or empty"),  # Empty list
+    ({"models": ["invalid"]}, ERROR_STATUS_CODE, "Invalid model name"),  # Invalid model
+    ({"models": ["performance", "invalid"]}, ERROR_STATUS_CODE, "Invalid model name"),  # Mixed valid/invalid
+    ({}, ERROR_STATUS_CODE, "model_settings.models cannot be null or empty"),  # Missing models field
+])
+def test_bulk_api_model_settings_validation(cluster_type, model_settings, expected_status, expected_error, caplog):
+    """
+    Validates model_settings field validation in Bulk API.
+    Tests valid models, invalid models, and edge cases.
+    """
+    form_kruize_url(cluster_type)
+    
+    payload = base_payload()
+    payload["model_settings"] = model_settings
+    payload["time_range"]["start"] = "2025-01-01T00:00:00Z"
+    payload["time_range"]["end"] = "2025-01-02T00:00:00Z"
+    
+    delete_and_create_metric_profile()
+    delete_and_create_metadata_profile()
+    
+    with caplog.at_level(logging.INFO):
+        response = post_bulk_api(payload, logging)
+        
+        assert response.status_code == expected_status, \
+            f"Expected status {expected_status} but got {response.status_code}. Response: {response.json()}"
+        
+        if expected_error:
+            assert expected_error in response.json()["message"], \
+                f"Expected error message to contain '{expected_error}' but got: {response.json()['message']}"
+        else:
+            # Valid model_settings should create a job
+            assert "job_id" in response.json(), "Expected job_id in response for valid model_settings"


### PR DESCRIPTION
## Description

Adds tests for cluster-support changes

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [x] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [x] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Add comprehensive validation coverage for Bulk API cluster name handling and model settings, including backend passthrough and datasource cluster list behavior.

Tests:
- Extend Bulk API integration tests to cover cluster_name and model_settings validation scenarios, including success, failure, and edge cases.
- Add unit tests for BulkJobManager to verify cluster name passthrough and backward compatibility when cluster name is absent.
- Add unit tests for KruizeDataSourceEntry to validate clusters JSONB parsing, filtering of invalid names, and behavior when clusters are missing.
- Add unit tests for BulkServiceValidation to cover cluster_name validation rules, trimming, length limits, and optional null handling.