### PR TITLE
Fix the jdk download link in stress test

### DIFF
--- a/tests/scripts/remote_monitoring_tests/stress_test/remote_monitoring_stress_test.sh
+++ b/tests/scripts/remote_monitoring_tests/stress_test/remote_monitoring_stress_test.sh
@@ -297,7 +297,7 @@ function check_jmeter_results() {
 
 function java21_install() {
 	JAVA_VERSION=21.0.11_10
-	JAVA_URL="https://github.com/adoptium/temurin21-binaries/releases/download/${JAVA_VERSION}/OpenJDK21U-jdk_x64_linux_hotspot_${JAVA_VERSION}.tar.gz"
+	JAVA_URL="https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11+10/OpenJDK21U-jdk_x64_linux_hotspot_${JAVA_VERSION}.tar.gz"
 	JAVA_INSTALL_DIR=/tmp/temurin21
 
 	# Check if Temurin 21 is already installed at the expected location


### PR DESCRIPTION
## Description

Fixed the jdk download link in stress test

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Tested manually by running the test

**Test Configuration**
* Kubernetes clusters tested on: openshift

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Bug Fixes:
- Fix the JDK 21 download link used by the remote monitoring stress test script to ensure Java can be installed successfully during tests.