### PR TITLE
[feat:podCount] scale test changes

### DIFF
--- a/scripts/kruize_metrics.py
+++ b/scripts/kruize_metrics.py
@@ -174,10 +174,11 @@ def get_kruize_db_metrics(namespace):
         return f"Error executing queries: {e}"
 
 def run_queries(map_type,server,prometheus_url=None):
+    global use_new_api
     TOKEN = 'TOKEN'
     if prometheus_url is None:
         if cluster_type == "openshift":
-            prometheus_url = f"https://thanos-querier-openshift-monitoring.apps.{server}/api/v1/query"
+            prometheus_url = f"https://thanos-querier-openshift-monitoring.{server}/api/v1/query"
         elif cluster_type == "minikube":
             prometheus_url = f"http://{server}:9090/api/v1/query"
 
@@ -202,6 +203,7 @@ def run_queries(map_type,server,prometheus_url=None):
             response = requests.get(prometheus_url, headers=headers, params={'query': query}, verify=False)
             if response.status_code == 200:
                 results_data[key] = response.json()['data']
+                print(f"Calling {prometheus_url} for {key} using query {query} and response is = {response.json()['data']}")
                 if "result" in results_data[key] and isinstance(results_data[key]["result"], list) and len(results_data[key]["result"]) > 0:
                     if "value" in results_data[key]["result"][0]:
                         results_map[key] = results_data[key]["result"][0]["value"][1]
@@ -307,8 +309,9 @@ def main(argv):
     global namespace
     global prometheus_url
     global outputdir
+    global use_new_api
 
-    parser = argparse.ArgumentParser(description='kruize_metrics.py -c <cluster_type> -s <cluster_name> -p <prometheus_url> -t <time duration for a query in mins:Default:60m> -d <duration the script runs in hours> -q <query_type:increase/total.Default:increase> -o <single data point:Default:true> -e <results dir:Default:results')
+    parser = argparse.ArgumentParser(description='kruize_metrics.py -c <cluster_type> -s <cluster_name> -p <prometheus_url> -t <time duration for a query in mins:Default:60m> -d <duration the script runs in hours> -q <query_type:increase/total.Default:increase> -o <single data point:Default:true> -e <results dir:Default:results --api-version <API version: v1/legacy.Default:legacy>')
     parser.add_argument('-c', '--cluster_type', help='Cluster type. Supported types:openshift/minikube')
     parser.add_argument('-s', '--cluster_name', help='Name/IP to access the openshift/minikube cluster. Example:kruize-rm.p1.openshiftapps.com/localhost. Prometheus URL is generated using this name if prometheus_url is None')
     parser.add_argument('-p', '--prometheus_url', help='Prometheus URL',default=None)
@@ -318,6 +321,7 @@ def main(argv):
     parser.add_argument('-o', '--get_one_data_point', help='Single data point', default='true')
     parser.add_argument('-r', '--resultsfile', help='Results file',default='kruizemetrics.csv')
     parser.add_argument('-e', '--outputdir', help='directory to store the results', default='results')
+    parser.add_argument('--api-version', type=str, help='API version (v1/legacy)', default='legacy')
     #args = parser.parse_args()
     args, unknown = parser.parse_known_args()
 
@@ -341,6 +345,9 @@ def main(argv):
     resultsfile = args.resultsfile
     prometheus_url = args.prometheus_url
     outputdir = args.outputdir
+
+    use_new_api = args.api_version.lower() in ['v1', 'true']
+    print("rosSimulationScalabilityTest :: api_version =", args.api_version)
 
     if cluster_type == "openshift":
         namespace = "openshift-tuning"
@@ -442,7 +449,32 @@ def main(argv):
             "kruize_cpu_max": "max(sum(rate(container_cpu_usage_seconds_total{pod=~"'"kruize-[^-]*-[^-]*$"'",container=\"kruize\"}"f"[{time_duration}])))",
             "updateRecommendations_notifications_total": "sum((KruizeNotifications_total{api=\"updateRecommendations\",application=\"Kruize\"}))"
         }
-    
+
+    if use_new_api:
+        queries_map["listRecommendations_count_success"] = f"sum(increase(kruizeAPI_count{{api=\"recommendations\",method=\"GET\", application=\"Kruize\",status=\"success\"}}[{time_duration}]))"
+        queries_map["listRecommendations_count_failure"] = f"sum(increase(kruizeAPI_count{{api=\"recommendations\",method=\"GET\", application=\"Kruize\",status=\"failure\"}}[{time_duration}]))"
+        queries_map["listRecommendations_sum_success"] = f"sum(increase(kruizeAPI_sum{{api=\"recommendations\",method=\"GET\", application=\"Kruize\",status=\"success\"}}[{time_duration}]))"
+        queries_map["listRecommendations_max_success"] = f"sum(increase(kruizeAPI_max{{api=\"recommendations\",method=\"GET\", application=\"Kruize\",status=\"success\"}}[{time_duration}]))"
+
+        queries_map["updateRecommendations_count_success"] = f"sum(increase(kruizeAPI_count{{api=\"recommendations\",method=\"POST\", application=\"Kruize\",status=\"success\"}}[{time_duration}]))"
+        queries_map["updateRecommendations_count_failure"] = f"sum(increase(kruizeAPI_count{{api=\"recommendations\",method=\"POST\", application=\"Kruize\",status=\"failure\"}}[{time_duration}]))"
+        queries_map["updateRecommendations_sum_success"] = f"sum(increase(kruizeAPI_sum{{api=\"recommendations\",method=\"POST\", application=\"Kruize\",status=\"success\"}}[{time_duration}]))"
+        queries_map["updateRecommendations_max_success"] = f"sum(increase(kruizeAPI_max{{api=\"recommendations\",method=\"POST\", application=\"Kruize\",status=\"success\"}}[{time_duration}]))"
+        queries_map["updateRecommendations_notifications_total"] = "sum((KruizeNotifications_total{api=\"recommendations\",method=\"POST\",application=\"Kruize\"}))"
+
+
+    if use_new_api:
+        queries_map_total["listRecommendations_count_success"] = "sum((kruizeAPI_count{api=\"recommendations\",method=\"GET\",application=\"Kruize\",status=\"success\"}))"
+        queries_map_total["listRecommendations_count_failure"] = "sum((kruizeAPI_count{api=\"recommendations\",method=\"GET\",application=\"Kruize\",status=\"failure\"}))"
+        queries_map_total["listRecommendations_sum_success"] = "sum((kruizeAPI_sum{api=\"recommendations\",method=\"GET\",application=\"Kruize\",status=\"success\"}))"
+        queries_map_total["listRecommendations_max_success"] = "max(max_over_time(kruizeAPI_max{{api=\"recommendations\",method=\"GET\",application=\"Kruize\",status=\"success\"}}[6h]))"
+
+        queries_map_total["updateRecommendations_count_success"] = "sum((kruizeAPI_count{api=\"recommendations\",method=\"POST\",application=\"Kruize\",status=\"success\"}))"
+        queries_map_total["updateRecommendations_count_failure"] = "sum((kruizeAPI_count{api=\"recommendations\",method=\"POST\",application=\"Kruize\",status=\"failure\"}))"
+        queries_map_total["updateRecommendations_sum_success"] = "sum((kruizeAPI_sum{api=\"recommendations\",method=\"POST\",application=\"Kruize\",status=\"success\"}))"
+        queries_map_total["updateRecommendations_max_success"] = "max(max_over_time(kruizeAPI_max{{api=\"recommendations\",method=\"POST\",application=\"Kruize\",status=\"success\"}}[6h]))"
+        queries_map_total["updateRecommendations_notifications_total"] = "sum((KruizeNotifications_total{api=\"recommendations\",method=\"POST\",application=\"Kruize\"}))"
+
     # Create a thread to run the job scheduler
     job_thread = threading.Thread(target=schedule_job(queries_type,server,prometheus_url))
     job_thread.start()

--- a/scripts/kruize_metrics.py
+++ b/scripts/kruize_metrics.py
@@ -174,11 +174,10 @@ def get_kruize_db_metrics(namespace):
         return f"Error executing queries: {e}"
 
 def run_queries(map_type,server,prometheus_url=None):
-    global use_new_api
     TOKEN = 'TOKEN'
     if prometheus_url is None:
         if cluster_type == "openshift":
-            prometheus_url = f"https://thanos-querier-openshift-monitoring.{server}/api/v1/query"
+            prometheus_url = f"https://thanos-querier-openshift-monitoring.apps.{server}/api/v1/query"
         elif cluster_type == "minikube":
             prometheus_url = f"http://{server}:9090/api/v1/query"
 
@@ -203,7 +202,6 @@ def run_queries(map_type,server,prometheus_url=None):
             response = requests.get(prometheus_url, headers=headers, params={'query': query}, verify=False)
             if response.status_code == 200:
                 results_data[key] = response.json()['data']
-                print(f"Calling {prometheus_url} for {key} using query {query} and response is = {response.json()['data']}")
                 if "result" in results_data[key] and isinstance(results_data[key]["result"], list) and len(results_data[key]["result"]) > 0:
                     if "value" in results_data[key]["result"][0]:
                         results_map[key] = results_data[key]["result"][0]["value"][1]
@@ -462,8 +460,6 @@ def main(argv):
         queries_map["updateRecommendations_max_success"] = f"sum(increase(kruizeAPI_max{{api=\"recommendations\",method=\"POST\", application=\"Kruize\",status=\"success\"}}[{time_duration}]))"
         queries_map["updateRecommendations_notifications_total"] = "sum((KruizeNotifications_total{api=\"recommendations\",method=\"POST\",application=\"Kruize\"}))"
 
-
-    if use_new_api:
         queries_map_total["listRecommendations_count_success"] = "sum((kruizeAPI_count{api=\"recommendations\",method=\"GET\",application=\"Kruize\",status=\"success\"}))"
         queries_map_total["listRecommendations_count_failure"] = "sum((kruizeAPI_count{api=\"recommendations\",method=\"GET\",application=\"Kruize\",status=\"failure\"}))"
         queries_map_total["listRecommendations_sum_success"] = "sum((kruizeAPI_sum{api=\"recommendations\",method=\"GET\",application=\"Kruize\",status=\"success\"}))"

--- a/scripts/kruize_metrics.py
+++ b/scripts/kruize_metrics.py
@@ -309,7 +309,7 @@ def main(argv):
     global outputdir
     global use_new_api
 
-    parser = argparse.ArgumentParser(description='kruize_metrics.py -c <cluster_type> -s <cluster_name> -p <prometheus_url> -t <time duration for a query in mins:Default:60m> -d <duration the script runs in hours> -q <query_type:increase/total.Default:increase> -o <single data point:Default:true> -e <results dir:Default:results --api-version <API version: v1/legacy.Default:legacy>')
+    parser = argparse.ArgumentParser(description='kruize_metrics.py -c <cluster_type> -s <cluster_name> -p <prometheus_url> -t <time duration for a query in mins:Default:60m> -d <duration the script runs in hours> -q <query_type:increase/total.Default:increase> -o <single data point:Default:true> -e <results dir:Default:results> --api-version <API version: v1/legacy.Default:legacy>')
     parser.add_argument('-c', '--cluster_type', help='Cluster type. Supported types:openshift/minikube')
     parser.add_argument('-s', '--cluster_name', help='Name/IP to access the openshift/minikube cluster. Example:kruize-rm.p1.openshiftapps.com/localhost. Prometheus URL is generated using this name if prometheus_url is None')
     parser.add_argument('-p', '--prometheus_url', help='Prometheus URL',default=None)
@@ -344,7 +344,7 @@ def main(argv):
     prometheus_url = args.prometheus_url
     outputdir = args.outputdir
 
-    use_new_api = args.api_version.lower() in ['v1', 'true']
+    use_new_api = args.api_version.lower() == 'v1'
     print("rosSimulationScalabilityTest :: api_version =", args.api_version)
 
     if cluster_type == "openshift":

--- a/scripts/kruize_metrics.py
+++ b/scripts/kruize_metrics.py
@@ -452,12 +452,12 @@ def main(argv):
         queries_map["listRecommendations_count_success"] = f"sum(increase(kruizeAPI_count{{api=\"recommendations\",method=\"GET\", application=\"Kruize\",status=\"success\"}}[{time_duration}]))"
         queries_map["listRecommendations_count_failure"] = f"sum(increase(kruizeAPI_count{{api=\"recommendations\",method=\"GET\", application=\"Kruize\",status=\"failure\"}}[{time_duration}]))"
         queries_map["listRecommendations_sum_success"] = f"sum(increase(kruizeAPI_sum{{api=\"recommendations\",method=\"GET\", application=\"Kruize\",status=\"success\"}}[{time_duration}]))"
-        queries_map["listRecommendations_max_success"] = f"sum(increase(kruizeAPI_max{{api=\"recommendations\",method=\"GET\", application=\"Kruize\",status=\"success\"}}[{time_duration}]))"
+        queries_map["listRecommendations_max_success"] = f"max(max_over_time(kruizeAPI_max{{api=\"recommendations\",method=\"GET\",application=\"Kruize\",status=\"success\"}}[{time_duration}]))"
 
         queries_map["updateRecommendations_count_success"] = f"sum(increase(kruizeAPI_count{{api=\"recommendations\",method=\"POST\", application=\"Kruize\",status=\"success\"}}[{time_duration}]))"
         queries_map["updateRecommendations_count_failure"] = f"sum(increase(kruizeAPI_count{{api=\"recommendations\",method=\"POST\", application=\"Kruize\",status=\"failure\"}}[{time_duration}]))"
         queries_map["updateRecommendations_sum_success"] = f"sum(increase(kruizeAPI_sum{{api=\"recommendations\",method=\"POST\", application=\"Kruize\",status=\"success\"}}[{time_duration}]))"
-        queries_map["updateRecommendations_max_success"] = f"sum(increase(kruizeAPI_max{{api=\"recommendations\",method=\"POST\", application=\"Kruize\",status=\"success\"}}[{time_duration}]))"
+        queries_map["updateRecommendations_max_success"] = f"max(max_over_time(kruizeAPI_max{{api=\"recommendations\",method=\"POST\",application=\"Kruize\",status=\"success\"}}[{time_duration}]))",
         queries_map["updateRecommendations_notifications_total"] = "sum((KruizeNotifications_total{api=\"recommendations\",method=\"POST\",application=\"Kruize\"}))"
 
         queries_map_total["listRecommendations_count_success"] = "sum((kruizeAPI_count{api=\"recommendations\",method=\"GET\",application=\"Kruize\",status=\"success\"}))"

--- a/tests/README.md
+++ b/tests/README.md
@@ -63,7 +63,7 @@ First, cleanup any previous instances of autotune using the below command:
 Use the below command to test :
 
 ```
-<AUTOTUNE_REPO>/tests/test_autotune.sh -c minikube [-i autotune image] [-o [operator image]] [--testsuite=Group of tests that you want to perform] [--testcase=Particular test case that you want to test] [-n namespace] [--resultsdir=results directory] [--skipsetup] [--cleanup_prometheus] [-t cleanup kruize setup]
+<AUTOTUNE_REPO>/tests/test_autotune.sh -c minikube [-i autotune image] [-o [operator image]] [--testsuite=Group of tests that you want to perform] [--testcase=Particular test case that you want to test] [-n namespace] [--resultsdir=results directory] [--skipsetup] [--cleanup_prometheus] [--api-version=<v1|legacy>] [-t cleanup kruize setup]
 ```
 
 Where values for test_autotune.sh are:
@@ -78,6 +78,7 @@ usage: test_autotune.sh [ -c ] : cluster type. Supported type - minikube
 			[ --resultsdir ] : optional. Results directory location, by default it creates the results directory in current working directory
 			[ --skipsetup ] : optional. Specifying this option skips the autotune setup & application deployment
 			[ --cleanup_prometheus ] : optional. Specifying this option along with -t option cleans up prometheus setup
+			[ --api-version ] : optional. API version to use for recommendations - 'v1' for new API (/kruize/api/v1/recommendations), 'legacy' for old APIs (updateRecommendations/listRecommendations). Default is 'legacy'
 
 Note: If you want to run a particular testcase then it is mandatory to specify the testsuite
 

--- a/tests/scripts/remote_monitoring_tests/scalability_test.md
+++ b/tests/scripts/remote_monitoring_tests/scalability_test.md
@@ -21,7 +21,7 @@ Use the below command to test :
 
 ```
 cd <KRUIZE_REPO>/tests/scripts/remote_monitoring_tests/scale_test
-./remote_monitoring_scale_test_bulk.sh [-i Kruize image] [-r results directory path] [-u No. of experiments (default - 5000)] [-d No. of days of results (default - 15)] [-n No. of clients (default - 20)] [-m results duration interval in mins, (default - 15)] [-t interval hours (default - 6)] [-s Initial start date (default - 2023-01-10T00:00:00.000Z)] [-q query db interval in mins, (default - 10)] [-c Experiment type [container|namespace|container_ns|gpucontainer] (default - container)]
+./remote_monitoring_scale_test_bulk.sh [-i Kruize image] [-r results directory path] [-u No. of experiments (default - 5000)] [-d No. of days of results (default - 15)] [-n No. of clients (default - 20)] [-m results duration interval in mins, (default - 15)] [-t interval hours (default - 6)] [-s Initial start date (default - 2023-01-10T00:00:00.000Z)] [-q query db interval in mins, (default - 10)] [-c Experiment type [container|namespace|container_ns|gpucontainer] (default - container)] [--api-version=<v1|legacy>]
 ```
 
 Where values for remote_monitoring_scale_test_bulk.sh are:
@@ -39,7 +39,8 @@ usage: remote_monitoring_fault_tolerant_tests.sh
 	[-s Initial start date (default - 2023-01-10T00:00:00.000Z)]
 	[-q query db interval in mins, (default - 10)]
     [-c Experiment type [container|namespace|container_ns|gpucontainer] (default - container)]
-    [-a Test case (default - scale_5k) Valid values - [scale_5k/migration] migration - Used by db_migration test]"
+    [-a Test case (default - scale_5k) Valid values - [scale_5k/migration] migration - Used by db_migration test]
+    [--api-version] : optional. API version to use - 'v1' for new API (/kruize/api/v1/recommendations), 'legacy' for old APIs (updateRecommendations/listRecommendations). Default is 'legacy'
 ```
 
 For example,
@@ -66,6 +67,13 @@ cd <KRUIZE_REPO>/tests/scripts/remote_monitoring_tests/scale_test
 
 ```
 
+To test with the new Recommendations API v1.0:
+
+```
+cd <KRUIZE_REPO>/tests/scripts/remote_monitoring_tests/scale_test
+./remote_monitoring_scale_test_bulk.sh -i quay.io/kruize/autotune_operator:0.7  -u 250  -d 15  -n 20 -t 6  -q 10  -s 2023-01-10T00:00:00.000Z  -r /tmp/scale_test_results --api-version=v1
+
+```
 
 Once the tests are complete, manually check the logs for any exceptions or errors or crashes. Verify if the execution times captured in exec_time.log are as expected.
 

--- a/tests/scripts/remote_monitoring_tests/scalability_test.md
+++ b/tests/scripts/remote_monitoring_tests/scalability_test.md
@@ -67,11 +67,11 @@ cd <KRUIZE_REPO>/tests/scripts/remote_monitoring_tests/scale_test
 
 ```
 
-To test with the new Recommendations API v1.0:
+To test with the new Recommendations API v1.0 available from 0.11 release
 
 ```
 cd <KRUIZE_REPO>/tests/scripts/remote_monitoring_tests/scale_test
-./remote_monitoring_scale_test_bulk.sh -i quay.io/kruize/autotune_operator:0.7  -u 250  -d 15  -n 20 -t 6  -q 10  -s 2023-01-10T00:00:00.000Z  -r /tmp/scale_test_results --api-version=v1
+./remote_monitoring_scale_test_bulk.sh -i quay.io/kruize/autotune_operator:0.11  -u 250  -d 15  -n 20 -t 6  -q 10  -s 2023-01-10T00:00:00.000Z  -r /tmp/scale_test_results --api-version=v1
 
 ```
 

--- a/tests/scripts/remote_monitoring_tests/scale_test/parse_metrics.py
+++ b/tests/scripts/remote_monitoring_tests/scale_test/parse_metrics.py
@@ -23,6 +23,11 @@ def find_max_exec_time(exec_file):
     # Define the pattern to match
     pattern = r"scaletest\d+-\d+: Total time elapsed: (\d{2,3}:\d{2}:\d{2})"
 
+    # Check if file exists
+    if not os.path.exists(exec_file):
+        print(f"Execution time log not found: {exec_file}")
+        return
+
     with open(exec_file, "r") as file:
         lines = file.readlines()
 
@@ -67,7 +72,7 @@ def compute_max_avg(csv_file, column_name):
         return None, None
 
     avg_value = total_sum / count
-    
+
     return max_value, avg_value
 
 

--- a/tests/scripts/remote_monitoring_tests/scale_test/remote_monitoring_scale_test_bulk.sh
+++ b/tests/scripts/remote_monitoring_tests/scale_test/remote_monitoring_scale_test_bulk.sh
@@ -179,7 +179,7 @@ do
 	esac
 done
 
-echo "remote_monitoring_scale_test_bulk :: api_version = "+${api_version}
+echo "remote_monitoring_scale_test_bulk.sh :: api_version = ${api_version}"
 # Set the API version to default if not passed on parameter
 if [ -z "${api_version}" ]; then
   api_version="legacy"
@@ -232,7 +232,6 @@ fi
 
 if [ -z "${SERVER_IP_ADDR}" ]; then
 	oc expose svc/kruize -n ${NAMESPACE}
-	oc patch route kruize -p '{"spec":{"tls":{"termination":"edge","insecureEdgeTerminationPolicy":"Allow"}}}'
 
 	SERVER_IP_ADDR=($(oc status --namespace=${NAMESPACE} | grep "kruize" | grep port | cut -d " " -f1 | cut -d "/" -f3))
 	port=0

--- a/tests/scripts/remote_monitoring_tests/scale_test/remote_monitoring_scale_test_bulk.sh
+++ b/tests/scripts/remote_monitoring_tests/scale_test/remote_monitoring_scale_test_bulk.sh
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 ### Script to run scale test with Kruize in remote monitoring mode ##
+# Usage: ./remote_monitoring_scale_test_bulk.sh [--api-version=v1|legacy]
 #
 
 CURRENT_DIR="$(dirname "$(realpath "$0")")"
@@ -53,7 +54,16 @@ total_results_count=0
 
 function usage() {
 	echo
-	echo "Usage: [-i Kruize image] [-u No. of experiments (default - 5000)] [-d No. of days of results (default - 15)] [-n No. of clients (default - 20)] [-m results duration interval in mins, (default - 15)] [-t interval hours (default - 6)] [-s Initial start date (default - 2023-01-10T00:00:00.000Z)] [-q query db interval in mins, (default - 10)] [-r <resultsdir path>] [-l restore DB (default - false)] [-f DB file path to restore (default - ./db_backup.sql)] [-b kruize setup (default - true)] [-c Experiment type [container|namespace|container_ns|gpucontainer] (default - container)] [-a Test case (default - scale_5k)]"
+	echo "Usage: [-i Kruize image] [-u No. of experiments (default - 5000)] [-d No. of days of results (default - 15)] [-n No. of clients (default - 20)] [-m results duration interval in mins, (default - 15)] [-t interval hours (default - 6)] [-s Initial start date (default - 2023-01-10T00:00:00.000Z)] [-q query db interval in mins, (default - 10)] [-r <resultsdir path>] [-l restore DB (default - false)] [-f DB file path to restore (default - ./db_backup.sql)] [-b kruize setup (default - true)] [-c Experiment type [container|namespace|container_ns|gpucontainer] (default - container)] [-a Test case (default - scale_5k)] [--api-version=<v1|legacy>]"
+	echo
+	echo "API Version Parameter:"
+	echo "  --api-version=v1      Use NEW v1 API (/kruize/api/v1/recommendations)"
+	echo "  --api-version=legacy  Use OLD/LEGACY APIs (/updateRecommendations, /generateRecommendations)"
+	echo "  Default: legacy (if no parameter specified)"
+	echo
+	echo "Examples:"
+	echo "  ./remote_monitoring_scale_test_bulk.sh -u 1000 -d 7                    # Uses legacy API (default)"
+	echo "  ./remote_monitoring_scale_test_bulk.sh -u 1000 -d 7 --api-version=v1  # Uses new v1 API"
 	exit -1
 }
 
@@ -108,9 +118,16 @@ function kruize_scale_test_remote_patch() {
 
 }
 
-while getopts r:i:u:d:t:n:m:s:l:f:b:e:q:c:a:h gopts
+while getopts r:i:u:d:t:n:m:s:l:f:b:e:q:c:a:h:-: gopts
 do
 	case ${gopts} in
+	-)
+		case "${OPTARG}" in
+			api-version=*)
+				api_version=${OPTARG#*=}
+				;;
+		esac
+		;;
 	r)
 		RESULTS_DIR="${OPTARG}"		
 		;;
@@ -162,6 +179,12 @@ do
 	esac
 done
 
+echo "remote_monitoring_scale_test_bulk :: api_version = "+${api_version}
+# Set the API version to default if not passed on parameter
+if [ -z "${api_version}" ]; then
+  api_version="legacy"
+fi
+
 start_time=$(get_date)
 LOG_DIR="${RESULTS_DIR}/remote-monitoring-scale-test-$(date +%Y%m%d%H%M)"
 mkdir -p ${LOG_DIR}
@@ -209,6 +232,7 @@ fi
 
 if [ -z "${SERVER_IP_ADDR}" ]; then
 	oc expose svc/kruize -n ${NAMESPACE}
+	oc patch route kruize -p '{"spec":{"tls":{"termination":"edge","insecureEdgeTerminationPolicy":"Allow"}}}'
 
 	SERVER_IP_ADDR=($(oc status --namespace=${NAMESPACE} | grep "kruize" | grep port | cut -d " " -f1 | cut -d "/" -f3))
 	port=0
@@ -230,8 +254,8 @@ fi
 echo ""
 echo "Running scale test for kruize on ${CLUSTER_TYPE}" | tee -a ${LOG}
 echo ""
-echo "nohup ./run_bulk_scalability_test.sh -c "${CLUSTER_TYPE}" -f "${EXP_TYPE}" -a "${SERVER_IP_ADDR}" -p "${port}" -u "${num_exps}" -d "${num_days_of_res}" -n "${num_clients}" -m "${minutes_jump}" -i "${interval_hours}" -s "${initial_start_date}" -q "${query_db_interval}" -r "${LOG_DIR}" -e "${total_results_count}" > >(tee -a ${LOG}) 2>&1 & "
-nohup ./run_bulk_scalability_test.sh -c "${CLUSTER_TYPE}" -f "${EXP_TYPE}" -a "${SERVER_IP_ADDR}" -p "${port}" -u "${num_exps}" -d "${num_days_of_res}" -n "${num_clients}" -m "${minutes_jump}" -i "${interval_hours}" -s "${initial_start_date}" -q "${query_db_interval}" -r "${LOG_DIR}" -e "${total_results_count}" > >(tee -a ${LOG}) 2>&1 &
+echo "nohup ./run_bulk_scalability_test.sh -c "${CLUSTER_TYPE}" -f "${EXP_TYPE}" -a "${SERVER_IP_ADDR}" -p "${port}" -u "${num_exps}" -d "${num_days_of_res}" -n "${num_clients}" -m "${minutes_jump}" -i "${interval_hours}" -s "${initial_start_date}" -q "${query_db_interval}" -r "${LOG_DIR}" -e "${total_results_count}" --api-version="${api_version}" > >(tee -a ${LOG}) 2>&1 &"
+nohup ./run_bulk_scalability_test.sh -c "${CLUSTER_TYPE}" -f "${EXP_TYPE}" -a "${SERVER_IP_ADDR}" -p "${port}" -u "${num_exps}" -d "${num_days_of_res}" -n "${num_clients}" -m "${minutes_jump}" -i "${interval_hours}" -s "${initial_start_date}" -q "${query_db_interval}" -r "${LOG_DIR}" -e "${total_results_count}" --api-version="${api_version}" > >(tee -a ${LOG}) 2>&1 &
 
 wait $!
 

--- a/tests/scripts/remote_monitoring_tests/scale_test/rosSimulationScalabilityTest.py
+++ b/tests/scripts/remote_monitoring_tests/scale_test/rosSimulationScalabilityTest.py
@@ -40,7 +40,9 @@ def updateRecommendation(experiment_name, endDate):
         # Send the request with the payload
         payloadRecommendationURL = "%s?experiment_name=%s&interval_end_time=%s" % (
             updateRecommendationURL, experiment_name, endDate.strftime('%Y-%m-%dT%H:%M:%S.%fZ')[:-4] + 'Z')
+        print(f"calling POST API {payloadRecommendationURL}")
         response = requests.post(payloadRecommendationURL, data={}, headers=headers, timeout=timeout)
+
         # Check the response
         if response.status_code == 201:
             #data = response.json()
@@ -57,6 +59,7 @@ def updateRecommendation(experiment_name, endDate):
         print('updateRecommendation Timeout occurred while connecting to', e)
 
 def postResultsInBulk(expName, bulkData):
+    print(f"calling POST API {updateExpURL} with {len(bulkData)} datapoints")
     json_payload = json.dumps(bulkData)
     try:
         # Send the request with the payload
@@ -73,7 +76,7 @@ def postResultsInBulk(expName, bulkData):
         print('An error occurred while connecting to', e)
 
 if __name__ == "__main__":
-    debug = False
+    debug = True
     # create an ArgumentParser object
     parser = argparse.ArgumentParser()
 
@@ -87,21 +90,30 @@ if __name__ == "__main__":
     parser.add_argument('--startdate', type=str, help='Specify start date and time in "2026-01-10T00:00:00.000Z" format.')
     parser.add_argument('--minutesjump', type=int,
                         help='specify the time difference between the start time and end time of the interval.')
+    parser.add_argument('--api-version', type=str, help='API version (v1/legacy)', default='legacy')
 
     # parse the arguments from the command line
     args = parser.parse_args()
+    use_new_api = args.api_version.lower() in ['v1', 'true']
+    print("rosSimulationScalabilityTest :: api_version =", args.api_version)
     if args.port != 0:
         createExpURL = 'http://%s:%s/createExperiment' % (args.ip, args.port)
         updateExpURL = 'http://%s:%s/updateResults' % (args.ip, args.port)
         createProfileURL = 'http://%s:%s/createPerformanceProfile' % (args.ip, args.port)
         updateExpURL = 'http://%s:%s/updateResults' % (args.ip, args.port)
-        updateRecommendationURL = 'http://%s:%s/updateRecommendations' % (args.ip, args.port)
+        if use_new_api:
+            updateRecommendationURL = 'http://%s:%s/kruize/api/v1/recommendations' % (args.ip, args.port)
+        else:
+            updateRecommendationURL = 'http://%s:%s/updateRecommendations' % (args.ip, args.port)
     else:
         createExpURL = 'http://%s/createExperiment' % (args.ip)
         updateExpURL = 'http://%s/updateResults' % (args.ip)
         createProfileURL = 'http://%s/createPerformanceProfile' % (args.ip)
         updateExpURL = 'http://%s/updateResults' % (args.ip)
-        updateRecommendationURL = 'http://%s/updateRecommendations' % (args.ip)
+        if use_new_api:
+            updateRecommendationURL = 'http://%s/kruize/api/v1/recommendations' % (args.ip)
+        else:
+            updateRecommendationURL = 'http://%s/updateRecommendations' % (args.ip)
 
     expnameprfix = args.name
     exptype = args.exptype
@@ -132,6 +144,7 @@ if __name__ == "__main__":
     # Create a performance profile
     profile_json_payload = json.dumps(profile_data)
     response = requests.post(createProfileURL, data=profile_json_payload, headers=headers)
+    print(f"calling POST API {createProfileURL}")
     if response.status_code == 201:
         if debug: print('Request successful!')
         if expcount > 10 : time.sleep(5)
@@ -154,6 +167,7 @@ if __name__ == "__main__":
             #requests.post(createProfileURL, data=profile_json_payload, headers=headers)
             createExp_start_time = time.time()
             response = requests.post(createExpURL, data=create_json_payload, headers=headers, timeout=timeout)
+            print(f"calling POST API {createExpURL}")
             createExp_elapsed_time = time.time() -createExp_start_time
             j = 0
             if args.startdate:

--- a/tests/scripts/remote_monitoring_tests/scale_test/rosSimulationScalabilityTest.py
+++ b/tests/scripts/remote_monitoring_tests/scale_test/rosSimulationScalabilityTest.py
@@ -59,9 +59,9 @@ def updateRecommendation(experiment_name, endDate):
         print('updateRecommendation Timeout occurred while connecting to', e)
 
 def postResultsInBulk(expName, bulkData):
-    print(f"calling POST API {updateExpURL} with {len(bulkData)} datapoints")
     json_payload = json.dumps(bulkData)
     try:
+        print(f"calling POST API {updateExpURL} with {len(bulkData)} datapoints")
         # Send the request with the payload
         response = requests.post(updateExpURL, data=json_payload, headers=headers, timeout=timeout)
         # Check the response
@@ -76,7 +76,7 @@ def postResultsInBulk(expName, bulkData):
         print('An error occurred while connecting to', e)
 
 if __name__ == "__main__":
-    debug = True
+    debug = False
     # create an ArgumentParser object
     parser = argparse.ArgumentParser()
 
@@ -143,8 +143,8 @@ if __name__ == "__main__":
 
     # Create a performance profile
     profile_json_payload = json.dumps(profile_data)
-    response = requests.post(createProfileURL, data=profile_json_payload, headers=headers)
     print(f"calling POST API {createProfileURL}")
+    response = requests.post(createProfileURL, data=profile_json_payload, headers=headers)
     if response.status_code == 201:
         if debug: print('Request successful!')
         if expcount > 10 : time.sleep(5)
@@ -166,8 +166,8 @@ if __name__ == "__main__":
             # Create experiment
             #requests.post(createProfileURL, data=profile_json_payload, headers=headers)
             createExp_start_time = time.time()
-            response = requests.post(createExpURL, data=create_json_payload, headers=headers, timeout=timeout)
             print(f"calling POST API {createExpURL}")
+            response = requests.post(createExpURL, data=create_json_payload, headers=headers, timeout=timeout)
             createExp_elapsed_time = time.time() -createExp_start_time
             j = 0
             if args.startdate:

--- a/tests/scripts/remote_monitoring_tests/scale_test/rosSimulationScalabilityTest.py
+++ b/tests/scripts/remote_monitoring_tests/scale_test/rosSimulationScalabilityTest.py
@@ -94,7 +94,7 @@ if __name__ == "__main__":
 
     # parse the arguments from the command line
     args = parser.parse_args()
-    use_new_api = args.api_version.lower() in ['v1', 'true']
+    use_new_api = args.api_version.lower() == 'v1'
     print("rosSimulationScalabilityTest :: api_version =", args.api_version)
     if args.port != 0:
         createExpURL = 'http://%s:%s/createExperiment' % (args.ip, args.port)

--- a/tests/scripts/remote_monitoring_tests/scale_test/rosSimulationScalabilityWrapper.sh
+++ b/tests/scripts/remote_monitoring_tests/scale_test/rosSimulationScalabilityWrapper.sh
@@ -29,6 +29,10 @@ outputdir="results"
 # Parse command-line arguments
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --api-version)
+            api_version="$2"
+            shift 2
+            ;;
         --ip)
             ip="$2"
             shift 2
@@ -90,6 +94,12 @@ if [[ -z "$ip" || -z "$port" || -z "$count" || -z "$minutesjump" || -z "$name_pr
     exit 1
 fi
 
+echo "rosSimulationScalabilityTest :: api_version = "+${api_version}
+# Set the API version to default if not passed on parameter
+if [ -z "${api_version}" ]; then
+  api_version="legacy"
+fi
+
 # Calculate the number of iterations based on interval and limit days
 iterations=$(( $limit_days * 24 / $interval_hours ))
 
@@ -99,7 +109,7 @@ for (( i = 0; i < $iterations; i++ )); do
     current_startdate=$(date -u -d "$initial_startdate + $(( i * interval_hours )) hours" +"%Y-%m-%dT%H:%M:%S.%3NZ")
 
     # Build the full command
-    full_command="python3 -u rosSimulationScalabilityTest.py --ip $ip --port $port --count $count --minutesjump $minutesjump --startdate $current_startdate --name ${name_prefix} --exptype ${exp_type}"
+    full_command="python3 -u rosSimulationScalabilityTest.py --ip $ip --port $port --count $count --minutesjump $minutesjump --startdate $current_startdate --name ${name_prefix} --exptype ${exp_type} --api-version ${api_version}"
 
     # Execute the command
     echo "Executing: $full_command"
@@ -109,7 +119,7 @@ for (( i = 0; i < $iterations; i++ )); do
     wait
 
     echo "Collecting kruize metrics"
-    metrics_command="python3 ../../../../scripts/kruize_metrics.py -c openshift -s ${prometheus_server} -t 360m -e ${outputdir}/results -r kruizeMetrics-${client_thread}.csv"
+    metrics_command="python3 ../../../../scripts/kruize_metrics.py -c openshift -s ${prometheus_server} -t 360m -e ${outputdir}/results -r kruizeMetrics-${client_thread}.csv --api-version ${api_version}"
     eval "${metrics_command}" &
 
     # Sleep for a short duration to avoid flooding the system with too many requests

--- a/tests/scripts/remote_monitoring_tests/scale_test/rosSimulationScalabilityWrapper.sh
+++ b/tests/scripts/remote_monitoring_tests/scale_test/rosSimulationScalabilityWrapper.sh
@@ -94,7 +94,7 @@ if [[ -z "$ip" || -z "$port" || -z "$count" || -z "$minutesjump" || -z "$name_pr
     exit 1
 fi
 
-echo "rosSimulationScalabilityTest :: api_version = "+${api_version}
+echo "rosSimulationScalabilityTest.sh :: api_version = ${api_version}"
 # Set the API version to default if not passed on parameter
 if [ -z "${api_version}" ]; then
   api_version="legacy"

--- a/tests/scripts/remote_monitoring_tests/scale_test/run_bulk_scalability_test.sh
+++ b/tests/scripts/remote_monitoring_tests/scale_test/run_bulk_scalability_test.sh
@@ -31,7 +31,7 @@ function usage() {
 	echo
 	echo "Usage: ./run_scalability_test.sh -c cluster_type[minikube|openshift (default - openshift)] [-a IP] [-p PORT] [-u No. of experiments per client (default - 250)]"
 	echo "	     [-d No. of days of results (default - 2)] [-n No. of clients] [-m results duration interval in mins (default - 15)] [-i interval hours (default - 6)]"
-        echo "       [-s Initial start date] [-q query db interval in mins (default - 5)] [-r <resultsdir path>] [-e total results count already in the DB]"
+        echo "       [-s Initial start date] [-q query db interval in mins (default - 5)] [-r <resultsdir path>] [-e total results count already in the DB] [--api-version=<v1|legacy>]"
 	exit -1
 }
 
@@ -100,7 +100,7 @@ function container_ns_scale_test() {
 	declare -a pid_array=()
 
 	# Each loops kicks off the specified no. of experiments and posts results for the specified no. of days
-	prometheus_server=$(echo ${IP} | cut -d "." -f 3- )
+	prometheus_server=$(echo ${IP} | cut -d "." -f 2- )
 	echo "Prometheus server = $prometheus_server"
 	for ((loop=1; loop<=num_clients; loop++));
 	do
@@ -110,7 +110,7 @@ function container_ns_scale_test() {
 			logfile="${SCALE_LOG_DIR}/${name}.log"
 			echo "logfile = $logfile"
 
-			nohup ./rosSimulationScalabilityWrapper.sh --ip "${IP}" --port "${PORT}" --name ${name} --count ${num_exps},${results_count} --exptype "container" --minutesjump ${minutes_jump} --initialstartdate ${initial_start_date} --limitdays ${num_days_of_res} --intervalhours ${interval_hours} --clientthread ${loop}  --prometheusserver ${prometheus_server} --outputdir ${RESULTS_DIR} >> ${logfile} 2>&1 &
+			nohup ./rosSimulationScalabilityWrapper.sh --ip "${IP}" --port "${PORT}" --name ${name} --count ${num_exps},${results_count} --exptype "container" --minutesjump ${minutes_jump} --initialstartdate ${initial_start_date} --limitdays ${num_days_of_res} --intervalhours ${interval_hours} --clientthread ${loop}  --prometheusserver ${prometheus_server} --outputdir ${RESULTS_DIR} --api-version ${api_version} >> ${logfile} 2>&1 &
 			pid_array+=($!)
 
 			echo
@@ -126,7 +126,7 @@ function container_ns_scale_test() {
 			logfile="${SCALE_LOG_DIR}/${name}.log"
 			echo "logfile = $logfile"
 
-			nohup ./rosSimulationScalabilityWrapper.sh --ip "${IP}" --port "${PORT}" --name ${name} --count ${num_exps},${results_count} --exptype "namespace" --minutesjump ${minutes_jump} --initialstartdate ${initial_start_date} --limitdays ${num_days_of_res} --intervalhours ${interval_hours} --clientthread ${loop}  --prometheusserver ${prometheus_server} --outputdir ${RESULTS_DIR} >> ${logfile} 2>&1 &
+			nohup ./rosSimulationScalabilityWrapper.sh --ip "${IP}" --port "${PORT}" --name ${name} --count ${num_exps},${results_count} --exptype "namespace" --minutesjump ${minutes_jump} --initialstartdate ${initial_start_date} --limitdays ${num_days_of_res} --intervalhours ${interval_hours} --clientthread ${loop}  --prometheusserver ${prometheus_server} --outputdir ${RESULTS_DIR} --api-version ${api_version} >> ${logfile} 2>&1 &
 			pid_array+=($!)
 			echo
 			echo "#####################################################################################"
@@ -157,7 +157,7 @@ function scale_test() {
 
 	declare -a pid_array=()
 	# Each loops kicks off the specified no. of experiments and posts results for the specified no. of days
-	prometheus_server=$(echo ${IP} | cut -d "." -f 3- )
+	prometheus_server=$(echo ${IP} | cut -d "." -f 2- )
 	echo "Prometheus server = $prometheus_server"
 	for ((loop=1; loop<=num_clients; loop++));
 	do
@@ -166,7 +166,7 @@ function scale_test() {
 		logfile="${SCALE_LOG_DIR}/${name}.log"
 		echo "logfile = $logfile"
 
-	        nohup ./rosSimulationScalabilityWrapper.sh --ip "${IP}" --port "${PORT}" --name ${name} --count ${num_exps},${results_count} --exptype "${exp_type}" --minutesjump ${minutes_jump} --initialstartdate ${initial_start_date} --limitdays ${num_days_of_res} --intervalhours ${interval_hours} --clientthread ${loop}  --prometheusserver ${prometheus_server} --outputdir ${RESULTS_DIR} >> ${logfile} 2>&1 &
+	        nohup ./rosSimulationScalabilityWrapper.sh --ip "${IP}" --port "${PORT}" --name ${name} --count ${num_exps},${results_count} --exptype "${exp_type}" --minutesjump ${minutes_jump} --initialstartdate ${initial_start_date} --limitdays ${num_days_of_res} --intervalhours ${interval_hours} --clientthread ${loop}  --prometheusserver ${prometheus_server} --outputdir ${RESULTS_DIR} --api-version ${api_version} >> ${logfile} 2>&1 &
 
 	        pid_array+=($!)
 
@@ -194,9 +194,16 @@ function scale_test() {
 	echo "###########################################################################"
 }
 
-while getopts c:a:p:r:u:n:d:m:i:e:s:q:f:h gopts
+while getopts c:a:p:r:u:n:d:m:i:e:s:q:f:h:-: gopts
 do
 	case ${gopts} in
+	-)
+		case "${OPTARG}" in
+			api-version=*)
+				api_version=${OPTARG#*=}
+				;;
+		esac
+		;;
 	c)
 		cluster_type=${OPTARG}
 		;;
@@ -244,6 +251,12 @@ done
 
 if [ -z "${IP}" ]; then
 	usage
+fi
+
+echo "run_bulk_scalability_test :: api_version = "+${api_version}
+# Set the API version to default if not passed on parameter
+if [ -z "${api_version}" ]; then
+  api_version="legacy"
 fi
 
 SCALE_LOG_DIR="${RESULTS_DIR}/scale_logs"

--- a/tests/scripts/remote_monitoring_tests/scale_test/run_bulk_scalability_test.sh
+++ b/tests/scripts/remote_monitoring_tests/scale_test/run_bulk_scalability_test.sh
@@ -100,7 +100,7 @@ function container_ns_scale_test() {
 	declare -a pid_array=()
 
 	# Each loops kicks off the specified no. of experiments and posts results for the specified no. of days
-	prometheus_server=$(echo ${IP} | cut -d "." -f 2- )
+	prometheus_server=$(echo ${IP} | cut -d "." -f 3- )
 	echo "Prometheus server = $prometheus_server"
 	for ((loop=1; loop<=num_clients; loop++));
 	do
@@ -157,7 +157,7 @@ function scale_test() {
 
 	declare -a pid_array=()
 	# Each loops kicks off the specified no. of experiments and posts results for the specified no. of days
-	prometheus_server=$(echo ${IP} | cut -d "." -f 2- )
+	prometheus_server=$(echo ${IP} | cut -d "." -f 3- )
 	echo "Prometheus server = $prometheus_server"
 	for ((loop=1; loop<=num_clients; loop++));
 	do
@@ -253,7 +253,7 @@ if [ -z "${IP}" ]; then
 	usage
 fi
 
-echo "run_bulk_scalability_test :: api_version = "+${api_version}
+echo "run_bulk_scalability_test.sh :: api_version = ${api_version}"
 # Set the API version to default if not passed on parameter
 if [ -z "${api_version}" ]; then
   api_version="legacy"


### PR DESCRIPTION
## Description

Update scale test to take --api-version=v1 and peculate it down to use new recommendation API endpoint.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Add support for selecting between legacy and v1 recommendations APIs in remote monitoring scale tests and metrics collection, defaulting to legacy when unspecified.

New Features:
- Introduce an --api-version flag across scale test scripts to toggle between legacy and v1 recommendations APIs.
- Update recommendation metrics queries to use new kruizeAPI-based metrics when the v1 API is selected.

Enhancements:
- Add logging of selected API version and key API calls in scalability test scripts for easier debugging.
- Improve parse_metrics.py robustness by handling missing execution time log files gracefully.

Documentation:
- Document the new --api-version option and provide usage examples for running scale tests against the v1 recommendations API.