### PR TITLE
[0.11-PROD-ISSUE-FIX] Update DockerFile to fix CloudWatch failure

### DIFF
--- a/Dockerfile.autotune
+++ b/Dockerfile.autotune
@@ -43,7 +43,7 @@ RUN mvn -f pom.xml clean package
 COPY migrations target/bin/migrations
 
 # Create a jlinked JRE specific to the App
-RUN jlink --strip-debug --compress 2 --no-header-files --no-man-pages --module-path $AUTOTUNE_HOME/java/openjdk/jmods --add-modules java.base,java.compiler,java.desktop,java.logging,java.management,java.naming,java.security.jgss,java.sql,java.xml,jdk.compiler,jdk.httpserver,jdk.unsupported,jdk.crypto.ec --exclude-files=**java_**.properties,**J9TraceFormat**.dat,**OMRTraceFormat**.dat,**j9ddr**.dat,**public_suffix_list**.dat --output jre
+RUN jlink --strip-debug --compress 2 --no-header-files --no-man-pages --module-path $AUTOTUNE_HOME/java/openjdk/jmods --add-modules java.base,java.compiler,java.desktop,java.logging,java.management,java.naming,java.security.jgss,java.sql,java.xml,jdk.compiler,jdk.httpserver,jdk.unsupported,jdk.crypto.ec,jdk.net --exclude-files=**java_**.properties,**J9TraceFormat**.dat,**OMRTraceFormat**.dat,**j9ddr**.dat,**public_suffix_list**.dat --output jre
 
 ##########################################################
 #            Runtime Docker Image

--- a/src/main/java/com/autotune/utils/CloudWatchAppender.java
+++ b/src/main/java/com/autotune/utils/CloudWatchAppender.java
@@ -109,7 +109,8 @@ public class CloudWatchAppender extends AbstractAppender {
                 LoggerConfig loggerConfig = config.getLoggerConfig("com.autotune");
                 loggerConfig.addAppender(appender, level, filter);
                 context.updateLoggers(config);
-                LOGGER.debug("Enabled CloudWatch logs");
+                LOGGER.info("CloudWatch logging enabled — region: {}, log group: {}, log stream: {}, log level: {}",
+                        cloudwatch_logs_region, cw_logs_log_group, cw_logs_log_stream, cw_logs_log_level_uc);
 
             } catch (Exception e) {
                 LOGGER.error(e.getMessage());

--- a/src/test/java/com/autotune/utils/CloudWatchAppenderTest.java
+++ b/src/test/java/com/autotune/utils/CloudWatchAppenderTest.java
@@ -1,0 +1,259 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.autotune.utils;
+
+import com.autotune.operator.KruizeDeploymentInfo;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link CloudWatchAppender#configureLoggerForCloudWatchLog()}.
+ *
+ * Covers three scenarios:
+ *
+ * 1. CREDENTIALS ABSENT (simulates test/dev cluster — why the bug was hidden)
+ *    When credentials are null or empty, the method short-circuits at the guard
+ *    on line 76 of CloudWatchAppender.java.  The AWS SDK is never touched, so
+ *    neither jdk.net nor Apache HC5 are loaded.  No exception, no appender.
+ *
+ * 2. NEGATIVE — reproduces the production crash (simulates the broken jlink JRE)
+ *    Directly attempts to load {@code jdk.net.Sockets} via Class.forName() on a
+ *    ClassLoader that has the jdk.net module forcibly hidden, reproducing the
+ *    exact {@code NoClassDefFoundError: jdk/net/Sockets} seen in the pod logs.
+ *    This is the automated proof of the failure mode WITHOUT the Dockerfile fix.
+ *
+ * 3. POSITIVE — verifies the fix (jdk.net present in the running JRE)
+ *    Asserts that {@code jdk.net.Sockets} IS loadable in the current JRE and
+ *    that {@code configureLoggerForCloudWatchLog()} completes without any
+ *    class-loading error when credentials are present.
+ *    This test passes only when {@code ,jdk.net} is included in the
+ *    {@code jlink --add-modules} list in Dockerfile.autotune.
+ */
+class CloudWatchAppenderTest {
+
+    // --- saved static state -------------------------------------------------
+
+    private String savedAccessKeyId;
+    private String savedSecretAccessKey;
+    private String savedRegion;
+    private String savedLogGroup;
+    private String savedLogStream;
+    private String savedLogLevel;
+
+    // --- lifecycle ----------------------------------------------------------
+
+    @BeforeEach
+    void saveDeploymentInfo() {
+        savedAccessKeyId     = KruizeDeploymentInfo.cloudwatch_logs_access_key_id;
+        savedSecretAccessKey = KruizeDeploymentInfo.cloudwatch_logs_secret_access_key;
+        savedRegion          = KruizeDeploymentInfo.cloudwatch_logs_region;
+        savedLogGroup        = KruizeDeploymentInfo.cloudwatch_logs_log_group;
+        savedLogStream       = KruizeDeploymentInfo.cloudwatch_logs_log_stream;
+        savedLogLevel        = KruizeDeploymentInfo.cloudwatch_logs_log_level;
+    }
+
+    @AfterEach
+    void restoreDeploymentInfo() {
+        KruizeDeploymentInfo.cloudwatch_logs_access_key_id     = savedAccessKeyId;
+        KruizeDeploymentInfo.cloudwatch_logs_secret_access_key = savedSecretAccessKey;
+        KruizeDeploymentInfo.cloudwatch_logs_region            = savedRegion;
+        KruizeDeploymentInfo.cloudwatch_logs_log_group         = savedLogGroup;
+        KruizeDeploymentInfo.cloudwatch_logs_log_stream        = savedLogStream;
+        KruizeDeploymentInfo.cloudwatch_logs_log_level         = savedLogLevel;
+    }
+
+    // =========================================================================
+    // 1. CREDENTIALS ABSENT — simulates test/dev cluster
+    // =========================================================================
+
+    @Test
+    @DisplayName("No appender registered when all credentials are null")
+    void shouldSkipConfigurationWhenAllCredentialsAreNull() {
+        // Given – no CloudWatch credentials (mirrors test cluster config)
+        KruizeDeploymentInfo.cloudwatch_logs_access_key_id     = null;
+        KruizeDeploymentInfo.cloudwatch_logs_secret_access_key = null;
+        KruizeDeploymentInfo.cloudwatch_logs_region            = null;
+
+        // When – should not throw and should not register any appender
+        assertDoesNotThrow(CloudWatchAppender::configureLoggerForCloudWatchLog);
+
+        // Then – cloudwatchRootAppender must NOT be present in the log4j config
+        assertFalse(
+                cloudWatchAppenderRegistered(),
+                "CloudWatch appender must not be registered when credentials are absent"
+        );
+    }
+
+    @Test
+    @DisplayName("No appender registered when credentials are empty strings")
+    void shouldSkipConfigurationWhenCredentialsAreEmpty() {
+        // Given
+        KruizeDeploymentInfo.cloudwatch_logs_access_key_id     = "";
+        KruizeDeploymentInfo.cloudwatch_logs_secret_access_key = "";
+        KruizeDeploymentInfo.cloudwatch_logs_region            = "";
+
+        // When
+        assertDoesNotThrow(CloudWatchAppender::configureLoggerForCloudWatchLog);
+
+        // Then
+        assertFalse(
+                cloudWatchAppenderRegistered(),
+                "CloudWatch appender must not be registered when credentials are empty"
+        );
+    }
+
+    @Test
+    @DisplayName("No appender registered when only access key is missing")
+    void shouldSkipConfigurationWhenAccessKeyIdIsMissing() {
+        // Given – secret + region present but access key absent
+        KruizeDeploymentInfo.cloudwatch_logs_access_key_id     = null;
+        KruizeDeploymentInfo.cloudwatch_logs_secret_access_key = "dummy-secret";
+        KruizeDeploymentInfo.cloudwatch_logs_region            = "us-east-1";
+
+        // When
+        assertDoesNotThrow(CloudWatchAppender::configureLoggerForCloudWatchLog);
+
+        // Then
+        assertFalse(
+                cloudWatchAppenderRegistered(),
+                "CloudWatch appender must not be registered when access key id is missing"
+        );
+    }
+
+    // =========================================================================
+    // 2. NEGATIVE
+    //
+    //    The pod log showed:
+    //      Exception in thread "main" java.lang.NoClassDefFoundError: jdk/net/Sockets
+    //        at DefaultHttpClientConnectionOperator.<clinit>
+    //        at Apache5HttpClient.createClient
+    //        at CloudWatchAppender.configureLoggerForCloudWatchLog
+    //        at Autotune.main
+    //      Caused by: java.lang.ClassNotFoundException: jdk.net.Sockets
+    //
+    //    The crash happens because the jlink command in Dockerfile.autotune
+    //    did NOT include ,jdk.net in --add-modules, so the stripped JRE
+    //    shipped inside the container image was missing jdk.net.Sockets.
+    //
+    //    Note: it is not possible to reproduce the NoClassDefFoundError
+    //    in-process on a full JDK — JPMS resolves named-module classes
+    //    (jdk.net.*) directly from the module layer, bypassing the classloader
+    //    hierarchy, so a custom excluding ClassLoader has no effect.
+    //    The real failure only occurs inside the stripped jlink JRE built
+    //    without ,jdk.net.  The negative test below therefore asserts the
+    //    *precondition* of the crash: the jdk.net module is absent.
+    //    Run this test inside the container built WITHOUT the Dockerfile fix
+    //    to see it fail.
+    // =========================================================================
+
+    @Test
+    @DisplayName("NEGATIVE: jdk.net module absent → jdk.net.Sockets not loadable")
+    void jdkNetSocketsNotLoadableWhenModuleAbsent() {
+        /*
+         *
+         * This test asserts the precondition :
+         *   the jdk.net module must NOT be absent from the JRE.
+         *
+         * On a developer machine (full JDK) jdk.net is always present,
+         * so this test passes unconditionally in local development.
+         *
+         * Inside the container image built from Dockerfile.autotune
+         * WITHOUT the fix (no ,jdk.net in --add-modules line 46):
+         *   ModuleLayer.boot().findModule("jdk.net") → empty Optional
+         *   Class.forName("jdk.net.Sockets")         → ClassNotFoundException
+         *
+         * The assertFalse below then FAILS, printing exactly why.
+         */
+        boolean jdkNetModuleAbsent = ModuleLayer.boot().findModule("jdk.net").isEmpty();
+
+        assertFalse(
+                jdkNetModuleAbsent,
+                "The 'jdk.net' module is absent from " +
+                "this JRE. causing:\n" +
+                "  java.lang.NoClassDefFoundError: jdk/net/Sockets\n" +
+                "    at DefaultHttpClientConnectionOperator.<clinit>\n" +
+                "    at Apache5HttpClient.createClient\n" +
+                "    at CloudWatchAppender.configureLoggerForCloudWatchLog\n" +
+                "    at Autotune.main\n" +
+                "  Caused by: java.lang.ClassNotFoundException: jdk.net.Sockets\n\n" +
+                "Fix: add ',jdk.net' to --add-modules in Dockerfile.autotune line 46."
+        );
+    }
+
+    // =========================================================================
+    // 3. POSITIVE — verifies the Dockerfile fix is in place
+    //
+    //    These pass only when ,jdk.net is present in the jlink --add-modules
+    //    list in Dockerfile.autotune.  On a developer JDK they always pass
+    //    (full JDK always has jdk.net); inside the jlink container image they
+    //    pass only after the fix.
+    // =========================================================================
+
+    @Test
+    @DisplayName("POSITIVE: jdk.net.Sockets is loadable — confirms ,jdk.net is in the jlink JRE")
+    void jdkNetSocketsMustBeLoadable() throws ClassNotFoundException {
+        /*
+         * If this throws ClassNotFoundException the jlink JRE in the container
+         * was built WITHOUT ,jdk.net in --add-modules (Dockerfile.autotune line
+         * 46).  Apache HC5 will then crash at startup with:
+         *   NoClassDefFoundError: jdk/net/Sockets
+         * exactly as seen in the pod logs on the OpenShift stage cluster.
+         */
+        Class<?> socketsClass = Class.forName("jdk.net.Sockets");
+        assertNotNull(
+                socketsClass,
+                "jdk.net.Sockets must be loadable. " +
+                "Add ',jdk.net' to --add-modules in Dockerfile.autotune line 46."
+        );
+    }
+
+    @Test
+    @DisplayName("POSITIVE: configureLoggerForCloudWatchLog must not throw NoClassDefFoundError when credentials are present")
+    void shouldNotThrowNoClassDefFoundErrorWhenCredentialsPresent() {
+        // Given – credentials present, identical to the stage cluster config
+        KruizeDeploymentInfo.cloudwatch_logs_access_key_id     = "AKIADUMMYACCESSKEY";
+        KruizeDeploymentInfo.cloudwatch_logs_secret_access_key = "dummySecretAccessKey0000000000000000000";
+        KruizeDeploymentInfo.cloudwatch_logs_region            = "us-east-1";
+        KruizeDeploymentInfo.cloudwatch_logs_log_group         = "kruize-test-logs";
+        KruizeDeploymentInfo.cloudwatch_logs_log_stream        = "kruize-test-stream";
+        KruizeDeploymentInfo.cloudwatch_logs_log_level         = "INFO";
+
+        // When / Then
+        // Any AWS auth/network error is caught inside the method at line 114-116.
+        // A NoClassDefFoundError: jdk/net/Sockets would NOT be caught there —
+        // it would propagate and fail this assertion, reproducing the prod crash.
+        assertDoesNotThrow(
+                CloudWatchAppender::configureLoggerForCloudWatchLog,
+                "configureLoggerForCloudWatchLog() threw an unexpected error. " +
+                "If the error is NoClassDefFoundError: jdk/net/Sockets, " +
+                "add ',jdk.net' to --add-modules in Dockerfile.autotune line 46."
+        );
+    }
+
+    // --- helpers ------------------------------------------------------------
+
+    private boolean cloudWatchAppenderRegistered() {
+        LoggerContext ctx = (LoggerContext) org.apache.logging.log4j.LogManager.getContext(false);
+        Configuration config = ctx.getConfiguration();
+        return config.getAppenders().containsKey("cloudwatchRootAppender");
+    }
+}

--- a/src/test/java/com/autotune/utils/CloudWatchAppenderTest.java
+++ b/src/test/java/com/autotune/utils/CloudWatchAppenderTest.java
@@ -31,22 +31,22 @@ import static org.junit.jupiter.api.Assertions.*;
  * Covers three scenarios:
  *
  * 1. CREDENTIALS ABSENT (simulates test/dev cluster — why the bug was hidden)
- *    When credentials are null or empty, the method short-circuits at the guard
- *    on line 76 of CloudWatchAppender.java.  The AWS SDK is never touched, so
- *    neither jdk.net nor Apache HC5 are loaded.  No exception, no appender.
+ *    When credentials are null or empty, the method short-circuits at the
+ *    credential guard.  The AWS SDK is never touched, so neither jdk.net nor
+ *    Apache HC5 are loaded.  No exception, no appender registered.
  *
- * 2. NEGATIVE — reproduces the production crash (simulates the broken jlink JRE)
- *    Directly attempts to load {@code jdk.net.Sockets} via Class.forName() on a
- *    ClassLoader that has the jdk.net module forcibly hidden, reproducing the
- *    exact {@code NoClassDefFoundError: jdk/net/Sockets} seen in the pod logs.
- *    This is the automated proof of the failure mode WITHOUT the Dockerfile fix.
+ * 2. NEGATIVE — documents the production crash condition
+ *    Asserts that the {@code jdk.net} module is present in the running JRE.
+ *    When {@code jdk.net} is absent (e.g. a stripped jlink JRE that omits the
+ *    module), Apache HttpClient 5 — pulled in by {@code awssdk:apache5-client}
+ *    — fails at startup with {@code NoClassDefFoundError: jdk/net/Sockets}.
+ *    This test fails with a descriptive message when run in such a JRE,
+ *    documenting the exact condition that caused the production crash.
  *
- * 3. POSITIVE — verifies the fix (jdk.net present in the running JRE)
- *    Asserts that {@code jdk.net.Sockets} IS loadable in the current JRE and
- *    that {@code configureLoggerForCloudWatchLog()} completes without any
+ * 3. POSITIVE — verifies the runtime is correctly configured
+ *    Asserts that {@code jdk.net.Sockets} is loadable and that
+ *    {@code configureLoggerForCloudWatchLog()} completes without any
  *    class-loading error when credentials are present.
- *    This test passes only when {@code ,jdk.net} is included in the
- *    {@code jlink --add-modules} list in Dockerfile.autotune.
  */
 class CloudWatchAppenderTest {
 
@@ -150,79 +150,66 @@ class CloudWatchAppenderTest {
     //        at Autotune.main
     //      Caused by: java.lang.ClassNotFoundException: jdk.net.Sockets
     //
-    //    The crash happens because the jlink command in Dockerfile.autotune
-    //    did NOT include ,jdk.net in --add-modules, so the stripped JRE
-    //    shipped inside the container image was missing jdk.net.Sockets.
+    //    Root cause: the jlink-built JRE shipped in the container image did not
+    //    include the jdk.net module, so jdk.net.Sockets was unavailable when
+    //    Apache HttpClient 5 tried to load it in a static initializer.
     //
     //    Note: it is not possible to reproduce the NoClassDefFoundError
     //    in-process on a full JDK — JPMS resolves named-module classes
-    //    (jdk.net.*) directly from the module layer, bypassing the classloader
-    //    hierarchy, so a custom excluding ClassLoader has no effect.
-    //    The real failure only occurs inside the stripped jlink JRE built
-    //    without ,jdk.net.  The negative test below therefore asserts the
-    //    *precondition* of the crash: the jdk.net module is absent.
-    //    Run this test inside the container built WITHOUT the Dockerfile fix
-    //    to see it fail.
+    //    directly from the module layer, bypassing the classloader hierarchy,
+    //    so a custom excluding ClassLoader has no effect.  The test below
+    //    therefore asserts the precondition of the crash: jdk.net must be
+    //    present.  Run it inside a jlink JRE that omits jdk.net to see it fail.
     // =========================================================================
 
     @Test
-    @DisplayName("NEGATIVE: jdk.net module absent → jdk.net.Sockets not loadable")
-    void jdkNetSocketsNotLoadableWhenModuleAbsent() {
+    @DisplayName("NEGATIVE: jdk.net module must be present — absence causes NoClassDefFoundError: jdk/net/Sockets at startup")
+    void jdkNetModuleMustBePresentToPreventStartupCrash() {
         /*
+         * Apache HttpClient 5 (awssdk:apache5-client >= 2.46.x) references
+         * jdk.net.Sockets in a static initializer.  If the jdk.net module is
+         * absent from the JRE, the JVM throws:
+         *   NoClassDefFoundError: jdk/net/Sockets
+         *   Caused by: ClassNotFoundException: jdk.net.Sockets
+         * crashing the process before it can serve any requests.
          *
-         * This test asserts the precondition :
-         *   the jdk.net module must NOT be absent from the JRE.
-         *
-         * On a developer machine (full JDK) jdk.net is always present,
-         * so this test passes unconditionally in local development.
-         *
-         * Inside the container image built from Dockerfile.autotune
-         * WITHOUT the fix (no ,jdk.net in --add-modules line 46):
-         *   ModuleLayer.boot().findModule("jdk.net") → empty Optional
-         *   Class.forName("jdk.net.Sockets")         → ClassNotFoundException
-         *
-         * The assertFalse below then FAILS, printing exactly why.
+         * On a full JDK jdk.net is always present, so this test always passes
+         * in local development.  Inside a stripped jlink JRE that omits jdk.net,
+         * ModuleLayer.boot().findModule("jdk.net") returns an empty Optional and
+         * this assertion fails — surfacing the missing-module condition before it
+         * manifests as a production crash.
          */
-        boolean jdkNetModuleAbsent = ModuleLayer.boot().findModule("jdk.net").isEmpty();
-
-        assertFalse(
-                jdkNetModuleAbsent,
-                "The 'jdk.net' module is absent from " +
-                "this JRE. causing:\n" +
-                "  java.lang.NoClassDefFoundError: jdk/net/Sockets\n" +
-                "    at DefaultHttpClientConnectionOperator.<clinit>\n" +
-                "    at Apache5HttpClient.createClient\n" +
-                "    at CloudWatchAppender.configureLoggerForCloudWatchLog\n" +
-                "    at Autotune.main\n" +
-                "  Caused by: java.lang.ClassNotFoundException: jdk.net.Sockets\n\n" +
-                "Fix: add ',jdk.net' to --add-modules in Dockerfile.autotune line 46."
+        assertTrue(
+                ModuleLayer.boot().findModule("jdk.net").isPresent(),
+                "The 'jdk.net' module is absent from this JRE. " +
+                "Apache HttpClient 5 requires it and will crash at startup with: " +
+                "NoClassDefFoundError: jdk/net/Sockets. " +
+                "Ensure the jlink --add-modules list used to build this JRE includes jdk.net."
         );
     }
 
     // =========================================================================
-    // 3. POSITIVE — verifies the Dockerfile fix is in place
+    // 3. POSITIVE — verifies the runtime is correctly configured
     //
-    //    These pass only when ,jdk.net is present in the jlink --add-modules
-    //    list in Dockerfile.autotune.  On a developer JDK they always pass
-    //    (full JDK always has jdk.net); inside the jlink container image they
-    //    pass only after the fix.
+    //    On a developer JDK these always pass (full JDK always has jdk.net).
+    //    Inside a jlink JRE they pass only when jdk.net is included in the
+    //    --add-modules list used to build the image.
     // =========================================================================
 
     @Test
-    @DisplayName("POSITIVE: jdk.net.Sockets is loadable — confirms ,jdk.net is in the jlink JRE")
+    @DisplayName("POSITIVE: jdk.net.Sockets is loadable — jdk.net module is present in the JRE")
     void jdkNetSocketsMustBeLoadable() throws ClassNotFoundException {
         /*
-         * If this throws ClassNotFoundException the jlink JRE in the container
-         * was built WITHOUT ,jdk.net in --add-modules (Dockerfile.autotune line
-         * 46).  Apache HC5 will then crash at startup with:
+         * Apache HttpClient 5 loads jdk.net.Sockets in a static initializer.
+         * If this throws ClassNotFoundException the JRE is missing the jdk.net
+         * module and Apache HC5 will crash at startup with:
          *   NoClassDefFoundError: jdk/net/Sockets
-         * exactly as seen in the pod logs on the OpenShift stage cluster.
          */
         Class<?> socketsClass = Class.forName("jdk.net.Sockets");
         assertNotNull(
                 socketsClass,
-                "jdk.net.Sockets must be loadable. " +
-                "Add ',jdk.net' to --add-modules in Dockerfile.autotune line 46."
+                "jdk.net.Sockets must be loadable — ensure the jdk.net module " +
+                "is included in the --add-modules list used to build the JRE."
         );
     }
 
@@ -238,14 +225,14 @@ class CloudWatchAppenderTest {
         KruizeDeploymentInfo.cloudwatch_logs_log_level         = "INFO";
 
         // When / Then
-        // Any AWS auth/network error is caught inside the method at line 114-116.
-        // A NoClassDefFoundError: jdk/net/Sockets would NOT be caught there —
+        // Any AWS auth/network error is caught and logged inside the method.
+        // A NoClassDefFoundError: jdk/net/Sockets is NOT caught there —
         // it would propagate and fail this assertion, reproducing the prod crash.
         assertDoesNotThrow(
                 CloudWatchAppender::configureLoggerForCloudWatchLog,
                 "configureLoggerForCloudWatchLog() threw an unexpected error. " +
-                "If the error is NoClassDefFoundError: jdk/net/Sockets, " +
-                "add ',jdk.net' to --add-modules in Dockerfile.autotune line 46."
+                "If the cause is NoClassDefFoundError: jdk/net/Sockets, " +
+                "the jdk.net module is missing from the JRE."
         );
     }
 


### PR DESCRIPTION
## Description

This PR contains changes to include `jdk.net` library in the dockerFile and corresponding unit tests for cloudwatch. 
## Background
Kruize 0.11 crashes on startup in prod with `NoClassDefFoundError: jdk/net/Sockets` because the AWS SDK was bumped from `2.42.25 → 2.46.5` in `pom.xml`, which switched the default HTTP client from Apache `HttpClient 4` to `Apache HttpClient 5`. HC5 requires the `jdk.net` JDK module, which is `not included in the custom jlink-built JRE` shipped in our container image. Kruize `0.10` was unaffected because it used HC4, which has no such dependency.

## Fix

Added `jdk.net` to the `--add-modules` flag on the jlink command . This makes the missing module available in the bundled JRE, keeps AWS SDK 2.46.5, and requires no code changes.


### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [x] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [x] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Ensure the container image includes the required JDK module for the updated AWS SDK HTTP client and add tests validating CloudWatch logging behavior and the jdk.net dependency.

Bug Fixes:
- Prevent startup failures caused by missing jdk.net.Sockets when using the newer AWS SDK/Apache HttpClient 5 in the containerized JRE.

Tests:
- Add CloudWatchAppender tests covering behavior with absent and present CloudWatch credentials and verifying that jdk.net.Sockets is loadable in the runtime JRE.