### PR TITLE
[feat:podCount] Documentation changes

### DIFF
--- a/design/KruizeLocalAPI.md
+++ b/design/KruizeLocalAPI.md
@@ -91,6 +91,10 @@ Documentation still in progress stay tuned.
     - Example Request and Response
     - Invalid Scenarios
 
+- [Recommendations API](#recommendations-api)
+    - Introduction
+    - Example Request and Response
+
 <a name="resource-analysis-terms-and-defaults"></a>
 
 ## Resource Analysis Terms and Defaults
@@ -4121,6 +4125,7 @@ The response will contain a array of JSON object with the recommendations for th
                   },
                   "monitoring_end_time": "2023-04-02T13:30:00.680Z",
                   "current": {
+                    "replicas": 7,
                     "limits": {
                       "memory": {
                         "amount": 1.048576E8,
@@ -4158,6 +4163,13 @@ The response will contain a array of JSON object with the recommendations for th
                         }
                       },
                       "monitoring_start_time": "2023-04-01T12:00:00.000Z",
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 7,
+                          "min": 7,
+                          "max": 7
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
                           "pods_count": 7,
@@ -4364,6 +4376,7 @@ When `interval_end_time` is not specified, Kruize will determine the latest time
                   },
                   "monitoring_end_time": "2023-04-02T13:30:00.680Z",
                   "current": {
+                    "replicas": 7,
                     "limits": {
                       "memory": {
                         "amount": 1.048576E8,
@@ -4401,6 +4414,13 @@ When `interval_end_time` is not specified, Kruize will determine the latest time
                         }
                       },
                       "monitoring_start_time": "2023-04-01T12:00:00.000Z",
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 7,
+                          "min": 7,
+                          "max": 7
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
                           "pods_count": 7,
@@ -5066,5 +5086,515 @@ When `interval_end_time` is not specified, Kruize will determine the latest time
 | 400              | No metrics available from `2024-01-15T00:00:00.000Z` to `2023-12-31T00:00:00.000Z`.                |
 | 400              | The gap between the interval_start_time and interval_end_time must be within a maximum of 15 days! |
 | 400              | The Start time should precede the End time!                                                        |                                           |
+| 500              | Internal Server Error                                                                              |
+
+<a name="recommendations-api"></a>
+
+### Recommendations API
+
+This is a new API endpoint introduced in the v0.11 release, which is in all respects similar to the existing `/generateRecommendations` API in local mode. The only difference is in the response: `requests` and `limits` are nested under `resources`, similar to the Kubernetes deployment spec. Other than this, the rest remains exactly the same as the other existing recommendation API endpoints.
+<hr>
+**Request**
+
+`POST /kruize/api/v1/recommendations?experiment_name=&interval_end_time=`
+`POST /kruize/api/v1/recommendations?experiment_name=&interval_end_time=&interval_start_time=`
+
+example
+`curl --location --request POST 'http://<URL>:<PORT>/kruize/api/v1/recommendations?interval_end_time=2023-01-02T00:15:00.000Z&experiment_name=temp_1'`
+
+success status code : 201
+**Response**
+The response will contain an array of JSON object with the new recommendations generated for the specified experiment.
+
+<details>
+<summary><b>Example Response Body with experiment_type as `container` </b></summary>
+
+```json
+[
+  {
+    "cluster_name": "cluster-one-division-bell",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment_5",
+        "namespace": "default_5",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "recommendations": {
+              "version": "1.0",
+              "notifications": {
+                "111000": {
+                  "type": "info",
+                  "message": "Recommendations Are Available",
+                  "code": 111000
+                }
+              },
+              "data": {
+                "2023-04-02T13:30:00.680Z": {
+                  "notifications": {
+                    "111101": {
+                      "type": "info",
+                      "message": "Short Term Recommendations Available",
+                      "code": 111101
+                    }
+                  },
+                  "monitoring_end_time": "2023-04-02T13:30:00.680Z",
+                  "current": {
+                    "replicas": 7,
+                    "resources": {
+                      "limits": {
+                        "memory": {
+                          "amount": 100.0,
+                          "format": "MiB"
+                        },
+                        "cpu": {
+                          "amount": 0.5,
+                          "format": "cores"
+                        }
+                      },
+                      "requests": {
+                        "memory": {
+                          "amount": 50.21,
+                          "format": "MiB"
+                        },
+                        "cpu": {
+                          "amount": 5.37,
+                          "format": "cores"
+                        }
+                      }
+                    }
+                  },
+                  "recommendation_terms": {
+                    "short_term": {
+                      "duration_in_hours": 24.0,
+                      "notifications": {
+                        "112101": {
+                          "type": "info",
+                          "message": "Cost Recommendations Available",
+                          "code": 112101
+                        },
+                        "112102": {
+                          "type": "info",
+                          "message": "Performance Recommendations Available",
+                          "code": 112102
+                        }
+                      },
+                      "monitoring_start_time": "2023-04-01T12:00:00.000Z",
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 7,
+                          "min": 7,
+                          "max": 7
+                        }
+                      },
+                      "recommendation_engines": {
+                        "cost": {
+                          "pods_count": 7,
+                          "confidence_level": 0.0,
+                          "config": {
+                            "resources": {
+                              "limits": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              },
+                              "requests": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "variation": {
+                            "resources": {
+                              "limits": {
+                                "memory": {
+                                  "amount": 138.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": -4.44,
+                                  "format": "cores"
+                                }
+                              },
+                              "requests": {
+                                "memory": {
+                                  "amount": 187.98999999999998,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": -4.44,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "notifications": {}
+                        },
+                        "performance": {
+                          "pods_count": 27,
+                          "confidence_level": 0.0,
+                          "config": {
+                            "resources": {
+                              "limits": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              },
+                              "requests": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "variation": {
+                            "resources": {
+                              "limits": {
+                                "memory": {
+                                  "amount": 138.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": -4.44,
+                                  "format": "cores"
+                                }
+                              },
+                              "requests": {
+                                "memory": {
+                                  "amount": 187.98999999999998,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": -4.44,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "notifications": {}
+                        }
+                      }
+                    },
+                    "medium_term": {
+                      "duration_in_hours": 33.8,
+                      "notifications": {
+                        "120001": {
+                          "type": "info",
+                          "message": "There is not enough data available to generate a recommendation.",
+                          "code": 120001
+                        }
+                      }
+                    },
+                    "long_term": {
+                      "duration_in_hours": 33.8,
+                      "notifications": {
+                        "120001": {
+                          "type": "info",
+                          "message": "There is not enough data available to generate a recommendation.",
+                          "code": 120001
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "recommendations": {
+              "version": "1.0",
+              "notifications": {
+                "120001": {
+                  "type": "info",
+                  "message": "There is not enough data available to generate a recommendation.",
+                  "code": 120001
+                }
+              },
+              "data": {}
+            }
+          }
+        ]
+      }
+    ],
+    "version": "v2.0",
+    "experiment_name": "temp_1"
+  }
+]
+```
+
+</details>
+
+<hr>
+`GET /kruize/api/v1/recommendations?experiment_name=&monitoring_end_time=&latest=`
+
+example
+`curl -H 'Accept: application/json' 'http://<URL>:<PORT>/kruize/api/v1/recommendations'`
+`curl -H 'Accept: application/json' 'http://<URL>:<PORT>/kruize/api/v1/recommendations?experiment_name=temp_1'`
+`curl -H 'Accept: application/json' 'http://<URL>:<PORT>/kruize/api/v1/recommendations?experiment_name=temp_1&latest=true'`
+success status code : 200
+
+**Response**
+<details>
+<summary><b>Example Response with experiment_type as `container` </b></summary>
+
+### Example Response
+
+```json
+[
+  {
+    "experiment_name": "experiment_1",
+    "cluster_name": "cluster-one-division-bell",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment_0",
+        "namespace": "default_0",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "recommendations": {
+              "version": "v2.0",
+              "notifications": {
+                "111000": {
+                  "type": "info",
+                  "message": "Recommendations Are Available",
+                  "code": 111000
+                }
+              },
+              "data": {
+                "2023-04-02T13:30:00.680Z": {
+                  "notifications": {
+                    "111101": {
+                      "type": "info",
+                      "message": "Short Term Recommendations Available",
+                      "code": 111101
+                    }
+                  },
+                  "monitoring_end_time": "2023-04-02T13:30:00.680Z",
+                  "current": {
+                    "replicas": 27,
+                    "resources": {
+                      "requests": {
+                        "memory": {
+                          "amount": 50.21,
+                          "format": "MiB"
+                        },
+                        "cpu": {
+                          "amount": 5.37,
+                          "format": "cores"
+                        }
+                      },
+                      "limits": {
+                        "memory": {
+                          "amount": 100.0,
+                          "format": "MiB"
+                        },
+                        "cpu": {
+                          "amount": 0.5,
+                          "format": "cores"
+                        }
+                      }
+                    }
+                  },
+                  "recommendation_terms": {
+                    "short_term": {
+                      "notifications": {
+                        "112101": {
+                          "type": "info",
+                          "message": "Cost Recommendations Available",
+                          "code": 112101
+                        },
+                        "112102": {
+                          "type": "info",
+                          "message": "Performance Recommendations Available",
+                          "code": 112102
+                        }
+                      },
+                      "monitoring_start_time": "2023-04-01T12:00:00.000Z",
+                      "duration_in_hours": 24.0,
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 27,
+                          "min": 27,
+                          "max": 27
+                        }
+                      },
+                      "recommendation_engines": {
+                        "cost": {
+                          "pods_count": 27,
+                          "confidence_level": 0.0,
+                          "config": {
+                            "resources": {
+                              "requests": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              },
+                              "limits": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "variation": {
+                            "resources": {
+                              "requests": {
+                                "memory": {
+                                  "amount": 187.98999999999998,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": -4.44,
+                                  "format": "cores"
+                                }
+                              },
+                              "limits": {
+                                "memory": {
+                                  "amount": 138.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.42999999999999994,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "notifications": {}
+                        },
+                        "performance": {
+                          "pods_count": 27,
+                          "confidence_level": 0.0,
+                          "config": {
+                            "resources": {
+                              "requests": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              },
+                              "limits": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "variation": {
+                            "resources": {
+                              "requests": {
+                                "memory": {
+                                  "amount": 187.98999999999998,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": -4.44,
+                                  "format": "cores"
+                                }
+                              },
+                              "limits": {
+                                "memory": {
+                                  "amount": 138.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.42999999999999994,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "notifications": {}
+                        }
+                      }
+                    },
+                    "medium_term": {
+                      "duration_in_hours": 143.0,
+                      "notifications": {
+                        "120001": {
+                          "type": "info",
+                          "message": "There is not enough data available to generate a recommendation.",
+                          "code": 120001
+                        }
+                      }
+                    },
+                    "long_term": {
+                      "duration_in_hours": 240.0,
+                      "notifications": {
+                        "120001": {
+                          "type": "info",
+                          "message": "There is not enough data available to generate a recommendation.",
+                          "code": 120001
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+]
+```
+
+</details>
+
+**Error Responses**
+
+| HTTP Status Code | Description                                                                                        |
+|------------------|----------------------------------------------------------------------------------------------------|
+| 400              | experiment_name is mandatory.                                                                      |
+| 400              | Given timestamp - \" 2023-011-02T00:00:00.000Z \" is not a valid timestamp format.                 |
+| 400              | Not Found: experiment_name does not exist: exp_1.                                                  |
+| 400              | The Start time should precede the End time!                                                        |
 | 500              | Internal Server Error                                                                              |
 

--- a/design/MonitoringModeAPI.md
+++ b/design/MonitoringModeAPI.md
@@ -3233,7 +3233,7 @@ Returns all the results of that experiment
                       },
                       "recommendation_engines": {
                         "cost": {
-                          "pods_count": 27,
+                          "pods_count": 0,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -3362,7 +3362,7 @@ Returns all the results of that experiment
                       },
                       "recommendation_engines": {
                         "cost": {
-                          "pods_count": 27,
+                          "pods_count": 0,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -3411,7 +3411,7 @@ Returns all the results of that experiment
                           "notifications": {}
                         },
                         "performance": {
-                          "pods_count": 27,
+                          "pods_count": 0,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -3612,7 +3612,7 @@ Returns the recommendation at a particular timestamp if it exists
                       },
                       "recommendation_engines": {
                         "cost": {
-                          "pods_count": 27,
+                          "pods_count": 0,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -3661,7 +3661,7 @@ Returns the recommendation at a particular timestamp if it exists
                           "notifications": {}
                         },
                         "performance": {
-                          "pods_count": 27,
+                          "pods_count": 0,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -5838,7 +5838,7 @@ structured and easily interpretable way for users or external systems to access 
                       },
                       "recommendation_engines": {
                         "cost": {
-                          "pods_count": 1,
+                          "pods_count": 0,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -5877,7 +5877,7 @@ structured and easily interpretable way for users or external systems to access 
                           }
                         },
                         "performance": {
-                          "pods_count": 1,
+                          "pods_count": 0,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -6018,7 +6018,7 @@ structured and easily interpretable way for users or external systems to access 
                       },
                       "recommendation_engines": {
                         "cost": {
-                          "pods_count": 1,
+                          "pods_count": 0,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -6057,7 +6057,7 @@ structured and easily interpretable way for users or external systems to access 
                           }
                         },
                         "performance": {
-                          "pods_count": 1,
+                          "pods_count": 0,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -6252,7 +6252,7 @@ structured and easily interpretable way for users or external systems to access 
                       },
                       "recommendation_engines": {
                         "cost": {
-                          "pods_count": 1,
+                          "pods_count": 0,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -6291,7 +6291,7 @@ structured and easily interpretable way for users or external systems to access 
                           }
                         },
                         "performance": {
-                          "pods_count": 1,
+                          "pods_count": 0,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {

--- a/design/MonitoringModeAPI.md
+++ b/design/MonitoringModeAPI.md
@@ -45,6 +45,11 @@ Documentation still in progress stay tuned.
     - Example Request and Response
     - Invalid Scenarios
 
+- [Recommendations API](#recommendations-api)
+    - Introduction
+    - Example Request and Response
+    - Invalid Scenarios
+
 <a name="resource-analysis-terms-and-defaults"></a>
 
 ## Resource Analysis Terms and Defaults
@@ -2070,6 +2075,7 @@ If no parameter is passed API returns all the latest recommendations available f
                   },
                   "monitoring_end_time": "2023-04-02T13:30:00.680Z",
                   "current": {
+                    "replicas": 27,
                     "requests": {
                       "memory": {
                         "amount": 50.21,
@@ -2107,6 +2113,13 @@ If no parameter is passed API returns all the latest recommendations available f
                       },
                       "monitoring_start_time": "2023-04-01T12:00:00.000Z",
                       "duration_in_hours": 24.0,
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 27,
+                          "min": 27,
+                          "max": 27
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
                           "pods_count": 27,
@@ -2269,6 +2282,7 @@ If no parameter is passed API returns all the latest recommendations available f
                   },
                   "monitoring_end_time": "2023-04-02T13:30:00.680Z",
                   "current": {
+                    "replicas": 27,
                     "requests": {
                       "memory": {
                         "amount": 50.21,
@@ -2306,6 +2320,13 @@ If no parameter is passed API returns all the latest recommendations available f
                       },
                       "monitoring_start_time": "2023-04-01T12:00:00.000Z",
                       "duration_in_hours": 24.0,
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 27,
+                          "min": 27,
+                          "max": 27
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
                           "pods_count": 27,
@@ -2920,6 +2941,7 @@ Returns the latest result of that experiment
                   },
                   "monitoring_end_time": "2023-04-02T13:30:00.680Z",
                   "current": {
+                    "replicas": 27,
                     "requests": {
                       "cpu": {
                         "amount": 5.37,
@@ -2957,6 +2979,13 @@ Returns the latest result of that experiment
                         }
                       },
                       "monitoring_start_time": "2023-04-01T12:00:00.000Z",
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 27,
+                          "min": 27,
+                          "max": 27
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
                           "pods_count": 27,
@@ -3158,6 +3187,7 @@ Returns all the results of that experiment
                   },
                   "monitoring_end_time": "2022-12-20T17:55:05.000Z",
                   "current": {
+                    "replicas": 27,
                     "requests": {
                       "memory": {
                         "amount": 490.93,
@@ -3195,9 +3225,16 @@ Returns all the results of that experiment
                           "code": 112102
                         }
                       },
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 27,
+                          "min": 27,
+                          "max": 27
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
-                          "pods_count": 0,
+                          "pods_count": 27,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -3278,6 +3315,7 @@ Returns all the results of that experiment
                     }
                   },
                   "current": {
+                    "replicas": 27,
                     "requests": {
                       "memory": {
                         "amount": 490.93,
@@ -3316,9 +3354,16 @@ Returns all the results of that experiment
                           "code": 112102
                         }
                       },
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 27,
+                          "min": 27,
+                          "max": 27
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
-                          "pods_count": 0,
+                          "pods_count": 27,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -3367,7 +3412,7 @@ Returns all the results of that experiment
                           "notifications": {}
                         },
                         "performance": {
-                          "pods_count": 0,
+                          "pods_count": 27,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -3521,6 +3566,7 @@ Returns the recommendation at a particular timestamp if it exists
                   },
                   "monitoring_end_time": "2022-12-20T17:55:05.000Z",
                   "current": {
+                    "replicas": 27,
                     "requests": {
                       "memory": {
                         "amount": 490.93,
@@ -3558,9 +3604,16 @@ Returns the recommendation at a particular timestamp if it exists
                         }
                       },
                       "monitoring_start_time": "2022-12-19T17:55:05.000Z",
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 27,
+                          "min": 27,
+                          "max": 27
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
-                          "pods_count": 0,
+                          "pods_count": 27,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -3609,7 +3662,7 @@ Returns the recommendation at a particular timestamp if it exists
                           "notifications": {}
                         },
                         "performance": {
-                          "pods_count": 0,
+                          "pods_count": 27,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -3743,6 +3796,7 @@ Returns the recommendation at a particular timestamp if it exists
                                     },
                                     "monitoring_end_time": "2024-10-04T09:16:40.000Z",
                                     "current": {
+                                        "replicas": 1,
                                         "limits": {
                                             "cpu": {
                                                 "amount": 2.0,
@@ -3780,6 +3834,13 @@ Returns the recommendation at a particular timestamp if it exists
                                                 }
                                             },
                                             "monitoring_start_time": "2024-10-03T09:16:40.000Z",
+                                            "metrics_info": {
+                                                "pod_count": {
+                                                    "avg": 1,
+                                                    "min": 1,
+                                                    "max": 1
+                                                }
+                                            },
                                             "recommendation_engines": {
                                                 "cost": {
                                                     "pods_count": 1,
@@ -3981,6 +4042,13 @@ Returns the recommendation at a particular timestamp if it exists
                                                 }
                                             },
                                             "monitoring_start_time": "2024-09-27T09:16:40.000Z",
+                                            "metrics_info": {
+                                                "pod_count": {
+                                                    "avg": 1,
+                                                    "min": 1,
+                                                    "max": 1
+                                                }
+                                            },
                                             "recommendation_engines": {
                                                 "cost": {
                                                     "pods_count": 1,
@@ -4325,6 +4393,7 @@ The response will contain an array of JSON object with the updated recommendatio
                   },
                   "monitoring_end_time": "2023-04-02T13:30:00.680Z",
                   "current": {
+                    "replicas": 7,
                     "limits": {
                       "memory": {
                         "amount": 100.0,
@@ -4362,6 +4431,13 @@ The response will contain an array of JSON object with the updated recommendatio
                         }
                       },
                       "monitoring_start_time": "2023-04-01T12:00:00.000Z",
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 7,
+                          "min": 7,
+                          "max": 7
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
                           "pods_count": 7,
@@ -4806,6 +4882,7 @@ structured and easily interpretable way for users or external systems to access 
                   },
                   "monitoring_end_time": "2023-01-21T00:00:00.000Z",
                   "current": {
+                    "replicas": 7,
                     "requests": {
                       "memory": {
                         "amount": 50.21,
@@ -4843,6 +4920,13 @@ structured and easily interpretable way for users or external systems to access 
                         }
                       },
                       "monitoring_start_time": "2023-01-20T00:00:00.000Z",
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 7,
+                          "min": 7,
+                          "max": 7
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
                           "pods_count": 7,
@@ -5036,6 +5120,13 @@ structured and easily interpretable way for users or external systems to access 
                         }
                       },
                       "monitoring_start_time": "2023-01-14T00:00:00.000Z",
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 7,
+                          "min": 7,
+                          "max": 7
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
                           "pods_count": 7,
@@ -5283,6 +5374,13 @@ structured and easily interpretable way for users or external systems to access 
                         }
                       },
                       "monitoring_start_time": "2023-01-06T00:00:00.000Z",
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 7,
+                          "min": 7,
+                          "max": 7
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
                           "pods_count": 7,
@@ -5702,6 +5800,7 @@ structured and easily interpretable way for users or external systems to access 
                   },
                   "monitoring_end_time": "2023-01-21T00:00:00.000Z",
                   "current": {
+                    "replicas": 1,
                     "requests": {
                       "memory": {
                         "amount": 50.21,
@@ -5731,9 +5830,16 @@ structured and easily interpretable way for users or external systems to access 
                         }
                       },
                       "monitoring_start_time": "2023-01-20T00:00:00.000Z",
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 1,
+                          "min": 1,
+                          "max": 1
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
-                          "pods_count": 0,
+                          "pods_count": 1,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -5772,7 +5878,7 @@ structured and easily interpretable way for users or external systems to access 
                           }
                         },
                         "performance": {
-                          "pods_count": 0,
+                          "pods_count": 1,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -5904,9 +6010,16 @@ structured and easily interpretable way for users or external systems to access 
                         }
                       },
                       "monitoring_start_time": "2023-01-14T00:00:00.000Z",
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 1,
+                          "min": 1,
+                          "max": 1
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
-                          "pods_count": 0,
+                          "pods_count": 1,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -5945,7 +6058,7 @@ structured and easily interpretable way for users or external systems to access 
                           }
                         },
                         "performance": {
-                          "pods_count": 0,
+                          "pods_count": 1,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -6131,9 +6244,16 @@ structured and easily interpretable way for users or external systems to access 
                         }
                       },
                       "monitoring_start_time": "2023-01-06T00:00:00.000Z",
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 1,
+                          "min": 1,
+                          "max": 1
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
-                          "pods_count": 0,
+                          "pods_count": 1,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -6172,7 +6292,7 @@ structured and easily interpretable way for users or external systems to access 
                           }
                         },
                         "performance": {
-                          "pods_count": 0,
+                          "pods_count": 1,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -6589,6 +6709,7 @@ The response will contain a array of JSON object with the recommendations for th
                   },
                   "monitoring_end_time": "2023-04-02T13:30:00.680Z",
                   "current": {
+                    "replicas": 7,
                     "limits": {
                       "memory": {
                         "amount": 100.0,
@@ -6626,6 +6747,13 @@ The response will contain a array of JSON object with the recommendations for th
                         }
                       },
                       "monitoring_start_time": "2023-04-01T12:00:00.000Z",
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 7,
+                          "min": 7,
+                          "max": 7
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
                           "pods_count": 7,
@@ -6792,6 +6920,724 @@ The response will contain a array of JSON object with the recommendations for th
 | 400              | The Start time should precede the End time!                                                        |                                           |
 | 500              | Internal Server Error                                                                              |
 
+### Recommendations API
+
+This is new API endpoint introduced in v0.11 release which is in all aspects similar to existing APIs 
+/updateRecommendations, /listRecommendations (in remote mode) and /generateRecommendations (in local mode). Which means the only difference is 
+in response, `requests` and `limits` are nested under `resources` similar to k8s deployment spec. Other than this, rest 
+all remains exactly same as other existing recommendation API endpoints.
+<hr>
+**Request**
+
+`POST /kruize/api/v1/recommendations?experiment_name=&interval_end_time=`
+`POST /kruize/api/v1/recommendations?experiment_name=&interval_end_time=&interval_start_time=`
+
+example
+`curl --location --request POST 'http://127.0.0.1:8080/kruize/api/v1/recommendations?interval_end_time=2023-01-02T00:15:00.000Z&experiment_name=temp_1'`
+
+success status code : 201
+**Response**
+The response will contain an array of JSON object with the new recommendations generated for the specified experiment.
+
+<details>
+<summary><b>Example Response Body with experiment_type as `container` </b></summary>
+
+```json
+[
+  {
+    "cluster_name": "cluster-one-division-bell",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment_5",
+        "namespace": "default_5",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "recommendations": {
+              "version": "1.0",
+              "notifications": {
+                "111000": {
+                  "type": "info",
+                  "message": "Recommendations Are Available",
+                  "code": 111000
+                }
+              },
+              "data": {
+                "2023-04-02T13:30:00.680Z": {
+                  "notifications": {
+                    "111101": {
+                      "type": "info",
+                      "message": "Short Term Recommendations Available",
+                      "code": 111101
+                    }
+                  },
+                  "monitoring_end_time": "2023-04-02T13:30:00.680Z",
+                  "current": {
+                    "replicas": 7,
+                    "resources": {
+                      "limits": {
+                        "memory": {
+                          "amount": 100.0,
+                          "format": "MiB"
+                        },
+                        "cpu": {
+                          "amount": 0.5,
+                          "format": "cores"
+                        }
+                      },
+                      "requests": {
+                        "memory": {
+                          "amount": 50.21,
+                          "format": "MiB"
+                        },
+                        "cpu": {
+                          "amount": 5.37,
+                          "format": "cores"
+                        }
+                      }
+                    }
+                  },
+                  "recommendation_terms": {
+                    "short_term": {
+                      "duration_in_hours": 24.0,
+                      "notifications": {
+                        "112101": {
+                          "type": "info",
+                          "message": "Cost Recommendations Available",
+                          "code": 112101
+                        },
+                        "112102": {
+                          "type": "info",
+                          "message": "Performance Recommendations Available",
+                          "code": 112102
+                        }
+                      },
+                      "monitoring_start_time": "2023-04-01T12:00:00.000Z",
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 7,
+                          "min": 7,
+                          "max": 7
+                        }
+                      },
+                      "recommendation_engines": {
+                        "cost": {
+                          "pods_count": 7,
+                          "confidence_level": 0.0,
+                          "config": {
+                            "resources": {
+                              "limits": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              },
+                              "requests": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "variation": {
+                            "resources": {
+                              "limits": {
+                                "memory": {
+                                  "amount": 138.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": -4.44,
+                                  "format": "cores"
+                                }
+                              },
+                              "requests": {
+                                "memory": {
+                                  "amount": 187.98999999999998,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": -4.44,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "notifications": {}
+                        },
+                        "performance": {
+                          "pods_count": 27,
+                          "confidence_level": 0.0,
+                          "config": {
+                            "resources": {
+                              "limits": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              },
+                              "requests": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "variation": {
+                            "resources": {
+                              "limits": {
+                                "memory": {
+                                  "amount": 138.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": -4.44,
+                                  "format": "cores"
+                                }
+                              },
+                              "requests": {
+                                "memory": {
+                                  "amount": 187.98999999999998,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": -4.44,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "notifications": {}
+                        }
+                      }
+                    },
+                    "medium_term": {
+                      "duration_in_hours": 33.8,
+                      "notifications": {
+                        "120001": {
+                          "type": "info",
+                          "message": "There is not enough data available to generate a recommendation.",
+                          "code": 120001
+                        }
+                      }
+                    },
+                    "long_term": {
+                      "duration_in_hours": 33.8,
+                      "notifications": {
+                        "120001": {
+                          "type": "info",
+                          "message": "There is not enough data available to generate a recommendation.",
+                          "code": 120001
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "recommendations": {
+              "version": "1.0",
+              "notifications": {
+                "120001": {
+                  "type": "info",
+                  "message": "There is not enough data available to generate a recommendation.",
+                  "code": 120001
+                }
+              },
+              "data": {}
+            }
+          }
+        ]
+      }
+    ],
+    "version": "v2.0",
+    "experiment_name": "temp_1"
+  }
+]
+```
+
+</details>
+
+<hr>
+`GET /kruize/api/v1/recommendations?experiment_name=&monitoring_end_time=&latest=`
+
+example
+`curl -H 'Accept: application/json' 'http://127.0.0.1:8080/kruize/api/v1/recommendations'`
+`curl -H 'Accept: application/json' 'http://127.0.0.1:8080/kruize/api/v1/recommendations?experiment_name=temp_1'`
+`curl -H 'Accept: application/json' 'http://127.0.0.1:8080/kruize/api/v1/recommendations?experiment_name=temp_1&latest=true'`
+success status code : 200
+
+**Response**
+<details>
+<summary><b>Example Response with experiment_type as `container` </b></summary>
+
+### Example Response
+
+```json
+[
+  {
+    "experiment_name": "experiment_1",
+    "cluster_name": "cluster-one-division-bell",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment_0",
+        "namespace": "default_0",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "recommendations": {
+              "version": "v2.0",
+              "notifications": {
+                "111000": {
+                  "type": "info",
+                  "message": "Recommendations Are Available",
+                  "code": 111000
+                }
+              },
+              "data": {
+                "2023-04-02T13:30:00.680Z": {
+                  "notifications": {
+                    "111101": {
+                      "type": "info",
+                      "message": "Short Term Recommendations Available",
+                      "code": 111101
+                    }
+                  },
+                  "monitoring_end_time": "2023-04-02T13:30:00.680Z",
+                  "current": {
+                    "replicas": 27,
+                    "resources": {
+                      "requests": {
+                        "memory": {
+                          "amount": 50.21,
+                          "format": "MiB"
+                        },
+                        "cpu": {
+                          "amount": 5.37,
+                          "format": "cores"
+                        }
+                      },
+                      "limits": {
+                        "memory": {
+                          "amount": 100.0,
+                          "format": "MiB"
+                        },
+                        "cpu": {
+                          "amount": 0.5,
+                          "format": "cores"
+                        }
+                      }
+                    }
+                  },
+                  "recommendation_terms": {
+                    "short_term": {
+                      "notifications": {
+                        "112101": {
+                          "type": "info",
+                          "message": "Cost Recommendations Available",
+                          "code": 112101
+                        },
+                        "112102": {
+                          "type": "info",
+                          "message": "Performance Recommendations Available",
+                          "code": 112102
+                        }
+                      },
+                      "monitoring_start_time": "2023-04-01T12:00:00.000Z",
+                      "duration_in_hours": 24.0,
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 7,
+                          "min": 7,
+                          "max": 7
+                        }
+                      },
+                      "recommendation_engines": {
+                        "cost": {
+                          "pods_count": 27,
+                          "confidence_level": 0.0,
+                          "config": {
+                            "resources": {
+                              "requests": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              },
+                              "limits": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "variation": {
+                            "resources": {
+                              "requests": {
+                                "memory": {
+                                  "amount": 187.98999999999998,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": -4.44,
+                                  "format": "cores"
+                                }
+                              },
+                              "limits": {
+                                "memory": {
+                                  "amount": 138.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.42999999999999994,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "notifications": {}
+                        },
+                        "performance": {
+                          "pods_count": 27,
+                          "confidence_level": 0.0,
+                          "config": {
+                            "resources": {
+                              "requests": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              },
+                              "limits": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "variation": {
+                            "resources": {
+                              "requests": {
+                                "memory": {
+                                  "amount": 187.98999999999998,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": -4.44,
+                                  "format": "cores"
+                                }
+                              },
+                              "limits": {
+                                "memory": {
+                                  "amount": 138.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.42999999999999994,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "notifications": {}
+                        }
+                      }
+                    },
+                    "medium_term": {
+                      "duration_in_hours": 143.0,
+                      "notifications": {
+                        "120001": {
+                          "type": "info",
+                          "message": "There is not enough data available to generate a recommendation.",
+                          "code": 120001
+                        }
+                      }
+                    },
+                    "long_term": {
+                      "duration_in_hours": 240.0,
+                      "notifications": {
+                        "120001": {
+                          "type": "info",
+                          "message": "There is not enough data available to generate a recommendation.",
+                          "code": 120001
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "experiment_name": "experiment_2",
+    "cluster_name": "cluster-one-division-bell",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment_2",
+        "namespace": "default_2",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "recommendations": {
+              "version": "v2.0",
+              "notifications": {
+                "111000": {
+                  "type": "info",
+                  "message": "Recommendations Are Available",
+                  "code": 111000
+                }
+              },
+              "data": {
+                "2023-04-02T13:30:00.680Z": {
+                  "notifications": {
+                    "111101": {
+                      "type": "info",
+                      "message": "Short Term Recommendations Available",
+                      "code": 111101
+                    }
+                  },
+                  "monitoring_end_time": "2023-04-02T13:30:00.680Z",
+                  "current": {
+                    "replicas": 27,
+                    "resources": {
+                      "requests": {
+                        "memory": {
+                          "amount": 50.21,
+                          "format": "MiB"
+                        },
+                        "cpu": {
+                          "amount": 5.37,
+                          "format": "cores"
+                        }
+                      },
+                      "limits": {
+                        "memory": {
+                          "amount": 100.0,
+                          "format": "MiB"
+                        },
+                        "cpu": {
+                          "amount": 0.5,
+                          "format": "cores"
+                        }
+                      }
+                    }
+                  },
+                  "recommendation_terms": {
+                    "short_term": {
+                      "notifications": {
+                        "112101": {
+                          "type": "info",
+                          "message": "Cost Recommendations Available",
+                          "code": 112101
+                        },
+                        "112102": {
+                          "type": "info",
+                          "message": "Performance Recommendations Available",
+                          "code": 112102
+                        }
+                      },
+                      "monitoring_start_time": "2023-04-01T12:00:00.000Z",
+                      "duration_in_hours": 24.0,
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 7,
+                          "min": 7,
+                          "max": 7
+                        }
+                      },
+                      "recommendation_engines": {
+                        "cost": {
+                          "pods_count": 27,
+                          "confidence_level": 0.0,
+                          "config": {
+                            "resources": {
+                              "requests": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              },
+                              "limits": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "variation": {
+                            "resources": {
+                              "requests": {
+                                "memory": {
+                                  "amount": 187.98999999999998,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": -4.44,
+                                  "format": "cores"
+                                }
+                              },
+                              "limits": {
+                                "memory": {
+                                  "amount": 138.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.42999999999999994,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "notifications": {}
+                        },
+                        "performance": {
+                          "pods_count": 27,
+                          "confidence_level": 0.0,
+                          "config": {
+                            "resources": {
+                              "requests": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              },
+                              "limits": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "variation": {
+                            "resources": {
+                              "requests": {
+                                "memory": {
+                                  "amount": 187.98999999999998,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": -4.44,
+                                  "format": "cores"
+                                }
+                              },
+                              "limits": {
+                                "memory": {
+                                  "amount": 138.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.42999999999999994,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "notifications": {}
+                        }
+                      }
+                    },
+                    "medium_term": {
+                      "duration_in_hours": 143.0,
+                      "notifications": {
+                        "120001": {
+                          "type": "info",
+                          "message": "There is not enough data available to generate a recommendation.",
+                          "code": 120001
+                        }
+                      }
+                    },
+                    "long_term": {
+                      "duration_in_hours": 240.0,
+                      "notifications": {
+                        "120001": {
+                          "type": "info",
+                          "message": "There is not enough data available to generate a recommendation.",
+                          "code": 120001
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+]
+```
+
+</details>
+<hr>
 
 ## Implementing Retry Mechanism for Kruize API Consumers
 

--- a/design/MonitoringModeAPI.md
+++ b/design/MonitoringModeAPI.md
@@ -6921,10 +6921,7 @@ The response will contain a array of JSON object with the recommendations for th
 
 ### Recommendations API
 
-This is new API endpoint introduced in v0.11 release which is in all aspects similar to existing APIs 
-/updateRecommendations, /listRecommendations (in remote mode) and /generateRecommendations (in local mode). Which means the only difference is 
-in response, `requests` and `limits` are nested under `resources` similar to k8s deployment spec. Other than this, rest 
-all remains exactly same as other existing recommendation API endpoints.
+This is a new API endpoint introduced in the v0.11 release, which is in all respects similar to the existing APIs /updateRecommendations, /listRecommendations (in remote mode), and /generateRecommendations (in local mode). The only difference is in the response: `requests` and `limits` are nested under `resources`, similar to the Kubernetes deployment spec. Other than this, the rest remains exactly the same as the other existing recommendation API endpoints.
 <hr>
 **Request**
 

--- a/design/MonitoringModeAPI.md
+++ b/design/MonitoringModeAPI.md
@@ -48,7 +48,6 @@ Documentation still in progress stay tuned.
 - [Recommendations API](#recommendations-api)
     - Introduction
     - Example Request and Response
-    - Invalid Scenarios
 
 <a name="resource-analysis-terms-and-defaults"></a>
 


### PR DESCRIPTION
## Description

This PR contains documentation changes
- Schema changes to include replicas and metrics_info for container recommendation response
- New section in documentation about new recommendation API.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Document the new recommendations API endpoint and update recommendation response examples with replicas and pod_count metrics.

Enhancements:
- Extend recommendation response schema examples to include current replicas and metrics_info.pod_count, and align pods_count values across cost and performance engines.

Documentation:
- Add documentation for the /kruize/api/v1/recommendations endpoint, including request/response examples and usage for container experiments.