### PR TITLE
backup database in binary format

### DIFF
--- a/tests/scripts/common/common_functions.sh
+++ b/tests/scripts/common/common_functions.sh
@@ -299,11 +299,11 @@ function restore_db() {
 	kruize_db_pod=$(kubectl get pods -o=name -n ${NAMESPACE} | grep kruize-db | cut -d '/' -f2)
 	db_file=$(basename ${db_backup_file})
 
-	echo "oc cp ${db_backup_file} ${NAMESPACE}/${kruize_db_pod}:/"
-	oc cp ${db_backup_file} ${NAMESPACE}/${kruize_db_pod}:/
+	echo "kubectl cp ${db_backup_file} ${NAMESPACE}/${kruize_db_pod}:/"
+	kubectl cp ${db_backup_file} ${NAMESPACE}/${kruize_db_pod}:/
 
-	echo "kubectl exec -it ${kruize_db_pod} -n ${NAMESPACE} -- psql -U admin -d kruizeDB -f ${db_file} > ${db_restore_log}"
-	kubectl exec -it ${kruize_db_pod} -n ${NAMESPACE} -- psql -U admin -d kruizeDB -f ${db_file} > ${db_restore_log}
+	echo "kubectl exec -it ${kruize_db_pod} -n ${NAMESPACE} -- pg_restore -U admin -d kruizeDB ${db_file} > ${db_restore_log}"
+	kubectl exec -it ${kruize_db_pod} -n ${NAMESPACE} -- pg_restore -U admin -d kruizeDB ${db_file} > ${db_restore_log}
 	echo "Restoring DB...done"
 	echo ""
 }

--- a/tests/scripts/remote_monitoring_tests/db_migration_test/db_migration_test.sh
+++ b/tests/scripts/remote_monitoring_tests/db_migration_test/db_migration_test.sh
@@ -154,9 +154,13 @@ total_results_count=$((${num_exps} * ${num_clients} * ${num_days_of_res} * 96))
 # Backup DB
 echo "" | tee -a ${LOG}
 echo "Backing up DB..." | tee -a ${LOG}
-db_backup_file="${LOG_DIR}/test_logs_50_15days/db_backup.sql"
-echo "kubectl -n openshift-tuning exec -it `kubectl get pods -o=name -n openshift-tuning | grep kruize-db` -- pg_dump -U admin -d kruizeDB > ${db_backup_file}" | tee -a ${LOG}
-kubectl -n openshift-tuning exec -it `kubectl get pods -o=name -n openshift-tuning | grep kruize-db` -- pg_dump -U admin -d kruizeDB > ${db_backup_file}
+kruize_db_pod=$(kubectl get pods -o=name -n ${NAMESPACE} | grep kruize-db | cut -d '/' -f2)
+db_backup_file="${LOG_DIR}/test_logs_50_15days/db_backup.dmp"
+db_file=$(basename ${db_backup_file})
+echo "kubectl -n ${NAMESPACE} exec -it `kubectl get pods -o=name -n ${NAMESPACE} | grep kruize-db` -- pg_dump -U admin -d kruizeDB -Fc -b -v -f ${db_file}" | tee -a ${LOG}
+kubectl -n ${NAMESPACE} exec -it `kubectl get pods -o=name -n ${NAMESPACE} | grep kruize-db` -- pg_dump -U admin -d kruizeDB -Fc -b -v -f ${db_file} | tee -a ${LOG}
+echo "kubectl cp ${NAMESPACE}/${kruize_db_pod}:${db_file} ${db_backup_file}" | tee -a ${LOG}
+kubectl cp ${NAMESPACE}/${kruize_db_pod}:${db_file} ${db_backup_file} | tee -a ${LOG}
 echo "Backing up DB...Done" | tee -a ${LOG}
 echo "" | tee -a ${LOG}
 


### PR DESCRIPTION
## Description

This PR change the way database is backed up and restored to fix test failures with DB Migration tests.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Backup and restore the test database using PostgreSQL binary dump/restore to stabilize DB migration tests.

Bug Fixes:
- Switch DB migration tests to use binary pg_dump/pg_restore backups to resolve backup-related failures.

Enhancements:
- Update DB backup script to generate compressed custom-format dumps and copy them from the DB pod using kubectl.
- Align restore logic to use kubectl instead of oc and restore from binary dumps with pg_restore.