### PR TITLE
fix test faulure in local monitoring mode with new recommendation api

### DIFF
--- a/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
@@ -123,7 +123,8 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
         IntervalResults lastDatapoint = filteredResultsMap.get(monitoringEndTime);
 
         RecommendationConfigItem configItem = RecommendationUtils.getCurrentValue(lastDatapoint, AnalyzerConstants.MetricName.podCount, notifications);
-        if (configItem != null && configItem.getAmount() != null && configItem.getAmount() > 0) {
+        if (configItem != null && configItem.getAmount() != null) {
+            // RecommendationUtils.getCurrentValue ensured that configItem.getAmount() is never 0. It can be 'null'.
             int replicas = (int) Math.ceil(configItem.getAmount());
             currentConfig.setReplicas(replicas);
             LOGGER.debug("Current replicas for workload '{}' is {}", containerData.getContainer_name(), replicas);
@@ -153,10 +154,6 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
         for (RecommendationConstants.RecommendationNotification recommendationNotification : notifications) {
             timestampRecommendation.addNotification(new RecommendationNotification(recommendationNotification));
         }
-        // current config should be null if requests, limits and replica are not available to avoid empty current config {}
-        if (currentRequestsMap.isEmpty() && currentLimitsMap.isEmpty() && currentConfig.getReplicas() == null)
-            return null;
-
         if (!currentRequestsMap.isEmpty()) {
             currentConfig.setRequests(currentRequestsMap);
         }

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
@@ -123,8 +123,7 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
         IntervalResults lastDatapoint = filteredResultsMap.get(monitoringEndTime);
 
         RecommendationConfigItem configItem = RecommendationUtils.getCurrentValue(lastDatapoint, AnalyzerConstants.MetricName.podCount, notifications);
-        if (configItem != null && configItem.getAmount() != null) {
-            // RecommendationUtils.getCurrentValue ensured that configItem.getAmount() is never 0. It can be 'null'.
+        if (configItem != null && configItem.getAmount() != null && configItem.getAmount() > 0) {
             int replicas = (int) Math.ceil(configItem.getAmount());
             currentConfig.setReplicas(replicas);
             LOGGER.debug("Current replicas for workload '{}' is {}", containerData.getContainer_name(), replicas);

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
@@ -154,6 +154,10 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
         for (RecommendationConstants.RecommendationNotification recommendationNotification : notifications) {
             timestampRecommendation.addNotification(new RecommendationNotification(recommendationNotification));
         }
+        // current config should be null if requests, limits and replica are not available to avoid empty current config {}
+        if (currentRequestsMap.isEmpty() && currentLimitsMap.isEmpty() && currentConfig.getReplicas() == null)
+            return null;
+
         if (!currentRequestsMap.isEmpty()) {
             currentConfig.setRequests(currentRequestsMap);
         }

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
@@ -433,7 +433,7 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
                 max = calcPodCounts.stream().mapToDouble(Double::doubleValue).max().orElse(0.0);
             } else if (metricName == AnalyzerConstants.MetricName.podCount) { // Compute min, max, avg directly from podCount datapoints.
                 avg = metricDatapoints.stream()
-                        .mapToDouble(MetricAggregationInfoResults::getSum)
+                        .mapToDouble(MetricAggregationInfoResults::getAvg)
                         .average()
                         .orElse(0.0);
                 if (avg > 0.0) {

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
@@ -401,7 +401,7 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
             if (null == metricAggregationInfoResults) {
                 // Unable to calculate pod count aggregation values
                 if (notifications != null)
-                    notifications.add(new RecommendationNotification(RecommendationConstants.RecommendationNotification.NOTICE_POD_COUNT_DERIVED_FROM_CPU));
+                    notifications.add(new RecommendationNotification(RecommendationConstants.RecommendationNotification.ERROR_NOT_ENOUGH_DATA_FOR_POD_COUNT));
             }
         }
 

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
@@ -125,7 +125,7 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
         RecommendationConfigItem configItem = RecommendationUtils.getCurrentValue(lastDatapoint, AnalyzerConstants.MetricName.podCount, notifications);
         if (configItem != null && configItem.getAmount() != null) {
             // RecommendationUtils.getCurrentValue ensured that configItem.getAmount() is never 0. It can be 'null'.
-            int replicas = (int) Math.ceil(configItem.getAmount());
+            int replicas = (int) Math.round(configItem.getAmount());
             currentConfig.setReplicas(replicas);
             LOGGER.debug("Current replicas for workload '{}' is {}", containerData.getContainer_name(), replicas);
         }
@@ -429,24 +429,24 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
                 max = calcPodCounts.stream().mapToDouble(Double::doubleValue).max().orElse(0.0);
             } else if (metricName == AnalyzerConstants.MetricName.podCount) { // Compute min, max, avg directly from podCount datapoints.
                 avg = metricDatapoints.stream()
-                        .mapToDouble(MetricAggregationInfoResults::getAvg)
+                        .mapToDouble(MetricAggregationInfoResults::getSum)
                         .average()
                         .orElse(0.0);
                 if (avg > 0.0) {
                     min = metricDatapoints.stream()
-                            .mapToDouble(MetricAggregationInfoResults::getMin)
+                            .mapToDouble(MetricAggregationInfoResults::getSum)
                             .min()
                             .orElse(0.0);
                     max = metricDatapoints.stream()
-                            .mapToDouble(MetricAggregationInfoResults::getMax)
+                            .mapToDouble(MetricAggregationInfoResults::getSum)
                             .max()
                             .orElse(0.0);
                 }
             }
             metricAggregationInfoResults = new MetricAggregationInfoResults();
-            metricAggregationInfoResults.setAvg(Math.ceil(avg));
-            metricAggregationInfoResults.setMin(Math.ceil(min));
-            metricAggregationInfoResults.setMax(Math.ceil(max));
+            metricAggregationInfoResults.setAvg((double) Math.round(avg));
+            metricAggregationInfoResults.setMin((double) Math.round(min));
+            metricAggregationInfoResults.setMax((double) Math.round(max));
         }
 
         LOGGER.debug("Aggregation Info for metric {}: avg = {} min={}, max={}", metricName, avg, min, max);

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/ContainerRecommendationProcessor.java
@@ -383,6 +383,10 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
             // 2. Calculate from 'cpuUsage' datapoints using formulae avg of 'sum/avg', min of 'sum/avg', max of 'sum/avg'
             if (null == metricAggregationInfoResults) {
                 metricAggregationInfoResults = getPodCountAggrInfoFromMetric(filteredResultsMap, AnalyzerConstants.MetricName.cpuUsage);
+                if (metricAggregationInfoResults != null) {
+                    if (notifications != null)
+                        notifications.add(new RecommendationNotification(RecommendationConstants.RecommendationNotification.NOTICE_POD_COUNT_DERIVED_FROM_CPU));
+                }
             }
 
             // 3. Calculate from 'memoryUsage' datapoints using formulae avg of 'sum/avg', min of 'sum/avg', max of 'sum/avg'
@@ -391,11 +395,11 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
                 if (null != metricAggregationInfoResults) {
                     if (notifications != null)
                         notifications.add(new RecommendationNotification(RecommendationConstants.RecommendationNotification.NOTICE_POD_COUNT_DERIVED_FROM_MEMORY));
-                } else {
-                    if (notifications != null)
-                        notifications.add(new RecommendationNotification(RecommendationConstants.RecommendationNotification.ERROR_NOT_ENOUGH_DATA_FOR_POD_COUNT));
                 }
-            } else {
+            }
+
+            if (null == metricAggregationInfoResults) {
+                // Unable to calculate pod count aggregation values
                 if (notifications != null)
                     notifications.add(new RecommendationNotification(RecommendationConstants.RecommendationNotification.NOTICE_POD_COUNT_DERIVED_FROM_CPU));
             }
@@ -434,11 +438,11 @@ public final class ContainerRecommendationProcessor extends BaseRecommendationPr
                         .orElse(0.0);
                 if (avg > 0.0) {
                     min = metricDatapoints.stream()
-                            .mapToDouble(MetricAggregationInfoResults::getSum)
+                            .mapToDouble(MetricAggregationInfoResults::getMin)
                             .min()
                             .orElse(0.0);
                     max = metricDatapoints.stream()
-                            .mapToDouble(MetricAggregationInfoResults::getSum)
+                            .mapToDouble(MetricAggregationInfoResults::getMax)
                             .max()
                             .orElse(0.0);
                 }

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/NamespaceRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/NamespaceRecommendationProcessor.java
@@ -146,10 +146,6 @@ public final class NamespaceRecommendationProcessor extends BaseRecommendationPr
         for (RecommendationConstants.RecommendationNotification recommendationNotification : notifications) {
             timestampRecommendation.addNotification(new RecommendationNotification(recommendationNotification));
         }
-        // current config should be null if requests and limits are not available to avoid empty current config {}
-        if (currentNamespaceRequestsMap.isEmpty() && currentNamespaceLimitsMap.isEmpty())
-            return null;
-
         if (!currentNamespaceRequestsMap.isEmpty()) {
             currentNamespaceConfig.setRequests(currentNamespaceRequestsMap);
         }

--- a/src/main/java/com/autotune/analyzer/recommendations/engine/NamespaceRecommendationProcessor.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/engine/NamespaceRecommendationProcessor.java
@@ -146,6 +146,10 @@ public final class NamespaceRecommendationProcessor extends BaseRecommendationPr
         for (RecommendationConstants.RecommendationNotification recommendationNotification : notifications) {
             timestampRecommendation.addNotification(new RecommendationNotification(recommendationNotification));
         }
+        // current config should be null if requests and limits are not available to avoid empty current config {}
+        if (currentNamespaceRequestsMap.isEmpty() && currentNamespaceLimitsMap.isEmpty())
+            return null;
+
         if (!currentNamespaceRequestsMap.isEmpty()) {
             currentNamespaceConfig.setRequests(currentNamespaceRequestsMap);
         }

--- a/src/main/java/com/autotune/analyzer/recommendations/utils/RecommendationUtils.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/utils/RecommendationUtils.java
@@ -72,6 +72,7 @@ public class RecommendationUtils {
                     format = metricAggregationInfoResults.getFormat();
                 }
             }
+            // fallback for replicas in case podCount metrics is unavailable or empty
             if ((currentValue == null || currentValue == 0.0) && metricName == AnalyzerConstants.MetricName.podCount) {
                 if (currentDatapoint.getMetricResultsMap().containsKey(AnalyzerConstants.MetricName.cpuUsage)) {
                     MetricResults cpuMetricResults = currentDatapoint.getMetricResultsMap().get(AnalyzerConstants.MetricName.cpuUsage);

--- a/src/main/java/com/autotune/analyzer/recommendations/utils/RecommendationUtils.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/utils/RecommendationUtils.java
@@ -68,7 +68,10 @@ public class RecommendationUtils {
                 MetricResults metricResults = currentDatapoint.getMetricResultsMap().get(metricName);
                 MetricAggregationInfoResults metricAggregationInfoResults = metricResults.getAggregationInfoResult();
                 if (null != metricAggregationInfoResults) {
-                    currentValue = metricAggregationInfoResults.getAvg();
+                    currentValue = metricAggregationInfoResults.getSum();
+                    if (currentValue == 0.0) {
+                        currentValue = metricAggregationInfoResults.getAvg();
+                    }
                     format = metricAggregationInfoResults.getFormat();
                 }
             }

--- a/src/main/java/com/autotune/analyzer/recommendations/utils/RecommendationUtils.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/utils/RecommendationUtils.java
@@ -71,7 +71,8 @@ public class RecommendationUtils {
                     currentValue = metricAggregationInfoResults.getAvg();
                     format = metricAggregationInfoResults.getFormat();
                 }
-            } else if (metricName == AnalyzerConstants.MetricName.podCount) { // fallback for replicas in case podCount metrics is unavailable
+            }
+            if ((currentValue == null || currentValue == 0.0) && metricName == AnalyzerConstants.MetricName.podCount) {
                 if (currentDatapoint.getMetricResultsMap().containsKey(AnalyzerConstants.MetricName.cpuUsage)) {
                     MetricResults cpuMetricResults = currentDatapoint.getMetricResultsMap().get(AnalyzerConstants.MetricName.cpuUsage);
                     currentValue = getPodCount(cpuMetricResults.getAggregationInfoResult());

--- a/src/main/java/com/autotune/analyzer/recommendations/utils/RecommendationUtils.java
+++ b/src/main/java/com/autotune/analyzer/recommendations/utils/RecommendationUtils.java
@@ -68,10 +68,7 @@ public class RecommendationUtils {
                 MetricResults metricResults = currentDatapoint.getMetricResultsMap().get(metricName);
                 MetricAggregationInfoResults metricAggregationInfoResults = metricResults.getAggregationInfoResult();
                 if (null != metricAggregationInfoResults) {
-                    currentValue = metricAggregationInfoResults.getSum();
-                    if (currentValue == 0.0) {
-                        currentValue = metricAggregationInfoResults.getAvg();
-                    }
+                    currentValue = metricAggregationInfoResults.getAvg();
                     format = metricAggregationInfoResults.getFormat();
                 }
             }

--- a/tests/scripts/helpers/runtime_utils.py
+++ b/tests/scripts/helpers/runtime_utils.py
@@ -645,7 +645,7 @@ def _generate_and_list_recommendations_for_petclinic(
         list_reco_json = response.json()
 
         error_msg = validate_list_reco_json(list_reco_json, list_reco_json_local_monitoring_schema)
-        assert error_msg == ""
+        assert error_msg == "", f"error_msg = {error_msg}"
 
         validate_local_monitoring_recommendation_data_present(list_reco_json)
         return list_reco_json

--- a/tests/scripts/helpers/utils.py
+++ b/tests/scripts/helpers/utils.py
@@ -848,7 +848,8 @@ def validate_container(update_results_container, update_results_json, list_reco_
 
                 current_config = list_reco_container["recommendations"]["data"][interval_end_time]["current"]
                 if pytest.USE_NEW_API:
-                    current_config.update(current_config.pop("resources"))
+                    if "resources" in current_config:
+                        current_config.update(current_config.pop("resources"))
                 # validate current config
                 assert current_config is not None
                 validate_current(current_config, CONTAINER_EXPERIMENT_TYPE)
@@ -960,7 +961,8 @@ def validate_namespace(update_results_namespace, update_results_json, list_reco_
                 terms_obj = list_reco_namespace["recommendations"]["data"][interval_end_time]["recommendation_terms"]
                 current_config = list_reco_namespace["recommendations"]["data"][interval_end_time]["current"]
                 if pytest.USE_NEW_API:
-                    current_config.update(current_config.pop("resources"))
+                    if "resources" in current_config:
+                        current_config.update(current_config.pop("resources"))
                 duration_terms = {'short_term': 4, 'medium_term': 7, 'long_term': 15}
                 for term in duration_terms.keys():
                     if check_if_recommendations_are_present(terms_obj[term]):
@@ -1056,7 +1058,8 @@ def validate_local_monitoring_container(create_exp_container, list_reco_containe
 
         current_config = list_reco_container["recommendations"]["data"][interval_end_time]["current"]
         if pytest.USE_NEW_API:
-            current_config.update(current_config.pop("resources"))
+            if "resources" in current_config:
+                current_config.update(current_config.pop("resources"))
         # validate current config
         assert current_config is not None
         validate_current(current_config, CONTAINER_EXPERIMENT_TYPE)
@@ -1156,7 +1159,8 @@ def validate_local_monitoring_namespace(create_exp_namespace, list_reco_namespac
         terms_obj = list_reco_namespace["recommendations"]["data"][interval_end_time]["recommendation_terms"]
         current_config = list_reco_namespace["recommendations"]["data"][interval_end_time]["current"]
         if pytest.USE_NEW_API:
-            current_config.update(current_config.pop("resources"))
+            if "resources" in current_config:
+                current_config.update(current_config.pop("resources"))
         duration_terms = {'short_term': 4, 'medium_term': 7, 'long_term': 15}
         for term in duration_terms.keys():
             if check_if_recommendations_are_present(terms_obj[term]):


### PR DESCRIPTION
## Description

Please describe the issue or feature and the summary of changes made to fix this. 

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Ensure current recommendation configs are only produced when valid resource or replica data is available and tighten validation in local monitoring tests.

Bug Fixes:
- Ignore zero or missing podCount values when deriving current replica counts for container recommendations.
- Return null current configs for containers and namespaces when no requests, limits, or replicas are present to avoid empty current config objects.
- Improve podCount fallback logic to derive replicas from CPU usage when primary metrics are absent.
- Expose validation failure details in local monitoring recommendation tests to aid debugging.

Tests:
- Augment local monitoring recommendation test assertions to include validation error messages on failure.