### PR TITLE
Merge mvp_demo changes into master for Kruize release 0.11.1

### DIFF
--- a/Dockerfile.autotune
+++ b/Dockerfile.autotune
@@ -43,7 +43,7 @@ RUN mvn -f pom.xml clean package
 COPY migrations target/bin/migrations
 
 # Create a jlinked JRE specific to the App
-RUN jlink --strip-debug --compress 2 --no-header-files --no-man-pages --module-path $AUTOTUNE_HOME/java/openjdk/jmods --add-modules java.base,java.compiler,java.desktop,java.logging,java.management,java.naming,java.security.jgss,java.sql,java.xml,jdk.compiler,jdk.httpserver,jdk.unsupported,jdk.crypto.ec --exclude-files=**java_**.properties,**J9TraceFormat**.dat,**OMRTraceFormat**.dat,**j9ddr**.dat,**public_suffix_list**.dat --output jre
+RUN jlink --strip-debug --compress 2 --no-header-files --no-man-pages --module-path $AUTOTUNE_HOME/java/openjdk/jmods --add-modules java.base,java.compiler,java.desktop,java.logging,java.management,java.naming,java.security.jgss,java.sql,java.xml,jdk.compiler,jdk.httpserver,jdk.unsupported,jdk.crypto.ec,jdk.net --exclude-files=**java_**.properties,**J9TraceFormat**.dat,**OMRTraceFormat**.dat,**j9ddr**.dat,**public_suffix_list**.dat --output jre
 
 ##########################################################
 #            Runtime Docker Image

--- a/design/KruizeLocalAPI.md
+++ b/design/KruizeLocalAPI.md
@@ -91,6 +91,10 @@ Documentation still in progress stay tuned.
     - Example Request and Response
     - Invalid Scenarios
 
+- [Recommendations API](#recommendations-api)
+    - Introduction
+    - Example Request and Response
+
 <a name="resource-analysis-terms-and-defaults"></a>
 
 ## Resource Analysis Terms and Defaults
@@ -4121,6 +4125,7 @@ The response will contain a array of JSON object with the recommendations for th
                   },
                   "monitoring_end_time": "2023-04-02T13:30:00.680Z",
                   "current": {
+                    "replicas": 7,
                     "limits": {
                       "memory": {
                         "amount": 1.048576E8,
@@ -4158,6 +4163,13 @@ The response will contain a array of JSON object with the recommendations for th
                         }
                       },
                       "monitoring_start_time": "2023-04-01T12:00:00.000Z",
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 7,
+                          "min": 7,
+                          "max": 7
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
                           "pods_count": 7,
@@ -4364,6 +4376,7 @@ When `interval_end_time` is not specified, Kruize will determine the latest time
                   },
                   "monitoring_end_time": "2023-04-02T13:30:00.680Z",
                   "current": {
+                    "replicas": 7,
                     "limits": {
                       "memory": {
                         "amount": 1.048576E8,
@@ -4401,6 +4414,13 @@ When `interval_end_time` is not specified, Kruize will determine the latest time
                         }
                       },
                       "monitoring_start_time": "2023-04-01T12:00:00.000Z",
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 7,
+                          "min": 7,
+                          "max": 7
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
                           "pods_count": 7,
@@ -5066,5 +5086,515 @@ When `interval_end_time` is not specified, Kruize will determine the latest time
 | 400              | No metrics available from `2024-01-15T00:00:00.000Z` to `2023-12-31T00:00:00.000Z`.                |
 | 400              | The gap between the interval_start_time and interval_end_time must be within a maximum of 15 days! |
 | 400              | The Start time should precede the End time!                                                        |                                           |
+| 500              | Internal Server Error                                                                              |
+
+<a name="recommendations-api"></a>
+
+### Recommendations API
+
+This is a new API endpoint introduced in the v0.11 release, which is in all respects similar to the existing `/generateRecommendations` API in local mode. The only difference is in the response: `requests` and `limits` are nested under `resources`, similar to the Kubernetes deployment spec. Other than this, the rest remains exactly the same as the other existing recommendation API endpoints.
+<hr>
+**Request**
+
+`POST /kruize/api/v1/recommendations?experiment_name=&interval_end_time=`
+`POST /kruize/api/v1/recommendations?experiment_name=&interval_end_time=&interval_start_time=`
+
+example
+`curl --location --request POST 'http://<URL>:<PORT>/kruize/api/v1/recommendations?interval_end_time=2023-01-02T00:15:00.000Z&experiment_name=temp_1'`
+
+success status code : 201
+**Response**
+The response will contain an array of JSON object with the new recommendations generated for the specified experiment.
+
+<details>
+<summary><b>Example Response Body with experiment_type as `container` </b></summary>
+
+```json
+[
+  {
+    "cluster_name": "cluster-one-division-bell",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment_5",
+        "namespace": "default_5",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "recommendations": {
+              "version": "1.0",
+              "notifications": {
+                "111000": {
+                  "type": "info",
+                  "message": "Recommendations Are Available",
+                  "code": 111000
+                }
+              },
+              "data": {
+                "2023-04-02T13:30:00.680Z": {
+                  "notifications": {
+                    "111101": {
+                      "type": "info",
+                      "message": "Short Term Recommendations Available",
+                      "code": 111101
+                    }
+                  },
+                  "monitoring_end_time": "2023-04-02T13:30:00.680Z",
+                  "current": {
+                    "replicas": 7,
+                    "resources": {
+                      "limits": {
+                        "memory": {
+                          "amount": 100.0,
+                          "format": "MiB"
+                        },
+                        "cpu": {
+                          "amount": 0.5,
+                          "format": "cores"
+                        }
+                      },
+                      "requests": {
+                        "memory": {
+                          "amount": 50.21,
+                          "format": "MiB"
+                        },
+                        "cpu": {
+                          "amount": 5.37,
+                          "format": "cores"
+                        }
+                      }
+                    }
+                  },
+                  "recommendation_terms": {
+                    "short_term": {
+                      "duration_in_hours": 24.0,
+                      "notifications": {
+                        "112101": {
+                          "type": "info",
+                          "message": "Cost Recommendations Available",
+                          "code": 112101
+                        },
+                        "112102": {
+                          "type": "info",
+                          "message": "Performance Recommendations Available",
+                          "code": 112102
+                        }
+                      },
+                      "monitoring_start_time": "2023-04-01T12:00:00.000Z",
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 7,
+                          "min": 7,
+                          "max": 7
+                        }
+                      },
+                      "recommendation_engines": {
+                        "cost": {
+                          "pods_count": 7,
+                          "confidence_level": 0.0,
+                          "config": {
+                            "resources": {
+                              "limits": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              },
+                              "requests": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "variation": {
+                            "resources": {
+                              "limits": {
+                                "memory": {
+                                  "amount": 138.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": -4.44,
+                                  "format": "cores"
+                                }
+                              },
+                              "requests": {
+                                "memory": {
+                                  "amount": 187.98999999999998,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": -4.44,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "notifications": {}
+                        },
+                        "performance": {
+                          "pods_count": 27,
+                          "confidence_level": 0.0,
+                          "config": {
+                            "resources": {
+                              "limits": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              },
+                              "requests": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "variation": {
+                            "resources": {
+                              "limits": {
+                                "memory": {
+                                  "amount": 138.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": -4.44,
+                                  "format": "cores"
+                                }
+                              },
+                              "requests": {
+                                "memory": {
+                                  "amount": 187.98999999999998,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": -4.44,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "notifications": {}
+                        }
+                      }
+                    },
+                    "medium_term": {
+                      "duration_in_hours": 33.8,
+                      "notifications": {
+                        "120001": {
+                          "type": "info",
+                          "message": "There is not enough data available to generate a recommendation.",
+                          "code": 120001
+                        }
+                      }
+                    },
+                    "long_term": {
+                      "duration_in_hours": 33.8,
+                      "notifications": {
+                        "120001": {
+                          "type": "info",
+                          "message": "There is not enough data available to generate a recommendation.",
+                          "code": 120001
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "recommendations": {
+              "version": "1.0",
+              "notifications": {
+                "120001": {
+                  "type": "info",
+                  "message": "There is not enough data available to generate a recommendation.",
+                  "code": 120001
+                }
+              },
+              "data": {}
+            }
+          }
+        ]
+      }
+    ],
+    "version": "v2.0",
+    "experiment_name": "temp_1"
+  }
+]
+```
+
+</details>
+
+<hr>
+`GET /kruize/api/v1/recommendations?experiment_name=&monitoring_end_time=&latest=`
+
+example
+`curl -H 'Accept: application/json' 'http://<URL>:<PORT>/kruize/api/v1/recommendations'`
+`curl -H 'Accept: application/json' 'http://<URL>:<PORT>/kruize/api/v1/recommendations?experiment_name=temp_1'`
+`curl -H 'Accept: application/json' 'http://<URL>:<PORT>/kruize/api/v1/recommendations?experiment_name=temp_1&latest=true'`
+success status code : 200
+
+**Response**
+<details>
+<summary><b>Example Response with experiment_type as `container` </b></summary>
+
+### Example Response
+
+```json
+[
+  {
+    "experiment_name": "experiment_1",
+    "cluster_name": "cluster-one-division-bell",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment_0",
+        "namespace": "default_0",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "recommendations": {
+              "version": "v2.0",
+              "notifications": {
+                "111000": {
+                  "type": "info",
+                  "message": "Recommendations Are Available",
+                  "code": 111000
+                }
+              },
+              "data": {
+                "2023-04-02T13:30:00.680Z": {
+                  "notifications": {
+                    "111101": {
+                      "type": "info",
+                      "message": "Short Term Recommendations Available",
+                      "code": 111101
+                    }
+                  },
+                  "monitoring_end_time": "2023-04-02T13:30:00.680Z",
+                  "current": {
+                    "replicas": 27,
+                    "resources": {
+                      "requests": {
+                        "memory": {
+                          "amount": 50.21,
+                          "format": "MiB"
+                        },
+                        "cpu": {
+                          "amount": 5.37,
+                          "format": "cores"
+                        }
+                      },
+                      "limits": {
+                        "memory": {
+                          "amount": 100.0,
+                          "format": "MiB"
+                        },
+                        "cpu": {
+                          "amount": 0.5,
+                          "format": "cores"
+                        }
+                      }
+                    }
+                  },
+                  "recommendation_terms": {
+                    "short_term": {
+                      "notifications": {
+                        "112101": {
+                          "type": "info",
+                          "message": "Cost Recommendations Available",
+                          "code": 112101
+                        },
+                        "112102": {
+                          "type": "info",
+                          "message": "Performance Recommendations Available",
+                          "code": 112102
+                        }
+                      },
+                      "monitoring_start_time": "2023-04-01T12:00:00.000Z",
+                      "duration_in_hours": 24.0,
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 27,
+                          "min": 27,
+                          "max": 27
+                        }
+                      },
+                      "recommendation_engines": {
+                        "cost": {
+                          "pods_count": 27,
+                          "confidence_level": 0.0,
+                          "config": {
+                            "resources": {
+                              "requests": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              },
+                              "limits": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "variation": {
+                            "resources": {
+                              "requests": {
+                                "memory": {
+                                  "amount": 187.98999999999998,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": -4.44,
+                                  "format": "cores"
+                                }
+                              },
+                              "limits": {
+                                "memory": {
+                                  "amount": 138.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.42999999999999994,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "notifications": {}
+                        },
+                        "performance": {
+                          "pods_count": 27,
+                          "confidence_level": 0.0,
+                          "config": {
+                            "resources": {
+                              "requests": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              },
+                              "limits": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "variation": {
+                            "resources": {
+                              "requests": {
+                                "memory": {
+                                  "amount": 187.98999999999998,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": -4.44,
+                                  "format": "cores"
+                                }
+                              },
+                              "limits": {
+                                "memory": {
+                                  "amount": 138.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.42999999999999994,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "notifications": {}
+                        }
+                      }
+                    },
+                    "medium_term": {
+                      "duration_in_hours": 143.0,
+                      "notifications": {
+                        "120001": {
+                          "type": "info",
+                          "message": "There is not enough data available to generate a recommendation.",
+                          "code": 120001
+                        }
+                      }
+                    },
+                    "long_term": {
+                      "duration_in_hours": 240.0,
+                      "notifications": {
+                        "120001": {
+                          "type": "info",
+                          "message": "There is not enough data available to generate a recommendation.",
+                          "code": 120001
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+]
+```
+
+</details>
+
+**Error Responses**
+
+| HTTP Status Code | Description                                                                                        |
+|------------------|----------------------------------------------------------------------------------------------------|
+| 400              | experiment_name is mandatory.                                                                      |
+| 400              | Given timestamp - \" 2023-011-02T00:00:00.000Z \" is not a valid timestamp format.                 |
+| 400              | Not Found: experiment_name does not exist: exp_1.                                                  |
+| 400              | The Start time should precede the End time!                                                        |
 | 500              | Internal Server Error                                                                              |
 

--- a/design/MonitoringModeAPI.md
+++ b/design/MonitoringModeAPI.md
@@ -3233,7 +3233,7 @@ Returns all the results of that experiment
                       },
                       "recommendation_engines": {
                         "cost": {
-                          "pods_count": 27,
+                          "pods_count": 0,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -3362,7 +3362,7 @@ Returns all the results of that experiment
                       },
                       "recommendation_engines": {
                         "cost": {
-                          "pods_count": 27,
+                          "pods_count": 0,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -3411,7 +3411,7 @@ Returns all the results of that experiment
                           "notifications": {}
                         },
                         "performance": {
-                          "pods_count": 27,
+                          "pods_count": 0,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -3612,7 +3612,7 @@ Returns the recommendation at a particular timestamp if it exists
                       },
                       "recommendation_engines": {
                         "cost": {
-                          "pods_count": 27,
+                          "pods_count": 0,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -3661,7 +3661,7 @@ Returns the recommendation at a particular timestamp if it exists
                           "notifications": {}
                         },
                         "performance": {
-                          "pods_count": 27,
+                          "pods_count": 0,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -5838,7 +5838,7 @@ structured and easily interpretable way for users or external systems to access 
                       },
                       "recommendation_engines": {
                         "cost": {
-                          "pods_count": 1,
+                          "pods_count": 0,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -5877,7 +5877,7 @@ structured and easily interpretable way for users or external systems to access 
                           }
                         },
                         "performance": {
-                          "pods_count": 1,
+                          "pods_count": 0,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -6018,7 +6018,7 @@ structured and easily interpretable way for users or external systems to access 
                       },
                       "recommendation_engines": {
                         "cost": {
-                          "pods_count": 1,
+                          "pods_count": 0,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -6057,7 +6057,7 @@ structured and easily interpretable way for users or external systems to access 
                           }
                         },
                         "performance": {
-                          "pods_count": 1,
+                          "pods_count": 0,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -6252,7 +6252,7 @@ structured and easily interpretable way for users or external systems to access 
                       },
                       "recommendation_engines": {
                         "cost": {
-                          "pods_count": 1,
+                          "pods_count": 0,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -6291,7 +6291,7 @@ structured and easily interpretable way for users or external systems to access 
                           }
                         },
                         "performance": {
-                          "pods_count": 1,
+                          "pods_count": 0,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {

--- a/design/MonitoringModeAPI.md
+++ b/design/MonitoringModeAPI.md
@@ -45,6 +45,11 @@ Documentation still in progress stay tuned.
     - Example Request and Response
     - Invalid Scenarios
 
+- [Recommendations API](#recommendations-api)
+    - Introduction
+    - Example Request and Response
+    - Invalid Scenarios
+
 <a name="resource-analysis-terms-and-defaults"></a>
 
 ## Resource Analysis Terms and Defaults
@@ -2070,6 +2075,7 @@ If no parameter is passed API returns all the latest recommendations available f
                   },
                   "monitoring_end_time": "2023-04-02T13:30:00.680Z",
                   "current": {
+                    "replicas": 27,
                     "requests": {
                       "memory": {
                         "amount": 50.21,
@@ -2107,6 +2113,13 @@ If no parameter is passed API returns all the latest recommendations available f
                       },
                       "monitoring_start_time": "2023-04-01T12:00:00.000Z",
                       "duration_in_hours": 24.0,
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 27,
+                          "min": 27,
+                          "max": 27
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
                           "pods_count": 27,
@@ -2269,6 +2282,7 @@ If no parameter is passed API returns all the latest recommendations available f
                   },
                   "monitoring_end_time": "2023-04-02T13:30:00.680Z",
                   "current": {
+                    "replicas": 27,
                     "requests": {
                       "memory": {
                         "amount": 50.21,
@@ -2306,6 +2320,13 @@ If no parameter is passed API returns all the latest recommendations available f
                       },
                       "monitoring_start_time": "2023-04-01T12:00:00.000Z",
                       "duration_in_hours": 24.0,
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 27,
+                          "min": 27,
+                          "max": 27
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
                           "pods_count": 27,
@@ -2920,6 +2941,7 @@ Returns the latest result of that experiment
                   },
                   "monitoring_end_time": "2023-04-02T13:30:00.680Z",
                   "current": {
+                    "replicas": 27,
                     "requests": {
                       "cpu": {
                         "amount": 5.37,
@@ -2957,6 +2979,13 @@ Returns the latest result of that experiment
                         }
                       },
                       "monitoring_start_time": "2023-04-01T12:00:00.000Z",
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 27,
+                          "min": 27,
+                          "max": 27
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
                           "pods_count": 27,
@@ -3158,6 +3187,7 @@ Returns all the results of that experiment
                   },
                   "monitoring_end_time": "2022-12-20T17:55:05.000Z",
                   "current": {
+                    "replicas": 27,
                     "requests": {
                       "memory": {
                         "amount": 490.93,
@@ -3195,9 +3225,16 @@ Returns all the results of that experiment
                           "code": 112102
                         }
                       },
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 27,
+                          "min": 27,
+                          "max": 27
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
-                          "pods_count": 0,
+                          "pods_count": 27,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -3278,6 +3315,7 @@ Returns all the results of that experiment
                     }
                   },
                   "current": {
+                    "replicas": 27,
                     "requests": {
                       "memory": {
                         "amount": 490.93,
@@ -3316,9 +3354,16 @@ Returns all the results of that experiment
                           "code": 112102
                         }
                       },
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 27,
+                          "min": 27,
+                          "max": 27
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
-                          "pods_count": 0,
+                          "pods_count": 27,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -3367,7 +3412,7 @@ Returns all the results of that experiment
                           "notifications": {}
                         },
                         "performance": {
-                          "pods_count": 0,
+                          "pods_count": 27,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -3521,6 +3566,7 @@ Returns the recommendation at a particular timestamp if it exists
                   },
                   "monitoring_end_time": "2022-12-20T17:55:05.000Z",
                   "current": {
+                    "replicas": 27,
                     "requests": {
                       "memory": {
                         "amount": 490.93,
@@ -3558,9 +3604,16 @@ Returns the recommendation at a particular timestamp if it exists
                         }
                       },
                       "monitoring_start_time": "2022-12-19T17:55:05.000Z",
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 27,
+                          "min": 27,
+                          "max": 27
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
-                          "pods_count": 0,
+                          "pods_count": 27,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -3609,7 +3662,7 @@ Returns the recommendation at a particular timestamp if it exists
                           "notifications": {}
                         },
                         "performance": {
-                          "pods_count": 0,
+                          "pods_count": 27,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -3743,6 +3796,7 @@ Returns the recommendation at a particular timestamp if it exists
                                     },
                                     "monitoring_end_time": "2024-10-04T09:16:40.000Z",
                                     "current": {
+                                        "replicas": 1,
                                         "limits": {
                                             "cpu": {
                                                 "amount": 2.0,
@@ -3780,6 +3834,13 @@ Returns the recommendation at a particular timestamp if it exists
                                                 }
                                             },
                                             "monitoring_start_time": "2024-10-03T09:16:40.000Z",
+                                            "metrics_info": {
+                                                "pod_count": {
+                                                    "avg": 1,
+                                                    "min": 1,
+                                                    "max": 1
+                                                }
+                                            },
                                             "recommendation_engines": {
                                                 "cost": {
                                                     "pods_count": 1,
@@ -3981,6 +4042,13 @@ Returns the recommendation at a particular timestamp if it exists
                                                 }
                                             },
                                             "monitoring_start_time": "2024-09-27T09:16:40.000Z",
+                                            "metrics_info": {
+                                                "pod_count": {
+                                                    "avg": 1,
+                                                    "min": 1,
+                                                    "max": 1
+                                                }
+                                            },
                                             "recommendation_engines": {
                                                 "cost": {
                                                     "pods_count": 1,
@@ -4325,6 +4393,7 @@ The response will contain an array of JSON object with the updated recommendatio
                   },
                   "monitoring_end_time": "2023-04-02T13:30:00.680Z",
                   "current": {
+                    "replicas": 7,
                     "limits": {
                       "memory": {
                         "amount": 100.0,
@@ -4362,6 +4431,13 @@ The response will contain an array of JSON object with the updated recommendatio
                         }
                       },
                       "monitoring_start_time": "2023-04-01T12:00:00.000Z",
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 7,
+                          "min": 7,
+                          "max": 7
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
                           "pods_count": 7,
@@ -4806,6 +4882,7 @@ structured and easily interpretable way for users or external systems to access 
                   },
                   "monitoring_end_time": "2023-01-21T00:00:00.000Z",
                   "current": {
+                    "replicas": 7,
                     "requests": {
                       "memory": {
                         "amount": 50.21,
@@ -4843,6 +4920,13 @@ structured and easily interpretable way for users or external systems to access 
                         }
                       },
                       "monitoring_start_time": "2023-01-20T00:00:00.000Z",
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 7,
+                          "min": 7,
+                          "max": 7
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
                           "pods_count": 7,
@@ -5036,6 +5120,13 @@ structured and easily interpretable way for users or external systems to access 
                         }
                       },
                       "monitoring_start_time": "2023-01-14T00:00:00.000Z",
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 7,
+                          "min": 7,
+                          "max": 7
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
                           "pods_count": 7,
@@ -5283,6 +5374,13 @@ structured and easily interpretable way for users or external systems to access 
                         }
                       },
                       "monitoring_start_time": "2023-01-06T00:00:00.000Z",
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 7,
+                          "min": 7,
+                          "max": 7
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
                           "pods_count": 7,
@@ -5702,6 +5800,7 @@ structured and easily interpretable way for users or external systems to access 
                   },
                   "monitoring_end_time": "2023-01-21T00:00:00.000Z",
                   "current": {
+                    "replicas": 1,
                     "requests": {
                       "memory": {
                         "amount": 50.21,
@@ -5731,9 +5830,16 @@ structured and easily interpretable way for users or external systems to access 
                         }
                       },
                       "monitoring_start_time": "2023-01-20T00:00:00.000Z",
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 1,
+                          "min": 1,
+                          "max": 1
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
-                          "pods_count": 0,
+                          "pods_count": 1,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -5772,7 +5878,7 @@ structured and easily interpretable way for users or external systems to access 
                           }
                         },
                         "performance": {
-                          "pods_count": 0,
+                          "pods_count": 1,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -5904,9 +6010,16 @@ structured and easily interpretable way for users or external systems to access 
                         }
                       },
                       "monitoring_start_time": "2023-01-14T00:00:00.000Z",
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 1,
+                          "min": 1,
+                          "max": 1
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
-                          "pods_count": 0,
+                          "pods_count": 1,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -5945,7 +6058,7 @@ structured and easily interpretable way for users or external systems to access 
                           }
                         },
                         "performance": {
-                          "pods_count": 0,
+                          "pods_count": 1,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -6131,9 +6244,16 @@ structured and easily interpretable way for users or external systems to access 
                         }
                       },
                       "monitoring_start_time": "2023-01-06T00:00:00.000Z",
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 1,
+                          "min": 1,
+                          "max": 1
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
-                          "pods_count": 0,
+                          "pods_count": 1,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -6172,7 +6292,7 @@ structured and easily interpretable way for users or external systems to access 
                           }
                         },
                         "performance": {
-                          "pods_count": 0,
+                          "pods_count": 1,
                           "confidence_level": 0.0,
                           "config": {
                             "requests": {
@@ -6589,6 +6709,7 @@ The response will contain a array of JSON object with the recommendations for th
                   },
                   "monitoring_end_time": "2023-04-02T13:30:00.680Z",
                   "current": {
+                    "replicas": 7,
                     "limits": {
                       "memory": {
                         "amount": 100.0,
@@ -6626,6 +6747,13 @@ The response will contain a array of JSON object with the recommendations for th
                         }
                       },
                       "monitoring_start_time": "2023-04-01T12:00:00.000Z",
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 7,
+                          "min": 7,
+                          "max": 7
+                        }
+                      },
                       "recommendation_engines": {
                         "cost": {
                           "pods_count": 7,
@@ -6792,6 +6920,724 @@ The response will contain a array of JSON object with the recommendations for th
 | 400              | The Start time should precede the End time!                                                        |                                           |
 | 500              | Internal Server Error                                                                              |
 
+### Recommendations API
+
+This is new API endpoint introduced in v0.11 release which is in all aspects similar to existing APIs 
+/updateRecommendations, /listRecommendations (in remote mode) and /generateRecommendations (in local mode). Which means the only difference is 
+in response, `requests` and `limits` are nested under `resources` similar to k8s deployment spec. Other than this, rest 
+all remains exactly same as other existing recommendation API endpoints.
+<hr>
+**Request**
+
+`POST /kruize/api/v1/recommendations?experiment_name=&interval_end_time=`
+`POST /kruize/api/v1/recommendations?experiment_name=&interval_end_time=&interval_start_time=`
+
+example
+`curl --location --request POST 'http://127.0.0.1:8080/kruize/api/v1/recommendations?interval_end_time=2023-01-02T00:15:00.000Z&experiment_name=temp_1'`
+
+success status code : 201
+**Response**
+The response will contain an array of JSON object with the new recommendations generated for the specified experiment.
+
+<details>
+<summary><b>Example Response Body with experiment_type as `container` </b></summary>
+
+```json
+[
+  {
+    "cluster_name": "cluster-one-division-bell",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment_5",
+        "namespace": "default_5",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "recommendations": {
+              "version": "1.0",
+              "notifications": {
+                "111000": {
+                  "type": "info",
+                  "message": "Recommendations Are Available",
+                  "code": 111000
+                }
+              },
+              "data": {
+                "2023-04-02T13:30:00.680Z": {
+                  "notifications": {
+                    "111101": {
+                      "type": "info",
+                      "message": "Short Term Recommendations Available",
+                      "code": 111101
+                    }
+                  },
+                  "monitoring_end_time": "2023-04-02T13:30:00.680Z",
+                  "current": {
+                    "replicas": 7,
+                    "resources": {
+                      "limits": {
+                        "memory": {
+                          "amount": 100.0,
+                          "format": "MiB"
+                        },
+                        "cpu": {
+                          "amount": 0.5,
+                          "format": "cores"
+                        }
+                      },
+                      "requests": {
+                        "memory": {
+                          "amount": 50.21,
+                          "format": "MiB"
+                        },
+                        "cpu": {
+                          "amount": 5.37,
+                          "format": "cores"
+                        }
+                      }
+                    }
+                  },
+                  "recommendation_terms": {
+                    "short_term": {
+                      "duration_in_hours": 24.0,
+                      "notifications": {
+                        "112101": {
+                          "type": "info",
+                          "message": "Cost Recommendations Available",
+                          "code": 112101
+                        },
+                        "112102": {
+                          "type": "info",
+                          "message": "Performance Recommendations Available",
+                          "code": 112102
+                        }
+                      },
+                      "monitoring_start_time": "2023-04-01T12:00:00.000Z",
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 7,
+                          "min": 7,
+                          "max": 7
+                        }
+                      },
+                      "recommendation_engines": {
+                        "cost": {
+                          "pods_count": 7,
+                          "confidence_level": 0.0,
+                          "config": {
+                            "resources": {
+                              "limits": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              },
+                              "requests": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "variation": {
+                            "resources": {
+                              "limits": {
+                                "memory": {
+                                  "amount": 138.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": -4.44,
+                                  "format": "cores"
+                                }
+                              },
+                              "requests": {
+                                "memory": {
+                                  "amount": 187.98999999999998,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": -4.44,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "notifications": {}
+                        },
+                        "performance": {
+                          "pods_count": 27,
+                          "confidence_level": 0.0,
+                          "config": {
+                            "resources": {
+                              "limits": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              },
+                              "requests": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "variation": {
+                            "resources": {
+                              "limits": {
+                                "memory": {
+                                  "amount": 138.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": -4.44,
+                                  "format": "cores"
+                                }
+                              },
+                              "requests": {
+                                "memory": {
+                                  "amount": 187.98999999999998,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": -4.44,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "notifications": {}
+                        }
+                      }
+                    },
+                    "medium_term": {
+                      "duration_in_hours": 33.8,
+                      "notifications": {
+                        "120001": {
+                          "type": "info",
+                          "message": "There is not enough data available to generate a recommendation.",
+                          "code": 120001
+                        }
+                      }
+                    },
+                    "long_term": {
+                      "duration_in_hours": 33.8,
+                      "notifications": {
+                        "120001": {
+                          "type": "info",
+                          "message": "There is not enough data available to generate a recommendation.",
+                          "code": 120001
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "container_image_name": "kruize/tfb-db:1.15",
+            "container_name": "tfb-server-0",
+            "recommendations": {
+              "version": "1.0",
+              "notifications": {
+                "120001": {
+                  "type": "info",
+                  "message": "There is not enough data available to generate a recommendation.",
+                  "code": 120001
+                }
+              },
+              "data": {}
+            }
+          }
+        ]
+      }
+    ],
+    "version": "v2.0",
+    "experiment_name": "temp_1"
+  }
+]
+```
+
+</details>
+
+<hr>
+`GET /kruize/api/v1/recommendations?experiment_name=&monitoring_end_time=&latest=`
+
+example
+`curl -H 'Accept: application/json' 'http://127.0.0.1:8080/kruize/api/v1/recommendations'`
+`curl -H 'Accept: application/json' 'http://127.0.0.1:8080/kruize/api/v1/recommendations?experiment_name=temp_1'`
+`curl -H 'Accept: application/json' 'http://127.0.0.1:8080/kruize/api/v1/recommendations?experiment_name=temp_1&latest=true'`
+success status code : 200
+
+**Response**
+<details>
+<summary><b>Example Response with experiment_type as `container` </b></summary>
+
+### Example Response
+
+```json
+[
+  {
+    "experiment_name": "experiment_1",
+    "cluster_name": "cluster-one-division-bell",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment_0",
+        "namespace": "default_0",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "recommendations": {
+              "version": "v2.0",
+              "notifications": {
+                "111000": {
+                  "type": "info",
+                  "message": "Recommendations Are Available",
+                  "code": 111000
+                }
+              },
+              "data": {
+                "2023-04-02T13:30:00.680Z": {
+                  "notifications": {
+                    "111101": {
+                      "type": "info",
+                      "message": "Short Term Recommendations Available",
+                      "code": 111101
+                    }
+                  },
+                  "monitoring_end_time": "2023-04-02T13:30:00.680Z",
+                  "current": {
+                    "replicas": 27,
+                    "resources": {
+                      "requests": {
+                        "memory": {
+                          "amount": 50.21,
+                          "format": "MiB"
+                        },
+                        "cpu": {
+                          "amount": 5.37,
+                          "format": "cores"
+                        }
+                      },
+                      "limits": {
+                        "memory": {
+                          "amount": 100.0,
+                          "format": "MiB"
+                        },
+                        "cpu": {
+                          "amount": 0.5,
+                          "format": "cores"
+                        }
+                      }
+                    }
+                  },
+                  "recommendation_terms": {
+                    "short_term": {
+                      "notifications": {
+                        "112101": {
+                          "type": "info",
+                          "message": "Cost Recommendations Available",
+                          "code": 112101
+                        },
+                        "112102": {
+                          "type": "info",
+                          "message": "Performance Recommendations Available",
+                          "code": 112102
+                        }
+                      },
+                      "monitoring_start_time": "2023-04-01T12:00:00.000Z",
+                      "duration_in_hours": 24.0,
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 7,
+                          "min": 7,
+                          "max": 7
+                        }
+                      },
+                      "recommendation_engines": {
+                        "cost": {
+                          "pods_count": 27,
+                          "confidence_level": 0.0,
+                          "config": {
+                            "resources": {
+                              "requests": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              },
+                              "limits": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "variation": {
+                            "resources": {
+                              "requests": {
+                                "memory": {
+                                  "amount": 187.98999999999998,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": -4.44,
+                                  "format": "cores"
+                                }
+                              },
+                              "limits": {
+                                "memory": {
+                                  "amount": 138.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.42999999999999994,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "notifications": {}
+                        },
+                        "performance": {
+                          "pods_count": 27,
+                          "confidence_level": 0.0,
+                          "config": {
+                            "resources": {
+                              "requests": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              },
+                              "limits": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "variation": {
+                            "resources": {
+                              "requests": {
+                                "memory": {
+                                  "amount": 187.98999999999998,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": -4.44,
+                                  "format": "cores"
+                                }
+                              },
+                              "limits": {
+                                "memory": {
+                                  "amount": 138.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.42999999999999994,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "notifications": {}
+                        }
+                      }
+                    },
+                    "medium_term": {
+                      "duration_in_hours": 143.0,
+                      "notifications": {
+                        "120001": {
+                          "type": "info",
+                          "message": "There is not enough data available to generate a recommendation.",
+                          "code": 120001
+                        }
+                      }
+                    },
+                    "long_term": {
+                      "duration_in_hours": 240.0,
+                      "notifications": {
+                        "120001": {
+                          "type": "info",
+                          "message": "There is not enough data available to generate a recommendation.",
+                          "code": 120001
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "experiment_name": "experiment_2",
+    "cluster_name": "cluster-one-division-bell",
+    "kubernetes_objects": [
+      {
+        "type": "deployment",
+        "name": "tfb-qrh-deployment_2",
+        "namespace": "default_2",
+        "containers": [
+          {
+            "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+            "container_name": "tfb-server-1",
+            "recommendations": {
+              "version": "v2.0",
+              "notifications": {
+                "111000": {
+                  "type": "info",
+                  "message": "Recommendations Are Available",
+                  "code": 111000
+                }
+              },
+              "data": {
+                "2023-04-02T13:30:00.680Z": {
+                  "notifications": {
+                    "111101": {
+                      "type": "info",
+                      "message": "Short Term Recommendations Available",
+                      "code": 111101
+                    }
+                  },
+                  "monitoring_end_time": "2023-04-02T13:30:00.680Z",
+                  "current": {
+                    "replicas": 27,
+                    "resources": {
+                      "requests": {
+                        "memory": {
+                          "amount": 50.21,
+                          "format": "MiB"
+                        },
+                        "cpu": {
+                          "amount": 5.37,
+                          "format": "cores"
+                        }
+                      },
+                      "limits": {
+                        "memory": {
+                          "amount": 100.0,
+                          "format": "MiB"
+                        },
+                        "cpu": {
+                          "amount": 0.5,
+                          "format": "cores"
+                        }
+                      }
+                    }
+                  },
+                  "recommendation_terms": {
+                    "short_term": {
+                      "notifications": {
+                        "112101": {
+                          "type": "info",
+                          "message": "Cost Recommendations Available",
+                          "code": 112101
+                        },
+                        "112102": {
+                          "type": "info",
+                          "message": "Performance Recommendations Available",
+                          "code": 112102
+                        }
+                      },
+                      "monitoring_start_time": "2023-04-01T12:00:00.000Z",
+                      "duration_in_hours": 24.0,
+                      "metrics_info": {
+                        "pod_count": {
+                          "avg": 7,
+                          "min": 7,
+                          "max": 7
+                        }
+                      },
+                      "recommendation_engines": {
+                        "cost": {
+                          "pods_count": 27,
+                          "confidence_level": 0.0,
+                          "config": {
+                            "resources": {
+                              "requests": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              },
+                              "limits": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "variation": {
+                            "resources": {
+                              "requests": {
+                                "memory": {
+                                  "amount": 187.98999999999998,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": -4.44,
+                                  "format": "cores"
+                                }
+                              },
+                              "limits": {
+                                "memory": {
+                                  "amount": 138.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.42999999999999994,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "notifications": {}
+                        },
+                        "performance": {
+                          "pods_count": 27,
+                          "confidence_level": 0.0,
+                          "config": {
+                            "resources": {
+                              "requests": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              },
+                              "limits": {
+                                "memory": {
+                                  "amount": 238.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.9299999999999999,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "variation": {
+                            "resources": {
+                              "requests": {
+                                "memory": {
+                                  "amount": 187.98999999999998,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": -4.44,
+                                  "format": "cores"
+                                }
+                              },
+                              "limits": {
+                                "memory": {
+                                  "amount": 138.2,
+                                  "format": "MiB"
+                                },
+                                "cpu": {
+                                  "amount": 0.42999999999999994,
+                                  "format": "cores"
+                                }
+                              }
+                            }
+                          },
+                          "notifications": {}
+                        }
+                      }
+                    },
+                    "medium_term": {
+                      "duration_in_hours": 143.0,
+                      "notifications": {
+                        "120001": {
+                          "type": "info",
+                          "message": "There is not enough data available to generate a recommendation.",
+                          "code": 120001
+                        }
+                      }
+                    },
+                    "long_term": {
+                      "duration_in_hours": 240.0,
+                      "notifications": {
+                        "120001": {
+                          "type": "info",
+                          "message": "There is not enough data available to generate a recommendation.",
+                          "code": 120001
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+]
+```
+
+</details>
+<hr>
 
 ## Implementing Retry Mechanism for Kruize API Consumers
 

--- a/design/MonitoringModeAPI.md
+++ b/design/MonitoringModeAPI.md
@@ -6921,10 +6921,7 @@ The response will contain a array of JSON object with the recommendations for th
 
 ### Recommendations API
 
-This is new API endpoint introduced in v0.11 release which is in all aspects similar to existing APIs 
-/updateRecommendations, /listRecommendations (in remote mode) and /generateRecommendations (in local mode). Which means the only difference is 
-in response, `requests` and `limits` are nested under `resources` similar to k8s deployment spec. Other than this, rest 
-all remains exactly same as other existing recommendation API endpoints.
+This is a new API endpoint introduced in the v0.11 release, which is in all respects similar to the existing APIs /updateRecommendations, /listRecommendations (in remote mode), and /generateRecommendations (in local mode). The only difference is in the response: `requests` and `limits` are nested under `resources`, similar to the Kubernetes deployment spec. Other than this, the rest remains exactly the same as the other existing recommendation API endpoints.
 <hr>
 **Request**
 

--- a/design/MonitoringModeAPI.md
+++ b/design/MonitoringModeAPI.md
@@ -48,7 +48,6 @@ Documentation still in progress stay tuned.
 - [Recommendations API](#recommendations-api)
     - Introduction
     - Example Request and Response
-    - Invalid Scenarios
 
 <a name="resource-analysis-terms-and-defaults"></a>
 

--- a/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
@@ -92,7 +92,7 @@ spec:
               done
       containers:
         - name: kruize
-          image: quay.io/kruize/autotune_operator:0.11
+          image: quay.io/kruize/autotune_operator:0.11.1
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume

--- a/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
@@ -120,7 +120,7 @@ spec:
               done
       containers:
         - name: kruize
-          image: quay.io/kruize/autotune_operator:0.11
+          image: quay.io/kruize/autotune_operator:0.11.1
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume

--- a/manifests/crc/default-db-included-installation/aks/kruize-crc-aks.yaml
+++ b/manifests/crc/default-db-included-installation/aks/kruize-crc-aks.yaml
@@ -156,7 +156,7 @@ spec:
     spec:
       containers:
         - name: kruize
-          image: quay.io/kruize/autotune_operator:0.11
+          image: quay.io/kruize/autotune_operator:0.11.1
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume
@@ -221,7 +221,7 @@ spec:
         spec:
           containers:
             - name: kruizecronjob
-              image: quay.io/kruize/autotune_operator:0.11
+              image: quay.io/kruize/autotune_operator:0.11.1
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume
@@ -356,7 +356,7 @@ spec:
         spec:
           containers:
             - name: kruizedeletejob
-              image: quay.io/kruize/autotune_operator:0.11
+              image: quay.io/kruize/autotune_operator:0.11.1
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume

--- a/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
@@ -285,7 +285,7 @@ spec:
               done
       containers:
         - name: kruize
-          image: quay.io/kruize/autotune_operator:0.11
+          image: quay.io/kruize/autotune_operator:0.11.1
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume
@@ -358,7 +358,7 @@ spec:
         spec:
           containers:
             - name: kruizecronjob
-              image: quay.io/kruize/autotune_operator:0.11
+              image: quay.io/kruize/autotune_operator:0.11.1
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume
@@ -493,7 +493,7 @@ spec:
         spec:
           containers:
             - name: kruizedeletejob
-              image: quay.io/kruize/autotune_operator:0.11
+              image: quay.io/kruize/autotune_operator:0.11.1
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume

--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -363,7 +363,7 @@ spec:
               done
       containers:
         - name: kruize
-          image: quay.io/kruize/autotune_operator:0.11
+          image: quay.io/kruize/autotune_operator:0.11.1
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume
@@ -443,7 +443,7 @@ spec:
         spec:
           containers:
             - name: kruizecronjob
-              image: quay.io/kruize/autotune_operator:0.11
+              image: quay.io/kruize/autotune_operator:0.11.1
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume
@@ -484,7 +484,7 @@ spec:
         spec:
           containers:
             - name: kruizedeletejob
-              image: quay.io/kruize/autotune_operator:0.11
+              image: quay.io/kruize/autotune_operator:0.11.1
               imagePullPolicy: Always
               volumeMounts:
                 - name: config-volume

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.autotune</groupId>
     <artifactId>autotune</artifactId>
-    <version>0.11</version>
+    <version>0.11.1</version>
     <properties>
         <fabric8-version>7.8.0</fabric8-version>
         <org-json-version>20260522</org-json-version>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>autotune</artifactId>
     <version>0.11</version>
     <properties>
-        <fabric8-version>7.7.0</fabric8-version>
+        <fabric8-version>7.8.0</fabric8-version>
         <org-json-version>20260522</org-json-version>
         <jetty-version>12.1.7</jetty-version>
         <log4j-version>2.26.0</log4j-version>

--- a/src/main/java/com/autotune/utils/CloudWatchAppender.java
+++ b/src/main/java/com/autotune/utils/CloudWatchAppender.java
@@ -109,7 +109,8 @@ public class CloudWatchAppender extends AbstractAppender {
                 LoggerConfig loggerConfig = config.getLoggerConfig("com.autotune");
                 loggerConfig.addAppender(appender, level, filter);
                 context.updateLoggers(config);
-                LOGGER.debug("Enabled CloudWatch logs");
+                LOGGER.info("CloudWatch logging enabled — region: {}, log group: {}, log stream: {}, log level: {}",
+                        cloudwatch_logs_region, cw_logs_log_group, cw_logs_log_stream, cw_logs_log_level_uc);
 
             } catch (Exception e) {
                 LOGGER.error(e.getMessage());

--- a/src/test/java/com/autotune/utils/CloudWatchAppenderTest.java
+++ b/src/test/java/com/autotune/utils/CloudWatchAppenderTest.java
@@ -1,0 +1,259 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Red Hat, IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.autotune.utils;
+
+import com.autotune.operator.KruizeDeploymentInfo;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link CloudWatchAppender#configureLoggerForCloudWatchLog()}.
+ *
+ * Covers three scenarios:
+ *
+ * 1. CREDENTIALS ABSENT (simulates test/dev cluster — why the bug was hidden)
+ *    When credentials are null or empty, the method short-circuits at the guard
+ *    on line 76 of CloudWatchAppender.java.  The AWS SDK is never touched, so
+ *    neither jdk.net nor Apache HC5 are loaded.  No exception, no appender.
+ *
+ * 2. NEGATIVE — reproduces the production crash (simulates the broken jlink JRE)
+ *    Directly attempts to load {@code jdk.net.Sockets} via Class.forName() on a
+ *    ClassLoader that has the jdk.net module forcibly hidden, reproducing the
+ *    exact {@code NoClassDefFoundError: jdk/net/Sockets} seen in the pod logs.
+ *    This is the automated proof of the failure mode WITHOUT the Dockerfile fix.
+ *
+ * 3. POSITIVE — verifies the fix (jdk.net present in the running JRE)
+ *    Asserts that {@code jdk.net.Sockets} IS loadable in the current JRE and
+ *    that {@code configureLoggerForCloudWatchLog()} completes without any
+ *    class-loading error when credentials are present.
+ *    This test passes only when {@code ,jdk.net} is included in the
+ *    {@code jlink --add-modules} list in Dockerfile.autotune.
+ */
+class CloudWatchAppenderTest {
+
+    // --- saved static state -------------------------------------------------
+
+    private String savedAccessKeyId;
+    private String savedSecretAccessKey;
+    private String savedRegion;
+    private String savedLogGroup;
+    private String savedLogStream;
+    private String savedLogLevel;
+
+    // --- lifecycle ----------------------------------------------------------
+
+    @BeforeEach
+    void saveDeploymentInfo() {
+        savedAccessKeyId     = KruizeDeploymentInfo.cloudwatch_logs_access_key_id;
+        savedSecretAccessKey = KruizeDeploymentInfo.cloudwatch_logs_secret_access_key;
+        savedRegion          = KruizeDeploymentInfo.cloudwatch_logs_region;
+        savedLogGroup        = KruizeDeploymentInfo.cloudwatch_logs_log_group;
+        savedLogStream       = KruizeDeploymentInfo.cloudwatch_logs_log_stream;
+        savedLogLevel        = KruizeDeploymentInfo.cloudwatch_logs_log_level;
+    }
+
+    @AfterEach
+    void restoreDeploymentInfo() {
+        KruizeDeploymentInfo.cloudwatch_logs_access_key_id     = savedAccessKeyId;
+        KruizeDeploymentInfo.cloudwatch_logs_secret_access_key = savedSecretAccessKey;
+        KruizeDeploymentInfo.cloudwatch_logs_region            = savedRegion;
+        KruizeDeploymentInfo.cloudwatch_logs_log_group         = savedLogGroup;
+        KruizeDeploymentInfo.cloudwatch_logs_log_stream        = savedLogStream;
+        KruizeDeploymentInfo.cloudwatch_logs_log_level         = savedLogLevel;
+    }
+
+    // =========================================================================
+    // 1. CREDENTIALS ABSENT — simulates test/dev cluster
+    // =========================================================================
+
+    @Test
+    @DisplayName("No appender registered when all credentials are null")
+    void shouldSkipConfigurationWhenAllCredentialsAreNull() {
+        // Given – no CloudWatch credentials (mirrors test cluster config)
+        KruizeDeploymentInfo.cloudwatch_logs_access_key_id     = null;
+        KruizeDeploymentInfo.cloudwatch_logs_secret_access_key = null;
+        KruizeDeploymentInfo.cloudwatch_logs_region            = null;
+
+        // When – should not throw and should not register any appender
+        assertDoesNotThrow(CloudWatchAppender::configureLoggerForCloudWatchLog);
+
+        // Then – cloudwatchRootAppender must NOT be present in the log4j config
+        assertFalse(
+                cloudWatchAppenderRegistered(),
+                "CloudWatch appender must not be registered when credentials are absent"
+        );
+    }
+
+    @Test
+    @DisplayName("No appender registered when credentials are empty strings")
+    void shouldSkipConfigurationWhenCredentialsAreEmpty() {
+        // Given
+        KruizeDeploymentInfo.cloudwatch_logs_access_key_id     = "";
+        KruizeDeploymentInfo.cloudwatch_logs_secret_access_key = "";
+        KruizeDeploymentInfo.cloudwatch_logs_region            = "";
+
+        // When
+        assertDoesNotThrow(CloudWatchAppender::configureLoggerForCloudWatchLog);
+
+        // Then
+        assertFalse(
+                cloudWatchAppenderRegistered(),
+                "CloudWatch appender must not be registered when credentials are empty"
+        );
+    }
+
+    @Test
+    @DisplayName("No appender registered when only access key is missing")
+    void shouldSkipConfigurationWhenAccessKeyIdIsMissing() {
+        // Given – secret + region present but access key absent
+        KruizeDeploymentInfo.cloudwatch_logs_access_key_id     = null;
+        KruizeDeploymentInfo.cloudwatch_logs_secret_access_key = "dummy-secret";
+        KruizeDeploymentInfo.cloudwatch_logs_region            = "us-east-1";
+
+        // When
+        assertDoesNotThrow(CloudWatchAppender::configureLoggerForCloudWatchLog);
+
+        // Then
+        assertFalse(
+                cloudWatchAppenderRegistered(),
+                "CloudWatch appender must not be registered when access key id is missing"
+        );
+    }
+
+    // =========================================================================
+    // 2. NEGATIVE
+    //
+    //    The pod log showed:
+    //      Exception in thread "main" java.lang.NoClassDefFoundError: jdk/net/Sockets
+    //        at DefaultHttpClientConnectionOperator.<clinit>
+    //        at Apache5HttpClient.createClient
+    //        at CloudWatchAppender.configureLoggerForCloudWatchLog
+    //        at Autotune.main
+    //      Caused by: java.lang.ClassNotFoundException: jdk.net.Sockets
+    //
+    //    The crash happens because the jlink command in Dockerfile.autotune
+    //    did NOT include ,jdk.net in --add-modules, so the stripped JRE
+    //    shipped inside the container image was missing jdk.net.Sockets.
+    //
+    //    Note: it is not possible to reproduce the NoClassDefFoundError
+    //    in-process on a full JDK — JPMS resolves named-module classes
+    //    (jdk.net.*) directly from the module layer, bypassing the classloader
+    //    hierarchy, so a custom excluding ClassLoader has no effect.
+    //    The real failure only occurs inside the stripped jlink JRE built
+    //    without ,jdk.net.  The negative test below therefore asserts the
+    //    *precondition* of the crash: the jdk.net module is absent.
+    //    Run this test inside the container built WITHOUT the Dockerfile fix
+    //    to see it fail.
+    // =========================================================================
+
+    @Test
+    @DisplayName("NEGATIVE: jdk.net module absent → jdk.net.Sockets not loadable")
+    void jdkNetSocketsNotLoadableWhenModuleAbsent() {
+        /*
+         *
+         * This test asserts the precondition :
+         *   the jdk.net module must NOT be absent from the JRE.
+         *
+         * On a developer machine (full JDK) jdk.net is always present,
+         * so this test passes unconditionally in local development.
+         *
+         * Inside the container image built from Dockerfile.autotune
+         * WITHOUT the fix (no ,jdk.net in --add-modules line 46):
+         *   ModuleLayer.boot().findModule("jdk.net") → empty Optional
+         *   Class.forName("jdk.net.Sockets")         → ClassNotFoundException
+         *
+         * The assertFalse below then FAILS, printing exactly why.
+         */
+        boolean jdkNetModuleAbsent = ModuleLayer.boot().findModule("jdk.net").isEmpty();
+
+        assertFalse(
+                jdkNetModuleAbsent,
+                "The 'jdk.net' module is absent from " +
+                "this JRE. causing:\n" +
+                "  java.lang.NoClassDefFoundError: jdk/net/Sockets\n" +
+                "    at DefaultHttpClientConnectionOperator.<clinit>\n" +
+                "    at Apache5HttpClient.createClient\n" +
+                "    at CloudWatchAppender.configureLoggerForCloudWatchLog\n" +
+                "    at Autotune.main\n" +
+                "  Caused by: java.lang.ClassNotFoundException: jdk.net.Sockets\n\n" +
+                "Fix: add ',jdk.net' to --add-modules in Dockerfile.autotune line 46."
+        );
+    }
+
+    // =========================================================================
+    // 3. POSITIVE — verifies the Dockerfile fix is in place
+    //
+    //    These pass only when ,jdk.net is present in the jlink --add-modules
+    //    list in Dockerfile.autotune.  On a developer JDK they always pass
+    //    (full JDK always has jdk.net); inside the jlink container image they
+    //    pass only after the fix.
+    // =========================================================================
+
+    @Test
+    @DisplayName("POSITIVE: jdk.net.Sockets is loadable — confirms ,jdk.net is in the jlink JRE")
+    void jdkNetSocketsMustBeLoadable() throws ClassNotFoundException {
+        /*
+         * If this throws ClassNotFoundException the jlink JRE in the container
+         * was built WITHOUT ,jdk.net in --add-modules (Dockerfile.autotune line
+         * 46).  Apache HC5 will then crash at startup with:
+         *   NoClassDefFoundError: jdk/net/Sockets
+         * exactly as seen in the pod logs on the OpenShift stage cluster.
+         */
+        Class<?> socketsClass = Class.forName("jdk.net.Sockets");
+        assertNotNull(
+                socketsClass,
+                "jdk.net.Sockets must be loadable. " +
+                "Add ',jdk.net' to --add-modules in Dockerfile.autotune line 46."
+        );
+    }
+
+    @Test
+    @DisplayName("POSITIVE: configureLoggerForCloudWatchLog must not throw NoClassDefFoundError when credentials are present")
+    void shouldNotThrowNoClassDefFoundErrorWhenCredentialsPresent() {
+        // Given – credentials present, identical to the stage cluster config
+        KruizeDeploymentInfo.cloudwatch_logs_access_key_id     = "AKIADUMMYACCESSKEY";
+        KruizeDeploymentInfo.cloudwatch_logs_secret_access_key = "dummySecretAccessKey0000000000000000000";
+        KruizeDeploymentInfo.cloudwatch_logs_region            = "us-east-1";
+        KruizeDeploymentInfo.cloudwatch_logs_log_group         = "kruize-test-logs";
+        KruizeDeploymentInfo.cloudwatch_logs_log_stream        = "kruize-test-stream";
+        KruizeDeploymentInfo.cloudwatch_logs_log_level         = "INFO";
+
+        // When / Then
+        // Any AWS auth/network error is caught inside the method at line 114-116.
+        // A NoClassDefFoundError: jdk/net/Sockets would NOT be caught there —
+        // it would propagate and fail this assertion, reproducing the prod crash.
+        assertDoesNotThrow(
+                CloudWatchAppender::configureLoggerForCloudWatchLog,
+                "configureLoggerForCloudWatchLog() threw an unexpected error. " +
+                "If the error is NoClassDefFoundError: jdk/net/Sockets, " +
+                "add ',jdk.net' to --add-modules in Dockerfile.autotune line 46."
+        );
+    }
+
+    // --- helpers ------------------------------------------------------------
+
+    private boolean cloudWatchAppenderRegistered() {
+        LoggerContext ctx = (LoggerContext) org.apache.logging.log4j.LogManager.getContext(false);
+        Configuration config = ctx.getConfiguration();
+        return config.getAppenders().containsKey("cloudwatchRootAppender");
+    }
+}

--- a/src/test/java/com/autotune/utils/CloudWatchAppenderTest.java
+++ b/src/test/java/com/autotune/utils/CloudWatchAppenderTest.java
@@ -31,22 +31,22 @@ import static org.junit.jupiter.api.Assertions.*;
  * Covers three scenarios:
  *
  * 1. CREDENTIALS ABSENT (simulates test/dev cluster — why the bug was hidden)
- *    When credentials are null or empty, the method short-circuits at the guard
- *    on line 76 of CloudWatchAppender.java.  The AWS SDK is never touched, so
- *    neither jdk.net nor Apache HC5 are loaded.  No exception, no appender.
+ *    When credentials are null or empty, the method short-circuits at the
+ *    credential guard.  The AWS SDK is never touched, so neither jdk.net nor
+ *    Apache HC5 are loaded.  No exception, no appender registered.
  *
- * 2. NEGATIVE — reproduces the production crash (simulates the broken jlink JRE)
- *    Directly attempts to load {@code jdk.net.Sockets} via Class.forName() on a
- *    ClassLoader that has the jdk.net module forcibly hidden, reproducing the
- *    exact {@code NoClassDefFoundError: jdk/net/Sockets} seen in the pod logs.
- *    This is the automated proof of the failure mode WITHOUT the Dockerfile fix.
+ * 2. NEGATIVE — documents the production crash condition
+ *    Asserts that the {@code jdk.net} module is present in the running JRE.
+ *    When {@code jdk.net} is absent (e.g. a stripped jlink JRE that omits the
+ *    module), Apache HttpClient 5 — pulled in by {@code awssdk:apache5-client}
+ *    — fails at startup with {@code NoClassDefFoundError: jdk/net/Sockets}.
+ *    This test fails with a descriptive message when run in such a JRE,
+ *    documenting the exact condition that caused the production crash.
  *
- * 3. POSITIVE — verifies the fix (jdk.net present in the running JRE)
- *    Asserts that {@code jdk.net.Sockets} IS loadable in the current JRE and
- *    that {@code configureLoggerForCloudWatchLog()} completes without any
+ * 3. POSITIVE — verifies the runtime is correctly configured
+ *    Asserts that {@code jdk.net.Sockets} is loadable and that
+ *    {@code configureLoggerForCloudWatchLog()} completes without any
  *    class-loading error when credentials are present.
- *    This test passes only when {@code ,jdk.net} is included in the
- *    {@code jlink --add-modules} list in Dockerfile.autotune.
  */
 class CloudWatchAppenderTest {
 
@@ -150,79 +150,66 @@ class CloudWatchAppenderTest {
     //        at Autotune.main
     //      Caused by: java.lang.ClassNotFoundException: jdk.net.Sockets
     //
-    //    The crash happens because the jlink command in Dockerfile.autotune
-    //    did NOT include ,jdk.net in --add-modules, so the stripped JRE
-    //    shipped inside the container image was missing jdk.net.Sockets.
+    //    Root cause: the jlink-built JRE shipped in the container image did not
+    //    include the jdk.net module, so jdk.net.Sockets was unavailable when
+    //    Apache HttpClient 5 tried to load it in a static initializer.
     //
     //    Note: it is not possible to reproduce the NoClassDefFoundError
     //    in-process on a full JDK — JPMS resolves named-module classes
-    //    (jdk.net.*) directly from the module layer, bypassing the classloader
-    //    hierarchy, so a custom excluding ClassLoader has no effect.
-    //    The real failure only occurs inside the stripped jlink JRE built
-    //    without ,jdk.net.  The negative test below therefore asserts the
-    //    *precondition* of the crash: the jdk.net module is absent.
-    //    Run this test inside the container built WITHOUT the Dockerfile fix
-    //    to see it fail.
+    //    directly from the module layer, bypassing the classloader hierarchy,
+    //    so a custom excluding ClassLoader has no effect.  The test below
+    //    therefore asserts the precondition of the crash: jdk.net must be
+    //    present.  Run it inside a jlink JRE that omits jdk.net to see it fail.
     // =========================================================================
 
     @Test
-    @DisplayName("NEGATIVE: jdk.net module absent → jdk.net.Sockets not loadable")
-    void jdkNetSocketsNotLoadableWhenModuleAbsent() {
+    @DisplayName("NEGATIVE: jdk.net module must be present — absence causes NoClassDefFoundError: jdk/net/Sockets at startup")
+    void jdkNetModuleMustBePresentToPreventStartupCrash() {
         /*
+         * Apache HttpClient 5 (awssdk:apache5-client >= 2.46.x) references
+         * jdk.net.Sockets in a static initializer.  If the jdk.net module is
+         * absent from the JRE, the JVM throws:
+         *   NoClassDefFoundError: jdk/net/Sockets
+         *   Caused by: ClassNotFoundException: jdk.net.Sockets
+         * crashing the process before it can serve any requests.
          *
-         * This test asserts the precondition :
-         *   the jdk.net module must NOT be absent from the JRE.
-         *
-         * On a developer machine (full JDK) jdk.net is always present,
-         * so this test passes unconditionally in local development.
-         *
-         * Inside the container image built from Dockerfile.autotune
-         * WITHOUT the fix (no ,jdk.net in --add-modules line 46):
-         *   ModuleLayer.boot().findModule("jdk.net") → empty Optional
-         *   Class.forName("jdk.net.Sockets")         → ClassNotFoundException
-         *
-         * The assertFalse below then FAILS, printing exactly why.
+         * On a full JDK jdk.net is always present, so this test always passes
+         * in local development.  Inside a stripped jlink JRE that omits jdk.net,
+         * ModuleLayer.boot().findModule("jdk.net") returns an empty Optional and
+         * this assertion fails — surfacing the missing-module condition before it
+         * manifests as a production crash.
          */
-        boolean jdkNetModuleAbsent = ModuleLayer.boot().findModule("jdk.net").isEmpty();
-
-        assertFalse(
-                jdkNetModuleAbsent,
-                "The 'jdk.net' module is absent from " +
-                "this JRE. causing:\n" +
-                "  java.lang.NoClassDefFoundError: jdk/net/Sockets\n" +
-                "    at DefaultHttpClientConnectionOperator.<clinit>\n" +
-                "    at Apache5HttpClient.createClient\n" +
-                "    at CloudWatchAppender.configureLoggerForCloudWatchLog\n" +
-                "    at Autotune.main\n" +
-                "  Caused by: java.lang.ClassNotFoundException: jdk.net.Sockets\n\n" +
-                "Fix: add ',jdk.net' to --add-modules in Dockerfile.autotune line 46."
+        assertTrue(
+                ModuleLayer.boot().findModule("jdk.net").isPresent(),
+                "The 'jdk.net' module is absent from this JRE. " +
+                "Apache HttpClient 5 requires it and will crash at startup with: " +
+                "NoClassDefFoundError: jdk/net/Sockets. " +
+                "Ensure the jlink --add-modules list used to build this JRE includes jdk.net."
         );
     }
 
     // =========================================================================
-    // 3. POSITIVE — verifies the Dockerfile fix is in place
+    // 3. POSITIVE — verifies the runtime is correctly configured
     //
-    //    These pass only when ,jdk.net is present in the jlink --add-modules
-    //    list in Dockerfile.autotune.  On a developer JDK they always pass
-    //    (full JDK always has jdk.net); inside the jlink container image they
-    //    pass only after the fix.
+    //    On a developer JDK these always pass (full JDK always has jdk.net).
+    //    Inside a jlink JRE they pass only when jdk.net is included in the
+    //    --add-modules list used to build the image.
     // =========================================================================
 
     @Test
-    @DisplayName("POSITIVE: jdk.net.Sockets is loadable — confirms ,jdk.net is in the jlink JRE")
+    @DisplayName("POSITIVE: jdk.net.Sockets is loadable — jdk.net module is present in the JRE")
     void jdkNetSocketsMustBeLoadable() throws ClassNotFoundException {
         /*
-         * If this throws ClassNotFoundException the jlink JRE in the container
-         * was built WITHOUT ,jdk.net in --add-modules (Dockerfile.autotune line
-         * 46).  Apache HC5 will then crash at startup with:
+         * Apache HttpClient 5 loads jdk.net.Sockets in a static initializer.
+         * If this throws ClassNotFoundException the JRE is missing the jdk.net
+         * module and Apache HC5 will crash at startup with:
          *   NoClassDefFoundError: jdk/net/Sockets
-         * exactly as seen in the pod logs on the OpenShift stage cluster.
          */
         Class<?> socketsClass = Class.forName("jdk.net.Sockets");
         assertNotNull(
                 socketsClass,
-                "jdk.net.Sockets must be loadable. " +
-                "Add ',jdk.net' to --add-modules in Dockerfile.autotune line 46."
+                "jdk.net.Sockets must be loadable — ensure the jdk.net module " +
+                "is included in the --add-modules list used to build the JRE."
         );
     }
 
@@ -238,14 +225,14 @@ class CloudWatchAppenderTest {
         KruizeDeploymentInfo.cloudwatch_logs_log_level         = "INFO";
 
         // When / Then
-        // Any AWS auth/network error is caught inside the method at line 114-116.
-        // A NoClassDefFoundError: jdk/net/Sockets would NOT be caught there —
+        // Any AWS auth/network error is caught and logged inside the method.
+        // A NoClassDefFoundError: jdk/net/Sockets is NOT caught there —
         // it would propagate and fail this assertion, reproducing the prod crash.
         assertDoesNotThrow(
                 CloudWatchAppender::configureLoggerForCloudWatchLog,
                 "configureLoggerForCloudWatchLog() threw an unexpected error. " +
-                "If the error is NoClassDefFoundError: jdk/net/Sockets, " +
-                "add ',jdk.net' to --add-modules in Dockerfile.autotune line 46."
+                "If the cause is NoClassDefFoundError: jdk/net/Sockets, " +
+                "the jdk.net module is missing from the JRE."
         );
     }
 

--- a/tests/scripts/common/common_functions.sh
+++ b/tests/scripts/common/common_functions.sh
@@ -299,11 +299,11 @@ function restore_db() {
 	kruize_db_pod=$(kubectl get pods -o=name -n ${NAMESPACE} | grep kruize-db | cut -d '/' -f2)
 	db_file=$(basename ${db_backup_file})
 
-	echo "oc cp ${db_backup_file} ${NAMESPACE}/${kruize_db_pod}:/"
-	oc cp ${db_backup_file} ${NAMESPACE}/${kruize_db_pod}:/
+	echo "kubectl cp ${db_backup_file} ${NAMESPACE}/${kruize_db_pod}:/"
+	kubectl cp ${db_backup_file} ${NAMESPACE}/${kruize_db_pod}:/
 
-	echo "kubectl exec -it ${kruize_db_pod} -n ${NAMESPACE} -- psql -U admin -d kruizeDB -f ${db_file} > ${db_restore_log}"
-	kubectl exec -it ${kruize_db_pod} -n ${NAMESPACE} -- psql -U admin -d kruizeDB -f ${db_file} > ${db_restore_log}
+	echo "kubectl exec -it ${kruize_db_pod} -n ${NAMESPACE} -- pg_restore -U admin -d kruizeDB ${db_file} > ${db_restore_log}"
+	kubectl exec -it ${kruize_db_pod} -n ${NAMESPACE} -- pg_restore -U admin -d kruizeDB ${db_file} > ${db_restore_log}
 	echo "Restoring DB...done"
 	echo ""
 }

--- a/tests/scripts/remote_monitoring_tests/db_migration_test/db_migration_test.sh
+++ b/tests/scripts/remote_monitoring_tests/db_migration_test/db_migration_test.sh
@@ -154,9 +154,13 @@ total_results_count=$((${num_exps} * ${num_clients} * ${num_days_of_res} * 96))
 # Backup DB
 echo "" | tee -a ${LOG}
 echo "Backing up DB..." | tee -a ${LOG}
-db_backup_file="${LOG_DIR}/test_logs_50_15days/db_backup.sql"
-echo "kubectl -n openshift-tuning exec -it `kubectl get pods -o=name -n openshift-tuning | grep kruize-db` -- pg_dump -U admin -d kruizeDB > ${db_backup_file}" | tee -a ${LOG}
-kubectl -n openshift-tuning exec -it `kubectl get pods -o=name -n openshift-tuning | grep kruize-db` -- pg_dump -U admin -d kruizeDB > ${db_backup_file}
+kruize_db_pod=$(kubectl get pods -o=name -n ${NAMESPACE} | grep kruize-db | cut -d '/' -f2)
+db_backup_file="${LOG_DIR}/test_logs_50_15days/db_backup.dmp"
+db_file=$(basename ${db_backup_file})
+echo "kubectl -n ${NAMESPACE} exec -it `kubectl get pods -o=name -n ${NAMESPACE} | grep kruize-db` -- pg_dump -U admin -d kruizeDB -Fc -b -v -f ${db_file}" | tee -a ${LOG}
+kubectl -n ${NAMESPACE} exec -it `kubectl get pods -o=name -n ${NAMESPACE} | grep kruize-db` -- pg_dump -U admin -d kruizeDB -Fc -b -v -f ${db_file} | tee -a ${LOG}
+echo "kubectl cp ${NAMESPACE}/${kruize_db_pod}:${db_file} ${db_backup_file}" | tee -a ${LOG}
+kubectl cp ${NAMESPACE}/${kruize_db_pod}:${db_file} ${db_backup_file} | tee -a ${LOG}
 echo "Backing up DB...Done" | tee -a ${LOG}
 echo "" | tee -a ${LOG}
 

--- a/tests/scripts/remote_monitoring_tests/db_migration_test/db_migration_test.sh
+++ b/tests/scripts/remote_monitoring_tests/db_migration_test/db_migration_test.sh
@@ -48,7 +48,7 @@ initial_start_date="2023-12-20T00:00:00.000Z"
 query_db_interval=10
 db_backup_file="./db_backup.sql"
 
-replicas=10
+replicas=5
 
 target="crc"
 kruize_image_prev="quay.io/kruize/autotune_operator:0.0.19.5_rm"
@@ -144,8 +144,8 @@ ${KRUIZE_REPO_PATH}/scripts/enable_user_workload_monitoring_openshift.sh | tee -
 pushd ${SCALE_TEST} > /dev/null
 	echo "" | tee -a ${LOG}
 	echo "Run scalability test to load 50 exps / 15 days data and update Recommendations with ${kruize_image_prev}" | tee -a ${LOG}
-	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a migration" | tee -a ${LOG}
-	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a "migration"
+	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a migration -g ${replicas} " | tee -a ${LOG}
+	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a "migration" -g ${replicas}
 popd > /dev/null 
 	echo "" | tee -a ${LOG}
 
@@ -171,8 +171,8 @@ pushd ${SCALE_TEST} > /dev/null
 	restore_db=true
 	num_days_of_res=1
 
-	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -l ${restore_db} -f ${db_backup_file} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a migration --api-version=${api_version}" | tee -a ${LOG}
-	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -l ${restore_db} -f ${db_backup_file} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a "migration" --api-version=${api_version}
+	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -l ${restore_db} -f ${db_backup_file} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a migration -g ${replicas} --api-version=${api_version}" | tee -a ${LOG}
+	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -l ${restore_db} -f ${db_backup_file} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a "migration" -g ${replicas} --api-version=${api_version}
 
 	echo "" | tee -a ${LOG}
 	echo "" | tee -a ${LOG}

--- a/tests/scripts/remote_monitoring_tests/db_migration_test/db_migration_test_without_postgres_restart.sh
+++ b/tests/scripts/remote_monitoring_tests/db_migration_test/db_migration_test_without_postgres_restart.sh
@@ -48,7 +48,7 @@ initial_start_date="2023-12-20T00:00:00.000Z"
 query_db_interval=10
 db_backup_file="./db_backup.sql"
 
-replicas=10
+replicas=5
 
 target="crc"
 kruize_image_prev="quay.io/kruize/autotune_operator:0.0.19.5_rm"
@@ -142,8 +142,8 @@ ${KRUIZE_REPO_PATH}/scripts/enable_user_workload_monitoring_openshift.sh | tee -
 pushd ${SCALE_TEST} > /dev/null
 	echo "" | tee -a ${LOG}
 	echo "Run scalability test to load 50 exps / 15 days data and update Recommendations with ${kruize_image_prev}" | tee -a ${LOG}
-	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a migration" | tee -a ${LOG}
-	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a "migration"
+	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a migration -g ${replicas}" | tee -a ${LOG}
+	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a "migration" -g ${replicas} 
 popd > /dev/null
 	echo "" | tee -a ${LOG}
 
@@ -176,8 +176,8 @@ pushd ${SCALE_TEST} > /dev/null
 
 	num_days_of_res=1
 
-	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -b ${kruize_setup} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a migration --api-version=${api_version}" | tee -a ${LOG}
-	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -b ${kruize_setup} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a "migration" --api-version=${api_version}
+	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -b ${kruize_setup} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a migration -g ${replicas} --api-version=${api_version}" | tee -a ${LOG}
+	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_current} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -b ${kruize_setup} -r ${LOG_DIR}/test_logs_50_16days -e ${total_results_count} -a "migration" -g ${replicas} --api-version=${api_version}
 
 	echo "" | tee -a ${LOG}
 	echo "" | tee -a ${LOG}

--- a/tests/scripts/remote_monitoring_tests/db_migration_test/db_migration_test_without_postgres_restart.sh
+++ b/tests/scripts/remote_monitoring_tests/db_migration_test/db_migration_test_without_postgres_restart.sh
@@ -143,7 +143,7 @@ pushd ${SCALE_TEST} > /dev/null
 	echo "" | tee -a ${LOG}
 	echo "Run scalability test to load 50 exps / 15 days data and update Recommendations with ${kruize_image_prev}" | tee -a ${LOG}
 	echo "./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a migration -g ${replicas}" | tee -a ${LOG}
-	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a "migration" -g ${replicas} 
+	./remote_monitoring_scale_test_bulk.sh -i ${kruize_image_prev} -u ${num_exps} -d ${num_days_of_res} -n ${num_clients} -t ${interval_hours} -q ${query_db_interval} -s ${initial_start_date} -r ${LOG_DIR}/test_logs_50_15days -a "migration" -g ${replicas}
 popd > /dev/null
 	echo "" | tee -a ${LOG}
 

--- a/tests/scripts/remote_monitoring_tests/perf_profile_migration_test/run_test.sh
+++ b/tests/scripts/remote_monitoring_tests/perf_profile_migration_test/run_test.sh
@@ -42,7 +42,7 @@ query_db_interval=10
 
 kruize_setup=true
 
-replicas=10
+replicas=5
 
 target="crc"
 KRUIZE_IMAGE="quay.io/kruize/autotune:mvp_demo"

--- a/tests/scripts/remote_monitoring_tests/scalability_test.md
+++ b/tests/scripts/remote_monitoring_tests/scalability_test.md
@@ -21,7 +21,7 @@ Use the below command to test :
 
 ```
 cd <KRUIZE_REPO>/tests/scripts/remote_monitoring_tests/scale_test
-./remote_monitoring_scale_test_bulk.sh [-i Kruize image] [-r results directory path] [-u No. of experiments (default - 5000)] [-d No. of days of results (default - 15)] [-n No. of clients (default - 20)] [-m results duration interval in mins, (default - 15)] [-t interval hours (default - 6)] [-s Initial start date (default - 2023-01-10T00:00:00.000Z)] [-q query db interval in mins, (default - 10)] [-c Experiment type [container|namespace|container_ns|gpucontainer] (default - container)] [--api-version=<v1|legacy>]
+./remote_monitoring_scale_test_bulk.sh [-i Kruize image] [-r results directory path] [-u No. of experiments (default - 5000)] [-d No. of days of results (default - 15)] [-n No. of clients (default - 20)] [-m results duration interval in mins, (default - 15)] [-t interval hours (default - 6)] [-s Initial start date (default - 2023-01-10T00:00:00.000Z)] [-q query db interval in mins, (default - 10)] [-c Experiment type [container|namespace|container_ns|gpucontainer] (default - container)] [-g No. of kruize replicas (default - 10] [--api-version=<v1|legacy>]
 ```
 
 Where values for remote_monitoring_scale_test_bulk.sh are:
@@ -38,8 +38,9 @@ usage: remote_monitoring_fault_tolerant_tests.sh
 	[-t interval hours (default - 6)]
 	[-s Initial start date (default - 2023-01-10T00:00:00.000Z)]
 	[-q query db interval in mins, (default - 10)]
-    [-c Experiment type [container|namespace|container_ns|gpucontainer] (default - container)]
-    [-a Test case (default - scale_5k) Valid values - [scale_5k/migration] migration - Used by db_migration test]
+	[-c Experiment type [container|namespace|container_ns|gpucontainer] (default - container)]
+	[-a Test case (default - scale_5k) Valid values - [scale_5k/migration] migration - Used by db_migration test]
+	[-g No. of kruize replicas (default - 10)] 
     [--api-version] : optional. API version to use - 'v1' for new API (/kruize/api/v1/recommendations), 'legacy' for old APIs (updateRecommendations/listRecommendations). Default is 'legacy'
 ```
 

--- a/tests/scripts/remote_monitoring_tests/scalability_test.md
+++ b/tests/scripts/remote_monitoring_tests/scalability_test.md
@@ -21,7 +21,7 @@ Use the below command to test :
 
 ```
 cd <KRUIZE_REPO>/tests/scripts/remote_monitoring_tests/scale_test
-./remote_monitoring_scale_test_bulk.sh [-i Kruize image] [-r results directory path] [-u No. of experiments (default - 5000)] [-d No. of days of results (default - 15)] [-n No. of clients (default - 20)] [-m results duration interval in mins, (default - 15)] [-t interval hours (default - 6)] [-s Initial start date (default - 2023-01-10T00:00:00.000Z)] [-q query db interval in mins, (default - 10)] [-c Experiment type [container|namespace|container_ns|gpucontainer] (default - container)] [-g No. of kruize replicas (default - 10] [--api-version=<v1|legacy>]
+./remote_monitoring_scale_test_bulk.sh [-i Kruize image] [-r results directory path] [-u No. of experiments (default - 5000)] [-d No. of days of results (default - 15)] [-n No. of clients (default - 20)] [-m results duration interval in mins, (default - 15)] [-t interval hours (default - 6)] [-s Initial start date (default - 2023-01-10T00:00:00.000Z)] [-q query db interval in mins, (default - 10)] [-c Experiment type [container|namespace|container_ns|gpucontainer] (default - container)] [-g No. of kruize replicas (default - 10)] [--api-version=<v1|legacy>]
 ```
 
 Where values for remote_monitoring_scale_test_bulk.sh are:

--- a/tests/scripts/remote_monitoring_tests/scale_test/remote_monitoring_scale_test_bulk.sh
+++ b/tests/scripts/remote_monitoring_tests/scale_test/remote_monitoring_scale_test_bulk.sh
@@ -48,13 +48,13 @@ db_backup_file="./db_backup.sql"
 replicas=10
 
 target="crc"
-KRUIZE_IMAGE="quay.io/kruize/autotune:mvp_demo"
+KRUIZE_IMAGE="quay.io/kruizehub/autotune-test-image:mvp_demo"
 hours=6
 total_results_count=0
 
 function usage() {
 	echo
-	echo "Usage: [-i Kruize image] [-u No. of experiments (default - 5000)] [-d No. of days of results (default - 15)] [-n No. of clients (default - 20)] [-m results duration interval in mins, (default - 15)] [-t interval hours (default - 6)] [-s Initial start date (default - 2023-01-10T00:00:00.000Z)] [-q query db interval in mins, (default - 10)] [-r <resultsdir path>] [-l restore DB (default - false)] [-f DB file path to restore (default - ./db_backup.sql)] [-b kruize setup (default - true)] [-c Experiment type [container|namespace|container_ns|gpucontainer] (default - container)] [-a Test case (default - scale_5k)] [--api-version=<v1|legacy>]"
+	echo "Usage: [-i Kruize image] [-u No. of experiments (default - 5000)] [-d No. of days of results (default - 15)] [-n No. of clients (default - 20)] [-m results duration interval in mins, (default - 15)] [-t interval hours (default - 6)] [-s Initial start date (default - 2023-01-10T00:00:00.000Z)] [-q query db interval in mins, (default - 10)] [-r <resultsdir path>] [-l restore DB (default - false)] [-f DB file path to restore (default - ./db_backup.sql)] [-b kruize setup (default - true)] [-c Experiment type [container|namespace|container_ns|gpucontainer] (default - container)] [-a Test case (default - scale_5k)] [-g No. of kruize replicas. Default - 10] [--api-version=<v1|legacy>]"
 	echo
 	echo "API Version Parameter:"
 	echo "  --api-version=v1      Use NEW v1 API (/kruize/api/v1/recommendations)"
@@ -118,7 +118,7 @@ function kruize_scale_test_remote_patch() {
 
 }
 
-while getopts r:i:u:d:t:n:m:s:l:f:b:e:q:c:a:h:-: gopts
+while getopts r:i:u:d:t:n:m:s:l:f:b:e:q:c:a:g:h:-: gopts
 do
 	case ${gopts} in
 	-)
@@ -172,6 +172,9 @@ do
 		;;
 	a)
 		testcase="${OPTARG}"
+		;;
+	g)
+		replicas="${OPTARG}"
 		;;
 	h)
 		usage


### PR DESCRIPTION
Merge mvp_demo changes into master for Kruize release 0.11.1

## Summary by Sourcery

Document and wire up the new unified /kruize/api/v1/recommendations endpoint for both monitoring and local modes, update release metadata to 0.11.1, and adjust remote monitoring scale and migration tests and DB backup/restore flows to support the new API and deployment image.

New Features:
- Introduce a unified Recommendations API (/kruize/api/v1/recommendations) that mirrors existing recommendation endpoints while returning requests and limits under a resources object aligned with Kubernetes specs.

Enhancements:
- Expose replicas and pod_count metrics_info fields in recommendations examples and log CloudWatch configuration details at info level when CloudWatch logging is enabled.

Build:
- Bump autotune project version to 0.11.1 and upgrade the Fabric8 Kubernetes client dependency.

Deployment:
- Update CRC and BYODB deployment manifests for all platforms to use the 0.11.1 Kruize operator images.

Documentation:
- Extend Monitoring and Local API design docs with the new /kruize/api/v1/recommendations endpoint, including request/response examples using Kubernetes-style resources nesting and pod_count metrics metadata.

Tests:
- Update remote monitoring scalability and DB migration test scripts to parameterize Kruize replicas, use the mvp_demo test image, and switch DB backup/restore to pg_dump/pg_restore with compressed dumps.
- Add CloudWatchAppender unit tests that validate behavior with and without credentials and guard against missing jdk.net module issues.