### PR TITLE
PR#6 Add model_settings and term_settings support to Bulk API

### DIFF
--- a/design/BulkAPI.md
+++ b/design/BulkAPI.md
@@ -63,6 +63,13 @@ progress of the job.
     "container",
     "namespace"
   ],
+  "cluster_name": "prod-cluster",
+  "model_settings": {
+    "models": ["performance", "cost"]
+  },
+  "term_settings": {
+    "terms": ["short", "medium", "long"]
+  },
   "webhook": {
     "url": "http://127.0.0.1:8080/webhook"
   }

--- a/src/main/java/com/autotune/analyzer/serviceObjects/BulkInput.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/BulkInput.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package com.autotune.analyzer.serviceObjects;
 
+import com.autotune.analyzer.kruizeObject.ModelSettings;
+import com.autotune.analyzer.kruizeObject.TermSettings;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +39,18 @@ public class BulkInput {
      * If not provided, cluster name from metadata will be used.
      */
     private String cluster_name;
+    
+    /**
+     * Optional model settings to customize which recommendation models to generate.
+     * If not provided, all models will be generated.
+     */
+    private ModelSettings model_settings;
+    
+    /**
+     * Optional term settings to customize which recommendation terms to generate.
+     * If not provided, all terms will be generated.
+     */
+    private TermSettings term_settings;
 
     // Getters and Setters
 
@@ -54,7 +68,7 @@ public class BulkInput {
     @JsonIgnore
     public boolean isEmpty() {
         return (filter == null && time_range == null && measurement_duration == null && metadata_profile == null
-                && datasource == null && cluster_name == null);
+                && datasource == null && cluster_name == null && model_settings == null && term_settings == null);
     }
 
     public TimeRange getTime_range() {
@@ -103,6 +117,22 @@ public class BulkInput {
 
     public void setCluster_name(String cluster_name) {
         this.cluster_name = cluster_name;
+    }
+
+    public ModelSettings getModel_settings() {
+        return model_settings;
+    }
+
+    public void setModel_settings(ModelSettings model_settings) {
+        this.model_settings = model_settings;
+    }
+
+    public TermSettings getTerm_settings() {
+        return term_settings;
+    }
+
+    public void setTerm_settings(TermSettings term_settings) {
+        this.term_settings = term_settings;
     }
 
     // Nested class for FilterWrapper that contains 'exclude' and 'include'

--- a/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
+++ b/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
@@ -646,6 +646,14 @@ public class BulkJobManager implements Runnable {
         RecommendationSettings rs = new RecommendationSettings();
         rs.setThreshold(CREATE_EXPERIMENT_CONFIG_BEAN.getThreshold());
         
+        // Pass through model_settings and term_settings from bulk payload if provided
+        if (bulkInput.getModel_settings() != null) {
+            rs.setModelSettings(bulkInput.getModel_settings());
+        }
+        if (bulkInput.getTerm_settings() != null) {
+            rs.setTermSettings(bulkInput.getTerm_settings());
+        }
+        
         createExperimentAPIObject.setRecommendationSettings(rs);
         TrialSettings trialSettings = new TrialSettings();
         trialSettings.setMeasurement_durationMinutes(CREATE_EXPERIMENT_CONFIG_BEAN.getMeasurementDurationStr());

--- a/src/main/java/com/autotune/common/bulk/BulkServiceValidation.java
+++ b/src/main/java/com/autotune/common/bulk/BulkServiceValidation.java
@@ -27,6 +27,8 @@ import org.slf4j.LoggerFactory;
 
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Utility class that performs validation for bulk service requests.
@@ -44,6 +46,10 @@ import java.time.format.DateTimeParseException;
 public class BulkServiceValidation {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BulkServiceValidation.class);
+
+    // Valid model and term names (case-insensitive)
+    private static final List<String> VALID_MODELS = Arrays.asList("performance", "cost");
+    private static final List<String> VALID_TERMS = Arrays.asList("short", "medium", "long");
 
     /**
      * Validates the bulk request payload and returns the corresponding validation output.
@@ -78,6 +84,14 @@ public class BulkServiceValidation {
         }
         // null means the field was not supplied (optional); a non-null trimmed value is written back.
         payload.setCluster_name(normalizedClusterName);
+
+        // Validate model_settings if provided
+        validationOutputData = buildErrorOutput(validateModelSettings(payload.getModel_settings()), jobID);
+        if (validationOutputData != null) return validationOutputData;
+
+        // Validate term_settings if provided
+        validationOutputData = buildErrorOutput(validateTermSettings(payload.getTerm_settings()), jobID);
+        if (validationOutputData != null) return validationOutputData;
 
         if (payload.getDatasource() != null) {
             validationOutputData = buildErrorOutput(validateDatasourceConnection(payload.getDatasource()), jobID);
@@ -215,6 +229,58 @@ public class BulkServiceValidation {
             return null;
         }
         return trimmed; // Normalized value
+    }
+
+    /**
+     * Validates the model_settings field if provided.
+     * Checks that models array is not null/empty and all names are valid (case-insensitive).
+     *
+     * @param modelSettings the model settings to validate (can be null)
+     * @return an error message if validation fails; otherwise an empty string
+     */
+    public static String validateModelSettings(com.autotune.analyzer.kruizeObject.ModelSettings modelSettings) {
+        if (modelSettings == null) {
+            return ""; // Optional field
+        }
+        List<String> models = modelSettings.getModels();
+        if (models == null || models.isEmpty()) {
+            return "model_settings.models cannot be null or empty";
+        }
+        for (String model : models) {
+            if (model == null || model.trim().isEmpty()) {
+                return "model_settings.models contains null or empty model name";
+            }
+            if (!VALID_MODELS.contains(model.toLowerCase())) {
+                return "Invalid model name: " + model + ". Valid models are: " + VALID_MODELS;
+            }
+        }
+        return "";
+    }
+
+    /**
+     * Validates the term_settings field if provided.
+     * Checks that terms array is not null/empty and all names are valid (case-insensitive).
+     *
+     * @param termSettings the term settings to validate (can be null)
+     * @return an error message if validation fails; otherwise an empty string
+     */
+    public static String validateTermSettings(com.autotune.analyzer.kruizeObject.TermSettings termSettings) {
+        if (termSettings == null) {
+            return ""; // Optional field
+        }
+        List<String> terms = termSettings.getTerms();
+        if (terms == null || terms.isEmpty()) {
+            return "term_settings.terms cannot be null or empty";
+        }
+        for (String term : terms) {
+            if (term == null || term.trim().isEmpty()) {
+                return "term_settings.terms contains null or empty term name";
+            }
+            if (!VALID_TERMS.contains(term.toLowerCase())) {
+                return "Invalid term name: " + term + ". Valid terms are: " + VALID_TERMS;
+            }
+        }
+        return "";
     }
 
 }

--- a/src/main/java/com/autotune/common/bulk/BulkServiceValidation.java
+++ b/src/main/java/com/autotune/common/bulk/BulkServiceValidation.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package com.autotune.common.bulk;
 
+import com.autotune.analyzer.kruizeObject.ModelSettings;
+import com.autotune.analyzer.kruizeObject.TermSettings;
 import com.autotune.analyzer.serviceObjects.BulkInput;
 import com.autotune.common.data.ValidationOutputData;
 import com.autotune.common.datasource.DataSourceInfo;
@@ -48,8 +50,15 @@ public class BulkServiceValidation {
     private static final Logger LOGGER = LoggerFactory.getLogger(BulkServiceValidation.class);
 
     // Valid model and term names (case-insensitive)
-    private static final List<String> VALID_MODELS = Arrays.asList("performance", "cost");
-    private static final List<String> VALID_TERMS = Arrays.asList("short", "medium", "long");
+    private static final List<String> VALID_MODELS = Arrays.asList(
+            KruizeConstants.JSONKeys.PERFORMANCE,
+            KruizeConstants.JSONKeys.COST
+    );
+    private static final List<String> VALID_TERMS = Arrays.asList(
+            KruizeConstants.JSONKeys.SHORT,
+            KruizeConstants.JSONKeys.MEDIUM,
+            KruizeConstants.JSONKeys.LONG
+    );
 
     /**
      * Validates the bulk request payload and returns the corresponding validation output.
@@ -238,7 +247,7 @@ public class BulkServiceValidation {
      * @param modelSettings the model settings to validate (can be null)
      * @return an error message if validation fails; otherwise an empty string
      */
-    public static String validateModelSettings(com.autotune.analyzer.kruizeObject.ModelSettings modelSettings) {
+    public static String validateModelSettings(ModelSettings modelSettings) {
         if (modelSettings == null) {
             return ""; // Optional field
         }
@@ -264,7 +273,7 @@ public class BulkServiceValidation {
      * @param termSettings the term settings to validate (can be null)
      * @return an error message if validation fails; otherwise an empty string
      */
-    public static String validateTermSettings(com.autotune.analyzer.kruizeObject.TermSettings termSettings) {
+    public static String validateTermSettings(TermSettings termSettings) {
         if (termSettings == null) {
             return ""; // Optional field
         }

--- a/tests/scripts/local_monitoring_tests/rest_apis/test_bulkAPI.py
+++ b/tests/scripts/local_monitoring_tests/rest_apis/test_bulkAPI.py
@@ -462,6 +462,8 @@ def test_bulk_api_model_settings_validation(cluster_type, model_settings, omit_m
         else:
             # Valid model_settings should create a job
             assert "job_id" in response.json(), "Expected job_id in response for valid model_settings"
+
+
 @pytest.mark.test_bulk_api_ros
 @pytest.mark.parametrize("term_settings, omit_term_settings, expected_status, expected_error", [
     ({"terms": ["short"]}, False, SUCCESS_200_STATUS_CODE, None),  # Valid single term

--- a/tests/scripts/local_monitoring_tests/rest_apis/test_bulkAPI.py
+++ b/tests/scripts/local_monitoring_tests/rest_apis/test_bulkAPI.py
@@ -422,17 +422,19 @@ def test_bulk_api_cluster_name_validation(cluster_type, cluster_name, expected_s
 
 
 @pytest.mark.test_bulk_api_ros
-@pytest.mark.parametrize("model_settings, expected_status, expected_error", [
-    ({"models": ["performance"]}, SUCCESS_200_STATUS_CODE, None),  # Valid single model
-    ({"models": ["cost"]}, SUCCESS_200_STATUS_CODE, None),  # Valid cost model
-    ({"models": ["performance", "cost"]}, SUCCESS_200_STATUS_CODE, None),  # Valid multiple models
-    ({"models": ["Performance", "COST"]}, SUCCESS_200_STATUS_CODE, None),  # Valid case-insensitive
-    ({"models": []}, ERROR_STATUS_CODE, "model_settings.models cannot be null or empty"),  # Empty list
-    ({"models": ["invalid"]}, ERROR_STATUS_CODE, "Invalid model name"),  # Invalid model
-    ({"models": ["performance", "invalid"]}, ERROR_STATUS_CODE, "Invalid model name"),  # Mixed valid/invalid
-    ({}, ERROR_STATUS_CODE, "model_settings.models cannot be null or empty"),  # Missing models field
+@pytest.mark.parametrize("model_settings, omit_model_settings, expected_status, expected_error", [
+    ({"models": ["performance"]}, False, SUCCESS_200_STATUS_CODE, None),  # Valid single model
+    ({"models": ["cost"]}, False, SUCCESS_200_STATUS_CODE, None),  # Valid cost model
+    ({"models": ["performance", "cost"]}, False, SUCCESS_200_STATUS_CODE, None),  # Valid multiple models
+    ({"models": ["Performance", "COST"]}, False, SUCCESS_200_STATUS_CODE, None),  # Valid case-insensitive
+    ({"models": []}, False, ERROR_STATUS_CODE, "model_settings.models cannot be null or empty"),  # Empty list
+    ({"models": ["invalid"]}, False, ERROR_STATUS_CODE, "Invalid model name"),  # Invalid model
+    ({"models": ["performance", "invalid"]}, False, ERROR_STATUS_CODE, "Invalid model name"),  # Mixed valid/invalid
+    ({}, False, ERROR_STATUS_CODE, "model_settings.models cannot be null or empty"),  # Missing models field
+    ({"models": ["performance", " "]}, False, ERROR_STATUS_CODE, "null or empty model name"),  # Whitespace-only element
+    (None, True, SUCCESS_200_STATUS_CODE, None),  # Omitted model_settings field, rely on defaults
 ])
-def test_bulk_api_model_settings_validation(cluster_type, model_settings, expected_status, expected_error, caplog):
+def test_bulk_api_model_settings_validation(cluster_type, model_settings, omit_model_settings, expected_status, expected_error, caplog):
     """
     Validates model_settings field validation in Bulk API.
     Tests valid models, invalid models, and edge cases.
@@ -440,7 +442,8 @@ def test_bulk_api_model_settings_validation(cluster_type, model_settings, expect
     form_kruize_url(cluster_type)
     
     payload = base_payload()
-    payload["model_settings"] = model_settings
+    if not omit_model_settings:
+        payload["model_settings"] = model_settings
     payload["time_range"]["start"] = "2025-01-01T00:00:00Z"
     payload["time_range"]["end"] = "2025-01-02T00:00:00Z"
     
@@ -459,3 +462,76 @@ def test_bulk_api_model_settings_validation(cluster_type, model_settings, expect
         else:
             # Valid model_settings should create a job
             assert "job_id" in response.json(), "Expected job_id in response for valid model_settings"
+@pytest.mark.test_bulk_api_ros
+@pytest.mark.parametrize("term_settings, omit_term_settings, expected_status, expected_error", [
+    ({"terms": ["short"]}, False, SUCCESS_200_STATUS_CODE, None),  # Valid single term
+    ({"terms": ["medium"]}, False, SUCCESS_200_STATUS_CODE, None),  # Valid medium term
+    ({"terms": ["long"]}, False, SUCCESS_200_STATUS_CODE, None),  # Valid long term
+    ({"terms": ["short", "medium", "long"]}, False, SUCCESS_200_STATUS_CODE, None),  # Valid multiple terms
+    ({"terms": ["Short", "MEDIUM"]}, False, SUCCESS_200_STATUS_CODE, None),  # Valid case-insensitive
+    ({"terms": []}, False, ERROR_STATUS_CODE, "term_settings.terms cannot be null or empty"),  # Empty list
+    ({"terms": ["invalid"]}, False, ERROR_STATUS_CODE, "Invalid term name"),  # Invalid term
+    ({"terms": ["short", "invalid"]}, False, ERROR_STATUS_CODE, "Invalid term name"),  # Mixed valid/invalid
+    ({}, False, ERROR_STATUS_CODE, "term_settings.terms cannot be null or empty"),  # Missing terms field
+    ({"terms": ["short", " "]}, False, ERROR_STATUS_CODE, "null or empty term name"),  # Whitespace-only element
+    (None, True, SUCCESS_200_STATUS_CODE, None),  # Omitted term_settings field, rely on defaults
+])
+def test_bulk_api_term_settings_validation(cluster_type, term_settings, omit_term_settings, expected_status, expected_error, caplog):
+    """
+    Validates term_settings field validation in Bulk API.
+    Tests valid terms, invalid terms, and edge cases.
+    """
+    form_kruize_url(cluster_type)
+    
+    payload = base_payload()
+    if not omit_term_settings:
+        payload["term_settings"] = term_settings
+    payload["time_range"]["start"] = "2025-01-01T00:00:00Z"
+    payload["time_range"]["end"] = "2025-01-02T00:00:00Z"
+    
+    delete_and_create_metric_profile()
+    delete_and_create_metadata_profile()
+    
+    with caplog.at_level(logging.INFO):
+        response = post_bulk_api(payload, logging)
+        
+        assert response.status_code == expected_status, \
+            f"Expected status {expected_status} but got {response.status_code}. Response: {response.json()}"
+        
+        if expected_error:
+            assert expected_error in response.json()["message"], \
+                f"Expected error message to contain '{expected_error}' but got: {response.json()['message']}"
+        else:
+            # Valid term settings should create a job
+            assert "job_id" in response.json(), "Expected job_id in response for valid term_settings"
+
+
+@pytest.mark.test_bulk_api_ros
+@pytest.mark.sanity
+def test_bulk_api_combined_custom_settings(cluster_type, caplog):
+    """
+    Validates that cluster_name, model_settings, and term_settings
+    can be used together in a single bulk API request.
+    """
+    form_kruize_url(cluster_type)
+    
+    payload = base_payload()
+    payload["cluster_name"] = "test-cluster"
+    payload["model_settings"] = {"models": ["performance"]}
+    payload["term_settings"] = {"terms": ["short", "medium"]}
+    payload["time_range"]["start"] = "2025-01-01T00:00:00Z"
+    payload["time_range"]["end"] = "2025-01-02T00:00:00Z"
+    
+    delete_and_create_metric_profile()
+    delete_and_create_metadata_profile()
+    
+    with caplog.at_level(logging.INFO):
+        response = post_bulk_api(payload, logging)
+        
+        assert response.status_code == SUCCESS_200_STATUS_CODE, \
+            f"Expected status {SUCCESS_200_STATUS_CODE} but got {response.status_code}. Response: {response.json()}"
+        
+        # Should successfully create a job with all custom settings
+        assert "job_id" in response.json(), "Expected job_id in response for combined custom settings"
+
+    


### PR DESCRIPTION
## Description

Add model_settings and term_settings support to Bulk API

New Fields Added to Bulk API
model_settings: Customize which recommendation models to generate

Valid values: "performance", "cost" (case-insensitive)
Default: Both models if not specified
term_settings: Customize which recommendation terms to generate

Valid values: "short", "medium", "long" (case-insensitive)
Default: All terms if not specified

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [x] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [x] Dependent changes merged
- [x] Documentation updated
- [x] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Add support in the Bulk API for optional model and term settings that are validated and propagated to experiment recommendation settings.

New Features:
- Introduce optional model_settings to control which recommendation models are generated in bulk jobs.
- Introduce optional term_settings to control which recommendation terms are generated in bulk jobs.

Enhancements:
- Extend bulk request validation to handle model_settings and term_settings with case-insensitive whitelists and clearer error messages.
- Propagate validated model and term settings from bulk requests into RecommendationSettings used when creating experiments.
- Update bulk API design documentation to illustrate usage of cluster_name, model_settings, and term_settings in request payloads.

Tests:
- Add bulk API tests covering valid, invalid, and omitted model_settings and term_settings, including combined usage with cluster_name.