### PR TITLE
add podCount metric queries in resource_optimization_local_monitoring_norecordingrules.yaml

### DIFF
--- a/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.yaml
+++ b/manifests/autotune/performance-profiles/resource_optimization_local_monitoring_norecordingrules.yaml
@@ -454,3 +454,26 @@ slo:
     aggregation_functions:
       - function: sum
         query: 'sum by(container, namespace, runtime, vendor, version)(jvm_info_total{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+
+  # Pod Count (based on READY containers, not total pods)
+  - name: podCount
+    datasource: prometheus
+    value_type: "double"
+    kubernetes_object: "container"
+
+    aggregation_functions:
+      # Current ready pods
+      - function: sum
+        query: 'sum(kube_pod_container_status_ready{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})'
+
+      # Avg ready pods over time
+      - function: avg
+        query: 'avg_over_time(sum(kube_pod_container_status_ready{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+      # Max ready pods over time
+      - function: max
+        query: 'max_over_time(sum(kube_pod_container_status_ready{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})[$MEASUREMENT_DURATION_IN_MIN$m:])'
+
+      # Min ready pods over time
+      - function: min
+        query: 'min_over_time(sum(kube_pod_container_status_ready{namespace="$NAMESPACE$", container="$CONTAINER_NAME$"})[$MEASUREMENT_DURATION_IN_MIN$m:])'


### PR DESCRIPTION
## Description

This PR address issue #2016. As part of this, podCount metric queries are added to resource_optimization_local_monitoring_norecordingrules.yaml file which was missed in earlier PR https://github.com/kruize/autotune/pull/1932


Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Add pod readiness-based podCount metric to the resource optimization local monitoring performance profile.

New Features:
- Introduce podCount metric leveraging Prometheus kube_pod_container_status_ready for current and time-windowed pod readiness statistics.

Enhancements:
- Extend resource_optimization_local_monitoring_norecordingrules profile with additional aggregation functions for pod readiness (sum, avg, max, min) metrics.