### PR TITLE
Reduced replicas for migration tests and added a parameter to scale test

### DIFF
--- a/tests/scripts/remote_monitoring_tests/db_migration_test/db_migration_test.sh
+++ b/tests/scripts/remote_monitoring_tests/db_migration_test/db_migration_test.sh
@@ -48,7 +48,7 @@ initial_start_date="2023-12-20T00:00:00.000Z"
 query_db_interval=10
 db_backup_file="./db_backup.sql"
 
-replicas=10
+replicas=5
 
 target="crc"
 kruize_image_prev="quay.io/kruize/autotune_operator:0.0.19.5_rm"
@@ -144,8 +144,8 @@ ${KRUIZE_REPO_PATH}/scripts/enable_user_workload_monitoring_openshift.sh | tee -
 pushd ${SCALE_TEST} > /dev/null
 	echo "" | tee -a ${LOG}
 	echo "Run scalability test to load 50 exps / 15 days data and update Recommendations with ${kruize_image_prev}" | tee -a ${LOG}
-	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a migration" | tee -a ${LOG}
-	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a "migration"
+	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a migration -g ${replicas} " | tee -a ${LOG}
+	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a "migration" -g ${replicas}
 popd > /dev/null 
 	echo "" | tee -a ${LOG}
 
@@ -171,8 +171,8 @@ pushd ${SCALE_TEST} > /dev/null
 	restore_db=true
 	num_days_of_res=1
 
-	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -l ${restore_db} -f ${db_backup_file} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a migration --api-version=${api_version}" | tee -a ${LOG}
-	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -l ${restore_db} -f ${db_backup_file} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a "migration" --api-version=${api_version}
+	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -l ${restore_db} -f ${db_backup_file} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a migration -g ${replicas} --api-version=${api_version}" | tee -a ${LOG}
+	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -l ${restore_db} -f ${db_backup_file} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a "migration" -g ${replicas} --api-version=${api_version}
 
 	echo "" | tee -a ${LOG}
 	echo "" | tee -a ${LOG}

--- a/tests/scripts/remote_monitoring_tests/db_migration_test/db_migration_test_without_postgres_restart.sh
+++ b/tests/scripts/remote_monitoring_tests/db_migration_test/db_migration_test_without_postgres_restart.sh
@@ -48,7 +48,7 @@ initial_start_date="2023-12-20T00:00:00.000Z"
 query_db_interval=10
 db_backup_file="./db_backup.sql"
 
-replicas=10
+replicas=5
 
 target="crc"
 kruize_image_prev="quay.io/kruize/autotune_operator:0.0.19.5_rm"
@@ -142,8 +142,8 @@ ${KRUIZE_REPO_PATH}/scripts/enable_user_workload_monitoring_openshift.sh | tee -
 pushd ${SCALE_TEST} > /dev/null
 	echo "" | tee -a ${LOG}
 	echo "Run scalability test to load 50 exps / 15 days data and update Recommendations with ${kruize_image_prev}" | tee -a ${LOG}
-	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a migration" | tee -a ${LOG}
-	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a "migration"
+	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a migration -g ${replicas}" | tee -a ${LOG}
+	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a "migration" -g ${replicas} 
 popd > /dev/null
 	echo "" | tee -a ${LOG}
 
@@ -176,8 +176,8 @@ pushd ${SCALE_TEST} > /dev/null
 
 	num_days_of_res=1
 
-	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -b ${kruize_setup} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a migration --api-version=${api_version}" | tee -a ${LOG}
-	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -b ${kruize_setup} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a "migration" --api-version=${api_version}
+	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -b ${kruize_setup} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a migration -g ${replicas} --api-version=${api_version}" | tee -a ${LOG}
+	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -b ${kruize_setup} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a "migration" -g ${replicas} --api-version=${api_version}
 
 	echo "" | tee -a ${LOG}
 	echo "" | tee -a ${LOG}

--- a/tests/scripts/remote_monitoring_tests/db_migration_test/db_migration_test_without_postgres_restart.sh
+++ b/tests/scripts/remote_monitoring_tests/db_migration_test/db_migration_test_without_postgres_restart.sh
@@ -143,7 +143,7 @@ pushd ${SCALE_TEST} > /dev/null
 	echo "" | tee -a ${LOG}
 	echo "Run scalability test to load 50 exps / 15 days data and update Recommendations with ${kruize_image_prev}" | tee -a ${LOG}
 	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a migration -g ${replicas}" | tee -a ${LOG}
-	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a "migration" -g ${replicas} 
+	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a "migration" -g ${replicas}
 popd > /dev/null
 	echo "" | tee -a ${LOG}
 

--- a/tests/scripts/remote_monitoring_tests/perf_profile_migration_test/run_test.sh
+++ b/tests/scripts/remote_monitoring_tests/perf_profile_migration_test/run_test.sh
@@ -42,7 +42,7 @@ query_db_interval=10
 
 kruize_setup=true
 
-replicas=10
+replicas=5
 
 target="crc"
 KRUIZE_IMAGE="quay.io/kruize/autotune:mvp_demo"

--- a/tests/scripts/remote_monitoring_tests/scalability_test.md
+++ b/tests/scripts/remote_monitoring_tests/scalability_test.md
@@ -21,7 +21,7 @@ Use the below command to test :
 
 ```
 cd <KRUIZE_REPO>/tests/scripts/remote_monitoring_tests/scale_test
-./remote_monitoring_scale_test_bulk.sh [-i Kruize image] [-r results directory path] [-u No. of experiments (default - 5000)] [-d No. of days of results (default - 15)] [-n No. of clients (default - 20)] [-m results duration interval in mins, (default - 15)] [-t interval hours (default - 6)] [-s Initial start date (default - 2023-01-10T00:00:00.000Z)] [-q query db interval in mins, (default - 10)] [-c Experiment type [container|namespace|container_ns|gpucontainer] (default - container)] [--api-version=<v1|legacy>]
+./remote_monitoring_scale_test_bulk.sh [-i Kruize image] [-r results directory path] [-u No. of experiments (default - 5000)] [-d No. of days of results (default - 15)] [-n No. of clients (default - 20)] [-m results duration interval in mins, (default - 15)] [-t interval hours (default - 6)] [-s Initial start date (default - 2023-01-10T00:00:00.000Z)] [-q query db interval in mins, (default - 10)] [-c Experiment type [container|namespace|container_ns|gpucontainer] (default - container)] [-g No. of kruize replicas (default - 10] [--api-version=<v1|legacy>]
 ```
 
 Where values for remote_monitoring_scale_test_bulk.sh are:
@@ -38,8 +38,9 @@ usage: remote_monitoring_fault_tolerant_tests.sh
 	[-t interval hours (default - 6)]
 	[-s Initial start date (default - 2023-01-10T00:00:00.000Z)]
 	[-q query db interval in mins, (default - 10)]
-    [-c Experiment type [container|namespace|container_ns|gpucontainer] (default - container)]
-    [-a Test case (default - scale_5k) Valid values - [scale_5k/migration] migration - Used by db_migration test]
+	[-c Experiment type [container|namespace|container_ns|gpucontainer] (default - container)]
+	[-a Test case (default - scale_5k) Valid values - [scale_5k/migration] migration - Used by db_migration test]
+	[-g No. of kruize replicas (default - 10)] 
     [--api-version] : optional. API version to use - 'v1' for new API (/kruize/api/v1/recommendations), 'legacy' for old APIs (updateRecommendations/listRecommendations). Default is 'legacy'
 ```
 

--- a/tests/scripts/remote_monitoring_tests/scalability_test.md
+++ b/tests/scripts/remote_monitoring_tests/scalability_test.md
@@ -21,7 +21,7 @@ Use the below command to test :
 
 ```
 cd <KRUIZE_REPO>/tests/scripts/remote_monitoring_tests/scale_test
-./remote_monitoring_scale_test_bulk.sh [-i Kruize image] [-r results directory path] [-u No. of experiments (default - 5000)] [-d No. of days of results (default - 15)] [-n No. of clients (default - 20)] [-m results duration interval in mins, (default - 15)] [-t interval hours (default - 6)] [-s Initial start date (default - 2023-01-10T00:00:00.000Z)] [-q query db interval in mins, (default - 10)] [-c Experiment type [container|namespace|container_ns|gpucontainer] (default - container)] [-g No. of kruize replicas (default - 10] [--api-version=<v1|legacy>]
+./remote_monitoring_scale_test_bulk.sh [-i Kruize image] [-r results directory path] [-u No. of experiments (default - 5000)] [-d No. of days of results (default - 15)] [-n No. of clients (default - 20)] [-m results duration interval in mins, (default - 15)] [-t interval hours (default - 6)] [-s Initial start date (default - 2023-01-10T00:00:00.000Z)] [-q query db interval in mins, (default - 10)] [-c Experiment type [container|namespace|container_ns|gpucontainer] (default - container)] [-g No. of kruize replicas (default - 10)] [--api-version=<v1|legacy>]
 ```
 
 Where values for remote_monitoring_scale_test_bulk.sh are:

--- a/tests/scripts/remote_monitoring_tests/scale_test/remote_monitoring_scale_test_bulk.sh
+++ b/tests/scripts/remote_monitoring_tests/scale_test/remote_monitoring_scale_test_bulk.sh
@@ -48,13 +48,13 @@ db_backup_file="./db_backup.sql"
 replicas=10
 
 target="crc"
-KRUIZE_IMAGE="quay.io/kruize/autotune:mvp_demo"
+KRUIZE_IMAGE="quay.io/kruizehub/autotune-test-image:mvp_demo"
 hours=6
 total_results_count=0
 
 function usage() {
 	echo
-	echo "Usage: [-i Kruize image] [-u No. of experiments (default - 5000)] [-d No. of days of results (default - 15)] [-n No. of clients (default - 20)] [-m results duration interval in mins, (default - 15)] [-t interval hours (default - 6)] [-s Initial start date (default - 2023-01-10T00:00:00.000Z)] [-q query db interval in mins, (default - 10)] [-r <resultsdir path>] [-l restore DB (default - false)] [-f DB file path to restore (default - ./db_backup.sql)] [-b kruize setup (default - true)] [-c Experiment type [container|namespace|container_ns|gpucontainer] (default - container)] [-a Test case (default - scale_5k)] [--api-version=<v1|legacy>]"
+	echo "Usage: [-i Kruize image] [-u No. of experiments (default - 5000)] [-d No. of days of results (default - 15)] [-n No. of clients (default - 20)] [-m results duration interval in mins, (default - 15)] [-t interval hours (default - 6)] [-s Initial start date (default - 2023-01-10T00:00:00.000Z)] [-q query db interval in mins, (default - 10)] [-r <resultsdir path>] [-l restore DB (default - false)] [-f DB file path to restore (default - ./db_backup.sql)] [-b kruize setup (default - true)] [-c Experiment type [container|namespace|container_ns|gpucontainer] (default - container)] [-a Test case (default - scale_5k)] [-g No. of kruize replicas. Default - 10] [--api-version=<v1|legacy>]"
 	echo
 	echo "API Version Parameter:"
 	echo "  --api-version=v1      Use NEW v1 API (/kruize/api/v1/recommendations)"
@@ -118,7 +118,7 @@ function kruize_scale_test_remote_patch() {
 
 }
 
-while getopts r:i:u:d:t:n:m:s:l:f:b:e:q:c:a:h:-: gopts
+while getopts r:i:u:d:t:n:m:s:l:f:b:e:q:c:a:g:h:-: gopts
 do
 	case ${gopts} in
 	-)
@@ -172,6 +172,9 @@ do
 		;;
 	a)
 		testcase="${OPTARG}"
+		;;
+	g)
+		replicas="${OPTARG}"
 		;;
 	h)
 		usage


### PR DESCRIPTION
## Description

Reduced replicas for migration tests and added a parameter to scale test for replicas


Fixes # (issue)

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Tested this by submitting tests on CSD cluster

**Test Configuration**
* Kubernetes clusters tested on: openshift

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Reduce default replicas in migration-related tests and make the scalability test script accept a configurable replicas parameter.

New Features:
- Allow the remote monitoring scalability test script to accept the number of Kruize replicas via a new -g option.

Enhancements:
- Lower the default Kruize replica count from 10 to 5 in DB and performance profile migration test scripts.
- Update scalability test documentation and default test image reference to match the new script behavior.