### PR TITLE
[feat:podCount] Add metrics for new recommendations api

### DIFF
--- a/src/main/java/com/autotune/analyzer/services/RecommendationsResource.java
+++ b/src/main/java/com/autotune/analyzer/services/RecommendationsResource.java
@@ -104,7 +104,7 @@ public class RecommendationsResource extends HttpServlet {
     ) throws ServletException, IOException {
         LOGGER.info("RecommendationsResource GET request received");
         String statusValue = KruizeConstants.APIMessages.FAILURE;
-        Timer.Sample timerListRec = Timer.start(MetricsConfig.meterRegistry());
+        Timer.Sample timer = Timer.start(MetricsConfig.meterRegistry());
 
         response.setContentType(JSON_CONTENT_TYPE);
         response.setCharacterEncoding(CHARACTER_ENCODING);
@@ -242,9 +242,9 @@ public class RecommendationsResource extends HttpServlet {
             e.printStackTrace();
             sendErrorResponse(response, e, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
         } finally {
-            MetricsConfig.timerListRec = MetricsConfig.timerBListRec.tag("status", statusValue)
+            MetricsConfig.timerGETRecommendations = MetricsConfig.timerBGETRecommendations.tag("status", statusValue)
                     .register(MetricsConfig.meterRegistry());
-            timerListRec.stop(MetricsConfig.timerListRec);
+            timer.stop(MetricsConfig.timerGETRecommendations);
         }
     }
 
@@ -261,7 +261,7 @@ public class RecommendationsResource extends HttpServlet {
         int calCount = counter.incrementAndGet();
         LOGGER.debug("RecommendationsResource POST request received - count: {}", calCount);
         String statusValue = KruizeConstants.APIMessages.FAILURE;
-        Timer.Sample timerBRecommendationResource = Timer.start(MetricsConfig.meterRegistry());
+        Timer.Sample timer = Timer.start(MetricsConfig.meterRegistry());
         
         try {
             request.setCharacterEncoding(CHARACTER_ENCODING);
@@ -314,10 +314,10 @@ public class RecommendationsResource extends HttpServlet {
             sendErrorResponse(response, e, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
         } finally {
             LOGGER.debug("RecommendationsResource POST completed - count: {}", calCount);
-            MetricsConfig.timerRecommendationResource = MetricsConfig.timerBRecommendationResource
+            MetricsConfig.timerPOSTRecommendations = MetricsConfig.timerBPOSTRecommendations
                     .tag(KruizeConstants.DataSourceConstants.DataSourceQueryJSONKeys.STATUS, statusValue)
                     .register(MetricsConfig.meterRegistry());
-            timerBRecommendationResource.stop(MetricsConfig.timerRecommendationResource);
+            timer.stop(MetricsConfig.timerPOSTRecommendations);
         }
     }
 

--- a/src/main/java/com/autotune/utils/MetricsConfig.java
+++ b/src/main/java/com/autotune/utils/MetricsConfig.java
@@ -15,8 +15,9 @@ import io.micrometer.prometheus.PrometheusMeterRegistry;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class MetricsConfig {
-    
-    public static Timer timerListRec, timerListExp, timerCreateExp, timerUpdateResults, timerUpdateRecomendations, timerRecommendationResource;
+
+    public static Timer timerPOSTRecommendations, timerGETRecommendations;
+    public static Timer timerListRec, timerListExp, timerCreateExp, timerUpdateResults, timerUpdateRecomendations;
     public static Timer timerLoadRecExpName, timerLoadResultsExpName, timerLoadExpName, timerLoadRecExpNameDate, timerLoadBulkJobId, timerUpdateBulkJobId,  timerBoxPlots, timerUpdateExpDate;
     public static Timer timerLoadAllRec, timerLoadAllExp, timerLoadAllResults;
     public static Timer timerAddRecDB, timerAddResultsDB, timerAddExpDB, timerAddBulkResultsDB, timerSaveBulkJobDB, timerAddBulkJob;
@@ -26,7 +27,8 @@ public class MetricsConfig {
     public static Timer timerImportMetadata, timerGetMetadata;
     public static Timer timerJobStatus, timerCreateBulkJob, timerGetExpMap, timerCreateBulkExp, timerGenerateBulkRec, timerRunJob;
     public static Counter timerKruizeNotifications , timerBulkJobs;
-    public static Timer.Builder timerBListRec, timerBListExp, timerBCreateExp, timerBUpdateResults, timerBUpdateRecommendations, timerBUpdateExpDate, timerBRecommendationResource;
+    public static Timer.Builder timerBListRec, timerBListExp, timerBCreateExp, timerBUpdateResults, timerBUpdateRecommendations, timerBUpdateExpDate;
+    public static Timer.Builder timerBPOSTRecommendations, timerBGETRecommendations;
     public static Timer.Builder timerBLoadRecExpName, timerBLoadResultsExpName, timerBLoadExpName, timerBLoadRecExpNameDate, timerBBoxPlots;
     public static Timer.Builder timerBLoadAllRec, timerBLoadAllExp, timerBLoadAllResults;
     public static Timer.Builder timerBAddRecDB, timerBAddResultsDB, timerBAddExpDB, timerBAddBulkResultsDB, timerBLoadBulkJobId, timerBUpdateBulkJobId, timerBSaveBulkJobDB, timerBaddBulkJob;
@@ -60,7 +62,6 @@ public class MetricsConfig {
         timerBCreateExp = Timer.builder("kruizeAPI").description(API_METRIC_DESC).tag("api", "createExperiment").tag("method", "POST");
         timerBUpdateResults = Timer.builder("kruizeAPI").description(API_METRIC_DESC).tag("api", "updateResults").tag("method", "POST");
         timerBUpdateRecommendations = Timer.builder("kruizeAPI").description(API_METRIC_DESC).tag("api", "updateRecommendations").tag("method", "POST");
-        timerBRecommendationResource = Timer.builder("kruizeAPI").description(API_METRIC_DESC).tag("api", "recommendations").tag("method", "POST");
 
         timerBLoadRecExpName = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method", "loadRecommendationsByExperimentName");
         timerBLoadRecExpNameDate = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method", "loadRecommendationsByExperimentNameAndDate");
@@ -110,6 +111,9 @@ public class MetricsConfig {
         timerBAddLayerDB = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method", "addLayerToDB");
         timerBLoadAllLayers = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method", "loadAllLayers");
         timerBLoadLayerByName = Timer.builder("kruizeDB").description(DB_METRIC_DESC).tag("method", "loadLayerByName");
+
+        timerBPOSTRecommendations = Timer.builder("kruizeAPI").description(API_METRIC_DESC).tag("api", "recommendations").tag("method", "POST");
+        timerBGETRecommendations = Timer.builder("kruizeAPI").description(API_METRIC_DESC).tag("api", "recommendations").tag("method", "GET");
 
         new ClassLoaderMetrics().bindTo(meterRegistry);
         new ProcessorMetrics().bindTo(meterRegistry);


### PR DESCRIPTION
## Description

This PR is to have changes related to pushing metrics related to Kruize API to prometheus.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Add dedicated Prometheus timers for GET and POST /recommendations API endpoints and wire RecommendationsResource to use them.

New Features:
- Expose separate metrics timers for GET and POST recommendations API calls to Prometheus.

Enhancements:
- Align recommendations API metrics naming and tagging with existing Kruize API metrics configuration.