### PR TITLE
Bump Kruize release version to 0.11

### DIFF
--- a/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
@@ -92,7 +92,7 @@ spec:
               done
       containers:
         - name: kruize
-          image: quay.io/kruize/autotune_operator:0.10
+          image: quay.io/kruize/autotune_operator:0.11
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume

--- a/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
@@ -120,7 +120,7 @@ spec:
               done
       containers:
         - name: kruize
-          image: quay.io/kruize/autotune_operator:0.10
+          image: quay.io/kruize/autotune_operator:0.11
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume

--- a/manifests/crc/default-db-included-installation/aks/kruize-crc-aks.yaml
+++ b/manifests/crc/default-db-included-installation/aks/kruize-crc-aks.yaml
@@ -156,7 +156,7 @@ spec:
     spec:
       containers:
         - name: kruize
-          image: quay.io/kruize/autotune_operator:0.10
+          image: quay.io/kruize/autotune_operator:0.11
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume
@@ -221,7 +221,7 @@ spec:
         spec:
           containers:
             - name: kruizecronjob
-              image: quay.io/kruize/autotune_operator:0.10
+              image: quay.io/kruize/autotune_operator:0.11
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume
@@ -356,7 +356,7 @@ spec:
         spec:
           containers:
             - name: kruizedeletejob
-              image: quay.io/kruize/autotune_operator:0.10
+              image: quay.io/kruize/autotune_operator:0.11
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume

--- a/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
@@ -285,7 +285,7 @@ spec:
               done
       containers:
         - name: kruize
-          image: quay.io/kruize/autotune_operator:0.10
+          image: quay.io/kruize/autotune_operator:0.11
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume
@@ -358,7 +358,7 @@ spec:
         spec:
           containers:
             - name: kruizecronjob
-              image: quay.io/kruize/autotune_operator:0.10
+              image: quay.io/kruize/autotune_operator:0.11
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume
@@ -493,7 +493,7 @@ spec:
         spec:
           containers:
             - name: kruizedeletejob
-              image: quay.io/kruize/autotune_operator:0.10
+              image: quay.io/kruize/autotune_operator:0.11
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume

--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -363,7 +363,7 @@ spec:
               done
       containers:
         - name: kruize
-          image: quay.io/kruize/autotune_operator:0.10
+          image: quay.io/kruize/autotune_operator:0.11
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume
@@ -443,7 +443,7 @@ spec:
         spec:
           containers:
             - name: kruizecronjob
-              image: quay.io/kruize/autotune_operator:0.10
+              image: quay.io/kruize/autotune_operator:0.11
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume
@@ -484,7 +484,7 @@ spec:
         spec:
           containers:
             - name: kruizedeletejob
-              image: quay.io/kruize/autotune_operator:0.10
+              image: quay.io/kruize/autotune_operator:0.11
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.autotune</groupId>
     <artifactId>autotune</artifactId>
-    <version>0.10</version>
+    <version>0.11</version>
     <properties>
         <fabric8-version>7.7.0</fabric8-version>
         <org-json-version>20260522</org-json-version>


### PR DESCRIPTION
## Summary by Sourcery

Bump Kruize/autotune operator release to version 0.11 across manifests and build configuration.

Build:
- Update Maven project version to 0.11 in pom.xml.

Deployment:
- Update Kruize operator container image tags from 0.10 to 0.11 in CRC manifests for AKS, Minikube, and OpenShift, including BYODB installations.