### PR TITLE
Exclude Configmap and CatalogSource from workloads while collecting the metadata

### DIFF
--- a/design/MetadataProfileAPI.md
+++ b/design/MetadataProfileAPI.md
@@ -22,10 +22,9 @@ The following Kubernetes workload types are **supported** by Kruize:
 
 The following workload types are **not supported** by Kruize:
 
-- **DeploymentConfig** - OpenShift-specific deployment configuration (deprecated)
+- **DeploymentConfig**: Excluded because it is an OpenShift-specific deployment configuration that has been deprecated from [Red Hat OpenShift v4.14](https://access.redhat.com/articles/7041372) onwards. OpenShift users are encouraged to migrate to standard Kubernetes Deployments.
 
-The reason for excluding DeploymentConfig is that it is OpenShift-specific and has been deprecated from [Red Hat OpenShift v4.14](https://access.redhat.com/articles/7041372) onwards. OpenShift users are encouraged to migrate to standard Kubernetes Deployments.
-
+- **ConfigMap and CatalogSource**: Excluded because they are configuration and catalog resources, rather than actual executing containers that can be monitored to generate recommendations.
 ---
 
 ## CreateMetadataProfile

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -297,6 +297,8 @@ public class AnalyzerConstants {
         REPLICATION_CONTROLLER,
         DAEMONSET,
         JOB,
+        CRONJOB,
+        CATALOGSOURCE,
     }
 
     public enum RegisterRecommendationModelStatus {
@@ -997,6 +999,9 @@ public class AnalyzerConstants {
             public static final String REPLICATION_CONTROLLER = "replicationController";
             public static final String DAEMONSET = "daemonset";
             public static final String JOB = "job";
+            public static final String CONFIGMAP = "ConfigMap";
+            public static final String CATALOGSOURCE = "CatalogSource";
+
 
             private Types() {
 
@@ -1135,7 +1140,9 @@ public class AnalyzerConstants {
     public static String getUnsupportedWorkloadTypesFilter() {
         // List of unsupported K8S object types
         List<K8S_OBJECT_TYPES> unsupportedTypes = Arrays.asList(
-            K8S_OBJECT_TYPES.DEPLOYMENT_CONFIG
+            K8S_OBJECT_TYPES.DEPLOYMENT_CONFIG,
+            K8S_OBJECT_TYPES.CRONJOB,
+            K8S_OBJECT_TYPES.CATALOGSOURCE
         );
         
         // Build the filter string with case-insensitive regex matching


### PR DESCRIPTION
## Description

Exclude Configmap and CatalogSource from workloads while collecting the metadata.

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [X] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 
ITCP

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [X] Documentation updated
- [ ] Tests added or updated

## Summary by Sourcery

Exclude non-workload Kubernetes resources from metadata workload collection and update metadata profile documentation accordingly.

Bug Fixes:
- Prevent CronJob and CatalogSource resources from being treated as supported workloads during metadata collection.

Enhancements:
- Extend Kubernetes object type enumeration to include CronJob and CatalogSource for more accurate workload type filtering.

Documentation:
- Clarify unsupported workload types in MetadataProfileAPI documentation, including rationale for excluding DeploymentConfig, ConfigMap, and CatalogSource.