### PR TITLE
Add Integration tests for cloudwatch

### DIFF
--- a/tests/scripts/remote_monitoring_tests/Remote_monitoring_tests.md
+++ b/tests/scripts/remote_monitoring_tests/Remote_monitoring_tests.md
@@ -179,11 +179,46 @@ Here are the test scenarios:
 - Delete performance profile with when its associated with existing experiments
 
 
+### **CloudWatch Logging Integration tests**
+
+These tests validate the CloudWatch logging setup in Kruize by deploying the pod against two scenarios and inspecting the pod logs.
+
+**Scenario 1 — credentials-absent** *(always runs — no AWS credentials required)*
+- Kruize must start successfully with no CloudWatch credentials set
+- Pod logs must contain the skip message: `AWS access details are not provided. Skipping sending logs to CloudWatch.`
+- Pod logs must NOT contain `NoClassDefFoundError: jdk/net/Sockets`
+
+This scenario simulates the test/dev cluster configuration that **masked the jdk.net bug** — when credentials are absent, the credential guard in `CloudWatchAppender.configureLoggerForCloudWatchLog()` short-circuits before the AWS SDK client is constructed, so the missing `jdk.net` module is never exercised.
+
+**Scenario 2 — credentials-present** *(runs only when AWS env vars are set — see prerequisites below)*
+- Kruize must start successfully with valid CloudWatch credentials set
+- Pod logs must contain the success message: `CloudWatch logging enabled — region: <r>, log group: <g>, log stream: <s>, log level: <l>`
+- Pod logs must NOT contain `NoClassDefFoundError: jdk/net/Sockets`
+
+This scenario replicates the **stage/prod configuration that triggered the production crash** after the `awssdk-version` bump from `2.42.25` to `2.46.5` in `pom.xml` (which switched the default HTTP client from Apache HttpClient 4 to Apache HttpClient 5, requiring the `jdk.net` JDK module that was absent from the `jlink`-built container JRE).
+
 ## Prerequisites for running the tests:
 - Minikube setup or access to Openshift cluster
 - Tools like kubectl, oc, curl, jq, python
 - Various python modules pytest, json, pytest-html, requests, jinja2
   (these modules will be automatically installed while the test is run)
+
+**Additional prerequisites for CloudWatch logging credentials-present test:**
+- A dev AWS account (do **not** use production credentials)
+- A CloudWatch log group and log stream created on the dev account
+- An IAM user with the following permissions scoped to the dev log group:
+  `logs:CreateLogGroup`, `logs:CreateLogStream`, `logs:DescribeLogGroups`, `logs:DescribeLogStreams`, `logs:PutLogEvents`
+- The following environment variables exported before running:
+
+```
+export CLOUDWATCH_ACCESS_KEY_ID=<IAM access key id>
+export CLOUDWATCH_SECRET_ACCESS_KEY=<IAM secret access key>
+export CLOUDWATCH_REGION=<AWS region, e.g. us-east-1>
+export CLOUDWATCH_LOG_GROUP=<log group name, e.g. kruize-dev-logs>
+export CLOUDWATCH_LOG_STREAM=<log stream name, e.g. kruize-dev-stream>
+```
+
+If these variables are not set, the credentials-present test is automatically skipped and only the credentials-absent test runs.
 
 ## How to run the test?
 
@@ -208,7 +243,7 @@ usage: test_autotune.sh [ -c ] : cluster type. Supported type - minikube, opensh
 			[ --skipsetup ] : optional. Specifying this option skips the Kruize setup and performance profile creation in case of remote_monitoring_tests
 
 Note: If you want to run a particular testcase then it is mandatory to specify the testsuite
-Test cases supported are sanity, negative, extended and test_e2e
+Test cases supported are sanity, negative, extended, test_e2e and cloudwatch_logging
 
 ```
 
@@ -242,6 +277,76 @@ Remote monitoring tests can also be run without using the test_autotune.sh. To d
 - To run only a specific test within listRecommendations API
 ```
 	pytest -s test_list_recommendations.py::test_list_recommendations_single_exp --cluster_type <minikube|openshift>
+```
+
+Note: You can check the report.html for the results as it provides better readability
+
+## How to run the CloudWatch logging tests?
+
+### Using test_autotune.sh
+
+To run only the CloudWatch logging integration tests (credentials-absent scenario, no AWS credentials needed):
+
+```
+<KRUIZE_REPO>/tests/test_autotune.sh -c openshift --testsuite=remote_monitoring_tests --testcase=cloudwatch_logging --resultsdir=/home/results
+```
+
+To run both scenarios (credentials-absent and credentials-present), export the AWS env vars first:
+
+```
+export CLOUDWATCH_ACCESS_KEY_ID=<IAM access key id>
+export CLOUDWATCH_SECRET_ACCESS_KEY=<IAM secret access key>
+export CLOUDWATCH_REGION=us-east-1
+export CLOUDWATCH_LOG_GROUP=kruize-dev-logs
+export CLOUDWATCH_LOG_STREAM=kruize-dev-stream
+
+<KRUIZE_REPO>/tests/test_autotune.sh -c openshift --testsuite=remote_monitoring_tests --testcase=cloudwatch_logging --resultsdir=/home/results
+```
+
+### Running directly using pytest
+
+- Deploy Kruize using the deploy.sh from the kruize autotune repo
+- cd `<KRUIZE_REPO>/tests/scripts/remote_monitoring_tests`
+- python3 -m pip install --user -r requirements.txt
+- cd rest_apis
+
+To run only the credentials-absent test (no AWS credentials needed):
+```
+pytest -m cloudwatch_logging -k "credentials_absent" --html=<dir>/report.html --cluster_type <minikube|openshift>
+```
+
+To run both credentials-absent and credentials-present tests (AWS env vars must be set):
+```
+pytest -m cloudwatch_logging --html=<dir>/report.html --cluster_type <minikube|openshift>
+```
+
+To run a specific CloudWatch test:
+```
+pytest -s test_cloudwatch_logging.py::test_kruize_starts_and_skips_cloudwatch_when_credentials_absent --cluster_type openshift
+pytest -s test_cloudwatch_logging.py::test_kruize_starts_and_enables_cloudwatch_when_credentials_present --cluster_type openshift
+```
+
+### Using the shell orchestrator directly
+
+The shell orchestrator patches the deployment YAML, redeploys, reads pod logs, and reports results:
+
+```
+cd <KRUIZE_REPO>/tests/scripts/remote_monitoring_tests
+export KRUIZE_REPO=<path to kruize repo>
+export cluster_type=openshift
+export RESULTS=<results directory>
+
+# credentials-absent only (no AWS needed)
+source cloudwatch_logging_tests.sh
+cloudwatch_logging_tests
+
+# both scenarios (set AWS env vars first)
+export CLOUDWATCH_ACCESS_KEY_ID=<IAM access key id>
+export CLOUDWATCH_SECRET_ACCESS_KEY=<IAM secret access key>
+export CLOUDWATCH_REGION=us-east-1
+export CLOUDWATCH_LOG_GROUP=kruize-dev-logs
+export CLOUDWATCH_LOG_STREAM=kruize-dev-stream
+cloudwatch_logging_tests
 ```
 
 Note: You can check the report.html for the results as it provides better readability

--- a/tests/scripts/remote_monitoring_tests/cloudwatch_logging_tests.sh
+++ b/tests/scripts/remote_monitoring_tests/cloudwatch_logging_tests.sh
@@ -1,0 +1,260 @@
+#!/bin/bash
+#
+# Copyright (c) 2026 IBM Corporation and others.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+##### Integration tests for CloudWatch logging configuration in Kruize #####
+#
+# Scenarios tested:
+#
+#   credentials-absent  — CloudWatch credentials not set in kruizeconfigjson.
+#                         Kruize must start successfully and log the skip message.
+#                         (This is the test cluster condition that masked the jdk.net bug.)
+#
+#   credentials-present — Valid CloudWatch credentials set in kruizeconfigjson.
+#                         Kruize must start successfully and log the success message:
+#                         "CloudWatch logging enabled — region: ..."
+#                         (This is the stage cluster condition that triggered the crash.)
+#
+# Prerequisites (credentials-present scenario):
+#   The following env vars must be exported before running:
+#     CLOUDWATCH_ACCESS_KEY_ID      — IAM access key for the dev CloudWatch log group
+#     CLOUDWATCH_SECRET_ACCESS_KEY  — IAM secret access key
+#     CLOUDWATCH_REGION             — AWS region (e.g. us-east-1)
+#     CLOUDWATCH_LOG_GROUP          — CloudWatch log group name (e.g. kruize-dev-logs)
+#     CLOUDWATCH_LOG_STREAM         — CloudWatch log stream name (e.g. kruize-dev-stream)
+#
+# Usage:
+#   export CLOUDWATCH_ACCESS_KEY_ID=...
+#   export CLOUDWATCH_SECRET_ACCESS_KEY=...
+#   export CLOUDWATCH_REGION=us-east-1
+#   export CLOUDWATCH_LOG_GROUP=kruize-dev-logs
+#   export CLOUDWATCH_LOG_STREAM=kruize-dev-stream
+#   ./cloudwatch_logging_tests.sh
+#
+# Or via the remote_monitoring_tests.sh runner (set testcase=cloudwatch_logging).
+
+REMOTE_MONITORING_TEST_DIR="${KRUIZE_REPO}/tests/scripts/remote_monitoring_tests"
+APP_DEPLOYMENT="kruize"
+
+# Expected log messages — must match exactly what CloudWatchAppender emits
+CLOUDWATCH_SKIP_MSG="AWS access details are not provided. Skipping sending logs to CloudWatch."
+CLOUDWATCH_SUCCESS_MSG="CloudWatch logging enabled"
+
+function cloudwatch_logging_tests() {
+	start_time=$(get_date)
+	FAILED_CASES=()
+	TESTS=0
+	TESTS_FAILED=0
+	TESTS_PASSED=0
+	((TOTAL_TEST_SUITES++))
+
+	TEST_SUITE_DIR="${RESULTS}/cloudwatch_logging_tests"
+	mkdir -p "${TEST_SUITE_DIR}" 2>&1
+	KRUIZE_SETUP_LOG="${TEST_SUITE_DIR}/kruize_setup.log"
+
+	if [ "$cluster_type" == "openshift" ]; then
+		NAMESPACE="openshift-tuning"
+		YAML_FILE="${REMOTE_MONITORING_TEST_DIR}/../../../manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml"
+	elif [ "$cluster_type" == "minikube" ] || [ "$cluster_type" == "kind" ]; then
+		NAMESPACE="monitoring"
+		YAML_FILE="${REMOTE_MONITORING_TEST_DIR}/../../../manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml"
+	else
+		echo "Invalid cluster type found: ${cluster_type}"
+		return
+	fi
+
+	kubectl_cmd="kubectl -n ${NAMESPACE}"
+
+	echo ""
+	echo "******************* Executing test suite ${FUNCNAME} ****************"
+	echo ""
+
+	# --- Scenario 1: credentials absent ---
+	echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+	echo " Running scenario: credentials-absent"
+	echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+	run_cloudwatch_scenario "credentials-absent"
+	if [ "${TESTS_FAILED}" -ne "0" ]; then
+		FAILED_CASES+=("credentials-absent")
+	fi
+
+	# --- Scenario 2: credentials present (requires env vars) ---
+	if [ -z "${CLOUDWATCH_ACCESS_KEY_ID}" ] || [ -z "${CLOUDWATCH_SECRET_ACCESS_KEY}" ] || [ -z "${CLOUDWATCH_REGION}" ]; then
+		echo ""
+		echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+		echo " Skipping scenario: credentials-present"
+		echo " Reason: CLOUDWATCH_ACCESS_KEY_ID / CLOUDWATCH_SECRET_ACCESS_KEY /"
+		echo "         CLOUDWATCH_REGION env vars are not set."
+		echo " Set them to run the full credentials-present integration test."
+		echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+	else
+		echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+		echo " Running scenario: credentials-present"
+		echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+		run_cloudwatch_scenario "credentials-present"
+		if [ "${TESTS_FAILED}" -ne "0" ]; then
+			FAILED_CASES+=("credentials-present")
+		fi
+	fi
+
+	TESTS=$(($TESTS_PASSED + $TESTS_FAILED))
+	TOTAL_TESTS_FAILED=${TESTS_FAILED}
+	TOTAL_TESTS_PASSED=${TESTS_PASSED}
+	TOTAL_TESTS=${TESTS}
+
+	if [ "${TESTS_FAILED}" -ne "0" ]; then
+		FAILED_TEST_SUITE+=(${FUNCNAME})
+	fi
+
+	end_time=$(get_date)
+	elapsed_time=$(time_diff "${start_time}" "${end_time}")
+
+	FAILED_CASES=( $(printf '%s\n' "${FAILED_CASES[@]}" | uniq ) )
+	testsuitesummary ${FUNCNAME} "${elapsed_time}" ${FAILED_CASES}
+}
+
+# Run a single CloudWatch scenario by patching the YAML, deploying, and checking pod logs.
+# input: scenario name — "credentials-absent" or "credentials-present"
+run_cloudwatch_scenario() {
+	local scenario=$1
+	local POD_LOG="${TEST_SUITE_DIR}/${scenario}-pod.log"
+	local SETUP_LOG="${TEST_SUITE_DIR}/${scenario}-setup.log"
+
+	echo "Backing up YAML: ${YAML_FILE}"
+	cp "${YAML_FILE}" "${YAML_FILE}.cw.bak"
+
+	if [ "${scenario}" == "credentials-absent" ]; then
+		patch_cloudwatch_credentials "" "" "" "" ""
+	else
+		local log_group="${CLOUDWATCH_LOG_GROUP:-kruize-dev-logs}"
+		local log_stream="${CLOUDWATCH_LOG_STREAM:-kruize-dev-stream}"
+		patch_cloudwatch_credentials \
+			"${CLOUDWATCH_ACCESS_KEY_ID}" \
+			"${CLOUDWATCH_SECRET_ACCESS_KEY}" \
+			"${CLOUDWATCH_REGION}" \
+			"${log_group}" \
+			"${log_stream}"
+	fi
+
+	# Update the image to the build under test
+	if [ -n "${AUTOTUNE_IMAGE}" ]; then
+		sed -i.image.bak '
+		/kind: Deployment/,/kind:/{
+			/name: kruize$/,/containers:/{
+				/^        - name: kruize$/{
+					n
+					s|image: .*|image: '"${AUTOTUNE_IMAGE}"'|
+				}
+			}
+		}' "${YAML_FILE}"
+		echo "Updated image in YAML to ${AUTOTUNE_IMAGE}"
+	fi
+
+	echo "Applying YAML and restarting kruize..."
+	${kubectl_cmd} apply -f "${YAML_FILE}" > "${SETUP_LOG}" 2>&1
+	${kubectl_cmd} rollout restart deployment kruize >> "${SETUP_LOG}" 2>&1
+
+	# Wait for pod to be ready or fail
+	if ${kubectl_cmd} wait --for=condition=Ready pod -l app=${APP_DEPLOYMENT} --timeout=180s > /dev/null 2>&1; then
+		echo "Kruize pod is Ready"
+		local POD_NAME
+		POD_NAME=$(${kubectl_cmd} get pods | grep 'kruize' | grep -v -E 'kruize-db|kruize-ui' | awk 'NR==1{print $1}')
+		sleep 10
+		${kubectl_cmd} logs "${POD_NAME}" > "${POD_LOG}" 2>&1
+
+		check_cloudwatch_pod_log "${scenario}" "${POD_LOG}"
+	else
+		echo "ERROR: Kruize pod failed to become Ready for scenario '${scenario}'"
+		echo "Check ${SETUP_LOG} and ${POD_LOG} for details"
+		((TESTS_FAILED++))
+	fi
+
+	# Restore original YAML
+	mv "${YAML_FILE}.cw.bak" "${YAML_FILE}"
+}
+
+# Patch the cloudwatch block inside kruizeconfigjson in the deployment YAML.
+# inputs: accessKeyId, secretAccessKey, region, logGroup, logStream
+# Empty strings produce a no-credentials config (credentials-absent scenario).
+patch_cloudwatch_credentials() {
+	local access_key_id=$1
+	local secret_access_key=$2
+	local region=$3
+	local log_group=${4:-kruize-logs}
+	local log_stream=${5:-kruize-stream}
+
+	echo "Patching CloudWatch credentials in YAML (scenario: ${access_key_id:+present}${access_key_id:-absent})"
+
+	sed -i \
+		-e 's|"accessKeyId":[[:space:]]*"[^"]*"|"accessKeyId": "'"${access_key_id}"'"|g' \
+		-e 's|"secretAccessKey":[[:space:]]*"[^"]*"|"secretAccessKey": "'"${secret_access_key}"'"|g' \
+		-e 's|"region":[[:space:]]*"[^"]*"|"region": "'"${region}"'"|g' \
+		-e 's|"logGroup":[[:space:]]*"[^"]*"|"logGroup": "'"${log_group}"'"|g' \
+		-e 's|"logStream":[[:space:]]*"[^"]*"|"logStream": "'"${log_stream}"'"|g' \
+		"${YAML_FILE}"
+}
+
+# Assert the pod log contains the expected message for the given scenario.
+check_cloudwatch_pod_log() {
+	local scenario=$1
+	local pod_log=$2
+
+	echo ""
+	if [ "${scenario}" == "credentials-absent" ]; then
+		# Positive: pod must start cleanly and log the skip message
+		if grep -q "${CLOUDWATCH_SKIP_MSG}" "${pod_log}"; then
+			echo "PASS [credentials-absent]: Pod started and logged expected skip message:"
+			echo "  '${CLOUDWATCH_SKIP_MSG}'"
+			((TESTS_PASSED++))
+		else
+			echo "FAIL [credentials-absent]: Expected skip message not found in pod log."
+			echo "  Expected: '${CLOUDWATCH_SKIP_MSG}'"
+			echo "  Check: ${pod_log}"
+			((TESTS_FAILED++))
+		fi
+
+		# Negative: pod must NOT have crashed with the jdk.net error
+		if grep -q "NoClassDefFoundError: jdk/net/Sockets" "${pod_log}"; then
+			echo "FAIL [credentials-absent]: Pod crashed with NoClassDefFoundError: jdk/net/Sockets."
+			echo "  The 'jdk.net' module is missing from the jlink JRE."
+			echo "  Ensure jdk.net is included in the --add-modules list in the jlink build step."
+			((TESTS_FAILED++))
+		fi
+
+	elif [ "${scenario}" == "credentials-present" ]; then
+		# Positive: pod must start cleanly and log the CloudWatch success message
+		if grep -q "${CLOUDWATCH_SUCCESS_MSG}" "${pod_log}"; then
+			echo "PASS [credentials-present]: Pod started and logged expected CloudWatch success message:"
+			grep "${CLOUDWATCH_SUCCESS_MSG}" "${pod_log}"
+			((TESTS_PASSED++))
+		else
+			echo "FAIL [credentials-present]: Expected CloudWatch success message not found in pod log."
+			echo "  Expected pattern: '${CLOUDWATCH_SUCCESS_MSG}'"
+			echo "  Check: ${pod_log}"
+			((TESTS_FAILED++))
+		fi
+
+		# Negative: the exact production crash must not appear
+		if grep -q "NoClassDefFoundError: jdk/net/Sockets" "${pod_log}"; then
+			echo "FAIL [credentials-present]: Pod crashed with NoClassDefFoundError: jdk/net/Sockets."
+			echo "  This is the production bug — the 'jdk.net' module is missing from the jlink JRE."
+			echo "  Ensure jdk.net is included in the --add-modules list in the jlink build step."
+			((TESTS_FAILED++))
+		fi
+	fi
+	echo ""
+}

--- a/tests/scripts/remote_monitoring_tests/pytest.ini
+++ b/tests/scripts/remote_monitoring_tests/pytest.ini
@@ -8,3 +8,4 @@ markers =
     perf_profile: mark test as a performance profile test
     simulate_prod: mark test as a test to simulate prod by running 3 kruize replicas
     simulate_prod_single_pod: mark test as a single pod test for perf profile validation
+    cloudwatch_logging: mark test as a CloudWatch logging integration test

--- a/tests/scripts/remote_monitoring_tests/rest_apis/test_cloudwatch_logging.py
+++ b/tests/scripts/remote_monitoring_tests/rest_apis/test_cloudwatch_logging.py
@@ -1,0 +1,240 @@
+"""
+Copyright (c) 2026 Red Hat, IBM Corporation and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Integration tests for CloudWatch logging configuration in Kruize.
+
+These tests replicate the manual verification performed on the dev OpenShift
+cluster after the jdk.net fix was applied to the container image.
+
+Two scenarios are covered:
+
+  credentials-absent  — CloudWatch credentials are empty in kruizeconfigjson.
+                        Kruize must start cleanly and emit the skip message.
+                        This is the condition on the test cluster that masked
+                        the jdk.net bug (credentials were never set there).
+
+  credentials-present — Valid CloudWatch credentials are set.
+                        Kruize must start cleanly and emit:
+                          "CloudWatch logging enabled — region: ..."
+                        Before the fix, this crashed with:
+                          NoClassDefFoundError: jdk/net/Sockets
+                        because the jdk.net module was absent from the
+                        jlink-built JRE in the container image.
+
+Prerequisites (credentials-present tests):
+  The following environment variables must be set:
+    CLOUDWATCH_ACCESS_KEY_ID      — IAM access key for the dev CloudWatch log group
+    CLOUDWATCH_SECRET_ACCESS_KEY  — IAM secret access key
+    CLOUDWATCH_REGION             — AWS region (e.g. us-east-1)
+    CLOUDWATCH_LOG_GROUP          — CloudWatch log group  (e.g. kruize-dev-logs)
+    CLOUDWATCH_LOG_STREAM         — CloudWatch log stream (e.g. kruize-dev-stream)
+  Tests that require these variables are skipped automatically when they are absent.
+"""
+
+import os
+import time
+import pytest
+import subprocess
+
+# ---------------------------------------------------------------------------
+# Constants — must match exactly what CloudWatchAppender emits
+# ---------------------------------------------------------------------------
+
+# Emitted by CloudWatchAppender.configureLoggerForCloudWatchLog() when all
+# three mandatory credentials (accessKeyId, secretAccessKey, region) are absent.
+CLOUDWATCH_SKIP_MSG = "AWS access details are not provided. Skipping sending logs to CloudWatch."
+
+# Emitted on successful CloudWatch setup (after the jdk.net fix).
+# Partial match — the full message includes region/group/stream values.
+CLOUDWATCH_SUCCESS_MSG = "CloudWatch logging enabled"
+
+# Emitted when the jdk.net module is absent from the jlink JRE (the production bug).
+JDKNET_CRASH_MSG = "NoClassDefFoundError: jdk/net/Sockets"
+
+# Namespace where kruize runs — determined by cluster_type at runtime
+NAMESPACE_OPENSHIFT = "openshift-tuning"
+NAMESPACE_DEFAULT   = "monitoring"
+
+POD_READY_TIMEOUT   = 180   # seconds to wait for the pod to become Ready
+LOG_SETTLE_SECONDS  = 10    # seconds to wait after pod is Ready before reading logs
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _namespace(cluster_type: str) -> str:
+    return NAMESPACE_OPENSHIFT if cluster_type == "openshift" else NAMESPACE_DEFAULT
+
+
+def _get_kruize_pod_name(namespace: str) -> str:
+    """Return the name of the running kruize pod (excluding db and ui pods)."""
+    result = subprocess.run(
+        ["kubectl", "-n", namespace, "get", "pods",
+         "--no-headers", "-o", "custom-columns=NAME:.metadata.name"],
+        capture_output=True, text=True, check=True
+    )
+    for line in result.stdout.splitlines():
+        name = line.strip()
+        if "kruize" in name and "kruize-db" not in name and "kruize-ui" not in name:
+            return name
+    raise RuntimeError(f"No kruize pod found in namespace '{namespace}'")
+
+
+def _wait_for_pod_ready(namespace: str, timeout: int = POD_READY_TIMEOUT) -> None:
+    """Wait until the kruize pod reaches Ready condition."""
+    subprocess.run(
+        ["kubectl", "-n", namespace, "wait",
+         "--for=condition=Ready", "pod",
+         "-l", "app=kruize",
+         f"--timeout={timeout}s"],
+        check=True
+    )
+
+
+def _get_pod_logs(namespace: str, pod_name: str) -> str:
+    """Fetch and return the full log of the given pod."""
+    result = subprocess.run(
+        ["kubectl", "-n", namespace, "logs", pod_name],
+        capture_output=True, text=True, check=True
+    )
+    return result.stdout
+
+
+def _restart_kruize(namespace: str) -> None:
+    """Trigger a rollout restart and wait for the new pod to be Ready."""
+    subprocess.run(
+        ["kubectl", "-n", namespace, "rollout", "restart", "deployment/kruize"],
+        check=True
+    )
+    _wait_for_pod_ready(namespace)
+    time.sleep(LOG_SETTLE_SECONDS)
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1 — credentials absent
+# Simulates the test/dev cluster config that masked the jdk.net bug.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.cloudwatch_logging
+def test_kruize_starts_and_skips_cloudwatch_when_credentials_absent(cluster_type):
+    """
+    SCENARIO: credentials-absent
+
+    When CloudWatch credentials are not set in kruizeconfigjson, Kruize must:
+      1. Start successfully (pod reaches Ready state).
+      2. Log the skip message indicating CloudWatch setup was bypassed.
+      3. NOT crash with NoClassDefFoundError: jdk/net/Sockets.
+
+    This mirrors the test-cluster condition where missing credentials caused
+    the credential guard in CloudWatchAppender to short-circuit, hiding the
+    jdk.net bug from pre-release testing.
+    """
+    namespace = _namespace(cluster_type)
+
+    _wait_for_pod_ready(namespace)
+    time.sleep(LOG_SETTLE_SECONDS)
+
+    pod_name = _get_kruize_pod_name(namespace)
+    logs = _get_pod_logs(namespace, pod_name)
+
+    # Must log the skip message — confirms credentials guard fired correctly
+    assert CLOUDWATCH_SKIP_MSG in logs, (
+        f"Expected skip message not found in pod logs.\n"
+        f"Expected: '{CLOUDWATCH_SKIP_MSG}'\n"
+        f"This means credentials may have been set unexpectedly, or the "
+        f"credential guard in CloudWatchAppender.configureLoggerForCloudWatchLog() "
+        f"is not working correctly."
+    )
+
+    # Must NOT have hit the jdk.net crash
+    assert JDKNET_CRASH_MSG not in logs, (
+        f"Pod crashed with '{JDKNET_CRASH_MSG}'.\n"
+        f"The 'jdk.net' module is missing from the jlink JRE in the container image.\n"
+        f"Ensure jdk.net is included in the --add-modules list in the jlink build step."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2 — credentials present
+# Replicates the stage/prod config that triggered the production crash.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.cloudwatch_logging
+@pytest.mark.skipif(
+    not all([
+        os.environ.get("CLOUDWATCH_ACCESS_KEY_ID"),
+        os.environ.get("CLOUDWATCH_SECRET_ACCESS_KEY"),
+        os.environ.get("CLOUDWATCH_REGION"),
+    ]),
+    reason=(
+        "Skipped: CLOUDWATCH_ACCESS_KEY_ID, CLOUDWATCH_SECRET_ACCESS_KEY, and "
+        "CLOUDWATCH_REGION must all be set to run the credentials-present test. "
+        "Set them using dev AWS account credentials (not prod). "
+        "See tests/scripts/remote_monitoring_tests/cloudwatch_logging_tests.sh for details."
+    )
+)
+def test_kruize_starts_and_enables_cloudwatch_when_credentials_present(cluster_type):
+    """
+    SCENARIO: credentials-present
+
+    When valid CloudWatch credentials are set in kruizeconfigjson, Kruize must:
+      1. Start successfully (pod reaches Ready state).
+      2. Log the CloudWatch success message including region, log group, log stream.
+      3. NOT crash with NoClassDefFoundError: jdk/net/Sockets.
+
+    BEFORE the fix: this test would fail because the pod crashed at startup with
+      java.lang.NoClassDefFoundError: jdk/net/Sockets
+        at DefaultHttpClientConnectionOperator.<clinit>
+        at Apache5HttpClient.createClient
+        at CloudWatchAppender.configureLoggerForCloudWatchLog
+        at Autotune.main
+      Caused by: java.lang.ClassNotFoundException: jdk.net.Sockets
+
+    Root cause: awssdk-version bumped from 2.42.25 to 2.46.5 in pom.xml switched
+    the default HTTP client from apache-client (HC4) to apache5-client (HC5).
+    HC5 requires jdk.net.Sockets which was absent from the jlink-built JRE because
+    jdk.net was not listed in the --add-modules flag.
+
+    AFTER the fix (jdk.net added to --add-modules): this test passes.
+    """
+    namespace  = _namespace(cluster_type)
+    pod_name   = _get_kruize_pod_name(namespace)
+    logs       = _get_pod_logs(namespace, pod_name)
+
+    # Must NOT have hit the production crash — this was the exact failure on stage
+    assert JDKNET_CRASH_MSG not in logs, (
+        f"PRODUCTION BUG REPRODUCED: Pod crashed with '{JDKNET_CRASH_MSG}'.\n"
+        f"This is the exact crash seen on the OpenShift stage cluster after the "
+        f"awssdk-version bump from 2.42.25 to 2.46.5 in pom.xml.\n"
+        f"Root cause: the 'jdk.net' module is absent from the jlink JRE.\n"
+        f"Fix: ensure jdk.net is included in the --add-modules list in the jlink build step."
+    )
+
+    # Must log the CloudWatch success message — confirms setup completed
+    assert CLOUDWATCH_SUCCESS_MSG in logs, (
+        f"CloudWatch success message not found in pod logs.\n"
+        f"Expected pattern: '{CLOUDWATCH_SUCCESS_MSG}'\n"
+        f"Full expected format: 'CloudWatch logging enabled — region: <r>, "
+        f"log group: <g>, log stream: <s>, log level: <l>'\n"
+        f"Either the CloudWatch setup failed silently, or the credentials "
+        f"in kruizeconfigjson are incorrect. Check the pod logs for errors."
+    )
+
+    # Print the actual success line for visibility in test output
+    for line in logs.splitlines():
+        if CLOUDWATCH_SUCCESS_MSG in line:
+            print(f"\n[cloudwatch] {line.strip()}")
+            break


### PR DESCRIPTION
## Description

This PR is on top of #2022 , contains integration tests for cloudwatch access via Kruize
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [x] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Add integration tests and supporting infrastructure to validate CloudWatch logging behaviour in Kruize under both credential-present and credential-absent scenarios, and update logging output to support these tests.

New Features:
- Introduce CloudWatch logging integration tests in the remote monitoring test suite, including pytest-based tests and a shell orchestrator script to run credentials-present and credentials-absent scenarios.
- Add a JUnit test suite for CloudWatchAppender to cover credential guard behaviour and validate the runtime environment for CloudWatch logging.

Enhancements:
- Update CloudWatchAppender to emit a structured info-level message when CloudWatch logging is successfully enabled.
- Extend remote monitoring test documentation with detailed instructions and prerequisites for running CloudWatch logging tests, and register a new pytest marker and testcase for this suite.

Tests:
- Add end-to-end CloudWatch logging tests that deploy Kruize, inspect pod logs, and assert correct behaviour with and without AWS credentials, including checks for absence of the jdk.net-related crash.
- Add Java unit tests for CloudWatchAppender to validate behaviour with missing credentials and to assert presence of required JDK modules for the AWS SDK HTTP client.