### PR TITLE
Revert "label queries syntax fix"

### DIFF
--- a/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.json
+++ b/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.json
@@ -40,7 +40,7 @@
       "aggregation_functions": [
         {
           "function": "sum",
-          "query": "sum by (namespace, workload, workload_type) (max_over_time(kube_pod_labels{pod!=\"\" LABEL_FILTER ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (namespace, pod) group_left(workload, workload_type) max_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!=\"\", $UNSUPPORTED_WORKLOAD_TYPES$ ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          "query": "sum by (namespace, workload, workload_type) (max_over_time(kube_pod_labels{pod!=\"\",LABEL_FILTER,ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (namespace, pod) group_left(workload, workload_type) max_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!=\"\", $UNSUPPORTED_WORKLOAD_TYPES$ ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))"
         }
       ]
     },

--- a/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.yaml
+++ b/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.yaml
@@ -29,7 +29,7 @@ query_variables:
   kubernetes_object: "container"
   aggregation_functions:
   - function: sum
-    query: 'sum by (namespace, workload, workload_type) (max_over_time(kube_pod_labels{pod!="" LABEL_FILTER ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (namespace, pod) group_left(workload, workload_type) max_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!="", $UNSUPPORTED_WORKLOAD_TYPES$ ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+    query: 'sum by (namespace, workload, workload_type) (max_over_time(kube_pod_labels{pod!="",LABEL_FILTER,ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (namespace, pod) group_left(workload, workload_type) max_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!="", $UNSUPPORTED_WORKLOAD_TYPES$ ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
 - name: containersForAdditionalLabel
   datasource: prometheus

--- a/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
+++ b/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
@@ -609,7 +609,7 @@ public class BulkJobManager implements Runnable {
                 continue;
             }
 
-            String promKey = "label_" + key.replace(".", "_").replace("/", "_");
+            String promKey = "label_" + key;
 
             if (value instanceof List<?> listValue) {
                 List<String> values = new ArrayList<>();

--- a/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceMetadataHelper.java
+++ b/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceMetadataHelper.java
@@ -453,7 +453,7 @@ public class DataSourceMetadataHelper {
         List<Metric> metrics = metadataProfile.getQueryVariables();
         for (Metric metric : metrics) {
             String name = metric.getName();
-            if (name.equals(metricName)) {
+            if (name.contains(metricName)) {
                 return metric.getAggregationFunctionsMap().get(KruizeConstants.JSONKeys.SUM).getQuery();
             }
         }

--- a/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
@@ -191,11 +191,6 @@ public class DataSourceMetadataOperator {
 
         MetadataProfile metadataProfile = MetadataProfileCollection.getInstance().getMetadataProfileCollection().get(metadataProfileName);
 
-        if (null == metadataProfile) {
-            LOGGER.error("Metadata profile '{}' not found in MetadataProfileCollection", metadataProfileName);
-            return null;
-        }
-
         // Determine if pod label filters are present — if so, use label-aware workload template
         String includePodLabelFilter = includeResources.getOrDefault("podLabelFilter", "");
         String excludePodLabelFilter = excludeResources.getOrDefault("podLabelFilter", "");
@@ -226,19 +221,11 @@ public class DataSourceMetadataOperator {
                     ? finalLabelWorkloadTemplate
                     : getQueryTemplate(field, metadataProfile);
 
-            if (queryTemplate == null) {
-                LOGGER.error("Query template is null for field {}, cannot proceed", field);
-                queries.put(field, null);
-                return;
-            }
             String filteredQuery;
-            // For the label workload template, only allow %s substitution; avoid replacing
-            // the field!="" pattern which may legitimately appear inside PromQL label selectors.
-            boolean isLabelTemplate = useLabelTemplate && field.equals("workload");
             if (queryTemplate.contains("%s")) {
                 filteredQuery = String.format(queryTemplate, filter);
 
-            } else if (!isLabelTemplate && queryTemplate.contains(field + "!=\"\"")) {
+            } else if (queryTemplate.contains(field + "!=\"\"")) {
                 filteredQuery = queryTemplate.replace(
                     field + "!=\"\"",
                     filter.isEmpty() ? field + "!=\"\"" : filter
@@ -255,12 +242,6 @@ public class DataSourceMetadataOperator {
 
             queries.put(field, filteredQuery);
         });
-
-        // Abort if any required query template was missing
-        if (queries.containsValue(null)) {
-            LOGGER.error("One or more query templates could not be resolved for metadata profile '{}', aborting metadata fetch", metadataProfileName);
-            return null;
-        }
 
         // Construct queries
         String namespaceQuery = queries.get("namespace");
@@ -316,10 +297,6 @@ public class DataSourceMetadataOperator {
 
             if (op.validateResultArray(workloadDataResultArray)) {
                 datasourceWorkloads = dataSourceDetailsHelper.getWorkloadInfo(workloadDataResultArray);
-            }
-            if (hasLabelFilter && datasourceWorkloads.isEmpty()) {
-                LOGGER.info("Label filter matched zero workloads — skipping experiment creation");
-                return null;
             }
             dataSourceDetailsHelper.updateWorkloadDataSourceMetadataInfoObject(dataSourceName, dataSourceMetadataInfo,
                     datasourceWorkloads);
@@ -386,9 +363,10 @@ public class DataSourceMetadataOperator {
                                                          boolean hasLabelFilter) {
         if (hasLabelFilter) {
             StringBuilder labelFilter = new StringBuilder();
-            if (!includePodLabelFilter.isEmpty()) labelFilter.append(",").append(includePodLabelFilter);
+            if (!includePodLabelFilter.isEmpty()) labelFilter.append(includePodLabelFilter);
             if (!excludePodLabelFilter.isEmpty()) {
-                labelFilter.append(",").append(excludePodLabelFilter);
+                if (labelFilter.length() > 0) labelFilter.append(",");
+                labelFilter.append(excludePodLabelFilter);
             }
             workloadQuery = workloadQuery.replace(KruizeConstants.KRUIZE_BULK_API.LABEL_FILTER, labelFilter.toString());
         } else {
@@ -397,7 +375,7 @@ public class DataSourceMetadataOperator {
 
         workloadQuery = workloadQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "");
 
-        workloadQuery = workloadQuery.replaceAll("\\s{2,}", " ").replaceAll("\\s+}", "}").replaceAll("\\{\\s+", "{");
+        workloadQuery = workloadQuery.replaceAll(",{2,}", ",").replaceAll(",\\s*}", "}").replaceAll("\\{,", "{");
 
         return workloadQuery;
     }


### PR DESCRIPTION
This reverts commit a9e8428cc7c0ecc341a113ca51124e80b24f5eef.

## Description

Please describe the issue or feature and the summary of changes made to fix this. 

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Revert the label query syntax fix and restore the prior metadata query and label-filter behavior.

Enhancements:
- Restore the previous metadata query handling and label-filter behavior for bulk data source processing.
- Revert label-filter formatting and workload label key normalization changes to preserve existing Prometheus query compatibility.