### PR TITLE
revert bob merge

### DIFF
--- a/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.json
+++ b/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.json
@@ -33,18 +33,6 @@
       ]
     },
     {
-      "name": "workloadsWithPodLabelFilter",
-      "datasource": "prometheus",
-      "value_type": "double",
-      "kubernetes_object": "container",
-      "aggregation_functions": [
-        {
-          "function": "sum",
-          "query": "sum by (namespace, workload, workload_type) (max_over_time(kube_pod_labels{pod!=\"\" LABEL_FILTER ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (namespace, pod) group_left(workload, workload_type) max_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!=\"\", $UNSUPPORTED_WORKLOAD_TYPES$ ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))"
-        }
-      ]
-    },
-    {
       "name": "containersForAdditionalLabel",
       "datasource": "prometheus",
       "value_type": "double",

--- a/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.yaml
+++ b/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.yaml
@@ -23,14 +23,6 @@ query_variables:
   - function: sum
     query: 'sum by (namespace, workload, workload_type) (avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!="", $UNSUPPORTED_WORKLOAD_TYPES$ ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
-- name: workloadsWithPodLabelFilter
-  datasource: prometheus
-  value_type: "double"
-  kubernetes_object: "container"
-  aggregation_functions:
-  - function: sum
-    query: 'sum by (namespace, workload, workload_type) (max_over_time(kube_pod_labels{pod!="" LABEL_FILTER ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (namespace, pod) group_left(workload, workload_type) max_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!="", $UNSUPPORTED_WORKLOAD_TYPES$ ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))'
-
 - name: containersForAdditionalLabel
   datasource: prometheus
   value_type: "double"

--- a/src/main/java/com/autotune/analyzer/serviceObjects/BulkInput.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/BulkInput.java
@@ -162,7 +162,7 @@ public class BulkInput {
         private List<String> namespace;
         private List<String> workload;
         private List<String> containers;
-        private Map<String, Object> labels;
+        private Map<String, String> labels;
 
         // Getters and Setters
         public List<String> getNamespace() {
@@ -189,11 +189,11 @@ public class BulkInput {
             this.containers = containers;
         }
 
-        public Map<String, Object> getLabels() {
+        public Map<String, String> getLabels() {
             return labels;
         }
 
-        public void setLabels(Map<String, Object> labels) {
+        public void setLabels(Map<String, String> labels) {
             this.labels = labels;
         }
     }

--- a/src/main/java/com/autotune/analyzer/services/DSMetadataService.java
+++ b/src/main/java/com/autotune/analyzer/services/DSMetadataService.java
@@ -157,7 +157,7 @@ public class DSMetadataService extends HttpServlet {
                 }
 
                 DataSourceMetadataInfo metadataInfo = dataSourceManager.importMetadataFromDataSource(metadataProfileName,
-                        datasource, 0, 0, 0, measurementDuration, new HashMap<>(), new HashMap<>());
+                        datasource,"",0, 0, 0, measurementDuration, new HashMap<>(), new HashMap<>());
 
                 // Validate imported metadataInfo object
                 DataSourceMetadataValidation validationObject = new DataSourceMetadataValidation();

--- a/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
+++ b/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
@@ -154,9 +154,9 @@ public class BulkJobManager implements Runnable {
             Map<String, String> excludeResourcesMap = new HashMap<>();
             try {
                 if (this.bulkInput.getFilter() != null) {
-                    labelString = getLabelsForExperimentName(this.bulkInput.getFilter());
-                    includeResourcesMap = buildResourceFilters(this.bulkInput.getFilter().getInclude(), false);
-                    excludeResourcesMap = buildResourceFilters(this.bulkInput.getFilter().getExclude(), true);
+                    labelString = getLabels(this.bulkInput.getFilter());
+                    includeResourcesMap = buildRegexFilters(this.bulkInput.getFilter().getInclude());
+                    excludeResourcesMap = buildRegexFilters(this.bulkInput.getFilter().getExclude());
                 }
                 if (null == this.bulkInput.getDatasource()) {
                     this.bulkInput.setDatasource(CREATE_EXPERIMENT_CONFIG_BEAN.getDatasourceName());
@@ -178,10 +178,10 @@ public class BulkJobManager implements Runnable {
                 if (null != datasource) {
                     JSONObject daterange = processDateRange(this.bulkInput.getTime_range());
                     if (null != daterange) {
-                        metadataInfo = dataSourceManager.importMetadataFromDataSource(metadataProfileName, datasource, (Long) daterange.get(START_TIME),
+                        metadataInfo = dataSourceManager.importMetadataFromDataSource(metadataProfileName, datasource, labelString, (Long) daterange.get(START_TIME),
                                 (Long) daterange.get(END_TIME), (Integer) daterange.get(STEPS), measurementDuration, includeResourcesMap, excludeResourcesMap);
                     } else {
-                        metadataInfo = dataSourceManager.importMetadataFromDataSource(metadataProfileName, datasource, 0, 0,
+                        metadataInfo = dataSourceManager.importMetadataFromDataSource(metadataProfileName, datasource, labelString, 0, 0,
                                 0, measurementDuration, includeResourcesMap, excludeResourcesMap);
                     }
                     if (null == metadataInfo) {
@@ -192,9 +192,7 @@ public class BulkJobManager implements Runnable {
                         //  TODO: Remove getExperimentMap and instead collect all metadata, process it, and create experiments dynamically during metadata iteration.
                         jobData.getSummary().setTotal_experiments(createExperimentAPIObjectMap.size());
                         jobData.getSummary().setProcessed_experiments(0);
-                        if (createExperimentAPIObjectMap.isEmpty()) {
-                            setFinalJobStatus(COMPLETED, String.valueOf(HttpURLConnection.HTTP_OK), NOTHING_INFO, datasource);
-                        } else if (jobData.getSummary().getTotal_experiments() > KruizeDeploymentInfo.bulk_api_limit) {
+                        if (jobData.getSummary().getTotal_experiments() > KruizeDeploymentInfo.bulk_api_limit) {
                             setFinalJobStatus(FAILED, String.valueOf(HttpURLConnection.HTTP_BAD_REQUEST), LIMIT_INFO, datasource);
                         } else {
                             if (!KruizeDeploymentInfo.test_use_only_cache_job_in_mem) {                       // Todo Try to avoid this check in multiple places
@@ -549,31 +547,34 @@ public class BulkJobManager implements Runnable {
         }
     }
 
-    private String getLabelsForExperimentName(BulkInput.FilterWrapper filter) {
+    private String getLabels(BulkInput.FilterWrapper filter) {
+        String uniqueKey = null;
         try {
+            // Process labels in the 'include' section
             if (filter.getInclude() != null) {
-                Map<String, Object> includeLabels = filter.getInclude().getLabels();
+                // Initialize StringBuilder for uniqueKey
+                StringBuilder includeLabelsBuilder = new StringBuilder();
+                Map<String, String> includeLabels = filter.getInclude().getLabels();
                 if (includeLabels != null && !includeLabels.isEmpty()) {
-                    StringBuilder sb = new StringBuilder();
-                    includeLabels.forEach((key, value) -> {
-                        if (value == null) return;
-                        String val = (value instanceof List) ?
-                                ((List<?>) value).stream().findFirst().map(Object::toString).orElse("") :
-                                value.toString();
-                        if (val.isEmpty()) return;
-                        sb.append(key).append("=\"").append(val).append("\",");
-                    });
-                    if (sb.length() > 0) sb.setLength(sb.length() - 1);
-                    return sb.toString();
+                    includeLabels.forEach((key, value) ->
+                            includeLabelsBuilder.append(key).append("=").append("\"" + value + "\"").append(",")
+                    );
+                    // Remove trailing comma
+                    if (!includeLabelsBuilder.isEmpty()) {
+                        includeLabelsBuilder.setLength(includeLabelsBuilder.length() - 1);
+                    }
+                    LOGGER.debug("Include Labels: {}", includeLabelsBuilder);
+                    uniqueKey = includeLabelsBuilder.toString();
                 }
             }
         } catch (Exception e) {
-            LOGGER.error("Error building label string for experiment name: {}", e.getMessage());
+            e.printStackTrace();
+            LOGGER.error(e.getMessage());
         }
-        return null;
+        return uniqueKey;
     }
 
-    Map<String, String> buildResourceFilters(BulkInput.Filter filter, boolean exclude) {
+    private Map<String, String> buildRegexFilters(BulkInput.Filter filter) {
         Map<String, String> resourceFilters = new HashMap<>();
         if (filter != null) {
             resourceFilters.put("namespaceRegex", filter.getNamespace() != null ?
@@ -582,85 +583,8 @@ public class BulkJobManager implements Runnable {
                     filter.getWorkload().stream().map(String::trim).collect(Collectors.joining("|")) : "");
             resourceFilters.put("containerRegex", filter.getContainers() != null ?
                     filter.getContainers().stream().map(String::trim).collect(Collectors.joining("|")) : "");
-            if (filter.getLabels() != null && !filter.getLabels().isEmpty()) {
-                String labelFilter = buildLabelFilters(filter.getLabels(), exclude);
-                if (labelFilter.isEmpty()) {
-                    LOGGER.warn("All label entries were invalid or empty — no pod label filter will be applied");
-                } else {
-                    resourceFilters.put("podLabelFilter", labelFilter);
-                }
-            }
         }
         return resourceFilters;
-    }
-
-    String buildLabelFilters(Map<String, Object> labels, boolean exclude) {
-        StringBuilder sb = new StringBuilder();
-        for (Map.Entry<String, Object> entry : labels.entrySet()) {
-            String key = entry.getKey();
-            Object value = entry.getValue();
-
-            if (key == null || key.isBlank()) {
-                LOGGER.warn("Skipping label with null or empty key");
-                continue;
-            }
-            if (value == null) {
-                LOGGER.warn("Skipping label '{}' with null value", key);
-                continue;
-            }
-
-            String promKey = "label_" + key.replace(".", "_").replace("/", "_");
-
-            if (value instanceof List<?> listValue) {
-                List<String> values = new ArrayList<>();
-                for (Object item : listValue) {
-                    if (item == null) {
-                        LOGGER.warn("Skipping null entry in label '{}' list", key);
-                        continue;
-                    }
-                    if (!(item instanceof String)) {
-                        LOGGER.warn("Skipping non-string entry in label '{}' list: {}", key, item.getClass().getSimpleName());
-                        continue;
-                    }
-                    String str = ((String) item).trim();
-                    if (!str.isEmpty()) {
-                        values.add(escapePromQLLabelValue(str));
-                    }
-                }
-                if (values.isEmpty()) {
-                    LOGGER.warn("Label '{}' has no valid values after filtering, skipping", key);
-                    continue;
-                }
-                if (sb.length() > 0) sb.append(",");
-                if (values.size() == 1) {
-                    sb.append(promKey).append(exclude ? "!=" : "=")
-                            .append("\"").append(values.get(0)).append("\"");
-                } else {
-                    String regex = String.join("|", values);
-                    sb.append(promKey).append(exclude ? "!~" : "=~")
-                            .append("\"").append(regex).append("\"");
-                }
-            } else if (value instanceof String strValue) {
-                String trimmed = strValue.trim();
-                if (trimmed.isEmpty()) {
-                    LOGGER.warn("Skipping label '{}' with empty string value", key);
-                    continue;
-                }
-                if (sb.length() > 0) sb.append(",");
-                String escaped = escapePromQLLabelValue(trimmed);
-                sb.append(promKey).append(exclude ? "!=" : "=")
-                        .append("\"").append(escaped).append("\"");
-            } else {
-                LOGGER.warn("Skipping label '{}' with unsupported value type: {}", key, value.getClass().getSimpleName());
-            }
-        }
-        return sb.toString();
-    }
-
-    static String escapePromQLLabelValue(String value) {
-        return value.replace("\\", "\\\\")
-                .replace("\"", "\\\"")
-                .replace("\n", "\\n");
     }
 
     private JSONObject processDateRange(BulkInput.TimeRange timeRange) {

--- a/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceMetadataHelper.java
+++ b/src/main/java/com/autotune/common/data/dataSourceMetadata/DataSourceMetadataHelper.java
@@ -453,7 +453,7 @@ public class DataSourceMetadataHelper {
         List<Metric> metrics = metadataProfile.getQueryVariables();
         for (Metric metric : metrics) {
             String name = metric.getName();
-            if (name.equals(metricName)) {
+            if (name.contains(metricName)) {
                 return metric.getAggregationFunctionsMap().get(KruizeConstants.JSONKeys.SUM).getQuery();
             }
         }

--- a/src/main/java/com/autotune/common/datasource/DataSourceManager.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceManager.java
@@ -60,6 +60,7 @@ public class DataSourceManager {
      * Imports Metadata for a specific data source using associated DataSourceInfo.
      *
      * @param dataSourceInfo
+     * @param uniqueKey        this is used as labels in query example container="xyz" namespace="abc"
      * @param startTime        Get metadata from starttime to endtime
      * @param endTime          Get metadata from starttime to endtime
      * @param steps            the interval between data points in a range query
@@ -67,7 +68,7 @@ public class DataSourceManager {
      * @param excludeResources
      * @return
      */
-    public DataSourceMetadataInfo importMetadataFromDataSource(String metadataProfileName, DataSourceInfo dataSourceInfo, long startTime, long endTime, int steps, int measurementDuration, Map<String, String> includeResources,
+    public DataSourceMetadataInfo importMetadataFromDataSource(String metadataProfileName, DataSourceInfo dataSourceInfo, String uniqueKey, long startTime, long endTime, int steps, int measurementDuration, Map<String, String> includeResources,
                                                                Map<String, String> excludeResources) throws DataSourceDoesNotExist, IOException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
         String statusValue = "failure";
         io.micrometer.core.instrument.Timer.Sample timerImportMetadata = Timer.start(MetricsConfig.meterRegistry());
@@ -76,7 +77,7 @@ public class DataSourceManager {
                 throw new DataSourceDoesNotExist(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.MISSING_DATASOURCE_INFO);
             }
             DataSourceMetadataInfo dataSourceMetadataInfo = dataSourceMetadataOperator.createDataSourceMetadata(metadataProfileName,
-                    dataSourceInfo, startTime, endTime, steps, measurementDuration, includeResources, excludeResources);
+                    dataSourceInfo, uniqueKey, startTime, endTime, steps, measurementDuration, includeResources, excludeResources);
             if (null == dataSourceMetadataInfo) {
                 LOGGER.error(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.DATASOURCE_METADATA_INFO_NOT_AVAILABLE, "for datasource {}" + dataSourceInfo.getName());
                 return null;
@@ -141,7 +142,7 @@ public class DataSourceManager {
             if (null == dataSourceMetadataInfo) {
                 throw new DataSourceDoesNotExist(DATASOURCE_METADATA_INFO_NOT_AVAILABLE);
             }
-            dataSourceMetadataOperator.updateDataSourceMetadata(metadataProfileName, dataSource, 0, 0, 0, measurementDuration, new HashMap<>(), new HashMap<>());
+            dataSourceMetadataOperator.updateDataSourceMetadata(metadataProfileName, dataSource, "", 0, 0, 0, measurementDuration, null, null);
         } catch (Exception e) {
             LOGGER.error(e.getMessage());
         }

--- a/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
@@ -67,6 +67,7 @@ public class DataSourceMetadataOperator {
      * Currently supported DataSourceProvider - Prometheus
      *
      * @param dataSourceInfo   The DataSourceInfo object containing information about the data source.
+     * @param uniqueKey        this is used as labels in query example container="xyz" namespace="abc"
      * @param startTime        Get metadata from starttime to endtime
      * @param endTime          Get metadata from starttime to endtime
      * @param steps            the interval between data points in a range query
@@ -74,10 +75,10 @@ public class DataSourceMetadataOperator {
      * @param includeResources
      * @param excludeResources
      */
-    public DataSourceMetadataInfo createDataSourceMetadata(String metadataProfileName, DataSourceInfo dataSourceInfo, long startTime,
+    public DataSourceMetadataInfo createDataSourceMetadata(String metadataProfileName, DataSourceInfo dataSourceInfo, String uniqueKey, long startTime,
                                                            long endTime, int steps,  int measurementDuration, Map<String, String> includeResources,
                                                            Map<String, String> excludeResources) throws IOException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
-        return processQueriesAndPopulateDataSourceMetadataInfo(metadataProfileName, dataSourceInfo, startTime,
+        return processQueriesAndPopulateDataSourceMetadataInfo(metadataProfileName, dataSourceInfo, uniqueKey, startTime,
                 endTime, steps, measurementDuration, includeResources, excludeResources);
     }
 
@@ -120,10 +121,10 @@ public class DataSourceMetadataOperator {
      *                                                                                                                                                                                                                                                                          TODO - Currently Create and Update functions have identical functionalities, based on UI workflow and requirements
      *                                                                                                                                                                                                                                                                                 need to further enhance updateDataSourceMetadata() to support namespace, workload level granular updates
      */
-    public DataSourceMetadataInfo updateDataSourceMetadata(String metadataProfileName,DataSourceInfo dataSourceInfo, long startTime,
+    public DataSourceMetadataInfo updateDataSourceMetadata(String metadataProfileName,DataSourceInfo dataSourceInfo, String uniqueKey, long startTime,
                                                            long endTime, int steps, int measurementDuration, Map<String, String> includeResources,
                                                            Map<String, String> excludeResources) throws Exception {
-        return processQueriesAndPopulateDataSourceMetadataInfo(metadataProfileName, dataSourceInfo, startTime,
+        return processQueriesAndPopulateDataSourceMetadataInfo(metadataProfileName, dataSourceInfo, uniqueKey, startTime,
                 endTime, steps, measurementDuration, includeResources, excludeResources);
     }
 
@@ -157,6 +158,7 @@ public class DataSourceMetadataOperator {
      * DataSourceMetadataInfo object
      *
      * @param dataSourceInfo   The DataSourceInfo object containing information about the data source
+     * @param uniqueKey        this is used as labels in query example container="xyz" namespace="abc"
      * @param startTime        Get metadata from starttime to endtime
      * @param endTime          Get metadata from starttime to endtime
      * @param steps            the interval between data points in a range query
@@ -165,7 +167,7 @@ public class DataSourceMetadataOperator {
      * @return DataSourceMetadataInfo object with populated metadata fields
      * todo rename processQueriesAndFetchClusterMetadataInfo
      */
-    public DataSourceMetadataInfo processQueriesAndPopulateDataSourceMetadataInfo(String metadataProfileName, DataSourceInfo dataSourceInfo,
+    public DataSourceMetadataInfo processQueriesAndPopulateDataSourceMetadataInfo(String metadataProfileName, DataSourceInfo dataSourceInfo, String uniqueKey,
                                                                                   long startTime, long endTime, int steps, int measurementDuration,
                                                                                   Map<String, String> includeResources,
                                                                                   Map<String, String> excludeResources) throws IOException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
@@ -191,54 +193,17 @@ public class DataSourceMetadataOperator {
 
         MetadataProfile metadataProfile = MetadataProfileCollection.getInstance().getMetadataProfileCollection().get(metadataProfileName);
 
-        if (null == metadataProfile) {
-            LOGGER.error("Metadata profile '{}' not found in MetadataProfileCollection", metadataProfileName);
-            return null;
-        }
-
-        // Determine if pod label filters are present — if so, use label-aware workload template
-        String includePodLabelFilter = includeResources.getOrDefault("podLabelFilter", "");
-        String excludePodLabelFilter = excludeResources.getOrDefault("podLabelFilter", "");
-        boolean hasLabelFilter = !includePodLabelFilter.isEmpty() || !excludePodLabelFilter.isEmpty();
-
-        String labelWorkloadTemplate = null;
-        if (hasLabelFilter) {
-            labelWorkloadTemplate = dataSourceDetailsHelper.getQueryFromProfile(metadataProfile, "workloadsWithPodLabelFilter");
-            if (labelWorkloadTemplate == null) {
-                LOGGER.warn("workloadsWithPodLabelFilter query not found in metadata profile, falling back to standard query");
-                hasLabelFilter = false;
-            } else {
-                LOGGER.info("Label filter present — using workloadsWithPodLabelFilter template for workload query");
-            }
-        }
-
-        final boolean useLabelTemplate = hasLabelFilter;
-        final String finalLabelWorkloadTemplate = labelWorkloadTemplate;
-
         // Populate filters for each field
         fields.forEach(field -> {
             String includeRegex = includeResources.getOrDefault(field + "Regex", "");
             String excludeRegex = excludeResources.getOrDefault(field + "Regex", "");
             String filter = constructDynamicFilter(field, includeRegex, excludeRegex);
-
-            // For the workload field, use the label-aware template when a label filter is present
-            String queryTemplate = (field.equals("workload") && useLabelTemplate)
-                    ? finalLabelWorkloadTemplate
-                    : getQueryTemplate(field, metadataProfile);
-
-            if (queryTemplate == null) {
-                LOGGER.error("Query template is null for field {}, cannot proceed", field);
-                queries.put(field, null);
-                return;
-            }
+            String queryTemplate = getQueryTemplate(field, metadataProfile);
             String filteredQuery;
-            // For the label workload template, only allow %s substitution; avoid replacing
-            // the field!="" pattern which may legitimately appear inside PromQL label selectors.
-            boolean isLabelTemplate = useLabelTemplate && field.equals("workload");
             if (queryTemplate.contains("%s")) {
                 filteredQuery = String.format(queryTemplate, filter);
 
-            } else if (!isLabelTemplate && queryTemplate.contains(field + "!=\"\"")) {
+            } else if (queryTemplate.contains(field + "!=\"\"")) {
                 filteredQuery = queryTemplate.replace(
                     field + "!=\"\"",
                     filter.isEmpty() ? field + "!=\"\"" : filter
@@ -256,24 +221,22 @@ public class DataSourceMetadataOperator {
             queries.put(field, filteredQuery);
         });
 
-        // Abort if any required query template was missing
-        if (queries.containsValue(null)) {
-            LOGGER.error("One or more query templates could not be resolved for metadata profile '{}', aborting metadata fetch", metadataProfileName);
-            return null;
-        }
-
         // Construct queries
         String namespaceQuery = queries.get("namespace");
         String workloadQuery = queries.get("workload");
         String containerQuery = queries.get("container");
 
         String dataSourceName = dataSourceInfo.getName();
-
-        workloadQuery = substituteWorkloadQueryPlaceholders(
-                workloadQuery, includePodLabelFilter, excludePodLabelFilter, hasLabelFilter);
-
-        namespaceQuery = namespaceQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "");
-        containerQuery = containerQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "");
+        if (null != uniqueKey && !uniqueKey.isEmpty()) {
+            LOGGER.debug("uniquekey: {}", uniqueKey);
+            namespaceQuery = namespaceQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "," + uniqueKey);
+            workloadQuery = workloadQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "," + uniqueKey);
+            containerQuery = containerQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "," + uniqueKey);
+        } else {
+            namespaceQuery = namespaceQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "");
+            workloadQuery = workloadQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "");
+            containerQuery = containerQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "");
+        }
 
         namespaceQuery = namespaceQuery.replace(AnalyzerConstants.MEASUREMENT_DURATION_IN_MIN_VARAIBLE, Integer.toString(measurementDuration));
         workloadQuery = workloadQuery.replace(AnalyzerConstants.MEASUREMENT_DURATION_IN_MIN_VARAIBLE, Integer.toString(measurementDuration));
@@ -316,10 +279,6 @@ public class DataSourceMetadataOperator {
 
             if (op.validateResultArray(workloadDataResultArray)) {
                 datasourceWorkloads = dataSourceDetailsHelper.getWorkloadInfo(workloadDataResultArray);
-            }
-            if (hasLabelFilter && datasourceWorkloads.isEmpty()) {
-                LOGGER.info("Label filter matched zero workloads — skipping experiment creation");
-                return null;
             }
             dataSourceDetailsHelper.updateWorkloadDataSourceMetadataInfoObject(dataSourceName, dataSourceMetadataInfo,
                     datasourceWorkloads);
@@ -378,28 +337,6 @@ public class DataSourceMetadataOperator {
         }
         LOGGER.info("filterBuilder: {}", filterBuilder);
         return filterBuilder.toString();
-    }
-
-    static String substituteWorkloadQueryPlaceholders(String workloadQuery,
-                                                         String includePodLabelFilter,
-                                                         String excludePodLabelFilter,
-                                                         boolean hasLabelFilter) {
-        if (hasLabelFilter) {
-            StringBuilder labelFilter = new StringBuilder();
-            if (!includePodLabelFilter.isEmpty()) labelFilter.append(",").append(includePodLabelFilter);
-            if (!excludePodLabelFilter.isEmpty()) {
-                labelFilter.append(",").append(excludePodLabelFilter);
-            }
-            workloadQuery = workloadQuery.replace(KruizeConstants.KRUIZE_BULK_API.LABEL_FILTER, labelFilter.toString());
-        } else {
-            workloadQuery = workloadQuery.replace(KruizeConstants.KRUIZE_BULK_API.LABEL_FILTER, "");
-        }
-
-        workloadQuery = workloadQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "");
-
-        workloadQuery = workloadQuery.replaceAll("\\s{2,}", " ").replaceAll("\\s+}", "}").replaceAll("\\{\\s+", "{");
-
-        return workloadQuery;
     }
 
     private JsonArray fetchQueryResults(DataSourceInfo dataSourceInfo, String query, long startTime, long endTime, int steps) throws IOException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException {

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -957,7 +957,6 @@ public class KruizeConstants {
         public static final String END_TIME = "end_time";
         public static final String STEPS = "steps";
         public static final String ADDITIONAL_LABEL = "ADDITIONAL_LABEL";
-        public static final String LABEL_FILTER = "LABEL_FILTER";
         public static final String SUMMARY = "summary";
         public static final String SUMMARY_FILTER = "summaryFilter";
         public static final String EXPERIMENTS = "experiments";


### PR DESCRIPTION
## Description

Please describe the issue or feature and the summary of changes made to fix this. 

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Revert the previous bulk metadata label-filtering merge and restore the earlier query and job-processing behavior.

Bug Fixes:
- Restore bulk metadata filtering to use a single include-label selector when querying Prometheus.

Enhancements:
- Revert pod-label-specific query handling and associated metadata-profile support.
- Pass label selectors through the metadata import flow and simplify resource filter construction.
- Restore completion behavior for bulk jobs with no discovered experiments.

Chores:
- Change bulk filter label values to string-only input and update related API method signatures.