### PR TITLE
add support for --api-version to migration tests

### DIFF
--- a/tests/scripts/local_monitoring_tests/fault_tolerant_test/kruize_pod_restart_test.py
+++ b/tests/scripts/local_monitoring_tests/fault_tolerant_test/kruize_pod_restart_test.py
@@ -54,7 +54,7 @@ def main(argv):
 
     if api_version.lower() == "v1":
         pytest.USE_NEW_API = True
-    else
+    else:
         pytest.USE_NEW_API = False
     print(f"Cluster type = {cluster_type}")
     print(f"Results dir = {results_dir}")

--- a/tests/scripts/local_monitoring_tests/fault_tolerant_test/kruize_pod_restart_test.py
+++ b/tests/scripts/local_monitoring_tests/fault_tolerant_test/kruize_pod_restart_test.py
@@ -19,26 +19,29 @@ import json
 import os
 import sys
 import time
+import pytest
 
 sys.path.append("../../")
 from helpers.kruize import *
 from helpers.utils import *
 from helpers.generate_rm_jsons import *
 
+api_version = "legacy"
 
 def main(argv):
+    global api_version
     cluster_type = "minikube"
     results_dir = "."
     failed = 0
     try:
-        opts, args = getopt.getopt(argv, "h:c:a:u:r:")
+        opts, args = getopt.getopt(argv, "h:c:a:u:r:", ["api-version="])
     except getopt.GetoptError:
-        print("kruize_pod_restart_test.py -c <cluster type> -a <openshift kruize route> -r <results dir>")
+        print("kruize_pod_restart_test.py -c <cluster type> -a <openshift kruize route> -r <results dir> --api-version <v1/legacy>")
         print("Note: -a option is required only on openshift when kruize service is exposed")
         sys.exit(2)
     for opt, arg in opts:
         if opt == '-h':
-            print("kruize_pod_restart_test.py -c <cluster type> -a <openshift kruize route> -r <results dir>")
+            print("kruize_pod_restart_test.py -c <cluster type> -a <openshift kruize route> -r <results dir> --api-version <v1/legacy>")
             sys.exit(0)
         elif opt == '-c':
             cluster_type = arg
@@ -46,7 +49,13 @@ def main(argv):
             server_ip_addr = arg
         elif opt == '-r':
             results_dir = arg
+        elif opt == '--api-version':
+            api_version = str(arg)
 
+    if api_version.lower() == "v1":
+        pytest.USE_NEW_API = True
+    else
+        pytest.USE_NEW_API = False
     print(f"Cluster type = {cluster_type}")
     print(f"Results dir = {results_dir}")
 

--- a/tests/scripts/local_monitoring_tests/fault_tolerant_test/local_monitoring_fault_tolerant_tests.sh
+++ b/tests/scripts/local_monitoring_tests/fault_tolerant_test/local_monitoring_fault_tolerant_tests.sh
@@ -16,7 +16,7 @@
 #
 ### Script to run fault tolerant tests with Kruize in local monitoring mode ##
 #
-
+declare -l api_version
 CURRENT_DIR="$(dirname "$(realpath "$0")")"
 KRUIZE_REPO_PATH="${CURRENT_DIR}/../../../.."
 METRIC_PROFILE_DIR="${KRUIZE_REPO_PATH}/manifests/autotune/performance-profiles"
@@ -37,7 +37,12 @@ KRUIZE_IMAGE="quay.io/kruize/autotune:mvp_demo"
 
 function usage() {
 	echo
-	echo "Usage: -c cluster_type[minikube|openshift] [-i Kruize image] [-r <resultsdir path>]"
+	echo "Usage: -c cluster_type[minikube|openshift] [-i Kruize image] [-r <resultsdir path>] [--api-version=v1|legacy]"
+	echo
+  echo "API Version Parameter:"
+  echo "  --api-version=v1      Use NEW v1 API (/kruize/api/v1/recommendations)"
+  echo "  --api-version=legacy  Use OLD/LEGACY APIs (/updateRecommendations, /generateRecommendations)"
+  echo "  Default: legacy (if no parameter specified)"
 	exit -1
 }
 
@@ -52,9 +57,20 @@ function get_kruize_pod_log() {
 	kubectl logs -f ${kruize_pod} -n ${NAMESPACE} > ${log} 2>&1 &
 }
 
-while getopts c:r:i:t:h gopts
+while getopts c:r:i:t:h:-: gopts
 do
 	case ${gopts} in
+	-)
+    case "${OPTARG}" in
+      api-version=*)
+        api_version=${OPTARG#*=}
+        ;;
+      *)
+        echo "Error: Invalid option --${OPTARG}"
+        usage
+        ;;
+    esac
+    ;;
 	c)
 		CLUSTER_TYPE=${OPTARG}
 		;;
@@ -69,6 +85,12 @@ do
 		;;
 	esac
 done
+
+echo "local_monitoring_fault_tolerant_tests.sh :: api_version = ${api_version}"
+# Set the API version to default if not passed on parameter
+if [ -z "${api_version}" ]; then
+  api_version="legacy"
+fi
 
 if [ -z "${CLUSTER_TYPE}" ]; then
 	usage
@@ -155,14 +177,14 @@ TEST_LOG="${LOG_DIR}/kruize_pod_restart_test.log"
 echo ""
 echo "Running fault tolerant test for kruize on ${CLUSTER_TYPE}" | tee -a ${LOG}
 if [ "${CLUSTER_TYPE}" == "openshift" ]; then
-	echo "python3 kruize_pod_restart_test.py -c ${CLUSTER_TYPE} -a ${SERVER_IP_ADDR} -r ${LOG_DIR} | tee -a  ${TEST_LOG}" | tee -a ${LOG}
-	python3 kruize_pod_restart_test.py -c ${CLUSTER_TYPE} -a ${SERVER_IP_ADDR} -r "${LOG_DIR}" | tee -a  ${TEST_LOG}
+	echo "python3 kruize_pod_restart_test.py -c ${CLUSTER_TYPE} -a ${SERVER_IP_ADDR} -r ${LOG_DIR} --api-version ${api_version} | tee -a  ${TEST_LOG}" | tee -a ${LOG}
+	python3 kruize_pod_restart_test.py -c ${CLUSTER_TYPE} -a ${SERVER_IP_ADDR} -r "${LOG_DIR}" --api-version "${api_version}" | tee -a  ${TEST_LOG}
 	exit_code=$?
 	echo "exit_code = $exit_code"
 
 else
-	echo "python3 kruize_pod_restart_test.py -c ${CLUSTER_TYPE} -r ${LOG_DIR} | tee -a  ${TEST_LOG}" | tee -a ${LOG}
-	python3 kruize_pod_restart_test.py -c ${CLUSTER_TYPE} -r "${LOG_DIR}" | tee -a  ${TEST_LOG}
+	echo "python3 kruize_pod_restart_test.py -c ${CLUSTER_TYPE} -r ${LOG_DIR} --api-version ${api_version} | tee -a  ${TEST_LOG}" | tee -a ${LOG}
+	python3 kruize_pod_restart_test.py -c ${CLUSTER_TYPE} -r "${LOG_DIR}" --api-version "${api_version}" | tee -a  ${TEST_LOG}
 	exit_code=$?
 	echo "exit_code = $exit_code"
 fi

--- a/tests/scripts/local_monitoring_tests/fault_tolerant_test/local_monitoring_fault_tolerant_tests.sh
+++ b/tests/scripts/local_monitoring_tests/fault_tolerant_test/local_monitoring_fault_tolerant_tests.sh
@@ -20,6 +20,7 @@ declare -l api_version
 CURRENT_DIR="$(dirname "$(realpath "$0")")"
 KRUIZE_REPO_PATH="${CURRENT_DIR}/../../../.."
 METRIC_PROFILE_DIR="${KRUIZE_REPO_PATH}/manifests/autotune/performance-profiles"
+LOCAL_MONITORING_TEST_DIR="${KRUIZE_REPO_PATH}/tests/scripts/local_monitoring_tests"
 
 # Source the common functions scripts
 . ${CURRENT_DIR}/../../common/common_functions.sh
@@ -101,6 +102,9 @@ LOG_DIR="${RESULTS_DIR}/local-monitoring-fault-tolerant-test-$(date +%Y%m%d%H%M)
 mkdir -p ${LOG_DIR}
 
 LOG="${LOG_DIR}/local-monitoring-fault-tolerant-test.log"
+PIP_INSTALL_LOG="${LOG_DIR}/pip_install.log"
+
+install_python_requirements "${LOCAL_MONITORING_TEST_DIR}/requirements.txt" "${PIP_INSTALL_LOG}" | tee -a ${LOG}
 
 prometheus_pod_running=$(kubectl get pods --all-namespaces | grep "prometheus-k8s-0")
 if [ "${prometheus_pod_running}" == "" ]; then

--- a/tests/scripts/remote_monitoring_tests/db_migration_test/db_migration_test.sh
+++ b/tests/scripts/remote_monitoring_tests/db_migration_test/db_migration_test.sh
@@ -144,8 +144,8 @@ ${KRUIZE_REPO_PATH}/scripts/enable_user_workload_monitoring_openshift.sh | tee -
 pushd ${SCALE_TEST} > /dev/null
 	echo "" | tee -a ${LOG}
 	echo "Run scalability test to load 50 exps / 15 days data and update Recommendations with ${kruize_image_prev}" | tee -a ${LOG}
-	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a migration --api-version=${api_version}" | tee -a ${LOG}
-	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a "migration" --api-version=${api_version}
+	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a migration" | tee -a ${LOG}
+	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a "migration"
 popd > /dev/null 
 	echo "" | tee -a ${LOG}
 

--- a/tests/scripts/remote_monitoring_tests/db_migration_test/db_migration_test.sh
+++ b/tests/scripts/remote_monitoring_tests/db_migration_test/db_migration_test.sh
@@ -28,6 +28,7 @@ CURRENT_DIR="$(dirname "$(realpath "$0")")"
 KRUIZE_REPO_PATH="${CURRENT_DIR}/../../../.."
 SCALE_TEST="${CURRENT_DIR}/../scale_test"
 REMOTE_MONITORING_TEST_DIR="${KRUIZE_REPO_PATH}/tests/scripts/remote_monitoring_tests"
+declare -l api_version
 
 # Source the common functions scripts
 . ${CURRENT_DIR}/../../common/common_functions.sh
@@ -55,13 +56,29 @@ kruize_image_current="quay.io/kruize/autotune_operator:0.0.20.1_rm"
 
 function usage() {
 	echo
-	echo "Usage: [-i Kruize image previous release] [-j kruize image current release] [-u No. of experiments (default - 5000)] [-d No. of days of results (default - 15)] [-n No. of clients (default - 20)] [-m results duration interval in mins, (default - 15)] [-t interval hours (default - 6)] [-s Initial start date (default - 2023-01-10T00:00:00.000Z)] [-q query db interval in mins, (default - 10)] [-r <resultsdir path>]"
+	echo "Usage: [-i Kruize image previous release] [-j kruize image current release] [-u No. of experiments (default - 5000)] [-d No. of days of results (default - 15)] [-n No. of clients (default - 20)] [-m results duration interval in mins, (default - 15)] [-t interval hours (default - 6)] [-s Initial start date (default - 2023-01-10T00:00:00.000Z)] [-q query db interval in mins, (default - 10)] [-r <resultsdir path>] [--api-version=v1|legacy]"
+	echo
+	echo "API Version Parameter:"
+	echo "  --api-version=v1      Use NEW v1 API (/kruize/api/v1/recommendations)"
+	echo "  --api-version=legacy  Use OLD/LEGACY APIs (/updateRecommendations, /generateRecommendations)"
+	echo "  Default: legacy (if no parameter specified)"
 	exit -1
 }
 
-while getopts r:i:j:u:d:t:n:m:s:f:q:h gopts
+while getopts r:i:j:u:d:t:n:m:s:f:q:h:-: gopts
 do
 	case ${gopts} in
+	-)
+		case "${OPTARG}" in
+			api-version=*)
+				api_version=${OPTARG#*=}
+				;;
+			*)
+				echo "Error: Invalid option --${OPTARG}"
+				usage
+				;;
+		esac
+		;;
 	r)
 		RESULTS_DIR="${OPTARG}"		
 		;;
@@ -101,6 +118,12 @@ do
 	esac
 done
 
+echo "db_migration_test.sh :: api_version = ${api_version}"
+# Set the API version to default if not passed on parameter
+if [ -z "${api_version}" ]; then
+  api_version="legacy"
+fi
+
 start_time=$(get_date)
 
 
@@ -121,8 +144,8 @@ ${KRUIZE_REPO_PATH}/scripts/enable_user_workload_monitoring_openshift.sh | tee -
 pushd ${SCALE_TEST} > /dev/null
 	echo "" | tee -a ${LOG}
 	echo "Run scalability test to load 50 exps / 15 days data and update Recommendations with ${kruize_image_prev}" | tee -a ${LOG}
-	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a migration" | tee -a ${LOG}
-	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a "migration"
+	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a migration --api-version=${api_version}" | tee -a ${LOG}
+	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a "migration" --api-version=${api_version}
 popd > /dev/null 
 	echo "" | tee -a ${LOG}
 
@@ -148,8 +171,8 @@ pushd ${SCALE_TEST} > /dev/null
 	restore_db=true
 	num_days_of_res=1
 
-	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -l ${restore_db} -f ${db_backup_file} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a migration" | tee -a ${LOG}
-	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -l ${restore_db} -f ${db_backup_file} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a "migration"
+	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -l ${restore_db} -f ${db_backup_file} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a migration --api-version=${api_version}" | tee -a ${LOG}
+	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -l ${restore_db} -f ${db_backup_file} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a "migration" --api-version=${api_version}
 
 	echo "" | tee -a ${LOG}
 	echo "" | tee -a ${LOG}
@@ -173,10 +196,15 @@ do
 
 	        reco_json_dir="${LOG_DIR}/reco_jsons"
         	mkdir -p ${reco_json_dir}
-        	echo "curl -s http://${SERVER_IP_ADDR}/listRecommendations?experiment_name=${exp_name}&rm=true" | tee -a ${LOG}
-	        curl -s "http://${SERVER_IP_ADDR}/listRecommendations?experiment_name=${exp_name}&rm=true" > ${reco_json_dir}/${exp_name}_reco.json
+        	if [[ "${api_version}" == "v1" ]]; then
+        	  echo "curl -s http://${SERVER_IP_ADDR}/kruize/api/v1/recommendations?experiment_name=${exp_name}&rm=true" | tee -a ${LOG}
+        	  curl -s "http://${SERVER_IP_ADDR}/kruize/api/v1/recommendations?experiment_name=${exp_name}&rm=true" > ${reco_json_dir}/${exp_name}_reco.json
+        	else
+        	  echo "curl -s http://${SERVER_IP_ADDR}/listRecommendations?experiment_name=${exp_name}&rm=true" | tee -a ${LOG}
+	          curl -s "http://${SERVER_IP_ADDR}/listRecommendations?experiment_name=${exp_name}&rm=true" > ${reco_json_dir}/${exp_name}_reco.json
+	        fi
 
-		python3 validate_reco_json.py -f ${reco_json_dir}/${exp_name}_reco.json -e ${end_time}
+		python3 validate_reco_json.py -f ${reco_json_dir}/${exp_name}_reco.json -e ${end_time} --api-version ${api_version}
 		if [ $? != 0 ]; then
 			failed=1
 		fi

--- a/tests/scripts/remote_monitoring_tests/db_migration_test/db_migration_test_without_postgres_restart.sh
+++ b/tests/scripts/remote_monitoring_tests/db_migration_test/db_migration_test_without_postgres_restart.sh
@@ -28,6 +28,7 @@ CURRENT_DIR="$(dirname "$(realpath "$0")")"
 KRUIZE_REPO_PATH="${CURRENT_DIR}/../../../.."
 SCALE_TEST="${CURRENT_DIR}/../scale_test"
 REMOTE_MONITORING_TEST_DIR="${KRUIZE_REPO_PATH}/tests/scripts/remote_monitoring_tests"
+declare -l api_version
 
 # Source the common functions scripts
 . ${CURRENT_DIR}/../../common/common_functions.sh
@@ -56,13 +57,29 @@ hours=6
 
 function usage() {
 	echo
-	echo "Usage: [-i Kruize image previous release] [-j kruize image current release] [-u No. of experiments (default - 5000)] [-d No. of days of results (default - 15)] [-n No. of clients (default - 20)] [-m results duration interval in mins, (default - 15)] [-t interval hours (default - 6)] [-s Initial start date (default - 2023-01-10T00:00:00.000Z)] [-q query db interval in mins, (default - 10)] [-r <resultsdir path>]"
+	echo "Usage: [-i Kruize image previous release] [-j kruize image current release] [-u No. of experiments (default - 5000)] [-d No. of days of results (default - 15)] [-n No. of clients (default - 20)] [-m results duration interval in mins, (default - 15)] [-t interval hours (default - 6)] [-s Initial start date (default - 2023-01-10T00:00:00.000Z)] [-q query db interval in mins, (default - 10)] [-r <resultsdir path>] [--api-version=v1|legacy]"
+	echo
+	echo "API Version Parameter:"
+	echo "  --api-version=v1      Use NEW v1 API (/kruize/api/v1/recommendations)"
+	echo "  --api-version=legacy  Use OLD/LEGACY APIs (/updateRecommendations, /generateRecommendations)"
+	echo "  Default: legacy (if no parameter specified)"
 	exit -1
 }
 
-while getopts r:i:j:u:d:t:n:m:s:f:q:h gopts
+while getopts r:i:j:u:d:t:n:m:s:f:q:h:-: gopts
 do
 	case ${gopts} in
+	-)
+		case "${OPTARG}" in
+			api-version=*)
+				api_version=${OPTARG#*=}
+				;;
+			*)
+				echo "Error: Invalid option --${OPTARG}"
+				usage
+				;;
+		esac
+		;;
 	r)
 		RESULTS_DIR="${OPTARG}"		
 		;;
@@ -102,6 +119,12 @@ do
 	esac
 done
 
+echo "db_migration_test_without_postgres_restart.sh :: api_version = ${api_version}"
+# Set the API version to default if not passed on parameter
+if [ -z "${api_version}" ]; then
+  api_version="legacy"
+fi
+
 start_time=$(get_date)
 LOG_DIR="${RESULTS_DIR}/db-migration-test-without-kruize-db-restart-$(date +%Y%m%d%H%M)"
 mkdir -p ${LOG_DIR}
@@ -119,8 +142,8 @@ ${KRUIZE_REPO_PATH}/scripts/enable_user_workload_monitoring_openshift.sh | tee -
 pushd ${SCALE_TEST} > /dev/null
 	echo "" | tee -a ${LOG}
 	echo "Run scalability test to load 50 exps / 15 days data and update Recommendations with ${kruize_image_prev}" | tee -a ${LOG}
-	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a migration" | tee -a ${LOG}
-	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a "migration"
+	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a migration --api-version=${api_version}" | tee -a ${LOG}
+	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a "migration" --api-version=${api_version}
 popd > /dev/null
 	echo "" | tee -a ${LOG}
 
@@ -153,8 +176,8 @@ pushd ${SCALE_TEST} > /dev/null
 
 	num_days_of_res=1
 
-	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -b ${kruize_setup} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a migration" | tee -a ${LOG}
-	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -b ${kruize_setup} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a "migration"
+	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -b ${kruize_setup} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a migration --api-version=${api_version}" | tee -a ${LOG}
+	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -b ${kruize_setup} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a "migration" --api-version=${api_version}
 
 	echo "" | tee -a ${LOG}
 	echo "" | tee -a ${LOG}
@@ -178,8 +201,13 @@ do
 
 	        reco_json_dir="${LOG_DIR}/reco_jsons"
         	mkdir -p ${reco_json_dir}
-        	echo "curl -s http://${SERVER_IP_ADDR}/listRecommendations?experiment_name=${exp_name}&rm=true" | tee -a ${LOG}
-	        curl -s "http://${SERVER_IP_ADDR}/listRecommendations?experiment_name=${exp_name}&rm=true" > ${reco_json_dir}/${exp_name}_reco.json
+        	if [[ "${api_version}" == "v1" ]]; then
+        	  echo "curl -s http://${SERVER_IP_ADDR}/kruize/api/v1/recommendations?experiment_name=${exp_name}&rm=true" | tee -a ${LOG}
+	          curl -s "http://${SERVER_IP_ADDR}/kruize/api/v1/recommendations?experiment_name=${exp_name}&rm=true" > ${reco_json_dir}/${exp_name}_reco.json
+	        else
+	          echo "curl -s http://${SERVER_IP_ADDR}/listRecommendations?experiment_name=${exp_name}&rm=true" | tee -a ${LOG}
+	          curl -s "http://${SERVER_IP_ADDR}/listRecommendations?experiment_name=${exp_name}&rm=true" > ${reco_json_dir}/${exp_name}_reco.json
+	        fi
 
 		python3 validate_reco_json.py -f ${reco_json_dir}/${exp_name}_reco.json -e ${end_time}
 		if [ $? != 0 ]; then

--- a/tests/scripts/remote_monitoring_tests/db_migration_test/db_migration_test_without_postgres_restart.sh
+++ b/tests/scripts/remote_monitoring_tests/db_migration_test/db_migration_test_without_postgres_restart.sh
@@ -209,7 +209,7 @@ do
 	          curl -s "http://${SERVER_IP_ADDR}/listRecommendations?experiment_name=${exp_name}&rm=true" > ${reco_json_dir}/${exp_name}_reco.json
 	        fi
 
-		python3 validate_reco_json.py -f ${reco_json_dir}/${exp_name}_reco.json -e ${end_time}
+		python3 validate_reco_json.py -f ${reco_json_dir}/${exp_name}_reco.json -e ${end_time} --api-version ${api_version}
 		if [ $? != 0 ]; then
 			failed=1
 		fi

--- a/tests/scripts/remote_monitoring_tests/db_migration_test/db_migration_test_without_postgres_restart.sh
+++ b/tests/scripts/remote_monitoring_tests/db_migration_test/db_migration_test_without_postgres_restart.sh
@@ -142,8 +142,8 @@ ${KRUIZE_REPO_PATH}/scripts/enable_user_workload_monitoring_openshift.sh | tee -
 pushd ${SCALE_TEST} > /dev/null
 	echo "" | tee -a ${LOG}
 	echo "Run scalability test to load 50 exps / 15 days data and update Recommendations with ${kruize_image_prev}" | tee -a ${LOG}
-	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a migration --api-version=${api_version}" | tee -a ${LOG}
-	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a "migration" --api-version=${api_version}
+	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a migration" | tee -a ${LOG}
+	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a "migration"
 popd > /dev/null
 	echo "" | tee -a ${LOG}
 

--- a/tests/scripts/remote_monitoring_tests/db_migration_test/validate_reco_json.py
+++ b/tests/scripts/remote_monitoring_tests/db_migration_test/validate_reco_json.py
@@ -50,6 +50,7 @@ def validate_reco_json(json_file, end_time):
 	cpu = True
 	list_reco_json = json.load(open(json_file))
 
+	print(f"Validating recommendation json {list_reco_json}")
 	# Validate the json values
 	for containers in list_reco_json[0]["kubernetes_objects"][0]["containers"]:
 			actual_container_name = containers["container_name"]

--- a/tests/scripts/remote_monitoring_tests/db_migration_test/validate_reco_json.py
+++ b/tests/scripts/remote_monitoring_tests/db_migration_test/validate_reco_json.py
@@ -4,11 +4,7 @@ import json
 
 sys.path.append("../..")
 
-from helpers.fixtures import *
 from helpers.generate_rm_jsons import *
-from helpers.kruize import *
-from helpers.reco_json_schemas import *
-from helpers.list_reco_json_validate import *
 from helpers.utils import *
 
 failed = 0

--- a/tests/scripts/remote_monitoring_tests/db_migration_test/validate_reco_json.py
+++ b/tests/scripts/remote_monitoring_tests/db_migration_test/validate_reco_json.py
@@ -50,7 +50,6 @@ def validate_reco_json(json_file, end_time):
 	cpu = True
 	list_reco_json = json.load(open(json_file))
 
-	print(f"Validating recommendation json {list_reco_json}")
 	# Validate the json values
 	for containers in list_reco_json[0]["kubernetes_objects"][0]["containers"]:
 			actual_container_name = containers["container_name"]

--- a/tests/scripts/remote_monitoring_tests/db_migration_test/validate_reco_json.py
+++ b/tests/scripts/remote_monitoring_tests/db_migration_test/validate_reco_json.py
@@ -1,6 +1,7 @@
 import sys, getopt
 import datetime
 import json
+
 sys.path.append("../..")
 
 from helpers.fixtures import *
@@ -11,9 +12,11 @@ from helpers.list_reco_json_validate import *
 from helpers.utils import *
 
 failed = 0
+api_version = "legacy"
 
 def validate_engine(terms_obj, cpu):
 	global failed
+	global api_version
 	cpu_format_type = "cores"
 	memory_format_type = "MiB"
 	engines_list = ["cost", "performance"]
@@ -27,6 +30,8 @@ def validate_engine(terms_obj, cpu):
 				if engine_entry in terms_obj["recommendation_engines"]:
 					engine_obj = terms_obj["recommendation_engines"][engine_entry]
 					reco_config = engine_obj["config"]
+					if api_version == "v1":
+						reco_config.update(reco_config.pop("resources"))
 					usage_list = ["requests", "limits"]
 					for usage in usage_list:
 						if cpu == True:
@@ -103,21 +108,24 @@ def validate_reco_json(json_file, end_time):
 			long_term_recommendation = data_section[end_time]["recommendation_terms"]["long_term"]
 
 def main(argv):
+	global api_version
 	json_file = ""
 	end_time = ""
 	try:
-		opts, args = getopt.getopt(argv,"h:f:e:")
+		opts, args = getopt.getopt(argv,"h:f:e:",["api-version="])
 	except getopt.GetoptError:
-		print("validate_reco_json.py -f <reco json file> -e <interval end time>")
+		print("validate_reco_json.py -f <reco json file> -e <interval end time> --api-version v1")
 		sys.exit(2)
 	for opt, arg in opts:
 		if opt == '-h':
-			print("validate_reco_json.py -f <reco json file> -e <interval end time>")
+			print("validate_reco_json.py -f <reco json file> -e <interval end time> --api-version v1")
 			sys.exit(0)
 		elif opt == '-f':
 			json_file = arg
 		elif opt == '-e':
 			end_time = str(arg)
+		elif opt == '--api-version':
+			api_version = str(arg)
 
 	validate_reco_json(json_file, end_time)
 	if failed == 0:

--- a/tests/scripts/remote_monitoring_tests/fault_tolerant_tests/kruize_pod_restart_test.py
+++ b/tests/scripts/remote_monitoring_tests/fault_tolerant_tests/kruize_pod_restart_test.py
@@ -19,30 +19,34 @@ import json
 import os
 import sys
 import time
+import pytest
 
 sys.path.append("../../")
 from helpers.kruize import *
 from helpers.utils import *
 from helpers.generate_rm_jsons import *
 
+api_version = "legacy"
+
 
 def main(argv):
+    global api_version
     cluster_type = "minikube"
     results_dir = "."
     iterations = 2
     num_exps = 1
     failed = 0
     try:
-        opts, args = getopt.getopt(argv, "h:c:a:u:r:d:")
+        opts, args = getopt.getopt(argv, "h:c:a:u:r:d:", ["api-version="])
     except getopt.GetoptError:
         print(
-            "kruize_pod_restart_test.py -c <cluster type> -a <openshift kruize route> -u <no. of experiments> -d <no. of iterations to test restart (default - 2> -r <results dir>")
+            "kruize_pod_restart_test.py -c <cluster type> -a <openshift kruize route> -u <no. of experiments> -d <no. of iterations to test restart (default - 2> -r <results dir> --api-version <v1/legacy>")
         print("Note: -a option is required only on openshift when kruize service is exposed")
         sys.exit(2)
     for opt, arg in opts:
         if opt == '-h':
             print(
-                "kruize_pod_restart_test.py -c <cluster type> -a <openshift kruize route> -u <no. of experiments> -d <no. of iterations to test restart(default - 2> -r <results dir>")
+                "kruize_pod_restart_test.py -c <cluster type> -a <openshift kruize route> -u <no. of experiments> -d <no. of iterations to test restart(default - 2> -r <results dir> --api-version <v1/legacy>")
             sys.exit(0)
         elif opt == '-c':
             cluster_type = arg
@@ -54,6 +58,13 @@ def main(argv):
             results_dir = arg
         elif opt == '-d':
             iterations = int(arg)
+        elif opt == '--api-version':
+            api_version = str(arg)
+
+    if api_version.lower() == "v1":
+        pytest.USE_NEW_API = True
+    else:
+        pytest.USE_NEW_API = False
 
     print(f"Cluster type = {cluster_type}")
     print(f"No. of experiments = {num_exps}")

--- a/tests/scripts/remote_monitoring_tests/fault_tolerant_tests/remote_monitoring_fault_tolerant_tests.sh
+++ b/tests/scripts/remote_monitoring_tests/fault_tolerant_tests/remote_monitoring_fault_tolerant_tests.sh
@@ -22,6 +22,7 @@ declare -l api_version
 CURRENT_DIR="$(dirname "$(realpath "$0")")"
 KRUIZE_REPO_PATH="${CURRENT_DIR}/../../../.."
 PERFORMANCE_PROFILE_DIR="${KRUIZE_REPO_PATH}/manifests/autotune/performance-profiles"
+REMOTE_MONITORING_TEST_DIR="${KRUIZE_REPO_PATH}/tests/scripts/remote_monitoring_tests"
 
 # Source the common functions scripts
 . ${CURRENT_DIR}/../../common/common_functions.sh
@@ -111,6 +112,9 @@ LOG_DIR="${RESULTS_DIR}/remote-monitoring-fault-tolerant-test-$(date +%Y%m%d%H%M
 mkdir -p ${LOG_DIR}
 
 LOG="${LOG_DIR}/remote-monitoring-fault-tolerant-test.log"
+PIP_INSTALL_LOG="${LOG_DIR}/pip_install.log"
+
+install_python_requirements "${REMOTE_MONITORING_TEST_DIR}/requirements.txt" "${PIP_INSTALL_LOG}" | tee -a ${LOG}
 
 prometheus_pod_running=$(kubectl get pods --all-namespaces | grep "prometheus-k8s-0")
 if [ "${prometheus_pod_running}" == "" ]; then

--- a/tests/scripts/remote_monitoring_tests/fault_tolerant_tests/remote_monitoring_fault_tolerant_tests.sh
+++ b/tests/scripts/remote_monitoring_tests/fault_tolerant_tests/remote_monitoring_fault_tolerant_tests.sh
@@ -17,6 +17,8 @@
 ### Script to run fault tolerant tests with Kruize in remote monitoring mode ##
 #
 
+declare -l api_version
+
 CURRENT_DIR="$(dirname "$(realpath "$0")")"
 KRUIZE_REPO_PATH="${CURRENT_DIR}/../../../.."
 PERFORMANCE_PROFILE_DIR="${KRUIZE_REPO_PATH}/manifests/autotune/performance-profiles"
@@ -39,7 +41,12 @@ num_exps=1
 
 function usage() {
 	echo
-	echo "Usage: -c cluster_tyep[minikube|openshift] [-i Kruize image] [-u No. of experiments (default - 1)] [ -d no. of iterations to test restart (default - 2)] [-r <resultsdir path>]"
+	echo "Usage: -c cluster_tyep[minikube|openshift] [-i Kruize image] [-u No. of experiments (default - 1)] [ -d no. of iterations to test restart (default - 2)] [-r <resultsdir path>] [--api-version=v1|legacy]"
+	echo
+	echo "API Version Parameter:"
+	echo "  --api-version=v1      Use NEW v1 API (/kruize/api/v1/recommendations)"
+	echo "  --api-version=legacy  Use OLD/LEGACY APIs (/updateRecommendations, /generateRecommendations)"
+	echo "  Default: legacy (if no parameter specified)"
 	exit -1
 }
 
@@ -54,9 +61,20 @@ function get_kruize_pod_log() {
 	kubectl logs -f ${kruize_pod} -n ${NAMESPACE} > ${log} 2>&1 &
 }
 
-while getopts c:r:i:u:d:t:h gopts
+while getopts c:r:i:u:d:t:h:-: gopts
 do
 	case ${gopts} in
+	-)
+		case "${OPTARG}" in
+			api-version=*)
+				api_version=${OPTARG#*=}
+				;;
+			*)
+				echo "Error: Invalid option --${OPTARG}"
+				usage
+				;;
+		esac
+		;;
 	c)
 		CLUSTER_TYPE=${OPTARG}
 		;;
@@ -77,6 +95,12 @@ do
 		;;
 	esac
 done
+
+echo "remote_monitoring_fault_tolerant_tests.sh :: api_version = ${api_version}"
+# Set the API version to default if not passed on parameter
+if [ -z "${api_version}" ]; then
+  api_version="legacy"
+fi
 
 if [ -z "${CLUSTER_TYPE}" ]; then
 	usage
@@ -152,14 +176,14 @@ TEST_LOG="${LOG_DIR}/kruize_pod_restart_test.log"
 echo ""
 echo "Running fault tolerant test for kruize on ${CLUSTER_TYPE}" | tee -a ${LOG}
 if [ "${CLUSTER_TYPE}" == "openshift" ]; then
-	echo "python3 kruize_pod_restart_test.py -c ${CLUSTER_TYPE} -a ${SERVER_IP_ADDR} -u ${num_exps} -d ${iterations} -r ${LOG_DIR} | tee -a  ${TEST_LOG}" | tee -a ${LOG}
-	python3 kruize_pod_restart_test.py -c ${CLUSTER_TYPE} -a ${SERVER_IP_ADDR} -u ${num_exps} -d ${iterations} -r "${LOG_DIR}" | tee -a  ${TEST_LOG}
+	echo "python3 kruize_pod_restart_test.py -c ${CLUSTER_TYPE} -a ${SERVER_IP_ADDR} -u ${num_exps} -d ${iterations} -r ${LOG_DIR} --api-version ${api_version} | tee -a  ${TEST_LOG}" | tee -a ${LOG}
+	python3 kruize_pod_restart_test.py -c ${CLUSTER_TYPE} -a ${SERVER_IP_ADDR} -u ${num_exps} -d ${iterations} -r "${LOG_DIR}" --api-version "${api_version}" | tee -a  ${TEST_LOG}
 	exit_code=$?
 	echo "exit_code = $exit_code"
 
 else
-	echo "python3 kruize_pod_restart_test.py -c ${CLUSTER_TYPE} -u ${num_exps} -d ${iterations} -r ${LOG_DIR} | tee -a  ${TEST_LOG}" | tee -a ${LOG}
-	python3 kruize_pod_restart_test.py -c ${CLUSTER_TYPE} -u ${num_exps} -d ${iterations} -r "${LOG_DIR}" | tee -a  ${TEST_LOG}
+	echo "python3 kruize_pod_restart_test.py -c ${CLUSTER_TYPE} -u ${num_exps} -d ${iterations} -r ${LOG_DIR} --api-version ${api_version} | tee -a  ${TEST_LOG}" | tee -a ${LOG}
+	python3 kruize_pod_restart_test.py -c ${CLUSTER_TYPE} -u ${num_exps} -d ${iterations} -r "${LOG_DIR}" --api-version "${api_version}" | tee -a  ${TEST_LOG}
 	exit_code=$?
 	echo "exit_code = $exit_code"
 fi

--- a/tests/scripts/remote_monitoring_tests/json_files/resource_optimization_openshift_v2.json
+++ b/tests/scripts/remote_monitoring_tests/json_files/resource_optimization_openshift_v2.json
@@ -1,0 +1,426 @@
+{
+  "name": "resource-optimization-openshift",
+  "profile_version": 2.0,
+  "k8s_type": "openshift",
+  "slo": {
+    "slo_class": "resource_usage",
+    "direction": "minimize",
+    "objective_function": {
+      "function_type": "source"
+    },
+    "function_variables": [
+      {
+        "name": "cpuRequest",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg by(container, namespace)(kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", container=\"$CONTAINER_NAME$\", namespace=\"$NAMESPACE\", resource=\"cpu\", unit=\"core\"})"
+          },
+          {
+            "function": "sum",
+            "query": "sum by(container, namespace)(kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", container=\"$CONTAINER_NAME$\", namespace=\"$NAMESPACE\", resource=\"cpu\", unit=\"core\"})"
+          }
+        ]
+      },
+      {
+        "name": "cpuLimit",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg by(container, namespace)(kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", container=\"$CONTAINER_NAME$\", namespace=\"$NAMESPACE\", resource=\"cpu\", unit=\"core\"})"
+          },
+          {
+            "function": "sum",
+            "query": "sum by(container, namespace)(kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", container=\"$CONTAINER_NAME$\", namespace=\"$NAMESPACE$\", resource=\"cpu\", unit=\"core\"})"
+          }
+        ]
+      },
+      {
+        "name": "cpuUsage",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=”$CONTAINER_NAME$”}[15m]))",
+            "versions": "<=4.8"
+          },
+          {
+            "function": "avg",
+            "query": "avg by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=”$CONTAINER_NAME$”}[15m]))",
+            "versions": ">4.9"
+          },
+          {
+            "function": "min",
+            "query": "min by(container, namespace)(min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[15m]))",
+            "versions": "<=4.8"
+          },
+          {
+            "function": "min",
+            "query": "min by(container, namespace)(min_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[15m]))",
+            "versions": ">4.9"
+          },
+          {
+            "function": "max",
+            "query": "max by(container, namespace)(max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[15m]))",
+            "versions": "<=4.8"
+          },
+          {
+            "function": "max",
+            "query": "max by(container, namespace)(max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[15m]))",
+            "versions": ">4.9"
+          },
+          {
+            "function": "sum",
+            "query": "sum by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[15m]))",
+            "versions": "<=4.8"
+          },
+          {
+            "function": "sum",
+            "query": "sum by(container, namespace)(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=\"$CONTAINER_NAME$\"}[15m]))",
+            "versions": ">4.9"
+          }
+        ]
+      },
+      {
+        "name": "cpuThrottle",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg by(container,namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=”$CONTAINER_NAME$”}[15m]))"
+          },
+          {
+            "function": "max",
+            "query": "max by(container,namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=”$CONTAINER_NAME$”}[15m]))"
+          },
+          {
+            "function": "sum",
+            "query": "sum by(container,namespace)(rate(container_cpu_cfs_throttled_seconds_total{container!=\"\", container!=\"POD\", pod!=\"\", namespace=\"$NAMESPACE$\", container=”$CONTAINER_NAME$”}[15m]))"
+          }
+        ]
+      },
+      {
+        "name": "memoryRequest",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg by(container,namespace)(kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", container=”$CONTAINER_NAME$”, namespace=”$NAMESPACE”, resource=\"memory\", unit=\"byte\"})"
+          },
+          {
+            "function": "sum",
+            "query": "sum by(container,namespace)(kube_pod_container_resource_requests{container!=\"\", container!=\"POD\", pod!=\"\", container=”$CONTAINER_NAME$”, namespace=”$NAMESPACE”, resource=\"memory\", unit=\"byte\"})"
+          }
+        ]
+      },
+      {
+        "name": "memoryLimit",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg by(container,namespace)(kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", container=\"$CONTAINER_NAME$\", namespace=\"$NAMESPACE\", resource=\"memory\", unit=\"byte\"})"
+          },
+          {
+            "function": "sum",
+            "query": "sum by(container,namespace)(kube_pod_container_resource_limits{container!=\"\", container!=\"POD\", pod!=\"\", container=”$CONTAINER_NAME$”, namespace=”$NAMESPACE”, resource=\"memory\", unit=\"byte\"})"
+          }
+        ]
+      },
+      {
+        "name": "memoryUsage",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg by(container,namespace)(avg_over_time(container_memory_working_set_bytes{container!=\"\", container!=\"POD\", pod!=\"\", namespace=$NAMESPACE$, container=”$CONTAINER_NAME$”}[15m]))"
+          },
+          {
+            "function": "min",
+            "query": "min by(container,namespace)(min_over_time(container_memory_working_set_bytes{container!=\"\", container!=\"POD\", pod!=\"\", namespace=$NAMESPACE$, container=\"$CONTAINER_NAME$\"}[15m]))"
+          },
+          {
+            "function": "max",
+            "query": "max by(container,namespace)(max_over_time(container_memory_working_set_bytes{container!=\"\", container!=\"POD\", pod!=\"\", namespace=$NAMESPACE$, container=\"$CONTAINER_NAME$\"}[15m]))"
+          },
+          {
+            "function": "sum",
+            "query": "sum by(container,namespace)(avg_over_time(container_memory_working_set_bytes{container!=\"\", container!=\"POD\", pod!=\"\", namespace=$NAMESPACE$, container=\"$CONTAINER_NAME$\"}[15m]))"
+          }
+        ]
+      },
+      {
+        "name": "memoryRSS",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg by(container,namespace)(avg_over_time(container_memory_rss{container!=\"\", container!=\"POD\", pod!=\"\", namespace=$NAMESPACE$, container=”$CONTAINER_NAME$”}[15m]))"
+          },
+          {
+            "function": "min",
+            "query": "min by(container,namespace)(min_over_time(container_memory_rss{container!=\"\", container!=\"POD\", pod!=\"\", namespace=$NAMESPACE$, container=\"$CONTAINER_NAME$\"}[15m]))"
+          },
+          {
+            "function": "max",
+            "query": "max by(container,namespace)(max_over_time(container_memory_rss{container!=\"\", container!=\"POD\", pod!=\"\", namespace=$NAMESPACE$, container=\"$CONTAINER_NAME$\"}[15m]))"
+          },
+          {
+            "function": "sum",
+            "query": "sum by(container,namespace)(avg_over_time(container_memory_rss{container!=\"\", container!=\"POD\", pod!=\"\", namespace=$NAMESPACE$, container=”$CONTAINER_NAME$”}[15m]))"
+          }
+        ]
+      },
+      {
+        "name": "namespaceCpuRequest",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "sum",
+            "query": "sum by (namespace) (kube_resourcequota{namespace=\"$NAMESPACE$\", resource=\"requests.cpu\", type=\"hard\"})"
+          }
+        ]
+      },
+      {
+        "name": "namespaceCpuLimit",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "sum",
+            "query": "sum by (namespace) (kube_resourcequota{namespace=\"$NAMESPACE$\", resource=\"limits.cpu\", type=\"hard\"})"
+          }
+        ]
+      },
+      {
+        "name": "namespaceMemoryRequest",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "sum",
+            "query": "sum by (namespace) (kube_resourcequota{namespace=\"$NAMESPACE$\", resource=\"requests.memory\", type=\"hard\"})"
+          }
+        ]
+      },
+      {
+        "name": "namespaceMemoryLimit",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "sum",
+            "query": "sum by (namespace) (kube_resourcequota{namespace=\"$NAMESPACE$\", resource=\"limits.memory\", type=\"hard\"})"
+          }
+        ]
+      },
+      {
+        "name": "namespaceCpuUsage",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg_over_time(sum by(namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[15m:])"
+          },
+          {
+            "function": "max",
+            "query": "max_over_time(sum by(namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[15m:])"
+          },
+          {
+            "function": "min",
+            "query": "min_over_time(sum by(namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[15m:])"
+          }
+        ]
+      },
+      {
+        "name": "namespaceCpuThrottle",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"}[5m]))[15m:])"
+          },
+          {
+            "function": "max",
+            "query": "max_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"}[5m]))[15m:])"
+          },
+          {
+            "function": "min",
+            "query": "min_over_time(sum by(namespace) (rate(container_cpu_cfs_throttled_seconds_total{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"}[5m]))[15m:])"
+          }
+        ]
+      },
+      {
+        "name": "namespaceMemoryUsage",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[15m:])"
+          },
+          {
+            "function": "max",
+            "query": "max_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[15m:])"
+          },
+          {
+            "function": "min",
+            "query": "min_over_time(sum by(namespace) (container_memory_working_set_bytes{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[15m:])"
+          }
+        ]
+      },
+      {
+        "name": "namespaceMemoryRSS",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "avg",
+            "query": "avg_over_time(sum by(namespace) (container_memory_rss{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[15m:])"
+          },
+          {
+            "function": "max",
+            "query": "max_over_time(sum by(namespace) (container_memory_rss{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[15m:])"
+          },
+          {
+            "function": "min",
+            "query": "min_over_time(sum by(namespace) (container_memory_rss{namespace=\"$NAMESPACE$\", container!=\"\", container!=\"POD\", pod!=\"\"})[15m:])"
+          }
+        ]
+      },
+      {
+        "name": "namespaceTotalPods",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "max",
+            "query": "max_over_time(sum by(namespace) ((kube_pod_info{namespace=\"$NAMESPACE$\"}))[15m:])"
+          },
+          {
+            "function": "avg",
+            "query": "avg_over_time(sum by(namespace) ((kube_pod_info{namespace=\"$NAMESPACE$\"}))[15m:])"
+          }
+        ]
+      },
+      {
+        "name": "namespaceRunningPods",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "max",
+            "query": "max_over_time(sum by(namespace) ((kube_pod_status_phase{phase=\"Running\"}))[15m:])"
+          },
+          {
+            "function": "avg",
+            "query": "avg_over_time(sum by(namespace) ((kube_pod_status_phase{phase=\"Running\"}))[15m:])"
+          }
+        ]
+      },
+      {
+        "name": "namespaceMaxDate",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "namespace",
+        "aggregation_functions": [
+          {
+            "function": "max",
+            "query": "max(last_over_time(timestamp((sum by (namespace) (container_cpu_usage_seconds_total{namespace=\"$NAMESPACE$\"})) > 0 )[15d:]))"
+          }
+        ]
+      },
+      {
+        "name": "acceleratorCoreUsage",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "min",
+            "query": "min(min_over_time(DCGM_FI_DEV_GPU_UTIL{exported_namespace != \"\", exported_container != \"\", exported_pod != \"\"}[15m])) by (modelName, exported_container, exported_namespace, exported_pod, Hostname)"
+          },
+          {
+            "function": "max",
+            "query": "max(max_over_time(DCGM_FI_DEV_GPU_UTIL{exported_namespace != \"\", exported_container != \"\", exported_pod != \"\"}[15m])) by (modelName, exported_container, exported_namespace, exported_pod, Hostname)"
+          },
+          {
+            "function": "avg",
+            "query": "avg(avg_over_time(DCGM_FI_DEV_GPU_UTIL{exported_namespace != \"\", exported_container != \"\", exported_pod != \"\"}[15m])) by (modelName, exported_container, exported_namespace, exported_pod, Hostname)"
+          }
+        ]
+      },
+      {
+        "name": "acceleratorMemoryUsage",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "min",
+            "query": "min(min_over_time(DCGM_FI_DEV_MEM_COPY_UTIL{exported_namespace != \"\", exported_container != \"\", exported_pod != \"\"}[15m])) by (modelName, exported_container, exported_namespace, exported_pod, Hostname)"
+          },
+          {
+            "function": "max",
+            "query": "max(max_over_time(DCGM_FI_DEV_MEM_COPY_UTIL{exported_namespace != \"\", exported_container != \"\", exported_pod != \"\"}[15m])) by (modelName, exported_container, exported_namespace, exported_pod, Hostname)"
+          },
+          {
+            "function": "avg",
+            "query": "avg(avg_over_time(DCGM_FI_DEV_MEM_COPY_UTIL{exported_namespace != \"\", exported_container != \"\", exported_pod != \"\"}[15m])) by (modelName, exported_container, exported_namespace, exported_pod, Hostname)"
+          }
+        ]
+      },
+      {
+        "name": "acceleratorFrameBufferUsage",
+        "datasource": "prometheus",
+        "value_type": "double",
+        "kubernetes_object": "container",
+        "aggregation_functions": [
+          {
+            "function": "min",
+            "query": "min(min_over_time(DCGM_FI_DEV_FB_USED{exported_namespace != \"\", exported_container != \"\", exported_pod != \"\"}[15m])) by (modelName, GPU_I_PROFILE, exported_container, exported_namespace, exported_pod, Hostname)"
+          },
+          {
+            "function": "max",
+            "query": "max(max_over_time(DCGM_FI_DEV_FB_USED{exported_namespace != \"\", exported_container != \"\", exported_pod != \"\"}[15m])) by (modelName, GPU_I_PROFILE, exported_container, exported_namespace, exported_pod, Hostname)"
+          },
+          {
+            "function": "avg",
+            "query": "avg(avg_over_time(DCGM_FI_DEV_FB_USED{exported_namespace != \"\", exported_container != \"\", exported_pod != \"\"}[15m])) by (modelName, GPU_I_PROFILE, exported_container, exported_namespace, exported_pod, Hostname)"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/scripts/remote_monitoring_tests/perf_profile_migration_test/perf_profile_migration_test.sh
+++ b/tests/scripts/remote_monitoring_tests/perf_profile_migration_test/perf_profile_migration_test.sh
@@ -113,7 +113,7 @@ do
 	esac
 done
 
-echo "perf_profile_migrartion_test.sh :: api_version = ${api_version}"
+echo "perf_profile_migration_test.sh :: api_version = ${api_version}"
 # Set the API version to default if not passed on parameter
 if [ -z "${api_version}" ]; then
   api_version="legacy"

--- a/tests/scripts/remote_monitoring_tests/perf_profile_migration_test/perf_profile_migration_test.sh
+++ b/tests/scripts/remote_monitoring_tests/perf_profile_migration_test/perf_profile_migration_test.sh
@@ -24,6 +24,8 @@
 # The backed up DB is restored and new usage metrics or results for 1 day for 10 exps is posted
 # Invokes updateRecommendations for all the 10 exps
 
+declare -l api_version
+
 CURRENT_DIR="$(dirname "$(realpath "$0")")"
 KRUIZE_REPO_PATH="${CURRENT_DIR}/../../../.."
 SCALE_TEST="${CURRENT_DIR}/../scale_test"
@@ -52,13 +54,29 @@ kruize_image_current="quay.io/kruize/autotune_operator:0.7"
 
 function usage() {
 	echo
-	echo "Usage: [-i Kruize image previous release] [-j kruize image current release] [-u No. of experiments (default - 10)] [-d No. of days of results (default - 15)] [-n No. of clients (default - 10)] [-m results duration interval in mins, (default - 15)] [-t interval hours (default - 6)] [-s Initial start date (default - 2025-10-01T00:00:00.000Z)] [-q query db interval in mins, (default - 10)] [-r <resultsdir path>]"
+	echo "Usage: [-i Kruize image previous release] [-j kruize image current release] [-u No. of experiments (default - 10)] [-d No. of days of results (default - 15)] [-n No. of clients (default - 10)] [-m results duration interval in mins, (default - 15)] [-t interval hours (default - 6)] [-s Initial start date (default - 2025-10-01T00:00:00.000Z)] [-q query db interval in mins, (default - 10)] [-r <resultsdir path>] [--api-version=v1|legacy]"
+	echo
+	echo "API Version Parameter:"
+	echo "  --api-version=v1      Use NEW v1 API (/kruize/api/v1/recommendations)"
+	echo "  --api-version=legacy  Use OLD/LEGACY APIs (/updateRecommendations, /generateRecommendations)"
+	echo "  Default: legacy (if no parameter specified)"
 	exit -1
 }
 
-while getopts r:i:j:u:d:t:n:m:s:q:h gopts
+while getopts r:i:j:u:d:t:n:m:s:q:h:-: gopts
 do
 	case ${gopts} in
+	-)
+		case "${OPTARG}" in
+			api-version=*)
+				api_version=${OPTARG#*=}
+				;;
+			*)
+				echo "Error: Invalid option --${OPTARG}"
+				usage
+				;;
+		esac
+		;;
 	r)
 		RESULTS_DIR="${OPTARG}"		
 		;;
@@ -95,6 +113,12 @@ do
 	esac
 done
 
+echo "perf_profile_migrartion_test.sh :: api_version = ${api_version}"
+# Set the API version to default if not passed on parameter
+if [ -z "${api_version}" ]; then
+  api_version="legacy"
+fi
+
 start_time=$(get_date)
 LOG_DIR="${RESULTS_DIR}/perf-profile-migration-test-$(date +%Y%m%d%H%M)"
 mkdir -p ${LOG_DIR}
@@ -113,8 +137,8 @@ total_results_count=0
 # Run scalability test to load 10 exps / 15 days data and update Recommendations with previous release
 echo "" | tee -a ${LOG}
 echo "Run scalability test to load 10 exps / 15 days data and update Recommendations with ${kruize_image_prev}" | tee -a ${LOG}
-echo "./run_test.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_10_15days -e ${total_results_count}" | tee -a ${LOG}
-./run_test.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_10_15days -e ${total_results_count}
+echo "./run_test.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_10_15days -e ${total_results_count} --api-version=${api_version}" | tee -a ${LOG}
+./run_test.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_10_15days -e ${total_results_count} --api-version=${api_version}
 echo "" | tee -a ${LOG}
 
 sleep 20
@@ -145,8 +169,8 @@ kruize_setup=false
 total_results_count=$((${num_exps} * ${num_clients} * ${num_days_of_res} * 96))
 num_days_of_res=1
 
-echo "./run_test.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -b ${kruize_setup} -r ${LOG_DIR}/test_logs_10_16days -e ${total_results_count}" | tee -a ${LOG}
-./run_test.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -b ${kruize_setup} -r ${LOG_DIR}/test_logs_10_16days -e ${total_results_count}
+echo "./run_test.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -b ${kruize_setup} -r ${LOG_DIR}/test_logs_10_16days -e ${total_results_count} --api-version=${api_version}" | tee -a ${LOG}
+./run_test.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -b ${kruize_setup} -r ${LOG_DIR}/test_logs_10_16days -e ${total_results_count} --api-version=${api_version}
 
 echo "" | tee -a ${LOG}
 
@@ -167,10 +191,15 @@ do
 
 	        reco_json_dir="${LOG_DIR}/reco_jsons"
         	mkdir -p ${reco_json_dir}
-        	echo "curl -s http://${SERVER_IP_ADDR}/listRecommendations?experiment_name=${exp_name}&rm=true" | tee -a ${LOG}
-	        curl -s "http://${SERVER_IP_ADDR}/listRecommendations?experiment_name=${exp_name}&rm=true" > ${reco_json_dir}/${exp_name}_reco.json
+        	if [[ "${api_version}" == "v1" ]]; then
+        	  echo "curl -s http://${SERVER_IP_ADDR}/kruize/api/v1/recommendations?experiment_name=${exp_name}&rm=true" | tee -a ${LOG}
+        	  curl -s "http://${SERVER_IP_ADDR}/kruize/api/v1/recommendations?experiment_name=${exp_name}&rm=true" > ${reco_json_dir}/${exp_name}_reco.json
+        	else
+        	  echo "curl -s http://${SERVER_IP_ADDR}/listRecommendations?experiment_name=${exp_name}&rm=true" | tee -a ${LOG}
+        	  curl -s "http://${SERVER_IP_ADDR}/listRecommendations?experiment_name=${exp_name}&rm=true" > ${reco_json_dir}/${exp_name}_reco.json
+        	fi
 
-		python3 ../db_migration_test/validate_reco_json.py -f ${reco_json_dir}/${exp_name}_reco.json -e ${end_time}
+		python3 ../db_migration_test/validate_reco_json.py -f ${reco_json_dir}/${exp_name}_reco.json -e ${end_time} --api-version ${api_version}
 		if [ $? != 0 ]; then
 			failed=1
 		fi

--- a/tests/scripts/remote_monitoring_tests/perf_profile_migration_test/perf_profile_migration_test.sh
+++ b/tests/scripts/remote_monitoring_tests/perf_profile_migration_test/perf_profile_migration_test.sh
@@ -137,8 +137,8 @@ total_results_count=0
 # Run scalability test to load 10 exps / 15 days data and update Recommendations with previous release
 echo "" | tee -a ${LOG}
 echo "Run scalability test to load 10 exps / 15 days data and update Recommendations with ${kruize_image_prev}" | tee -a ${LOG}
-echo "./run_test.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_10_15days -e ${total_results_count} --api-version=${api_version}" | tee -a ${LOG}
-./run_test.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_10_15days -e ${total_results_count} --api-version=${api_version}
+echo "./run_test.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_10_15days -e ${total_results_count}" | tee -a ${LOG}
+./run_test.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_10_15days -e ${total_results_count}
 echo "" | tee -a ${LOG}
 
 sleep 20

--- a/tests/scripts/remote_monitoring_tests/perf_profile_migration_test/run_test.sh
+++ b/tests/scripts/remote_monitoring_tests/perf_profile_migration_test/run_test.sh
@@ -214,7 +214,7 @@ if [ -z "${SERVER_IP_ADDR}" ]; then
 fi
 
 if [ ${kruize_setup} == true ]; then
-	old_perf_profile="../json_files/resource_optimization_openshift_v1.json"
+	old_perf_profile="../json_files/resource_optimization_openshift_v2.json"
 	# Create perf profile using the provided json
 	create_performance_profile ${old_perf_profile}
 	curl -s "http://${SERVER_IP_ADDR}/listPerformanceProfiles" | jq > ${LOG_DIR}/listperf_profile_old.json

--- a/tests/scripts/remote_monitoring_tests/perf_profile_migration_test/run_test.sh
+++ b/tests/scripts/remote_monitoring_tests/perf_profile_migration_test/run_test.sh
@@ -17,6 +17,7 @@
 ### Script to run scale test with Kruize in remote monitoring mode ##
 #
 
+declare -l api_version
 CURRENT_DIR="$(dirname "$(realpath "$0")")"
 KRUIZE_REPO_PATH="${CURRENT_DIR}/../../../.."
 SCALE_TEST="${CURRENT_DIR}/../scale_test"
@@ -50,7 +51,12 @@ total_results_count=0
 
 function usage() {
 	echo
-	echo "Usage: [-i Kruize image] [-u No. of experiments (default - 10)] [-d No. of days of results (default - 15)] [-n No. of clients (default - 10)] [-m results duration interval in mins, (default - 15)] [-t interval hours (default - 6)] [-s Initial start date (default - 2025-10-01T00:00:00.000Z)] [-q query db interval in mins, (default - 10)] [-r <resultsdir path>] [-b kruize setup (default - true)] [-c Experiment type [container|namespace|container_ns] (default - container)]"
+	echo "Usage: [-i Kruize image] [-u No. of experiments (default - 10)] [-d No. of days of results (default - 15)] [-n No. of clients (default - 10)] [-m results duration interval in mins, (default - 15)] [-t interval hours (default - 6)] [-s Initial start date (default - 2025-10-01T00:00:00.000Z)] [-q query db interval in mins, (default - 10)] [-r <resultsdir path>] [-b kruize setup (default - true)] [-c Experiment type [container|namespace|container_ns] (default - container)] [--api-version=v1|legacy]"
+	echo
+	echo "API Version Parameter:"
+	echo "  --api-version=v1      Use NEW v1 API (/kruize/api/v1/recommendations)"
+	echo "  --api-version=legacy  Use OLD/LEGACY APIs (/updateRecommendations, /generateRecommendations)"
+	echo "  Default: legacy (if no parameter specified)"
 	exit -1
 }
 
@@ -94,9 +100,20 @@ function kruize_scale_test_remote_patch() {
 
 }
 
-while getopts r:i:u:d:t:n:m:s:b:e:q:c:h gopts
+while getopts r:i:u:d:t:n:m:s:b:e:q:c:h:-: gopts
 do
 	case ${gopts} in
+	-)
+		case "${OPTARG}" in
+			api-version=*)
+				api_version=${OPTARG#*=}
+				;;
+			*)
+				echo "Error: Invalid option --${OPTARG}"
+				usage
+				;;
+		esac
+		;;
 	r)
 		RESULTS_DIR="${OPTARG}"		
 		;;
@@ -138,6 +155,12 @@ do
 		;;
 	esac
 done
+
+echo "run_test.sh :: api_version = ${api_version}"
+# Set the API version to default if not passed on parameter
+if [ -z "${api_version}" ]; then
+  api_version="legacy"
+fi
 
 start_time=$(get_date)
 LOG_DIR="${RESULTS_DIR}/perf-test-$(date +%Y%m%d%H%M)"
@@ -212,8 +235,8 @@ pushd ${SCALE_TEST} > /dev/null
 	echo ""
 	echo "Running scale test for kruize on ${cluster_type}" | tee -a ${LOG}
 	echo ""
-	echo "nohup ./run_bulk_scalability_test.sh -c "${cluster_type}" -f "${EXP_TYPE}" -a "${SERVER_IP_ADDR}" -p "${port}" -u "${num_exps}" -d "${num_days_of_res}" -n "${num_clients}" -m "${minutes_jump}" -i "${interval_hours}" -s "${initial_start_date}" -q "${query_db_interval}" -r "${LOG_DIR}" -e "${total_results_count}" > >(tee -a ${LOG}) 2>&1 & "
-	nohup ./run_bulk_scalability_test.sh -c "${cluster_type}" -f "${EXP_TYPE}" -a "${SERVER_IP_ADDR}" -p "${port}" -u "${num_exps}" -d "${num_days_of_res}" -n "${num_clients}" -m "${minutes_jump}" -i "${interval_hours}" -s "${initial_start_date}" -q "${query_db_interval}" -r "${LOG_DIR}" -e "${total_results_count}" > >(tee -a ${LOG}) 2>&1 &
+	echo "nohup ./run_bulk_scalability_test.sh -c "${cluster_type}" -f "${EXP_TYPE}" -a "${SERVER_IP_ADDR}" -p "${port}" -u "${num_exps}" -d "${num_days_of_res}" -n "${num_clients}" -m "${minutes_jump}" -i "${interval_hours}" -s "${initial_start_date}" -q "${query_db_interval}" -r "${LOG_DIR}" -e "${total_results_count}" --api-version=${api_version}  > >(tee -a ${LOG}) 2>&1 & "
+	nohup ./run_bulk_scalability_test.sh -c "${cluster_type}" -f "${EXP_TYPE}" -a "${SERVER_IP_ADDR}" -p "${port}" -u "${num_exps}" -d "${num_days_of_res}" -n "${num_clients}" -m "${minutes_jump}" -i "${interval_hours}" -s "${initial_start_date}" -q "${query_db_interval}" -r "${LOG_DIR}" -e "${total_results_count}" --api-version="${api_version}" > >(tee -a ${LOG}) 2>&1 &
 popd > /dev/null
 wait $!
 

--- a/tests/scripts/remote_monitoring_tests/remote_monitoring_tests.sh
+++ b/tests/scripts/remote_monitoring_tests/remote_monitoring_tests.sh
@@ -41,7 +41,7 @@ function remote_monitoring_tests() {
 
 	target="crc"
 	perf_profile_json="${PERF_PROFILE_DIR}/resource_optimization_openshift.json"
-	perf_profile_json_v1="${REMOTE_MONITORING_TEST_DIR}/json_files/resource_optimization_openshift_v1.json"
+	perf_profile_json_v1="${REMOTE_MONITORING_TEST_DIR}/json_files/resource_optimization_openshift_v2.json"
 
 	remote_monitoring_tests=("test_e2e" "perf_profile" "sanity" "negative" "extended" "simulate_prod" "simulate_prod_single_pod")
 

--- a/tests/scripts/remote_monitoring_tests/rest_apis/test_update_performance_profile.py
+++ b/tests/scripts/remote_monitoring_tests/rest_apis/test_update_performance_profile.py
@@ -48,7 +48,7 @@ def test_update_performance_profile(cluster_type):
     """
     # Form the kruize url
     form_kruize_url(cluster_type)
-    perf_profile_json_file = "../json_files/resource_optimization_openshift_v1.json"
+    perf_profile_json_file = "../json_files/resource_optimization_openshift_v2.json"
     # Delete any existing profile
     response = delete_performance_profile(perf_profile_json_file)
     print("delete API status code = ", response.status_code)
@@ -105,7 +105,7 @@ def test_update_performance_profile_with_duplicate_data(cluster_type):
     """
     # Form the kruize url
     form_kruize_url(cluster_type)
-    perf_profile_json_file = "../json_files/resource_optimization_openshift_v1.json"
+    perf_profile_json_file = "../json_files/resource_optimization_openshift_v2.json"
     # Delete any existing profile
     response = delete_performance_profile(perf_profile_json_file)
     print("delete API status code = ", response.status_code)
@@ -167,7 +167,7 @@ def test_update_performance_profile_with_duplicate_slo_data(cluster_type):
     """
     # Form the kruize url
     form_kruize_url(cluster_type)
-    perf_profile_json_file = "../json_files/resource_optimization_openshift_v1.json"
+    perf_profile_json_file = "../json_files/resource_optimization_openshift_v2.json"
     # Delete any existing profile
     response = delete_performance_profile(perf_profile_json_file)
     print("delete API status code = ", response.status_code)
@@ -261,7 +261,7 @@ def test_update_performance_profile_with_invalid_superset(cluster_type):
     """
     # Form the kruize url
     form_kruize_url(cluster_type)
-    perf_profile_json_file = "../json_files/resource_optimization_openshift_v1.json"
+    perf_profile_json_file = "../json_files/resource_optimization_openshift_v2.json"
     # Delete any existing profile
     response = delete_performance_profile(perf_profile_json_file)
     print("delete API status code = ", response.status_code)
@@ -313,7 +313,7 @@ def test_update_performance_profiles_mandatory_fields(cluster_type, field, expec
 
     # Form the kruize url
     form_kruize_url(cluster_type)
-    input_json_file_v1 = "../json_files/resource_optimization_openshift_v1.json"
+    input_json_file_v1 = "../json_files/resource_optimization_openshift_v2.json"
     input_json_file = perf_profile_dir / 'resource_optimization_openshift.json'
     # Delete any existing profile
     response = delete_performance_profile(input_json_file_v1)

--- a/tests/scripts/remote_monitoring_tests/rest_apis/test_update_recommendations.py
+++ b/tests/scripts/remote_monitoring_tests/rest_apis/test_update_recommendations.py
@@ -1171,7 +1171,7 @@ def test_update_recommendations_with_perf_profile_single_pod(cluster_type):
         }
     ]
 
-    perf_profile_v1_json_file = "../json_files/resource_optimization_openshift_v1.json"
+    perf_profile_v1_json_file = "../json_files/resource_optimization_openshift_v2.json"
     perf_profile_dir = get_metric_profile_dir()
     perf_profile_v2_json_file = perf_profile_dir / 'resource_optimization_openshift.json'
 
@@ -1438,7 +1438,7 @@ def test_update_recommendations_with_perf_profile_multi_pod(cluster_type):
         }
     ]
 
-    perf_profile_v1_json_file = "../json_files/resource_optimization_openshift_v1.json"
+    perf_profile_v1_json_file = "../json_files/resource_optimization_openshift_v2.json"
     perf_profile_dir = get_metric_profile_dir()
     perf_profile_v3_json_file = perf_profile_dir / 'resource_optimization_openshift.json'
 


### PR DESCRIPTION
## Description

This PR contains changes for migration test scripts to add support for --api-version arg

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Add API version selection support to remote monitoring migration and fault-tolerant test scripts, defaulting to legacy APIs while enabling use of the v1 recommendations API.

Enhancements:
- Extend shell and Python test harnesses to accept a --api-version flag and propagate it through scale, migration, and fault-tolerance workflows.
- Switch recommendation retrieval endpoints conditionally between legacy and /kruize/api/v1/recommendations based on the selected API version.
- Adjust recommendation JSON validation logic to handle structural differences between legacy and v1 APIs via an explicit api-version parameter.
- Wire the selected API version into pytest-based helpers so tests can toggle between old and new APIs consistently.

Tests:
- Update migration, performance profile, and fault-tolerant remote monitoring test scripts to run against either legacy or v1 recommendation APIs using a unified --api-version flag.