### PR TITLE
[BULK-PROFILE]-5: Add DB calls needed for CRUD API calls

### DIFF
--- a/src/main/java/com/autotune/database/dao/ExperimentDAO.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAO.java
@@ -5,11 +5,7 @@ import com.autotune.analyzer.serviceObjects.KubernetesAPIObject;
 import com.autotune.analyzer.utils.AnalyzerConstants;
 import com.autotune.common.data.ValidationOutputData;
 import com.autotune.database.table.*;
-import com.autotune.database.table.lm.KruizeBulkJobEntry;
-import com.autotune.database.table.lm.KruizeLMExperimentEntry;
-import com.autotune.database.table.lm.KruizeLMLayerEntry;
-import com.autotune.database.table.lm.KruizeLMMetadataProfileEntry;
-import com.autotune.database.table.lm.KruizeLMRecommendationEntry;
+import com.autotune.database.table.lm.*;
 
 import java.sql.Timestamp;
 import java.util.List;
@@ -178,4 +174,17 @@ public interface ExperimentDAO {
     Long getExperimentsCountFromDBByProfileName(String perfProfileName) throws Exception;
 
     ValidationOutputData updatePerformanceProfileInDB(KruizePerformanceProfileEntry kruizePerformanceProfileEntry);
+
+    // Bulk Profile operations
+    ValidationOutputData addBulkProfileToDB(KruizeBulkProfileEntry kruizeBulkProfileEntry);
+
+    KruizeBulkProfileEntry loadBulkProfileByName(String profileName) throws Exception;
+
+    List<KruizeBulkProfileEntry> loadAllBulkProfiles() throws Exception;
+
+    ValidationOutputData updateBulkProfileToDB(KruizeBulkProfileEntry kruizeBulkProfileEntry);
+
+    ValidationOutputData deleteBulkProfileByName(String profileName);
+
+    List<KruizeBulkProfileEntry> loadEnabledBulkProfiles() throws Exception;
 }

--- a/src/main/java/com/autotune/database/dao/ExperimentDAO.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAO.java
@@ -175,16 +175,16 @@ public interface ExperimentDAO {
 
     ValidationOutputData updatePerformanceProfileInDB(KruizePerformanceProfileEntry kruizePerformanceProfileEntry);
 
-    // Bulk Profile operations
-    ValidationOutputData addBulkProfileToDB(KruizeBulkProfileEntry kruizeBulkProfileEntry);
+    // Bulk Config operations
+    ValidationOutputData addBulkConfigToDB(KruizeBulkConfigEntry kruizeBulkConfigEntry);
 
-    KruizeBulkProfileEntry loadBulkProfileByName(String profileName) throws Exception;
+    KruizeBulkConfigEntry loadBulkConfigByName(String configName) throws Exception;
 
-    List<KruizeBulkProfileEntry> loadAllBulkProfiles() throws Exception;
+    List<KruizeBulkConfigEntry> loadAllBulkConfigs() throws Exception;
 
-    ValidationOutputData updateBulkProfileToDB(KruizeBulkProfileEntry kruizeBulkProfileEntry);
+    ValidationOutputData updateBulkConfigToDB(KruizeBulkConfigEntry kruizeBulkConfigEntry);
 
-    ValidationOutputData deleteBulkProfileByName(String profileName);
+    ValidationOutputData deleteBulkConfigByName(String configName);
 
-    List<KruizeBulkProfileEntry> loadEnabledBulkProfiles() throws Exception;
+    List<KruizeBulkConfigEntry> loadEnabledBulkConfigs() throws Exception;
 }

--- a/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
@@ -24,11 +24,7 @@ import com.autotune.common.data.ValidationOutputData;
 import com.autotune.database.helper.DBConstants;
 import com.autotune.database.init.KruizeHibernateUtil;
 import com.autotune.database.table.*;
-import com.autotune.database.table.lm.KruizeBulkJobEntry;
-import com.autotune.database.table.lm.KruizeLMExperimentEntry;
-import com.autotune.database.table.lm.KruizeLMLayerEntry;
-import com.autotune.database.table.lm.KruizeLMMetadataProfileEntry;
-import com.autotune.database.table.lm.KruizeLMRecommendationEntry;
+import com.autotune.database.table.lm.*;
 import com.autotune.utils.KruizeConstants;
 import com.autotune.utils.MetricsConfig;
 import io.micrometer.core.instrument.Timer;
@@ -2055,5 +2051,203 @@ public class ExperimentDAOImpl implements ExperimentDAO {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Adds BulkProfile to database
+     *
+     * @param kruizeBulkProfileEntry Bulk Profile Database object to be added
+     * @return validationOutputData contains the status of the DB insert operation
+     */
+    @Override
+    public ValidationOutputData addBulkProfileToDB(KruizeBulkProfileEntry kruizeBulkProfileEntry) {
+        ValidationOutputData validationOutputData = new ValidationOutputData(false, null, null);
+        Transaction tx = null;
+        try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
+            try {
+                tx = session.beginTransaction();
+                session.persist(kruizeBulkProfileEntry);
+                tx.commit();
+                validationOutputData.setSuccess(true);
+            } catch (ConstraintViolationException e) {
+                LOGGER.error("Bulk profile with name {} already exists", kruizeBulkProfileEntry.getProfileName());
+                if (tx != null) tx.rollback();
+                validationOutputData.setSuccess(false);
+                validationOutputData.setMessage("Bulk profile with name " + kruizeBulkProfileEntry.getProfileName() + " already exists");
+                validationOutputData.setErrorCode(HttpServletResponse.SC_CONFLICT);
+            } catch (HibernateException e) {
+                LOGGER.error("Not able to save bulk profile due to {}", e.getMessage());
+                if (tx != null) tx.rollback();
+                e.printStackTrace();
+                validationOutputData.setSuccess(false);
+                validationOutputData.setMessage(e.getMessage());
+            }
+        } catch (Exception e) {
+            LOGGER.error("Not able to save bulk profile due to {}", e.getMessage());
+            validationOutputData.setMessage(e.getMessage());
+        }
+        return validationOutputData;
+    }
+
+    /**
+     * Load a single bulk profile by name
+     *
+     * @param profileName Name of the bulk profile to load
+     * @return KruizeBulkProfileEntry or null if not found
+     */
+    @Override
+    public KruizeBulkProfileEntry loadBulkProfileByName(String profileName) throws Exception {
+        KruizeBulkProfileEntry kruizeBulkProfileEntry = null;
+        Transaction tx = null;
+        try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
+            try {
+                tx = session.beginTransaction();
+                Query<KruizeBulkProfileEntry> query = session.createQuery(
+                        DBConstants.SQLQUERY.SELECT_FROM_BULK_PROFILE_BY_NAME,
+                        KruizeBulkProfileEntry.class);
+                query.setParameter("profileName", profileName);
+                kruizeBulkProfileEntry = query.uniqueResult();
+                tx.commit();
+            } catch (NoResultException e) {
+                LOGGER.debug("Bulk profile {} not found", profileName);
+                if (tx != null) tx.rollback();
+            } catch (HibernateException e) {
+                LOGGER.error("Error loading bulk profile: {}", e.getMessage());
+                if (tx != null) tx.rollback();
+                throw new Exception("Error loading bulk profile: " + e.getMessage());
+            }
+        } catch (Exception e) {
+            LOGGER.error("Error loading bulk profile: {}", e.getMessage());
+            throw new Exception("Error loading bulk profile: " + e.getMessage());
+        }
+        return kruizeBulkProfileEntry;
+    }
+
+    /**
+     * Load all bulk profiles
+     *
+     * @return List of all bulk profiles
+     */
+    @Override
+    public List<KruizeBulkProfileEntry> loadAllBulkProfiles() throws Exception {
+        List<KruizeBulkProfileEntry> bulkProfiles = new ArrayList<>();
+        Transaction tx = null;
+        try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
+            try {
+                tx = session.beginTransaction();
+                Query<KruizeBulkProfileEntry> query = session.createQuery(
+                        DBConstants.SQLQUERY.SELECT_FROM_BULK_PROFILE + " k ORDER BY k.profileName",
+                        KruizeBulkProfileEntry.class);
+                bulkProfiles = query.list();
+                tx.commit();
+            } catch (HibernateException e) {
+                LOGGER.error("Error loading bulk profiles: {}", e.getMessage());
+                if (tx != null) tx.rollback();
+                throw new Exception("Error loading bulk profiles: " + e.getMessage());
+            }
+        } catch (Exception e) {
+            LOGGER.error("Error loading bulk profiles: {}", e.getMessage());
+            throw new Exception("Error loading bulk profiles: " + e.getMessage());
+        }
+        return bulkProfiles;
+    }
+
+    /**
+     * Update an existing bulk profile
+     *
+     * @param kruizeBulkProfileEntry Bulk Profile Database object to be updated
+     * @return validationOutputData contains the status of the DB update operation
+     */
+    @Override
+    public ValidationOutputData updateBulkProfileToDB(KruizeBulkProfileEntry kruizeBulkProfileEntry) {
+        ValidationOutputData validationOutputData = new ValidationOutputData(false, null, null);
+        Transaction tx = null;
+        try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
+            try {
+                tx = session.beginTransaction();
+                session.merge(kruizeBulkProfileEntry);
+                tx.commit();
+                validationOutputData.setSuccess(true);
+            } catch (HibernateException e) {
+                LOGGER.error("Not able to update bulk profile due to {}", e.getMessage());
+                if (tx != null) tx.rollback();
+                e.printStackTrace();
+                validationOutputData.setSuccess(false);
+                validationOutputData.setMessage(e.getMessage());
+            }
+        } catch (Exception e) {
+            LOGGER.error("Not able to update bulk profile due to {}", e.getMessage());
+            validationOutputData.setMessage(e.getMessage());
+        }
+        return validationOutputData;
+    }
+
+    /**
+     * Delete a bulk profile by name
+     *
+     * @param profileName Name of the bulk profile to delete
+     * @return validationOutputData contains the status of the DB delete operation
+     */
+    @Override
+    public ValidationOutputData deleteBulkProfileByName(String profileName) {
+        ValidationOutputData validationOutputData = new ValidationOutputData(false, null, null);
+        Transaction tx = null;
+        try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
+            try {
+                tx = session.beginTransaction();
+                Query query = session.createQuery(
+                        DELETE_BULK_PROFILE_BY_NAME, null);
+                query.setParameter("profileName", profileName);
+                int result = query.executeUpdate();
+                tx.commit();
+
+                if (result > 0) {
+                    validationOutputData.setSuccess(true);
+                } else {
+                    validationOutputData.setSuccess(false);
+                    validationOutputData.setMessage("Bulk profile not found: " + profileName);
+                    validationOutputData.setErrorCode(HttpServletResponse.SC_NOT_FOUND);
+                }
+            } catch (HibernateException e) {
+                LOGGER.error("Not able to delete bulk profile due to {}", e.getMessage());
+                if (tx != null) tx.rollback();
+                e.printStackTrace();
+                validationOutputData.setSuccess(false);
+                validationOutputData.setMessage(e.getMessage());
+            }
+        } catch (Exception e) {
+            LOGGER.error("Not able to delete bulk profile due to {}", e.getMessage());
+            validationOutputData.setMessage(e.getMessage());
+        }
+        return validationOutputData;
+    }
+
+    /**
+     * Load all enabled bulk profiles
+     *
+     * @return List of enabled bulk profiles
+     */
+    @Override
+    public List<KruizeBulkProfileEntry> loadEnabledBulkProfiles() throws Exception {
+        List<KruizeBulkProfileEntry> bulkProfiles = new ArrayList<>();
+        Transaction tx = null;
+        try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
+            try {
+                tx = session.beginTransaction();
+                Query<KruizeBulkProfileEntry> query = session.createQuery(
+                        LOAD_ALL_ENABLED_BULK_PROFILES,
+                        KruizeBulkProfileEntry.class);
+                bulkProfiles = query.list();
+                tx.commit();
+            } catch (HibernateException e) {
+                LOGGER.error("Error loading enabled bulk profiles: {}", e.getMessage());
+                if (tx != null) tx.rollback();
+                throw new Exception("Error loading enabled bulk profiles: " + e.getMessage());
+            }
+        } catch (Exception e) {
+            LOGGER.error("Error loading enabled bulk profiles: {}", e.getMessage());
+            throw new Exception("Error loading enabled bulk profiles: " + e.getMessage());
+        }
+        return bulkProfiles;
     }
 }

--- a/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
@@ -2054,150 +2054,150 @@ public class ExperimentDAOImpl implements ExperimentDAO {
     }
 
     /**
-     * Adds BulkProfile to database
+     * Adds BulkConfig to database
      *
-     * @param kruizeBulkProfileEntry Bulk Profile Database object to be added
+     * @param kruizeBulkConfigEntry Bulk Config Database object to be added
      * @return validationOutputData contains the status of the DB insert operation
      */
     @Override
-    public ValidationOutputData addBulkProfileToDB(KruizeBulkProfileEntry kruizeBulkProfileEntry) {
+    public ValidationOutputData addBulkConfigToDB(KruizeBulkConfigEntry kruizeBulkConfigEntry) {
         ValidationOutputData validationOutputData = new ValidationOutputData(false, null, null);
         Transaction tx = null;
         try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
             try {
                 tx = session.beginTransaction();
-                session.persist(kruizeBulkProfileEntry);
+                session.persist(kruizeBulkConfigEntry);
                 tx.commit();
                 validationOutputData.setSuccess(true);
             } catch (ConstraintViolationException e) {
-                LOGGER.error("Bulk profile with name {} already exists", kruizeBulkProfileEntry.getProfileName());
+                LOGGER.error("Bulk config with name {} already exists", kruizeBulkConfigEntry.getConfigName());
                 if (tx != null) tx.rollback();
                 validationOutputData.setSuccess(false);
-                validationOutputData.setMessage("Bulk profile with name " + kruizeBulkProfileEntry.getProfileName() + " already exists");
+                validationOutputData.setMessage("Bulk config with name " + kruizeBulkConfigEntry.getConfigName() + " already exists");
                 validationOutputData.setErrorCode(HttpServletResponse.SC_CONFLICT);
             } catch (HibernateException e) {
-                LOGGER.error("Not able to save bulk profile due to {}", e.getMessage());
+                LOGGER.error("Not able to save bulk config due to {}", e.getMessage());
                 if (tx != null) tx.rollback();
                 e.printStackTrace();
                 validationOutputData.setSuccess(false);
                 validationOutputData.setMessage(e.getMessage());
             }
         } catch (Exception e) {
-            LOGGER.error("Not able to save bulk profile due to {}", e.getMessage());
+            LOGGER.error("Not able to save bulk config due to {}", e.getMessage());
             validationOutputData.setMessage(e.getMessage());
         }
         return validationOutputData;
     }
 
     /**
-     * Load a single bulk profile by name
+     * Load a single bulk config by name
      *
-     * @param profileName Name of the bulk profile to load
-     * @return KruizeBulkProfileEntry or null if not found
+     * @param configName Name of the bulk config to load
+     * @return KruizeBulkConfigEntry or null if not found
      */
     @Override
-    public KruizeBulkProfileEntry loadBulkProfileByName(String profileName) throws Exception {
-        KruizeBulkProfileEntry kruizeBulkProfileEntry = null;
+    public KruizeBulkConfigEntry loadBulkConfigByName(String configName) throws Exception {
+        KruizeBulkConfigEntry kruizeBulkConfigEntry = null;
         Transaction tx = null;
         try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
             try {
                 tx = session.beginTransaction();
-                Query<KruizeBulkProfileEntry> query = session.createQuery(
-                        DBConstants.SQLQUERY.SELECT_FROM_BULK_PROFILE_BY_NAME,
-                        KruizeBulkProfileEntry.class);
-                query.setParameter("profileName", profileName);
-                kruizeBulkProfileEntry = query.uniqueResult();
+                Query<KruizeBulkConfigEntry> query = session.createQuery(
+                        DBConstants.SQLQUERY.SELECT_FROM_BULK_CONFIG_BY_NAME,
+                        KruizeBulkConfigEntry.class);
+                query.setParameter("configName", configName);
+                kruizeBulkConfigEntry = query.uniqueResult();
                 tx.commit();
             } catch (NoResultException e) {
-                LOGGER.debug("Bulk profile {} not found", profileName);
+                LOGGER.debug("Bulk config {} not found", configName);
                 if (tx != null) tx.rollback();
             } catch (HibernateException e) {
-                LOGGER.error("Error loading bulk profile: {}", e.getMessage());
+                LOGGER.error("Error loading bulk config: {}", e.getMessage());
                 if (tx != null) tx.rollback();
-                throw new Exception("Error loading bulk profile: " + e.getMessage());
+                throw new Exception("Error loading bulk config: " + e.getMessage());
             }
         } catch (Exception e) {
-            LOGGER.error("Error loading bulk profile: {}", e.getMessage());
-            throw new Exception("Error loading bulk profile: " + e.getMessage());
+            LOGGER.error("Error loading bulk config: {}", e.getMessage());
+            throw new Exception("Error loading bulk config: " + e.getMessage());
         }
-        return kruizeBulkProfileEntry;
+        return kruizeBulkConfigEntry;
     }
 
     /**
-     * Load all bulk profiles
+     * Load all bulk configs
      *
-     * @return List of all bulk profiles
+     * @return List of all bulk configs
      */
     @Override
-    public List<KruizeBulkProfileEntry> loadAllBulkProfiles() throws Exception {
-        List<KruizeBulkProfileEntry> bulkProfiles = new ArrayList<>();
+    public List<KruizeBulkConfigEntry> loadAllBulkConfigs() throws Exception {
+        List<KruizeBulkConfigEntry> bulkConfigs = new ArrayList<>();
         Transaction tx = null;
         try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
             try {
                 tx = session.beginTransaction();
-                Query<KruizeBulkProfileEntry> query = session.createQuery(
-                        DBConstants.SQLQUERY.SELECT_FROM_BULK_PROFILE + " k ORDER BY k.profileName",
-                        KruizeBulkProfileEntry.class);
-                bulkProfiles = query.list();
+                Query<KruizeBulkConfigEntry> query = session.createQuery(
+                        DBConstants.SQLQUERY.SELECT_FROM_BULK_CONFIG + " k ORDER BY k.configName",
+                        KruizeBulkConfigEntry.class);
+                bulkConfigs = query.list();
                 tx.commit();
             } catch (HibernateException e) {
-                LOGGER.error("Error loading bulk profiles: {}", e.getMessage());
+                LOGGER.error("Error loading bulk configs: {}", e.getMessage());
                 if (tx != null) tx.rollback();
-                throw new Exception("Error loading bulk profiles: " + e.getMessage());
+                throw new Exception("Error loading bulk configs: " + e.getMessage());
             }
         } catch (Exception e) {
-            LOGGER.error("Error loading bulk profiles: {}", e.getMessage());
-            throw new Exception("Error loading bulk profiles: " + e.getMessage());
+            LOGGER.error("Error loading bulk configs: {}", e.getMessage());
+            throw new Exception("Error loading bulk configs: " + e.getMessage());
         }
-        return bulkProfiles;
+        return bulkConfigs;
     }
 
     /**
-     * Update an existing bulk profile
+     * Update an existing bulk config
      *
-     * @param kruizeBulkProfileEntry Bulk Profile Database object to be updated
+     * @param kruizeBulkConfigEntry Bulk Config Database object to be updated
      * @return validationOutputData contains the status of the DB update operation
      */
     @Override
-    public ValidationOutputData updateBulkProfileToDB(KruizeBulkProfileEntry kruizeBulkProfileEntry) {
+    public ValidationOutputData updateBulkConfigToDB(KruizeBulkConfigEntry kruizeBulkConfigEntry) {
         ValidationOutputData validationOutputData = new ValidationOutputData(false, null, null);
         Transaction tx = null;
         try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
             try {
                 tx = session.beginTransaction();
-                session.merge(kruizeBulkProfileEntry);
+                session.merge(kruizeBulkConfigEntry);
                 tx.commit();
                 validationOutputData.setSuccess(true);
             } catch (HibernateException e) {
-                LOGGER.error("Not able to update bulk profile due to {}", e.getMessage());
+                LOGGER.error("Not able to update bulk config due to {}", e.getMessage());
                 if (tx != null) tx.rollback();
                 e.printStackTrace();
                 validationOutputData.setSuccess(false);
                 validationOutputData.setMessage(e.getMessage());
             }
         } catch (Exception e) {
-            LOGGER.error("Not able to update bulk profile due to {}", e.getMessage());
+            LOGGER.error("Not able to update bulk config due to {}", e.getMessage());
             validationOutputData.setMessage(e.getMessage());
         }
         return validationOutputData;
     }
 
     /**
-     * Delete a bulk profile by name
+     * Delete a bulk config by name
      *
-     * @param profileName Name of the bulk profile to delete
+     * @param configName Name of the bulk config to delete
      * @return validationOutputData contains the status of the DB delete operation
      */
     @Override
-    public ValidationOutputData deleteBulkProfileByName(String profileName) {
+    public ValidationOutputData deleteBulkConfigByName(String configName) {
         ValidationOutputData validationOutputData = new ValidationOutputData(false, null, null);
         Transaction tx = null;
         try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
             try {
                 tx = session.beginTransaction();
                 Query query = session.createQuery(
-                        DELETE_BULK_PROFILE_BY_NAME, null);
-                query.setParameter("profileName", profileName);
+                        DELETE_BULK_CONFIG_BY_NAME, null);
+                query.setParameter("configName", configName);
                 int result = query.executeUpdate();
                 tx.commit();
 
@@ -2205,49 +2205,49 @@ public class ExperimentDAOImpl implements ExperimentDAO {
                     validationOutputData.setSuccess(true);
                 } else {
                     validationOutputData.setSuccess(false);
-                    validationOutputData.setMessage("Bulk profile not found: " + profileName);
+                    validationOutputData.setMessage("Bulk config not found: " + configName);
                     validationOutputData.setErrorCode(HttpServletResponse.SC_NOT_FOUND);
                 }
             } catch (HibernateException e) {
-                LOGGER.error("Not able to delete bulk profile due to {}", e.getMessage());
+                LOGGER.error("Not able to delete bulk config due to {}", e.getMessage());
                 if (tx != null) tx.rollback();
                 e.printStackTrace();
                 validationOutputData.setSuccess(false);
                 validationOutputData.setMessage(e.getMessage());
             }
         } catch (Exception e) {
-            LOGGER.error("Not able to delete bulk profile due to {}", e.getMessage());
+            LOGGER.error("Not able to delete bulk config due to {}", e.getMessage());
             validationOutputData.setMessage(e.getMessage());
         }
         return validationOutputData;
     }
 
     /**
-     * Load all enabled bulk profiles
+     * Load all enabled bulk configs
      *
-     * @return List of enabled bulk profiles
+     * @return List of enabled bulk configs
      */
     @Override
-    public List<KruizeBulkProfileEntry> loadEnabledBulkProfiles() throws Exception {
-        List<KruizeBulkProfileEntry> bulkProfiles = new ArrayList<>();
+    public List<KruizeBulkConfigEntry> loadEnabledBulkConfigs() throws Exception {
+        List<KruizeBulkConfigEntry> bulkConfigs = new ArrayList<>();
         Transaction tx = null;
         try (Session session = KruizeHibernateUtil.getSessionFactory().openSession()) {
             try {
                 tx = session.beginTransaction();
-                Query<KruizeBulkProfileEntry> query = session.createQuery(
-                        LOAD_ALL_ENABLED_BULK_PROFILES,
-                        KruizeBulkProfileEntry.class);
-                bulkProfiles = query.list();
+                Query<KruizeBulkConfigEntry> query = session.createQuery(
+                        LOAD_ALL_ENABLED_BULK_CONFIGS,
+                        KruizeBulkConfigEntry.class);
+                bulkConfigs = query.list();
                 tx.commit();
             } catch (HibernateException e) {
-                LOGGER.error("Error loading enabled bulk profiles: {}", e.getMessage());
+                LOGGER.error("Error loading enabled bulk configs: {}", e.getMessage());
                 if (tx != null) tx.rollback();
-                throw new Exception("Error loading enabled bulk profiles: " + e.getMessage());
+                throw new Exception("Error loading enabled bulk configs: " + e.getMessage());
             }
         } catch (Exception e) {
-            LOGGER.error("Error loading enabled bulk profiles: {}", e.getMessage());
-            throw new Exception("Error loading enabled bulk profiles: " + e.getMessage());
+            LOGGER.error("Error loading enabled bulk configs: {}", e.getMessage());
+            throw new Exception("Error loading enabled bulk configs: " + e.getMessage());
         }
-        return bulkProfiles;
+        return bulkConfigs;
     }
 }

--- a/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
@@ -2070,20 +2070,26 @@ public class ExperimentDAOImpl implements ExperimentDAO {
                 tx.commit();
                 validationOutputData.setSuccess(true);
             } catch (ConstraintViolationException e) {
-                LOGGER.error("Bulk config with name {} already exists", kruizeBulkConfigEntry.getConfigName());
+                String errorMsg = String.format(DBConstants.BULK_CONFIG_MESSAGES.BULK_CONFIG_ALREADY_EXISTS,
+                        kruizeBulkConfigEntry.getConfigName());
+                LOGGER.error(errorMsg);
                 if (tx != null) tx.rollback();
                 validationOutputData.setSuccess(false);
-                validationOutputData.setMessage("Bulk config with name " + kruizeBulkConfigEntry.getConfigName() + " already exists");
+                validationOutputData.setMessage(errorMsg);
                 validationOutputData.setErrorCode(HttpServletResponse.SC_CONFLICT);
             } catch (HibernateException e) {
-                LOGGER.error("Not able to save bulk config due to {}", e.getMessage(), e);
+                String errorMsg = String.format(DBConstants.BULK_CONFIG_MESSAGES.ERROR_SAVING_BULK_CONFIG,
+                        e.getMessage());
+                LOGGER.error(errorMsg, e);
                 if (tx != null) tx.rollback();
                 validationOutputData.setSuccess(false);
-                validationOutputData.setMessage(e.getMessage());
+                validationOutputData.setMessage(errorMsg);
             }
         } catch (Exception e) {
-            LOGGER.error("Not able to save bulk config due to {}", e.getMessage(), e);
-            validationOutputData.setMessage(e.getMessage());
+            String errorMsg = String.format(DBConstants.BULK_CONFIG_MESSAGES.ERROR_SAVING_BULK_CONFIG,
+                    e.getMessage());
+            LOGGER.error(errorMsg, e);
+            validationOutputData.setMessage(errorMsg);
         }
         return validationOutputData;
     }
@@ -2111,13 +2117,17 @@ public class ExperimentDAOImpl implements ExperimentDAO {
                 LOGGER.debug("Bulk config {} not found", configName);
                 if (tx != null) tx.rollback();
             } catch (HibernateException e) {
-                LOGGER.error("Error loading bulk config: {}", e.getMessage());
+                String errorMsg = String.format(DBConstants.BULK_CONFIG_MESSAGES.ERROR_LOADING_BULK_CONFIG,
+                        e.getMessage());
+                LOGGER.error(errorMsg, e);
                 if (tx != null) tx.rollback();
-                throw new Exception("Error loading bulk config: " + e.getMessage());
+                throw new Exception(errorMsg);
             }
         } catch (Exception e) {
-            LOGGER.error("Error loading bulk config: {}", e.getMessage());
-            throw new Exception("Error loading bulk config: " + e.getMessage());
+            String errorMsg = String.format(DBConstants.BULK_CONFIG_MESSAGES.ERROR_LOADING_BULK_CONFIG,
+                    e.getMessage());
+            LOGGER.error(errorMsg, e);
+            throw new Exception(errorMsg);
         }
         return kruizeBulkConfigEntry;
     }
@@ -2140,13 +2150,17 @@ public class ExperimentDAOImpl implements ExperimentDAO {
                 bulkConfigs = query.list();
                 tx.commit();
             } catch (HibernateException e) {
-                LOGGER.error("Error loading bulk configs: {}", e.getMessage());
+                String errorMsg = String.format(DBConstants.BULK_CONFIG_MESSAGES.ERROR_LOADING_BULK_CONFIGS,
+                        e.getMessage());
+                LOGGER.error(errorMsg, e);
                 if (tx != null) tx.rollback();
-                throw new Exception("Error loading bulk configs: " + e.getMessage());
+                throw new Exception(errorMsg);
             }
         } catch (Exception e) {
-            LOGGER.error("Error loading bulk configs: {}", e.getMessage());
-            throw new Exception("Error loading bulk configs: " + e.getMessage());
+            String errorMsg = String.format(DBConstants.BULK_CONFIG_MESSAGES.ERROR_LOADING_BULK_CONFIGS,
+                        e.getMessage());
+            LOGGER.error(errorMsg, e);
+            throw new Exception(errorMsg);
         }
         return bulkConfigs;
     }
@@ -2168,14 +2182,18 @@ public class ExperimentDAOImpl implements ExperimentDAO {
                 tx.commit();
                 validationOutputData.setSuccess(true);
             } catch (HibernateException e) {
-                LOGGER.error("Not able to update bulk config due to {}", e.getMessage(), e);
+                String errorMsg = String.format(DBConstants.BULK_CONFIG_MESSAGES.ERROR_UPDATING_BULK_CONFIG,
+                        e.getMessage());
+                LOGGER.error(errorMsg, e);
                 if (tx != null) tx.rollback();
                 validationOutputData.setSuccess(false);
-                validationOutputData.setMessage(e.getMessage());
+                validationOutputData.setMessage(errorMsg);
             }
         } catch (Exception e) {
-            LOGGER.error("Not able to update bulk config due to {}", e.getMessage(), e);
-            validationOutputData.setMessage(e.getMessage());
+            String errorMsg = String.format(DBConstants.BULK_CONFIG_MESSAGES.ERROR_UPDATING_BULK_CONFIG,
+                    e.getMessage());
+            LOGGER.error(errorMsg, e);
+            validationOutputData.setMessage(errorMsg);
         }
         return validationOutputData;
     }
@@ -2202,19 +2220,25 @@ public class ExperimentDAOImpl implements ExperimentDAO {
                 if (result > 0) {
                     validationOutputData.setSuccess(true);
                 } else {
+                    String errorMsg = String.format(DBConstants.BULK_CONFIG_MESSAGES.BULK_CONFIG_NOT_FOUND,
+                            configName);
                     validationOutputData.setSuccess(false);
-                    validationOutputData.setMessage("Bulk config not found: " + configName);
+                    validationOutputData.setMessage(errorMsg);
                     validationOutputData.setErrorCode(HttpServletResponse.SC_NOT_FOUND);
                 }
             } catch (HibernateException e) {
-                LOGGER.error("Not able to delete bulk config due to {}", e.getMessage(), e);
+                String errorMsg = String.format(DBConstants.BULK_CONFIG_MESSAGES.ERROR_DELETING_BULK_CONFIG,
+                        e.getMessage());
+                LOGGER.error(errorMsg, e);
                 if (tx != null) tx.rollback();
                 validationOutputData.setSuccess(false);
-                validationOutputData.setMessage(e.getMessage());
+                validationOutputData.setMessage(errorMsg);
             }
         } catch (Exception e) {
-            LOGGER.error("Not able to delete bulk config due to {}", e.getMessage(), e);
-            validationOutputData.setMessage(e.getMessage());
+            String errorMsg = String.format(DBConstants.BULK_CONFIG_MESSAGES.ERROR_DELETING_BULK_CONFIG,
+                    e.getMessage());
+            LOGGER.error(errorMsg, e);
+            validationOutputData.setMessage(errorMsg);
         }
         return validationOutputData;
     }
@@ -2237,13 +2261,17 @@ public class ExperimentDAOImpl implements ExperimentDAO {
                 bulkConfigs = query.list();
                 tx.commit();
             } catch (HibernateException e) {
-                LOGGER.error("Error loading enabled bulk configs: {}", e.getMessage());
+                String errorMsg = String.format(DBConstants.BULK_CONFIG_MESSAGES.ERROR_LOADING_ENABLED_BULK_CONFIGS,
+                        e.getMessage());
+                LOGGER.error(errorMsg, e);
                 if (tx != null) tx.rollback();
-                throw new Exception("Error loading enabled bulk configs: " + e.getMessage());
+                throw new Exception(errorMsg);
             }
         } catch (Exception e) {
-            LOGGER.error("Error loading enabled bulk configs: {}", e.getMessage());
-            throw new Exception("Error loading enabled bulk configs: " + e.getMessage());
+            String errorMsg = String.format(DBConstants.BULK_CONFIG_MESSAGES.ERROR_LOADING_ENABLED_BULK_CONFIGS,
+                        e.getMessage());
+            LOGGER.error(errorMsg, e);
+            throw new Exception(errorMsg);
         }
         return bulkConfigs;
     }

--- a/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
@@ -2076,14 +2076,13 @@ public class ExperimentDAOImpl implements ExperimentDAO {
                 validationOutputData.setMessage("Bulk config with name " + kruizeBulkConfigEntry.getConfigName() + " already exists");
                 validationOutputData.setErrorCode(HttpServletResponse.SC_CONFLICT);
             } catch (HibernateException e) {
-                LOGGER.error("Not able to save bulk config due to {}", e.getMessage());
+                LOGGER.error("Not able to save bulk config due to {}", e.getMessage(), e);
                 if (tx != null) tx.rollback();
-                e.printStackTrace();
                 validationOutputData.setSuccess(false);
                 validationOutputData.setMessage(e.getMessage());
             }
         } catch (Exception e) {
-            LOGGER.error("Not able to save bulk config due to {}", e.getMessage());
+            LOGGER.error("Not able to save bulk config due to {}", e.getMessage(), e);
             validationOutputData.setMessage(e.getMessage());
         }
         return validationOutputData;

--- a/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
+++ b/src/main/java/com/autotune/database/dao/ExperimentDAOImpl.java
@@ -2169,14 +2169,13 @@ public class ExperimentDAOImpl implements ExperimentDAO {
                 tx.commit();
                 validationOutputData.setSuccess(true);
             } catch (HibernateException e) {
-                LOGGER.error("Not able to update bulk config due to {}", e.getMessage());
+                LOGGER.error("Not able to update bulk config due to {}", e.getMessage(), e);
                 if (tx != null) tx.rollback();
-                e.printStackTrace();
                 validationOutputData.setSuccess(false);
                 validationOutputData.setMessage(e.getMessage());
             }
         } catch (Exception e) {
-            LOGGER.error("Not able to update bulk config due to {}", e.getMessage());
+            LOGGER.error("Not able to update bulk config due to {}", e.getMessage(), e);
             validationOutputData.setMessage(e.getMessage());
         }
         return validationOutputData;
@@ -2209,14 +2208,13 @@ public class ExperimentDAOImpl implements ExperimentDAO {
                     validationOutputData.setErrorCode(HttpServletResponse.SC_NOT_FOUND);
                 }
             } catch (HibernateException e) {
-                LOGGER.error("Not able to delete bulk config due to {}", e.getMessage());
+                LOGGER.error("Not able to delete bulk config due to {}", e.getMessage(), e);
                 if (tx != null) tx.rollback();
-                e.printStackTrace();
                 validationOutputData.setSuccess(false);
                 validationOutputData.setMessage(e.getMessage());
             }
         } catch (Exception e) {
-            LOGGER.error("Not able to delete bulk config due to {}", e.getMessage());
+            LOGGER.error("Not able to delete bulk config due to {}", e.getMessage(), e);
             validationOutputData.setMessage(e.getMessage());
         }
         return validationOutputData;

--- a/src/main/java/com/autotune/database/helper/DBConstants.java
+++ b/src/main/java/com/autotune/database/helper/DBConstants.java
@@ -87,6 +87,9 @@ public class DBConstants {
         public static final String SELECT_FROM_METADATA_PROFILE_BY_NAME = "from KruizeLMMetadataProfileEntry k WHERE k.name = :name";
         public static final String SELECT_FROM_LAYER = "from KruizeLMLayerEntry";
         public static final String SELECT_FROM_LAYER_BY_NAME = "from KruizeLMLayerEntry k WHERE k.layer_name = :layerName";
+        public static final String SELECT_FROM_BULK_PROFILE = "from KruizeBulkProfileEntry";
+        public static final String SELECT_FROM_BULK_PROFILE_BY_NAME = "from KruizeBulkProfileEntry k WHERE k.profileName = :profileName";
+        public static final String LOAD_ALL_ENABLED_BULK_PROFILES = "FROM KruizeBulkProfileEntry WHERE enabled = true ORDER BY profile_name";
         public static final String DELETE_FROM_EXPERIMENTS_BY_EXP_NAME = "DELETE FROM KruizeExperimentEntry k WHERE k.experiment_name = :experimentName";
         public static final String DELETE_FROM_LM_EXPERIMENTS_BY_EXP_NAME = "DELETE FROM KruizeLMExperimentEntry k WHERE k.experiment_name = :experimentName";
         public static final String DELETE_FROM_RESULTS_BY_EXP_NAME = "DELETE FROM KruizeResultsEntry k WHERE k.experiment_name = :experimentName";
@@ -95,6 +98,7 @@ public class DBConstants {
         public static final String DELETE_FROM_METADATA_BY_DATASOURCE_NAME = "DELETE FROM KruizeDSMetadataEntry km WHERE km.datasource_name = :dataSourceName";
         public static final String DELETE_FROM_METRIC_PROFILE_BY_PROFILE_NAME = "DELETE FROM KruizeMetricProfileEntry km WHERE km.name = :metricProfileName";
         public static final String DELETE_FROM_METADATA_PROFILE_BY_PROFILE_NAME = "DELETE FROM KruizeLMMetadataProfileEntry km WHERE km.name = :metadataProfileName";
+        public static final String DELETE_BULK_PROFILE_BY_NAME = "DELETE FROM KruizeBulkProfileEntry WHERE profile_name = :profileName";
         public static final String DB_PARTITION_DATERANGE = "CREATE TABLE IF NOT EXISTS %s_%s%s%s PARTITION OF %s FOR VALUES FROM ('%s-%s-%s 00:00:00.000') TO ('%s-%s-%s 23:59:59');";
         public static final String SELECT_ALL_KRUIZE_TABLES = "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' " +
                 "and (table_name like 'kruize_results_%' or table_name like 'kruize_recommendations_%') ";

--- a/src/main/java/com/autotune/database/helper/DBConstants.java
+++ b/src/main/java/com/autotune/database/helper/DBConstants.java
@@ -87,9 +87,10 @@ public class DBConstants {
         public static final String SELECT_FROM_METADATA_PROFILE_BY_NAME = "from KruizeLMMetadataProfileEntry k WHERE k.name = :name";
         public static final String SELECT_FROM_LAYER = "from KruizeLMLayerEntry";
         public static final String SELECT_FROM_LAYER_BY_NAME = "from KruizeLMLayerEntry k WHERE k.layer_name = :layerName";
-        public static final String SELECT_FROM_BULK_PROFILE = "from KruizeBulkProfileEntry";
-        public static final String SELECT_FROM_BULK_PROFILE_BY_NAME = "from KruizeBulkProfileEntry k WHERE k.profileName = :profileName";
-        public static final String LOAD_ALL_ENABLED_BULK_PROFILES = "FROM KruizeBulkProfileEntry WHERE enabled = true ORDER BY profile_name";
+        public static final String SELECT_FROM_BULK_CONFIG = "from KruizeBulkConfigEntry";
+        public static final String SELECT_FROM_BULK_CONFIG_BY_NAME = "from KruizeBulkConfigEntry k WHERE k.configName = :configName";
+        public static final String LOAD_ALL_ENABLED_BULK_CONFIGS = "FROM KruizeBulkConfigEntry WHERE enabled = true ORDER BY config_name";
+        public static final String DELETE_BULK_CONFIG_BY_NAME = "DELETE FROM KruizeBulkConfigEntry k WHERE k.configName = :configName";
         public static final String DELETE_FROM_EXPERIMENTS_BY_EXP_NAME = "DELETE FROM KruizeExperimentEntry k WHERE k.experiment_name = :experimentName";
         public static final String DELETE_FROM_LM_EXPERIMENTS_BY_EXP_NAME = "DELETE FROM KruizeLMExperimentEntry k WHERE k.experiment_name = :experimentName";
         public static final String DELETE_FROM_RESULTS_BY_EXP_NAME = "DELETE FROM KruizeResultsEntry k WHERE k.experiment_name = :experimentName";

--- a/src/main/java/com/autotune/database/helper/DBConstants.java
+++ b/src/main/java/com/autotune/database/helper/DBConstants.java
@@ -127,6 +127,17 @@ public class DBConstants {
         public static final String DELETE_FROM_PERFORMANCE_PROFILE_BY_NAME = "DELETE FROM KruizePerformanceProfileEntry kpp WHERE kpp.name = :perfProfileName";
     }
 
+    public static final class BULK_CONFIG_MESSAGES {
+        public static final String BULK_CONFIG_ALREADY_EXISTS = "Bulk config with name %s already exists";
+        public static final String ERROR_SAVING_BULK_CONFIG = "Not able to save bulk config due to %s";
+        public static final String ERROR_LOADING_BULK_CONFIG = "Error loading bulk config: %s";
+        public static final String ERROR_LOADING_BULK_CONFIGS = "Error loading bulk configs: %s";
+        public static final String ERROR_LOADING_ENABLED_BULK_CONFIGS = "Error loading enabled bulk configs: %s";
+        public static final String ERROR_UPDATING_BULK_CONFIG = "Not able to update bulk config due to %s";
+        public static final String ERROR_DELETING_BULK_CONFIG = "Not able to delete bulk config due to %s";
+        public static final String BULK_CONFIG_NOT_FOUND = "Bulk config not found: %s";
+    }
+
     public static final class TABLE_NAMES {
         public static final String KRUIZE_EXPERIMENTS = "kruize_experiments";
         public static final String KRUIZE_RESULTS = "kruize_results";

--- a/src/main/java/com/autotune/database/helper/DBConstants.java
+++ b/src/main/java/com/autotune/database/helper/DBConstants.java
@@ -89,7 +89,7 @@ public class DBConstants {
         public static final String SELECT_FROM_LAYER_BY_NAME = "from KruizeLMLayerEntry k WHERE k.layer_name = :layerName";
         public static final String SELECT_FROM_BULK_CONFIG = "from KruizeBulkConfigEntry";
         public static final String SELECT_FROM_BULK_CONFIG_BY_NAME = "from KruizeBulkConfigEntry k WHERE k.configName = :configName";
-        public static final String LOAD_ALL_ENABLED_BULK_CONFIGS = "FROM KruizeBulkConfigEntry WHERE enabled = true ORDER BY config_name";
+        public static final String LOAD_ALL_ENABLED_BULK_CONFIGS = "FROM KruizeBulkConfigEntry WHERE enabled = true ORDER BY configName";
         public static final String DELETE_BULK_CONFIG_BY_NAME = "DELETE FROM KruizeBulkConfigEntry k WHERE k.configName = :configName";
         public static final String DELETE_FROM_EXPERIMENTS_BY_EXP_NAME = "DELETE FROM KruizeExperimentEntry k WHERE k.experiment_name = :experimentName";
         public static final String DELETE_FROM_LM_EXPERIMENTS_BY_EXP_NAME = "DELETE FROM KruizeLMExperimentEntry k WHERE k.experiment_name = :experimentName";

--- a/src/main/java/com/autotune/database/helper/DBConstants.java
+++ b/src/main/java/com/autotune/database/helper/DBConstants.java
@@ -99,7 +99,6 @@ public class DBConstants {
         public static final String DELETE_FROM_METADATA_BY_DATASOURCE_NAME = "DELETE FROM KruizeDSMetadataEntry km WHERE km.datasource_name = :dataSourceName";
         public static final String DELETE_FROM_METRIC_PROFILE_BY_PROFILE_NAME = "DELETE FROM KruizeMetricProfileEntry km WHERE km.name = :metricProfileName";
         public static final String DELETE_FROM_METADATA_PROFILE_BY_PROFILE_NAME = "DELETE FROM KruizeLMMetadataProfileEntry km WHERE km.name = :metadataProfileName";
-        public static final String DELETE_BULK_PROFILE_BY_NAME = "DELETE FROM KruizeBulkProfileEntry WHERE profile_name = :profileName";
         public static final String DB_PARTITION_DATERANGE = "CREATE TABLE IF NOT EXISTS %s_%s%s%s PARTITION OF %s FOR VALUES FROM ('%s-%s-%s 00:00:00.000') TO ('%s-%s-%s 23:59:59');";
         public static final String SELECT_ALL_KRUIZE_TABLES = "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' " +
                 "and (table_name like 'kruize_results_%' or table_name like 'kruize_recommendations_%') ";

--- a/src/main/java/com/autotune/database/table/lm/KruizeBulkConfigEntry.java
+++ b/src/main/java/com/autotune/database/table/lm/KruizeBulkConfigEntry.java
@@ -217,7 +217,7 @@ public class KruizeBulkConfigEntry {
         BulkConfig config = new BulkConfig();
         config.setConfigName(this.configName);
         config.setClusterName(this.clusterName);
-        
+
         // Required field: datasources
         if (this.datasources == null) {
             throw new IllegalStateException("Datasources cannot be null for config: " + configName);
@@ -275,7 +275,7 @@ public class KruizeBulkConfigEntry {
         
         config.setMetadataProfile(this.metadataProfile);
         config.setPerformanceProfile(this.performanceProfile);
-        
+
         // Optional field: trial settings
         if (this.trialSettings != null) {
             try {
@@ -327,11 +327,11 @@ public class KruizeBulkConfigEntry {
         if (config == null) {
             throw new IllegalArgumentException("BulkConfig cannot be null");
         }
-        
+
         KruizeBulkConfigEntry entry = new KruizeBulkConfigEntry();
         entry.setConfigName(config.getConfigName());
         entry.setClusterName(config.getClusterName());
-        
+
         // Required field: datasources
         if (config.getDatasources() == null) {
             throw new IllegalArgumentException("Datasources cannot be null for config: " + config.getConfigName());
@@ -357,6 +357,7 @@ public class KruizeBulkConfigEntry {
             try {
                 entry.setLabels(objectMapper.valueToTree(config.getLabels()));
             } catch (Exception e) {
+
                 throw new RuntimeException("Failed to convert labels for config: " + config.getConfigName(), e);
             }
         }
@@ -373,7 +374,7 @@ public class KruizeBulkConfigEntry {
         
         entry.setMetadataProfile(config.getMetadataProfile());
         entry.setPerformanceProfile(config.getPerformanceProfile());
-        
+
         // Optional field: trial settings
         if (config.getTrialSettings() != null) {
             try {


### PR DESCRIPTION
## Description

This PR is built on top of #1981 

#1981 needs to be merged before merging this PR

Fixes #1977 

This PR adds the necessary DAO changes needed for the bulk profile CRUD calls

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Add DAO support for managing bulk configuration entities required by the bulk profile CRUD APIs.

New Features:
- Introduce CRUD database operations for bulk configuration entities, including create, read (single and all), update, delete, and listing enabled configs.

Enhancements:
- Centralize HQL constants for bulk configuration and bulk profile deletion queries in DBConstants.
- Simplify lm table imports in DAO interfaces and implementations using wildcard imports.