### PR TITLE
Kruize Health API update

### DIFF
--- a/src/main/java/com/autotune/service/HealthService.java
+++ b/src/main/java/com/autotune/service/HealthService.java
@@ -15,26 +15,98 @@
  *******************************************************************************/
 package com.autotune.service;
 
+import com.autotune.analyzer.utils.GsonUTCDateAdapter;
+import com.autotune.service.health.HealthReport;
+import com.autotune.service.health.KruizeHealthAggregator;
+import com.autotune.utils.KruizeConstants;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Date;
 
-public class HealthService extends HttpServlet
-{
-	public static final int STATUS_UP = 1;
-	public static final int STATUS_DOWN = 0;
+import static com.autotune.analyzer.utils.AnalyzerConstants.ServiceConstants.CHARACTER_ENCODING;
+import static com.autotune.analyzer.utils.AnalyzerConstants.ServiceConstants.JSON_CONTENT_TYPE;
 
-	private static int CURRENT_STATUS = STATUS_UP;
+/**
+ * Servlet for the {@code GET /health} endpoint.
+ *
+ * <p>Returns a JSON body describing the overall health of Kruize, the
+ * PostgreSQL database connection, and every configured datasource:
+ *
+ * <pre>
+ * {
+ *   "overallStatus": "UP | DEGRADED | DOWN",
+ *   "database":   { "status": "UP", "database": "PostgreSQL", "latencyMs": 14, "checkedAt": "..." },
+ *   "datasources": [ { "name": "prometheus-1", "status": "UP", ... } ],
+ *   "timestamp":  "2025-01-01T12:00:00.000Z"
+ * }
+ * </pre>
+ *
+ * <p>HTTP status codes:
+ * <ul>
+ *   <li>{@code 200 OK} — {@code UP} or {@code DEGRADED} (service is running)</li>
+ *   <li>{@code 503 Service Unavailable} — {@code DOWN} (database unavailable)</li>
+ * </ul>
+ *
+ * <p>All business logic lives in {@link KruizeHealthAggregator}; this class is
+ * intentionally kept thin.
+ */
+public class HealthService extends HttpServlet {
 
-	@Override
-	protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-		if (CURRENT_STATUS == STATUS_UP) {
-			resp.setStatus(HttpServletResponse.SC_OK);
-			resp.getWriter().println("UP");
-		} else {
-			resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-			resp.getWriter().println("DOWN");
-		}
-	}
+    private static final Logger LOGGER = LoggerFactory.getLogger(HealthService.class);
+
+    // Legacy status constants kept for any existing external callers that might
+    // reference them via reflection or static imports.
+    public static final int STATUS_UP   = 1;
+    public static final int STATUS_DOWN = 0;
+    private static int CURRENT_STATUS   = STATUS_UP;
+
+    private static final Gson GSON = new GsonBuilder()
+            .registerTypeAdapter(Date.class, new GsonUTCDateAdapter())
+            .setPrettyPrinting()
+            .create();
+
+    private final KruizeHealthAggregator aggregator;
+
+    /** Production no-arg constructor used by the Jetty servlet container. */
+    public HealthService() {
+        this(new KruizeHealthAggregator());
+    }
+
+    /** Testable constructor — allows injecting a mock aggregator. */
+    HealthService(KruizeHealthAggregator aggregator) {
+        this.aggregator = aggregator;
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        resp.setContentType(JSON_CONTENT_TYPE);
+        resp.setCharacterEncoding(CHARACTER_ENCODING);
+
+        HealthReport report;
+        try {
+            report = aggregator.collectHealth();
+        } catch (Exception e) {
+            // Should never reach here — aggregator is designed to never throw —
+            // but guard defensively so the endpoint always returns valid JSON.
+            LOGGER.error("Unexpected error in health aggregator: {}", e.getMessage());
+            resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            resp.getWriter().println("{\"overallStatus\":\"DOWN\",\"message\":\"Internal health check error\"}");
+            return;
+        }
+
+        boolean isDown = KruizeConstants.HealthConstants.OverallStatus.DOWN
+                .equals(report.getOverallStatus());
+        resp.setStatus(isDown
+                ? HttpServletResponse.SC_SERVICE_UNAVAILABLE   // 503
+                : HttpServletResponse.SC_OK);                  // 200
+
+        resp.getWriter().println(GSON.toJson(report));
+    }
 }

--- a/src/main/java/com/autotune/service/HealthService.java
+++ b/src/main/java/com/autotune/service/HealthService.java
@@ -42,7 +42,7 @@ import static com.autotune.analyzer.utils.AnalyzerConstants.ServiceConstants.JSO
  * <pre>
  * {
  *   "overallStatus": "UP | DEGRADED | DOWN",
- *   "database":   { "status": "UP", "database": "PostgreSQL", "latencyMs": 14, "checkedAt": "..." },
+ *   "database":   { "status": "UP" },
  *   "datasources": [ { "name": "prometheus-1", "status": "UP", ... } ],
  *   "timestamp":  "2025-01-01T12:00:00.000Z"
  * }

--- a/src/main/java/com/autotune/service/health/DatabaseHealthChecker.java
+++ b/src/main/java/com/autotune/service/health/DatabaseHealthChecker.java
@@ -22,7 +22,6 @@ import org.hibernate.SessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Date;
 
 /**
  * Checks whether the Kruize PostgreSQL database is reachable by opening a
@@ -42,27 +41,22 @@ public class DatabaseHealthChecker {
      *         Status is {@code "UP"} on success, {@code "DOWN"} on any failure.
      */
     public DatabaseHealthResult check() {
-        long start = System.currentTimeMillis();
         Session session = null;
         try {
             SessionFactory factory = KruizeHibernateUtil.getSessionFactory();
             if (factory == null) {
                 LOGGER.warn("Hibernate SessionFactory is null — DB not initialised");
-                return down(start);
+                return down();
             }
             session = factory.openSession();
             session.createNativeQuery(KruizeConstants.HealthConstants.DB_LIVENESS_QUERY, Integer.class)
                    .getSingleResult();
-            long latencyMs = System.currentTimeMillis() - start;
-            LOGGER.debug("DB health check passed in {}ms", latencyMs);
+            LOGGER.debug("DB health check passed");
             return new DatabaseHealthResult(
-                    KruizeConstants.HealthConstants.ComponentStatus.UP,
-                    KruizeConstants.HealthConstants.DB_TYPE,
-                    latencyMs,
-                    new Date());
+                    KruizeConstants.HealthConstants.ComponentStatus.UP);
         } catch (Exception e) {
             LOGGER.warn("DB health check failed: {}", e.getMessage());
-            return down(start);
+            return down();
         } finally {
             if (session != null) {
                 try {
@@ -74,11 +68,8 @@ public class DatabaseHealthChecker {
         }
     }
 
-    private DatabaseHealthResult down(long startMs) {
+    private DatabaseHealthResult down() {
         return new DatabaseHealthResult(
-                KruizeConstants.HealthConstants.ComponentStatus.DOWN,
-                KruizeConstants.HealthConstants.DB_TYPE,
-                System.currentTimeMillis() - startMs,
-                new Date());
+                KruizeConstants.HealthConstants.ComponentStatus.DOWN);
     }
 }

--- a/src/main/java/com/autotune/service/health/DatabaseHealthChecker.java
+++ b/src/main/java/com/autotune/service/health/DatabaseHealthChecker.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.autotune.service.health;
+
+import com.autotune.database.init.KruizeHibernateUtil;
+import com.autotune.utils.KruizeConstants;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Date;
+
+/**
+ * Checks whether the Kruize PostgreSQL database is reachable by opening a
+ * Hibernate session and executing a lightweight {@code SELECT 1} probe.
+ *
+ * <p>The check is intentionally minimal: it verifies connectivity and that the
+ * connection pool is functional without touching any application table.
+ */
+public class DatabaseHealthChecker {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseHealthChecker.class);
+
+    /**
+     * Performs the database liveness probe.
+     *
+     * @return a {@link DatabaseHealthResult} — never {@code null}.
+     *         Status is {@code "UP"} on success, {@code "DOWN"} on any failure.
+     */
+    public DatabaseHealthResult check() {
+        long start = System.currentTimeMillis();
+        Session session = null;
+        try {
+            SessionFactory factory = KruizeHibernateUtil.getSessionFactory();
+            if (factory == null) {
+                LOGGER.warn("Hibernate SessionFactory is null — DB not initialised");
+                return down(start);
+            }
+            session = factory.openSession();
+            session.createNativeQuery(KruizeConstants.HealthConstants.DB_LIVENESS_QUERY, Integer.class)
+                   .getSingleResult();
+            long latencyMs = System.currentTimeMillis() - start;
+            LOGGER.debug("DB health check passed in {}ms", latencyMs);
+            return new DatabaseHealthResult(
+                    KruizeConstants.HealthConstants.ComponentStatus.UP,
+                    KruizeConstants.HealthConstants.DB_TYPE,
+                    latencyMs,
+                    new Date());
+        } catch (Exception e) {
+            LOGGER.warn("DB health check failed: {}", e.getMessage());
+            return down(start);
+        } finally {
+            if (session != null) {
+                try {
+                    session.close();
+                } catch (Exception ignored) {
+                    // best-effort close; do not mask the real result
+                }
+            }
+        }
+    }
+
+    private DatabaseHealthResult down(long startMs) {
+        return new DatabaseHealthResult(
+                KruizeConstants.HealthConstants.ComponentStatus.DOWN,
+                KruizeConstants.HealthConstants.DB_TYPE,
+                System.currentTimeMillis() - startMs,
+                new Date());
+    }
+}

--- a/src/main/java/com/autotune/service/health/DatabaseHealthResult.java
+++ b/src/main/java/com/autotune/service/health/DatabaseHealthResult.java
@@ -15,39 +15,19 @@
  *******************************************************************************/
 package com.autotune.service.health;
 
-import java.util.Date;
-
 /**
- * Immutable result of a single database liveness probe.
+ * Immutable health summary of the database.
  * Serialised directly to JSON by Gson in the /health response.
  */
 public class DatabaseHealthResult {
 
     private final String status;
-    private final String database;
-    private final long latencyMs;
-    private final Date checkedAt;
 
-    public DatabaseHealthResult(String status, String database, long latencyMs, Date checkedAt) {
-        this.status    = status;
-        this.database  = database;
-        this.latencyMs = latencyMs;
-        this.checkedAt = checkedAt;
+    public DatabaseHealthResult(String status) {
+        this.status = status;
     }
 
     public String getStatus() {
         return status;
-    }
-
-    public String getDatabase() {
-        return database;
-    }
-
-    public long getLatencyMs() {
-        return latencyMs;
-    }
-
-    public Date getCheckedAt() {
-        return checkedAt;
     }
 }

--- a/src/main/java/com/autotune/service/health/DatabaseHealthResult.java
+++ b/src/main/java/com/autotune/service/health/DatabaseHealthResult.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.autotune.service.health;
+
+import java.util.Date;
+
+/**
+ * Immutable result of a single database liveness probe.
+ * Serialised directly to JSON by Gson in the /health response.
+ */
+public class DatabaseHealthResult {
+
+    private final String status;
+    private final String database;
+    private final long latencyMs;
+    private final Date checkedAt;
+
+    public DatabaseHealthResult(String status, String database, long latencyMs, Date checkedAt) {
+        this.status    = status;
+        this.database  = database;
+        this.latencyMs = latencyMs;
+        this.checkedAt = checkedAt;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getDatabase() {
+        return database;
+    }
+
+    public long getLatencyMs() {
+        return latencyMs;
+    }
+
+    public Date getCheckedAt() {
+        return checkedAt;
+    }
+}

--- a/src/main/java/com/autotune/service/health/DatasourceHealthChecker.java
+++ b/src/main/java/com/autotune/service/health/DatasourceHealthChecker.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.autotune.service.health;
+
+import com.autotune.common.datasource.DataSourceInfo;
+import com.autotune.common.datasource.DataSourceOperatorImpl;
+import com.autotune.common.utils.CommonUtils;
+import com.autotune.utils.KruizeConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.util.Date;
+
+/**
+ * Checks whether a single datasource is reachable and healthy.
+ *
+ * <p>Reuses {@link DataSourceOperatorImpl#getOperator(String)} for provider
+ * dispatch and the existing {@code isServiceable()} probe — no new connection
+ * or authentication code is introduced here.
+ *
+ * <p>To support a new provider in the future, add a branch in
+ * {@link #check(DataSourceInfo)} that calls the relevant operator, or
+ * split this class into an interface + implementations at that point.
+ */
+public class DatasourceHealthChecker {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DatasourceHealthChecker.class);
+
+    /**
+     * Probes the given datasource and returns a fully-populated result.
+     * Never throws — all failures are captured in the returned object.
+     */
+    public DatasourceHealthResult check(DataSourceInfo ds) {
+        String name        = ds.getName();
+        String provider    = ds.getProvider();
+        String serviceName = ds.getServiceName();
+        String namespace   = ds.getNamespace();
+        String url         = ds.getUrl() != null ? ds.getUrl().toString() : "";
+
+        long start = System.currentTimeMillis();
+        try {
+            DataSourceOperatorImpl op = DataSourceOperatorImpl.getInstance().getOperator(provider);
+            if (op == null) {
+                LOGGER.warn("No operator available for datasource provider: {}", provider);
+                return down(name, provider, serviceName, namespace, url, start,
+                        KruizeConstants.HealthConstants.Messages.NO_CHECKER_AVAILABLE);
+            }
+
+            CommonUtils.DatasourceReachabilityStatus status = op.isServiceable(ds);
+            long latencyMs = System.currentTimeMillis() - start;
+
+            if (status == CommonUtils.DatasourceReachabilityStatus.REACHABLE) {
+                return new DatasourceHealthResult(name, provider, serviceName, namespace, url,
+                        KruizeConstants.HealthConstants.ComponentStatus.UP, latencyMs,
+                        KruizeConstants.HealthConstants.Messages.CONNECTION_SUCCESSFUL, new Date());
+            }
+            LOGGER.warn("Datasource {} reported not reachable during health check", name);
+            return down(name, provider, serviceName, namespace, url, start,
+                    KruizeConstants.HealthConstants.Messages.CONNECTION_REFUSED);
+
+        } catch (UnknownHostException e) {
+            LOGGER.warn("Health check for datasource {} failed — unknown host", name);
+            return down(name, provider, serviceName, namespace, url, start,
+                    KruizeConstants.HealthConstants.Messages.UNKNOWN_HOST);
+
+        } catch (SocketTimeoutException e) {
+            LOGGER.warn("Health check for datasource {} timed out", name);
+            return down(name, provider, serviceName, namespace, url, start,
+                    KruizeConstants.HealthConstants.Messages.CONNECTION_TIMEOUT);
+
+        } catch (Exception e) {
+            // Catches auth errors (401/403 surface as IOException), SSL failures, etc.
+            // Never expose the exception message — it may contain credentials or tokens.
+            LOGGER.warn("Health check for datasource {} failed: {}", name, e.getMessage());
+            return down(name, provider, serviceName, namespace, url, start,
+                    KruizeConstants.HealthConstants.Messages.CHECK_FAILED);
+        }
+    }
+
+    private DatasourceHealthResult down(String name, String provider, String serviceName,
+                                        String namespace, String url, long startMs, String message) {
+        return new DatasourceHealthResult(name, provider, serviceName, namespace, url,
+                KruizeConstants.HealthConstants.ComponentStatus.DOWN,
+                System.currentTimeMillis() - startMs, message, new Date());
+    }
+}

--- a/src/main/java/com/autotune/service/health/DatasourceHealthChecker.java
+++ b/src/main/java/com/autotune/service/health/DatasourceHealthChecker.java
@@ -24,7 +24,6 @@ import org.slf4j.LoggerFactory;
 
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
-import java.util.Date;
 
 /**
  * Checks whether a single datasource is reachable and healthy.
@@ -42,60 +41,45 @@ public class DatasourceHealthChecker {
     private static final Logger LOGGER = LoggerFactory.getLogger(DatasourceHealthChecker.class);
 
     /**
-     * Probes the given datasource and returns a fully-populated result.
+     * Probes the given datasource and returns a health summary.
      * Never throws — all failures are captured in the returned object.
      */
     public DatasourceHealthResult check(DataSourceInfo ds) {
-        String name        = ds.getName();
-        String provider    = ds.getProvider();
-        String serviceName = ds.getServiceName();
-        String namespace   = ds.getNamespace();
-        String url         = ds.getUrl() != null ? ds.getUrl().toString() : "";
-
-        long start = System.currentTimeMillis();
+        String name     = ds.getName();
+        String provider = ds.getProvider();
         try {
             DataSourceOperatorImpl op = DataSourceOperatorImpl.getInstance().getOperator(provider);
             if (op == null) {
                 LOGGER.warn("No operator available for datasource provider: {}", provider);
-                return down(name, provider, serviceName, namespace, url, start,
-                        KruizeConstants.HealthConstants.Messages.NO_CHECKER_AVAILABLE);
+                return down(name, provider);
             }
 
             CommonUtils.DatasourceReachabilityStatus status = op.isServiceable(ds);
-            long latencyMs = System.currentTimeMillis() - start;
-
             if (status == CommonUtils.DatasourceReachabilityStatus.REACHABLE) {
-                return new DatasourceHealthResult(name, provider, serviceName, namespace, url,
-                        KruizeConstants.HealthConstants.ComponentStatus.UP, latencyMs,
-                        KruizeConstants.HealthConstants.Messages.CONNECTION_SUCCESSFUL, new Date());
+                return new DatasourceHealthResult(name, provider,
+                        KruizeConstants.HealthConstants.ComponentStatus.UP);
             }
             LOGGER.warn("Datasource {} reported not reachable during health check", name);
-            return down(name, provider, serviceName, namespace, url, start,
-                    KruizeConstants.HealthConstants.Messages.CONNECTION_REFUSED);
+            return down(name, provider);
 
         } catch (UnknownHostException e) {
             LOGGER.warn("Health check for datasource {} failed — unknown host", name);
-            return down(name, provider, serviceName, namespace, url, start,
-                    KruizeConstants.HealthConstants.Messages.UNKNOWN_HOST);
+            return down(name, provider);
 
         } catch (SocketTimeoutException e) {
             LOGGER.warn("Health check for datasource {} timed out", name);
-            return down(name, provider, serviceName, namespace, url, start,
-                    KruizeConstants.HealthConstants.Messages.CONNECTION_TIMEOUT);
+            return down(name, provider);
 
         } catch (Exception e) {
             // Catches auth errors (401/403 surface as IOException), SSL failures, etc.
             // Never expose the exception message — it may contain credentials or tokens.
             LOGGER.warn("Health check for datasource {} failed: {}", name, e.getMessage());
-            return down(name, provider, serviceName, namespace, url, start,
-                    KruizeConstants.HealthConstants.Messages.CHECK_FAILED);
+            return down(name, provider);
         }
     }
 
-    private DatasourceHealthResult down(String name, String provider, String serviceName,
-                                        String namespace, String url, long startMs, String message) {
-        return new DatasourceHealthResult(name, provider, serviceName, namespace, url,
-                KruizeConstants.HealthConstants.ComponentStatus.DOWN,
-                System.currentTimeMillis() - startMs, message, new Date());
+    private DatasourceHealthResult down(String name, String provider) {
+        return new DatasourceHealthResult(name, provider,
+                KruizeConstants.HealthConstants.ComponentStatus.DOWN);
     }
 }

--- a/src/main/java/com/autotune/service/health/DatasourceHealthResult.java
+++ b/src/main/java/com/autotune/service/health/DatasourceHealthResult.java
@@ -15,48 +15,23 @@
  *******************************************************************************/
 package com.autotune.service.health;
 
-import java.util.Date;
-
 /**
- * Immutable result of a single datasource reachability/auth probe.
+ * Immutable health summary of a single datasource.
  * Serialised directly to JSON by Gson in the /health response.
- * The {@code message} field must never contain credentials, tokens or
- * connection strings — only safe, user-facing text from
- * {@link com.autotune.utils.KruizeConstants.HealthConstants.Messages}.
  */
 public class DatasourceHealthResult {
 
     private final String name;
     private final String provider;
-    private final String serviceName;
-    private final String namespace;
-    private final String url;
     private final String status;
-    private final long   latencyMs;
-    private final String message;
-    private final Date   checkedAt;
 
-    public DatasourceHealthResult(String name, String provider, String serviceName,
-                                  String namespace, String url, String status,
-                                  long latencyMs, String message, Date checkedAt) {
-        this.name        = name;
-        this.provider    = provider;
-        this.serviceName = serviceName;
-        this.namespace   = namespace;
-        this.url         = url;
-        this.status      = status;
-        this.latencyMs   = latencyMs;
-        this.message     = message;
-        this.checkedAt   = checkedAt;
+    public DatasourceHealthResult(String name, String provider, String status) {
+        this.name     = name;
+        this.provider = provider;
+        this.status   = status;
     }
 
-    public String getName()        { return name; }
-    public String getProvider()    { return provider; }
-    public String getServiceName() { return serviceName; }
-    public String getNamespace()   { return namespace; }
-    public String getUrl()         { return url; }
-    public String getStatus()      { return status; }
-    public long   getLatencyMs()   { return latencyMs; }
-    public String getMessage()     { return message; }
-    public Date   getCheckedAt()   { return checkedAt; }
+    public String getName()     { return name; }
+    public String getProvider() { return provider; }
+    public String getStatus()   { return status; }
 }

--- a/src/main/java/com/autotune/service/health/DatasourceHealthResult.java
+++ b/src/main/java/com/autotune/service/health/DatasourceHealthResult.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.autotune.service.health;
+
+import java.util.Date;
+
+/**
+ * Immutable result of a single datasource reachability/auth probe.
+ * Serialised directly to JSON by Gson in the /health response.
+ * The {@code message} field must never contain credentials, tokens or
+ * connection strings — only safe, user-facing text from
+ * {@link com.autotune.utils.KruizeConstants.HealthConstants.Messages}.
+ */
+public class DatasourceHealthResult {
+
+    private final String name;
+    private final String provider;
+    private final String serviceName;
+    private final String namespace;
+    private final String url;
+    private final String status;
+    private final long   latencyMs;
+    private final String message;
+    private final Date   checkedAt;
+
+    public DatasourceHealthResult(String name, String provider, String serviceName,
+                                  String namespace, String url, String status,
+                                  long latencyMs, String message, Date checkedAt) {
+        this.name        = name;
+        this.provider    = provider;
+        this.serviceName = serviceName;
+        this.namespace   = namespace;
+        this.url         = url;
+        this.status      = status;
+        this.latencyMs   = latencyMs;
+        this.message     = message;
+        this.checkedAt   = checkedAt;
+    }
+
+    public String getName()        { return name; }
+    public String getProvider()    { return provider; }
+    public String getServiceName() { return serviceName; }
+    public String getNamespace()   { return namespace; }
+    public String getUrl()         { return url; }
+    public String getStatus()      { return status; }
+    public long   getLatencyMs()   { return latencyMs; }
+    public String getMessage()     { return message; }
+    public Date   getCheckedAt()   { return checkedAt; }
+}

--- a/src/main/java/com/autotune/service/health/HealthReport.java
+++ b/src/main/java/com/autotune/service/health/HealthReport.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.autotune.service.health;
+
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Top-level health response object serialised directly to JSON by Gson.
+ *
+ * <pre>
+ * {
+ *   "overallStatus": "UP | DEGRADED | DOWN",
+ *   "database":      { ... },
+ *   "datasources":   [ ... ],
+ *   "timestamp":     "..."
+ * }
+ * </pre>
+ */
+public class HealthReport {
+
+    private final String overallStatus;
+    private final DatabaseHealthResult database;
+    private final List<DatasourceHealthResult> datasources;
+    private final Date timestamp;
+
+    public HealthReport(String overallStatus,
+                        DatabaseHealthResult database,
+                        List<DatasourceHealthResult> datasources,
+                        Date timestamp) {
+        this.overallStatus = overallStatus;
+        this.database      = database;
+        this.datasources   = datasources;
+        this.timestamp     = timestamp;
+    }
+
+    public String getOverallStatus()                     { return overallStatus; }
+    public DatabaseHealthResult getDatabase()            { return database; }
+    public List<DatasourceHealthResult> getDatasources() { return datasources; }
+    public Date getTimestamp()                           { return timestamp; }
+}

--- a/src/main/java/com/autotune/service/health/KruizeHealthAggregator.java
+++ b/src/main/java/com/autotune/service/health/KruizeHealthAggregator.java
@@ -90,12 +90,8 @@ public class KruizeHealthAggregator {
                         LOGGER.warn("Unexpected error checking datasource {}: {}",
                                 ds.getName(), ex.getMessage());
                         return new DatasourceHealthResult(
-                                ds.getName(), ds.getProvider(), ds.getServiceName(),
-                                ds.getNamespace(),
-                                ds.getUrl() != null ? ds.getUrl().toString() : "",
-                                KruizeConstants.HealthConstants.ComponentStatus.DOWN, 0L,
-                                KruizeConstants.HealthConstants.Messages.CHECK_FAILED,
-                                new Date());
+                                ds.getName(), ds.getProvider(),
+                                KruizeConstants.HealthConstants.ComponentStatus.DOWN);
                     });
             futures.add(f);
         }

--- a/src/main/java/com/autotune/service/health/KruizeHealthAggregator.java
+++ b/src/main/java/com/autotune/service/health/KruizeHealthAggregator.java
@@ -82,29 +82,37 @@ public class KruizeHealthAggregator {
     }
 
     private List<DatasourceHealthResult> checkInParallel(Collection<DataSourceInfo> dataSources) {
+        List<DataSourceInfo> dataSourceList = new ArrayList<>(dataSources);
         List<CompletableFuture<DatasourceHealthResult>> futures = new ArrayList<>();
-        for (DataSourceInfo ds : dataSources) {
+        for (DataSourceInfo ds : dataSourceList) {
             CompletableFuture<DatasourceHealthResult> f = CompletableFuture
                     .supplyAsync(() -> dsChecker.check(ds), executor)
                     .exceptionally(ex -> {
                         LOGGER.warn("Unexpected error checking datasource {}: {}",
                                 ds.getName(), ex.getMessage());
-                        return new DatasourceHealthResult(
-                                ds.getName(), ds.getProvider(),
-                                KruizeConstants.HealthConstants.ComponentStatus.DOWN);
+                        return downResult(ds);
                     });
             futures.add(f);
         }
 
         List<DatasourceHealthResult> results = new ArrayList<>();
+        int index = 0;
         for (CompletableFuture<DatasourceHealthResult> f : futures) {
+            DataSourceInfo ds = dataSourceList.get(index++);
             try {
                 results.add(f.get(dsTimeoutSeconds + 1L, TimeUnit.SECONDS));
             } catch (Exception e) {
-                LOGGER.warn("Datasource health future timed out: {}", e.getMessage());
+                LOGGER.warn("Datasource health future timed out for {}: {}", ds.getName(), e.getMessage());
+                results.add(downResult(ds));
             }
         }
         return results;
+    }
+
+    private DatasourceHealthResult downResult(DataSourceInfo ds) {
+        return new DatasourceHealthResult(
+                ds.getName(), ds.getProvider(),
+                KruizeConstants.HealthConstants.ComponentStatus.DOWN);
     }
 
     private String computeOverallStatus(DatabaseHealthResult db,

--- a/src/main/java/com/autotune/service/health/KruizeHealthAggregator.java
+++ b/src/main/java/com/autotune/service/health/KruizeHealthAggregator.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.autotune.service.health;
+
+import com.autotune.common.datasource.DataSourceCollection;
+import com.autotune.common.datasource.DataSourceInfo;
+import com.autotune.utils.KruizeConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Orchestrates all health checks and produces a {@link HealthReport}.
+ *
+ * <ol>
+ *   <li>Runs the database check synchronously.</li>
+ *   <li>Fans out datasource checks in parallel so one slow datasource does not
+ *       block the rest. Each check carries an individual timeout.</li>
+ *   <li>Computes {@code overallStatus}: {@code DOWN} if DB is down,
+ *       {@code DEGRADED} if any datasource is down, {@code UP} otherwise.</li>
+ * </ol>
+ */
+public class KruizeHealthAggregator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KruizeHealthAggregator.class);
+
+    private final DatabaseHealthChecker    dbChecker;
+    private final DatasourceHealthChecker  dsChecker;
+    private final ExecutorService          executor;
+    private final int                      dsTimeoutSeconds;
+
+    /** Production constructor. */
+    public KruizeHealthAggregator() {
+        this(new DatabaseHealthChecker(),
+             new DatasourceHealthChecker(),
+             Executors.newFixedThreadPool(KruizeConstants.HealthConstants.HEALTH_CHECK_THREAD_POOL_SIZE),
+             KruizeConstants.HealthConstants.DATASOURCE_CHECK_TIMEOUT_SECONDS);
+    }
+
+    /** Testable constructor — inject mocks and a synchronous executor. */
+    KruizeHealthAggregator(DatabaseHealthChecker dbChecker,
+                           DatasourceHealthChecker dsChecker,
+                           ExecutorService executor,
+                           int dsTimeoutSeconds) {
+        this.dbChecker        = dbChecker;
+        this.dsChecker        = dsChecker;
+        this.executor         = executor;
+        this.dsTimeoutSeconds = dsTimeoutSeconds;
+    }
+
+    /** Runs all checks and returns a fully-populated report. Never throws. */
+    public HealthReport collectHealth() {
+        DatabaseHealthResult dbResult = dbChecker.check();
+
+        Collection<DataSourceInfo> allDs =
+                DataSourceCollection.getInstance().getDataSourcesCollection().values();
+        List<DatasourceHealthResult> dsResults = checkInParallel(allDs);
+
+        String overallStatus = computeOverallStatus(dbResult, dsResults);
+        return new HealthReport(overallStatus, dbResult, dsResults, new Date());
+    }
+
+    private List<DatasourceHealthResult> checkInParallel(Collection<DataSourceInfo> dataSources) {
+        List<CompletableFuture<DatasourceHealthResult>> futures = new ArrayList<>();
+        for (DataSourceInfo ds : dataSources) {
+            CompletableFuture<DatasourceHealthResult> f = CompletableFuture
+                    .supplyAsync(() -> dsChecker.check(ds), executor)
+                    .exceptionally(ex -> {
+                        LOGGER.warn("Unexpected error checking datasource {}: {}",
+                                ds.getName(), ex.getMessage());
+                        return new DatasourceHealthResult(
+                                ds.getName(), ds.getProvider(), ds.getServiceName(),
+                                ds.getNamespace(),
+                                ds.getUrl() != null ? ds.getUrl().toString() : "",
+                                KruizeConstants.HealthConstants.ComponentStatus.DOWN, 0L,
+                                KruizeConstants.HealthConstants.Messages.CHECK_FAILED,
+                                new Date());
+                    });
+            futures.add(f);
+        }
+
+        List<DatasourceHealthResult> results = new ArrayList<>();
+        for (CompletableFuture<DatasourceHealthResult> f : futures) {
+            try {
+                results.add(f.get(dsTimeoutSeconds + 1L, TimeUnit.SECONDS));
+            } catch (Exception e) {
+                LOGGER.warn("Datasource health future timed out: {}", e.getMessage());
+            }
+        }
+        return results;
+    }
+
+    private String computeOverallStatus(DatabaseHealthResult db,
+                                        List<DatasourceHealthResult> dsResults) {
+        if (KruizeConstants.HealthConstants.ComponentStatus.DOWN.equals(db.getStatus())) {
+            return KruizeConstants.HealthConstants.OverallStatus.DOWN;
+        }
+        boolean anyDown = dsResults.stream().anyMatch(
+                r -> KruizeConstants.HealthConstants.ComponentStatus.DOWN.equals(r.getStatus()));
+        return anyDown
+                ? KruizeConstants.HealthConstants.OverallStatus.DEGRADED
+                : KruizeConstants.HealthConstants.OverallStatus.UP;
+    }
+}

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -1177,4 +1177,58 @@ public class KruizeConstants {
         public static final String MESSAGE_RECEIVED_SUCCESSFULLY = "Received Input: Request_Id={}, Value={}, Partition={}, Offset={}";
 
     }
+
+    /**
+     * Constants for the /health endpoint and its sub-checkers.
+     */
+    public static final class HealthConstants {
+
+        private HealthConstants() {
+        }
+
+        /** Overall health status values returned in the JSON response. */
+        public static final class OverallStatus {
+            public static final String UP       = "UP";
+            public static final String DEGRADED = "DEGRADED";
+            public static final String DOWN     = "DOWN";
+
+            private OverallStatus() {
+            }
+        }
+
+        /** Component-level status values (database, individual datasource). */
+        public static final class ComponentStatus {
+            public static final String UP   = "UP";
+            public static final String DOWN = "DOWN";
+
+            private ComponentStatus() {
+            }
+        }
+
+        /** Safe, non-leaky messages used in datasource health results. */
+        public static final class Messages {
+            public static final String CONNECTION_SUCCESSFUL   = "Connection successful";
+            public static final String CONNECTION_TIMEOUT      = "Connection timeout";
+            public static final String AUTHENTICATION_FAILED   = "Authentication failed";
+            public static final String CONNECTION_REFUSED      = "Connection refused";
+            public static final String UNKNOWN_HOST            = "Unknown host";
+            public static final String CHECK_FAILED            = "Health check failed";
+            public static final String NO_CHECKER_AVAILABLE    = "No health checker available for this provider";
+
+            private Messages() {
+            }
+        }
+
+        /** SQL probe used by the database health checker. */
+        public static final String DB_LIVENESS_QUERY = "SELECT 1";
+
+        /** Database type label reported in the health response. */
+        public static final String DB_TYPE = "PostgreSQL";
+
+        /** Per-datasource check timeout in seconds. */
+        public static final int DATASOURCE_CHECK_TIMEOUT_SECONDS = 10;
+
+        /** Thread-pool size for parallel datasource checks. */
+        public static final int HEALTH_CHECK_THREAD_POOL_SIZE = 5;
+    }
 }

--- a/src/test/java/com/autotune/service/health/KruizeHealthAggregatorTest.java
+++ b/src/test/java/com/autotune/service/health/KruizeHealthAggregatorTest.java
@@ -225,7 +225,30 @@ class KruizeHealthAggregatorTest {
     }
 
     // -------------------------------------------------------------------------
-    // Scenario 7 — empty datasource list (explicitly empty, DB up)
+    // Scenario 7 — checker throws unexpectedly
+    // -------------------------------------------------------------------------
+    @Test
+    @DisplayName("DEGRADED — datasource checker throws unexpectedly")
+    void shouldReturnDegradedWhenDatasourceCheckerThrows() {
+        // Given
+        DataSourceInfo ds = fakeDatasource("broken-ds", "prometheus");
+        DataSourceCollection.getInstance().getDataSourcesCollection().put(ds.getName(), ds);
+
+        when(mockDbChecker.check()).thenReturn(dbUp());
+        when(mockDsChecker.check(ds)).thenThrow(new RuntimeException("boom"));
+
+        // When
+        HealthReport report = aggregator.collectHealth();
+
+        // Then
+        assertEquals(KruizeConstants.HealthConstants.OverallStatus.DEGRADED, report.getOverallStatus());
+        assertEquals(1, report.getDatasources().size());
+        assertEquals(KruizeConstants.HealthConstants.ComponentStatus.DOWN,
+                report.getDatasources().get(0).getStatus());
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 8 — empty datasource list (explicitly empty, DB up)
     // -------------------------------------------------------------------------
     @Test
     @DisplayName("UP — healthy DB, datasource list explicitly empty")
@@ -258,14 +281,12 @@ class KruizeHealthAggregatorTest {
 
     private DatabaseHealthResult dbUp() {
         return new DatabaseHealthResult(
-                KruizeConstants.HealthConstants.ComponentStatus.UP,
-                KruizeConstants.HealthConstants.DB_TYPE, 10L, new Date());
+                KruizeConstants.HealthConstants.ComponentStatus.UP);
     }
 
     private DatabaseHealthResult dbDown() {
         return new DatabaseHealthResult(
-                KruizeConstants.HealthConstants.ComponentStatus.DOWN,
-                KruizeConstants.HealthConstants.DB_TYPE, 0L, new Date());
+                KruizeConstants.HealthConstants.ComponentStatus.DOWN);
     }
 
     /**

--- a/src/test/java/com/autotune/service/health/KruizeHealthAggregatorTest.java
+++ b/src/test/java/com/autotune/service/health/KruizeHealthAggregatorTest.java
@@ -158,8 +158,7 @@ class KruizeHealthAggregatorTest {
         DataSourceCollection.getInstance().getDataSourcesCollection().put(ds2.getName(), ds2);
         // Build result objects before stubbing to avoid nested mock interactions
         DatasourceHealthResult upResult   = dsUp("prometheus-1", "prometheus");
-        DatasourceHealthResult downResult = dsDown("thanos-1", "prometheus",
-                KruizeConstants.HealthConstants.Messages.CONNECTION_REFUSED);
+        DatasourceHealthResult downResult = dsDown("thanos-1", "prometheus");
 
         when(mockDbChecker.check()).thenReturn(dbUp());
         when(mockDsChecker.check(ds1)).thenReturn(upResult);
@@ -188,8 +187,7 @@ class KruizeHealthAggregatorTest {
         // Given
         DataSourceInfo ds = fakeDatasource("prometheus-1", "prometheus");
         DataSourceCollection.getInstance().getDataSourcesCollection().put(ds.getName(), ds);
-        DatasourceHealthResult authFailResult = dsDown("prometheus-1", "prometheus",
-                KruizeConstants.HealthConstants.Messages.AUTHENTICATION_FAILED);
+        DatasourceHealthResult authFailResult = dsDown("prometheus-1", "prometheus");
 
         when(mockDbChecker.check()).thenReturn(dbUp());
         when(mockDsChecker.check(ds)).thenReturn(authFailResult);
@@ -201,10 +199,6 @@ class KruizeHealthAggregatorTest {
         assertEquals(KruizeConstants.HealthConstants.OverallStatus.DEGRADED, report.getOverallStatus());
         DatasourceHealthResult r = report.getDatasources().get(0);
         assertEquals(KruizeConstants.HealthConstants.ComponentStatus.DOWN, r.getStatus());
-        assertEquals(KruizeConstants.HealthConstants.Messages.AUTHENTICATION_FAILED, r.getMessage());
-        // Message must not contain any credential or token
-        assertFalse(r.getMessage().toLowerCase().contains("token"));
-        assertFalse(r.getMessage().toLowerCase().contains("password"));
     }
 
     // -------------------------------------------------------------------------
@@ -216,8 +210,7 @@ class KruizeHealthAggregatorTest {
         // Given
         DataSourceInfo ds = fakeDatasource("slow-ds", "prometheus");
         DataSourceCollection.getInstance().getDataSourcesCollection().put(ds.getName(), ds);
-        DatasourceHealthResult timeoutResult = dsDown("slow-ds", "prometheus",
-                KruizeConstants.HealthConstants.Messages.CONNECTION_TIMEOUT);
+        DatasourceHealthResult timeoutResult = dsDown("slow-ds", "prometheus");
 
         when(mockDbChecker.check()).thenReturn(dbUp());
         when(mockDsChecker.check(ds)).thenReturn(timeoutResult);
@@ -227,8 +220,8 @@ class KruizeHealthAggregatorTest {
 
         // Then
         assertEquals(KruizeConstants.HealthConstants.OverallStatus.DEGRADED, report.getOverallStatus());
-        assertEquals(KruizeConstants.HealthConstants.Messages.CONNECTION_TIMEOUT,
-                report.getDatasources().get(0).getMessage());
+        assertEquals(KruizeConstants.HealthConstants.ComponentStatus.DOWN,
+                report.getDatasources().get(0).getStatus());
     }
 
     // -------------------------------------------------------------------------
@@ -281,14 +274,11 @@ class KruizeHealthAggregatorTest {
      */
     private DatasourceHealthResult dsUp(String name, String provider) {
         return new DatasourceHealthResult(
-                name, provider, "svc-" + name, "monitoring", "",
-                KruizeConstants.HealthConstants.ComponentStatus.UP, 20L,
-                KruizeConstants.HealthConstants.Messages.CONNECTION_SUCCESSFUL, new Date());
+                name, provider, KruizeConstants.HealthConstants.ComponentStatus.UP);
     }
 
-    private DatasourceHealthResult dsDown(String name, String provider, String message) {
+    private DatasourceHealthResult dsDown(String name, String provider) {
         return new DatasourceHealthResult(
-                name, provider, "svc-" + name, "monitoring", "",
-                KruizeConstants.HealthConstants.ComponentStatus.DOWN, 0L, message, new Date());
+                name, provider, KruizeConstants.HealthConstants.ComponentStatus.DOWN);
     }
 }

--- a/src/test/java/com/autotune/service/health/KruizeHealthAggregatorTest.java
+++ b/src/test/java/com/autotune/service/health/KruizeHealthAggregatorTest.java
@@ -1,0 +1,294 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.autotune.service.health;
+
+import com.autotune.common.datasource.DataSourceCollection;
+import com.autotune.common.datasource.DataSourceInfo;
+import com.autotune.utils.KruizeConstants;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit Test with Mocking Template Principles
+ *
+ * 1. One class under test:
+ *    Each test class focuses on validating the behavior of KruizeHealthAggregator.
+ *
+ * 2. Mock only direct dependencies:
+ *    DatabaseHealthChecker, DatasourceHealthCheckerRegistry and DataSourceCollection
+ *    are mocked/stubbed to keep tests isolated, fast, and deterministic.
+ *
+ * 3. No static or global side effects:
+ *    The DataSourceCollection singleton is pre-populated per test and restored
+ *    via tearDown to avoid cross-test pollution.
+ *
+ * 4. Clear Given–When–Then structure.
+ *
+ * 5. Deterministic assertions.
+ */
+class KruizeHealthAggregatorTest {
+
+    private DatabaseHealthChecker   mockDbChecker;
+    private DatasourceHealthChecker mockDsChecker;
+    private ExecutorService         executor;
+    private KruizeHealthAggregator  aggregator;
+
+    // Saved reference to the real DataSourceCollection map so we can restore it
+    private HashMap<String, DataSourceInfo> originalCollectionMap;
+
+    @BeforeEach
+    void setup() throws Exception {
+        mockDbChecker = mock(DatabaseHealthChecker.class);
+        mockDsChecker = mock(DatasourceHealthChecker.class);
+        // Synchronous single-thread executor so tests are deterministic
+        executor      = Executors.newSingleThreadExecutor();
+        aggregator    = new KruizeHealthAggregator(mockDbChecker, mockDsChecker, executor, 5);
+
+        // Snapshot the current in-memory datasource map and clear it
+        originalCollectionMap = new HashMap<>(
+                DataSourceCollection.getInstance().getDataSourcesCollection());
+        DataSourceCollection.getInstance().getDataSourcesCollection().clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        executor.shutdownNow();
+        // Restore original collection state
+        DataSourceCollection.getInstance().getDataSourcesCollection().clear();
+        DataSourceCollection.getInstance().getDataSourcesCollection()
+                .putAll(originalCollectionMap);
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 1 — healthy database, no datasources configured
+    // -------------------------------------------------------------------------
+    @Test
+    @DisplayName("UP — healthy DB, no datasources configured")
+    void shouldReturnUpWhenDbHealthyAndNoDatasources() {
+        // Given
+        when(mockDbChecker.check()).thenReturn(dbUp());
+
+        // When
+        HealthReport report = aggregator.collectHealth();
+
+        // Then
+        assertEquals(KruizeConstants.HealthConstants.OverallStatus.UP, report.getOverallStatus());
+        assertEquals(KruizeConstants.HealthConstants.ComponentStatus.UP, report.getDatabase().getStatus());
+        assertTrue(report.getDatasources().isEmpty());
+        assertNotNull(report.getTimestamp());
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 2 — database DOWN
+    // -------------------------------------------------------------------------
+    @Test
+    @DisplayName("DOWN — database unreachable")
+    void shouldReturnDownWhenDatabaseIsDown() {
+        // Given
+        when(mockDbChecker.check()).thenReturn(dbDown());
+
+        // When
+        HealthReport report = aggregator.collectHealth();
+
+        // Then
+        assertEquals(KruizeConstants.HealthConstants.OverallStatus.DOWN, report.getOverallStatus());
+        assertEquals(KruizeConstants.HealthConstants.ComponentStatus.DOWN, report.getDatabase().getStatus());
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 3 — all datasources healthy
+    // -------------------------------------------------------------------------
+    @Test
+    @DisplayName("UP — healthy DB, all datasources UP")
+    void shouldReturnUpWhenAllDatasourcesHealthy() {
+        // Given
+        DataSourceInfo ds = fakeDatasource("prometheus-1", "prometheus");
+        DataSourceCollection.getInstance().getDataSourcesCollection().put(ds.getName(), ds);
+        // Build the result object before setting up the stub to avoid nested mock interaction
+        DatasourceHealthResult upResult = dsUp("prometheus-1", "prometheus");
+
+        when(mockDbChecker.check()).thenReturn(dbUp());
+        when(mockDsChecker.check(ds)).thenReturn(upResult);
+
+        // When
+        HealthReport report = aggregator.collectHealth();
+
+        // Then
+        assertEquals(KruizeConstants.HealthConstants.OverallStatus.UP, report.getOverallStatus());
+        assertEquals(1, report.getDatasources().size());
+        assertEquals(KruizeConstants.HealthConstants.ComponentStatus.UP,
+                report.getDatasources().get(0).getStatus());
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 4 — one datasource DOWN → DEGRADED
+    // -------------------------------------------------------------------------
+    @Test
+    @DisplayName("DEGRADED — healthy DB, one datasource DOWN")
+    void shouldReturnDegradedWhenOneDatasourceIsDown() {
+        // Given
+        DataSourceInfo ds1 = fakeDatasource("prometheus-1", "prometheus");
+        DataSourceInfo ds2 = fakeDatasource("thanos-1", "prometheus");
+        DataSourceCollection.getInstance().getDataSourcesCollection().put(ds1.getName(), ds1);
+        DataSourceCollection.getInstance().getDataSourcesCollection().put(ds2.getName(), ds2);
+        // Build result objects before stubbing to avoid nested mock interactions
+        DatasourceHealthResult upResult   = dsUp("prometheus-1", "prometheus");
+        DatasourceHealthResult downResult = dsDown("thanos-1", "prometheus",
+                KruizeConstants.HealthConstants.Messages.CONNECTION_REFUSED);
+
+        when(mockDbChecker.check()).thenReturn(dbUp());
+        when(mockDsChecker.check(ds1)).thenReturn(upResult);
+        when(mockDsChecker.check(ds2)).thenReturn(downResult);
+
+        // When
+        HealthReport report = aggregator.collectHealth();
+
+        // Then
+        assertEquals(KruizeConstants.HealthConstants.OverallStatus.DEGRADED, report.getOverallStatus());
+        List<DatasourceHealthResult> results = report.getDatasources();
+        assertEquals(2, results.size());
+
+        long downCount = results.stream()
+                .filter(r -> KruizeConstants.HealthConstants.ComponentStatus.DOWN.equals(r.getStatus()))
+                .count();
+        assertEquals(1, downCount);
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 5 — authentication failure mapped to correct message
+    // -------------------------------------------------------------------------
+    @Test
+    @DisplayName("DEGRADED — datasource authentication failure")
+    void shouldReportAuthFailureWithSafeMessage() {
+        // Given
+        DataSourceInfo ds = fakeDatasource("prometheus-1", "prometheus");
+        DataSourceCollection.getInstance().getDataSourcesCollection().put(ds.getName(), ds);
+        DatasourceHealthResult authFailResult = dsDown("prometheus-1", "prometheus",
+                KruizeConstants.HealthConstants.Messages.AUTHENTICATION_FAILED);
+
+        when(mockDbChecker.check()).thenReturn(dbUp());
+        when(mockDsChecker.check(ds)).thenReturn(authFailResult);
+
+        // When
+        HealthReport report = aggregator.collectHealth();
+
+        // Then
+        assertEquals(KruizeConstants.HealthConstants.OverallStatus.DEGRADED, report.getOverallStatus());
+        DatasourceHealthResult r = report.getDatasources().get(0);
+        assertEquals(KruizeConstants.HealthConstants.ComponentStatus.DOWN, r.getStatus());
+        assertEquals(KruizeConstants.HealthConstants.Messages.AUTHENTICATION_FAILED, r.getMessage());
+        // Message must not contain any credential or token
+        assertFalse(r.getMessage().toLowerCase().contains("token"));
+        assertFalse(r.getMessage().toLowerCase().contains("password"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 6 — timeout on one datasource
+    // -------------------------------------------------------------------------
+    @Test
+    @DisplayName("DEGRADED — datasource check times out")
+    void shouldReturnDegradedOnDatasourceTimeout() {
+        // Given
+        DataSourceInfo ds = fakeDatasource("slow-ds", "prometheus");
+        DataSourceCollection.getInstance().getDataSourcesCollection().put(ds.getName(), ds);
+        DatasourceHealthResult timeoutResult = dsDown("slow-ds", "prometheus",
+                KruizeConstants.HealthConstants.Messages.CONNECTION_TIMEOUT);
+
+        when(mockDbChecker.check()).thenReturn(dbUp());
+        when(mockDsChecker.check(ds)).thenReturn(timeoutResult);
+
+        // When
+        HealthReport report = aggregator.collectHealth();
+
+        // Then
+        assertEquals(KruizeConstants.HealthConstants.OverallStatus.DEGRADED, report.getOverallStatus());
+        assertEquals(KruizeConstants.HealthConstants.Messages.CONNECTION_TIMEOUT,
+                report.getDatasources().get(0).getMessage());
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 7 — empty datasource list (explicitly empty, DB up)
+    // -------------------------------------------------------------------------
+    @Test
+    @DisplayName("UP — healthy DB, datasource list explicitly empty")
+    void shouldReturnUpWithEmptyDatasourceList() {
+        // Given — collection already cleared in @BeforeEach
+        when(mockDbChecker.check()).thenReturn(dbUp());
+
+        // When
+        HealthReport report = aggregator.collectHealth();
+
+        // Then
+        assertEquals(KruizeConstants.HealthConstants.OverallStatus.UP, report.getOverallStatus());
+        assertNotNull(report.getDatasources());
+        assertTrue(report.getDatasources().isEmpty());
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private DataSourceInfo fakeDatasource(String name, String provider) {
+        DataSourceInfo ds = mock(DataSourceInfo.class);
+        when(ds.getName()).thenReturn(name);
+        when(ds.getProvider()).thenReturn(provider);
+        when(ds.getServiceName()).thenReturn("svc-" + name);
+        when(ds.getNamespace()).thenReturn("monitoring");
+        when(ds.getUrl()).thenReturn(null);
+        return ds;
+    }
+
+    private DatabaseHealthResult dbUp() {
+        return new DatabaseHealthResult(
+                KruizeConstants.HealthConstants.ComponentStatus.UP,
+                KruizeConstants.HealthConstants.DB_TYPE, 10L, new Date());
+    }
+
+    private DatabaseHealthResult dbDown() {
+        return new DatabaseHealthResult(
+                KruizeConstants.HealthConstants.ComponentStatus.DOWN,
+                KruizeConstants.HealthConstants.DB_TYPE, 0L, new Date());
+    }
+
+    /**
+     * Build a healthy DatasourceHealthResult by name/provider — avoids calling
+     * mock methods inside a thenReturn() stub, which causes UnfinishedStubbing.
+     */
+    private DatasourceHealthResult dsUp(String name, String provider) {
+        return new DatasourceHealthResult(
+                name, provider, "svc-" + name, "monitoring", "",
+                KruizeConstants.HealthConstants.ComponentStatus.UP, 20L,
+                KruizeConstants.HealthConstants.Messages.CONNECTION_SUCCESSFUL, new Date());
+    }
+
+    private DatasourceHealthResult dsDown(String name, String provider, String message) {
+        return new DatasourceHealthResult(
+                name, provider, "svc-" + name, "monitoring", "",
+                KruizeConstants.HealthConstants.ComponentStatus.DOWN, 0L, message, new Date());
+    }
+}


### PR DESCRIPTION
## Description

Please describe the issue or feature and the summary of changes made to fix this. 

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Introduce a structured JSON-based /health endpoint that reports overall service health, database status, and per-datasource health, and wire it through a new health aggregation layer.

New Features:
- Expose a JSON /health API that returns overall Kruize health, PostgreSQL status, and detailed per-datasource health metadata including latency and timestamps.

Enhancements:
- Add a dedicated health aggregation component that runs database and datasource checks (in parallel for datasources) and derives an overall UP/DEGRADED/DOWN status.
- Define centralized health-related constants, status codes, and safe user-facing messages for health reporting.
- Refine HealthService to delegate health logic to the new aggregator, set appropriate HTTP status codes (200/503), and return JSON responses instead of plain text.

Build:
- Bump the Fabric8 client library version from 7.7.0 to 7.8.0.

Tests:
- Add unit tests for the health aggregation logic covering healthy, degraded, and down scenarios, including timeout and authentication failure cases.