### PR TITLE
CVE Fixes : Update micrometer and Netty versions in pom.xml

### DIFF
--- a/Dockerfile.autotune
+++ b/Dockerfile.autotune
@@ -16,7 +16,7 @@
 ##########################################################
 #            Build Docker Image
 ##########################################################
-FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2-1780550715 as mvnbuild-jdk25
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2-1786960640 as mvnbuild-jdk25
 ARG USER=autotune
 ARG AUTOTUNE_HOME=/home/$USER
 
@@ -49,7 +49,7 @@ RUN jlink --strip-debug --compress 2 --no-header-files --no-man-pages --module-p
 #            Runtime Docker Image
 ##########################################################
 # Use ubi-minimal as the base image
-FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2-1780550715
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2-1786960640
 
 ARG AUTOTUNE_VERSION
 ARG USER=autotune

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <jetty-version>12.1.7</jetty-version>
         <log4j-version>2.26.0</log4j-version>
         <java-version>25</java-version>
-        <prometheus-simpleclient>0.16.0</prometheus-simpleclient>
+        <prometheus-metrics-version>1.8.0</prometheus-metrics-version>
         <gson-version>2.14.0</gson-version>
         <maven-compiler-plugin-version>3.15.0</maven-compiler-plugin-version>
         <maven-assembly-plugin-version>3.7.1</maven-assembly-plugin-version>
@@ -129,20 +129,14 @@
         <!-- The Prometheus client -->
         <dependency>
             <groupId>io.prometheus</groupId>
-            <artifactId>simpleclient</artifactId>
-            <version>${prometheus-simpleclient}</version>
+            <artifactId>prometheus-metrics-instrumentation-jvm</artifactId>
+            <version>${prometheus-metrics-version}</version>
         </dependency>
-        <!-- Hotspot JVM metrics-->
+        <!-- Prometheus servlet exporter (javax/Jakarta EE 8 compatible) -->
         <dependency>
             <groupId>io.prometheus</groupId>
-            <artifactId>simpleclient_hotspot</artifactId>
-            <version>${prometheus-simpleclient}</version>
-        </dependency>
-        <!-- https://mvnrepository.com/artifact/io.prometheus/simpleclient_servlet -->
-        <dependency>
-            <groupId>io.prometheus</groupId>
-            <artifactId>simpleclient_servlet</artifactId>
-            <version>${prometheus-simpleclient}</version>
+            <artifactId>prometheus-metrics-exporter-servlet-javax</artifactId>
+            <version>${prometheus-metrics-version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
         <dependency>
@@ -198,6 +192,20 @@
         </dependency>
 
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Force Netty 4.1.136.Final across all transitive dependencies to fix CVE-2026-55833 -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.1.136.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
         <plugins>
             <!-- any other plugins -->

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <fabric8-version>7.8.0</fabric8-version>
         <org-json-version>20260522</org-json-version>
-        <jetty-version>12.1.7</jetty-version>
+        <jetty-version>12.1.10</jetty-version>
         <log4j-version>2.26.0</log4j-version>
         <java-version>25</java-version>
         <prometheus-metrics-version>1.8.0</prometheus-metrics-version>
@@ -24,7 +24,7 @@
         <hibernate-Validator>8.0.3.Final</hibernate-Validator>
         <micrometer-version>1.17.0</micrometer-version>
         <awssdk-version>2.46.5</awssdk-version>
-        <jackson-version>2.22.0</jackson-version>
+        <jackson-version>2.22.1</jackson-version>
         <evalex-version>3.6.2</evalex-version>
         <mockito-version>5.23.0</mockito-version>
         <kafka-version>4.2.0</kafka-version>
@@ -202,6 +202,11 @@
                 <version>4.1.136.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>at.yawk.lz4</groupId>
+                <artifactId>lz4-java</artifactId>
+                <version>1.11.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <postgresql-version>42.7.11</postgresql-version>
         <hibernate-version>6.6.45.Final</hibernate-version>
         <hibernate-Validator>8.0.3.Final</hibernate-Validator>
-        <micrometer-version>1.12.10</micrometer-version>
+        <micrometer-version>1.17.0</micrometer-version>
         <awssdk-version>2.46.5</awssdk-version>
         <jackson-version>2.22.0</jackson-version>
         <evalex-version>3.6.2</evalex-version>

--- a/src/main/java/com/autotune/Autotune.java
+++ b/src/main/java/com/autotune/Autotune.java
@@ -42,8 +42,8 @@ import com.autotune.utils.KruizeConstants;
 import com.autotune.utils.MetricsConfig;
 import com.autotune.utils.ServerContext;
 import com.autotune.utils.filter.KruizeCORSFilter;
-import io.prometheus.client.exporter.MetricsServlet;
-import io.prometheus.client.hotspot.DefaultExports;
+import io.prometheus.metrics.exporter.servlet.javax.PrometheusMetricsServlet;
+import io.prometheus.metrics.instrumentation.jvm.JvmMetrics;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.eclipse.jetty.server.Server;
@@ -299,11 +299,10 @@ public class Autotune {
     private static void addAutotuneServlets(ServletContextHandler context) {
         context.addServlet(HealthService.class, ServerContext.HEALTH_SERVICE);
         // Start the Prometheus end point (/metrics) for Autotune
+        JvmMetrics.builder().register();
         context.addServlet(
-                new ServletHolder(
-                    new MetricsServlet(MetricsConfig.meterRegistry().getPrometheusRegistry())
-                ), ServerContext.METRICS_SERVICE);
-        DefaultExports.initialize();
+                new ServletHolder(new PrometheusMetricsServlet()),
+                ServerContext.METRICS_SERVICE);
     }
 
     private static void disableServerLogging() {

--- a/src/main/java/com/autotune/utils/MetricsConfig.java
+++ b/src/main/java/com/autotune/utils/MetricsConfig.java
@@ -9,8 +9,8 @@ import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.core.instrument.config.NamingConvention;
-import io.micrometer.prometheus.PrometheusConfig;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 
 import java.util.concurrent.atomic.AtomicInteger;
 


### PR DESCRIPTION
## Description

This PR updates the micrometer and Netty versions to fix the following CVEs:

- CVE-2026-40984
- CVE-2026-55833
- CVE-2026-55831
- CVE-2026-59899
- CVE-2026-56819
- CVE-2026-56746
- CVE-2026-56745
- CVE-2026-59949


Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [x] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Update metrics dependencies to address security vulnerabilities and migrate Prometheus and Micrometer integration to the newer metrics libraries.

Bug Fixes:
- Bump Micrometer to 1.17.0 to remediate CVE-2026-40984.
- Enforce Netty 4.1.136.Final via BOM to fix CVE-2026-55833.

Enhancements:
- Replace legacy Prometheus simpleclient dependencies with prometheus-metrics JVM instrumentation and servlet exporter.
- Update metrics wiring to use PrometheusMetricsServlet, JvmMetrics, and the prometheusmetrics Micrometer registry.

## Summary by Sourcery

Refresh vulnerable dependencies and modernize Prometheus metrics integration.

Bug Fixes:
- Update Micrometer, Netty, Jetty, Jackson, and LZ4 dependencies to remediate reported security vulnerabilities.

Enhancements:
- Migrate Prometheus monitoring from the legacy Simpleclient stack to the Prometheus metrics libraries and Micrometer Prometheus metrics registry.

Build:
- Manage Netty and LZ4 versions centrally through Maven dependency management.