### PR TITLE
Add label filter builder and workload query template for Bulk API

### DIFF
--- a/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.json
+++ b/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.json
@@ -33,7 +33,7 @@
       ]
     },
     {
-      "name": "workloadsWithPodLabelFilter",
+      "name":  "workloadsWithPodLabelFilter",
       "datasource": "prometheus",
       "value_type": "double",
       "kubernetes_object": "container",

--- a/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.json
+++ b/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.json
@@ -33,6 +33,18 @@
       ]
     },
     {
+      "name": "workloadsWithPodLabelFilter",
+      "datasource": "prometheus",
+      "value_type": "double",
+      "kubernetes_object": "container",
+      "aggregation_functions": [
+        {
+          "function": "sum",
+          "query": "sum by (namespace, workload, workload_type) (max_over_time(kube_pod_labels{pod!=\"\" LABEL_FILTER ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (namespace, pod) group_left(workload, workload_type) max_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!=\"\", $UNSUPPORTED_WORKLOAD_TYPES$ ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+        }
+      ]
+    },
+    {
       "name": "containersForAdditionalLabel",
       "datasource": "prometheus",
       "value_type": "double",

--- a/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.yaml
+++ b/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.yaml
@@ -23,6 +23,14 @@ query_variables:
   - function: sum
     query: 'sum by (namespace, workload, workload_type) (avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!="", $UNSUPPORTED_WORKLOAD_TYPES$ ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
+- name: workloadsWithPodLabelFilter
+  datasource: prometheus
+  value_type: "double"
+  kubernetes_object: "container"
+  aggregation_functions:
+  - function: sum
+    query: 'sum by (namespace, workload, workload_type) (max_over_time(kube_pod_labels{pod!="" LABEL_FILTER ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (namespace, pod) group_left(workload, workload_type) max_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!="", $UNSUPPORTED_WORKLOAD_TYPES$ ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+
 - name: containersForAdditionalLabel
   datasource: prometheus
   value_type: "double"

--- a/src/main/java/com/autotune/analyzer/serviceObjects/BulkInput.java
+++ b/src/main/java/com/autotune/analyzer/serviceObjects/BulkInput.java
@@ -162,7 +162,7 @@ public class BulkInput {
         private List<String> namespace;
         private List<String> workload;
         private List<String> containers;
-        private Map<String, String> labels;
+        private Map<String, Object> labels;
 
         // Getters and Setters
         public List<String> getNamespace() {
@@ -189,11 +189,11 @@ public class BulkInput {
             this.containers = containers;
         }
 
-        public Map<String, String> getLabels() {
+        public Map<String, Object> getLabels() {
             return labels;
         }
 
-        public void setLabels(Map<String, String> labels) {
+        public void setLabels(Map<String, Object> labels) {
             this.labels = labels;
         }
     }

--- a/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
+++ b/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
@@ -624,7 +624,7 @@ public class BulkJobManager implements Runnable {
                     }
                     String str = ((String) item).trim();
                     if (!str.isEmpty()) {
-                        values.add(escapePromQLLabelValue(str));
+                        values.add(str);
                     }
                 }
                 if (values.isEmpty()) {
@@ -634,9 +634,11 @@ public class BulkJobManager implements Runnable {
                 if (sb.length() > 0) sb.append(",");
                 if (values.size() == 1) {
                     sb.append(promKey).append(exclude ? "!=" : "=")
-                            .append("\"").append(values.get(0)).append("\"");
+                            .append("\"").append(escapePromQLLabelValue(values.get(0))).append("\"");
                 } else {
-                    String regex = String.join("|", values);
+                    String regex = values.stream()
+                            .map(BulkJobManager::escapePromQLRegexValue)
+                            .collect(Collectors.joining("|"));
                     sb.append(promKey).append(exclude ? "!~" : "=~")
                             .append("\"").append(regex).append("\"");
                 }
@@ -661,6 +663,11 @@ public class BulkJobManager implements Runnable {
         return value.replace("\\", "\\\\")
                 .replace("\"", "\\\"")
                 .replace("\n", "\\n");
+    }
+
+    static String escapePromQLRegexValue(String value) {
+        return escapePromQLLabelValue(value)
+                .replaceAll("([.+*?^${}()\\[\\]|])", "\\\\$1");
     }
 
     private JSONObject processDateRange(BulkInput.TimeRange timeRange) {

--- a/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
+++ b/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
@@ -100,6 +100,18 @@ import static com.autotune.utils.KruizeConstants.KRUIZE_BULK_API.NotificationCon
  */
 public class BulkJobManager implements Runnable {
     private static final Logger LOGGER = LoggerFactory.getLogger(BulkJobManager.class);
+
+    // Label filter log messages
+    private static final String LOG_LABEL_EXPERIMENT_NAME_ERROR = "Error building label string for experiment name: {}";
+    private static final String LOG_LABEL_ALL_INVALID = "All label entries were invalid or empty — no pod label filter will be applied";
+    private static final String LOG_LABEL_NULL_KEY = "Skipping label with null or empty key";
+    private static final String LOG_LABEL_NULL_VALUE = "Skipping label '{}' with null value";
+    private static final String LOG_LABEL_NULL_LIST_ENTRY = "Skipping null entry in label '{}' list";
+    private static final String LOG_LABEL_NON_STRING_ENTRY = "Skipping non-string entry in label '{}' list: {}";
+    private static final String LOG_LABEL_NO_VALID_VALUES = "Label '{}' has no valid values after filtering, skipping";
+    private static final String LOG_LABEL_EMPTY_VALUE = "Skipping label '{}' with empty string value";
+    private static final String LOG_LABEL_UNSUPPORTED_TYPE = "Skipping label '{}' with unsupported value type: {}";
+
     ExecutorService createExecutor = Executors.newFixedThreadPool(bulk_thread_pool_size);
     ExecutorService generateExecutor = Executors.newFixedThreadPool(bulk_thread_pool_size);
     private String jobID;
@@ -568,12 +580,12 @@ public class BulkJobManager implements Runnable {
                 }
             }
         } catch (Exception e) {
-            LOGGER.error("Error building label string for experiment name: {}", e.getMessage());
+            LOGGER.error(LOG_LABEL_EXPERIMENT_NAME_ERROR, e.getMessage());
         }
         return null;
     }
 
-    Map<String, String> buildResourceFilters(BulkInput.Filter filter, boolean exclude) {
+    private Map<String, String> buildResourceFilters(BulkInput.Filter filter, boolean exclude) {
         Map<String, String> resourceFilters = new HashMap<>();
         if (filter != null) {
             resourceFilters.put("namespaceRegex", filter.getNamespace() != null ?
@@ -585,7 +597,7 @@ public class BulkJobManager implements Runnable {
             if (filter.getLabels() != null && !filter.getLabels().isEmpty()) {
                 String labelFilter = buildLabelFilters(filter.getLabels(), exclude);
                 if (labelFilter.isEmpty()) {
-                    LOGGER.warn("All label entries were invalid or empty — no pod label filter will be applied");
+                    LOGGER.warn(LOG_LABEL_ALL_INVALID);
                 } else {
                     resourceFilters.put("podLabelFilter", labelFilter);
                 }
@@ -594,18 +606,18 @@ public class BulkJobManager implements Runnable {
         return resourceFilters;
     }
 
-    String buildLabelFilters(Map<String, Object> labels, boolean exclude) {
+    private String buildLabelFilters(Map<String, Object> labels, boolean exclude) {
         StringBuilder sb = new StringBuilder();
         for (Map.Entry<String, Object> entry : labels.entrySet()) {
             String key = entry.getKey();
             Object value = entry.getValue();
 
             if (key == null || key.isBlank()) {
-                LOGGER.warn("Skipping label with null or empty key");
+                LOGGER.warn(LOG_LABEL_NULL_KEY);
                 continue;
             }
             if (value == null) {
-                LOGGER.warn("Skipping label '{}' with null value", key);
+                LOGGER.warn(LOG_LABEL_NULL_VALUE, key);
                 continue;
             }
 
@@ -615,11 +627,11 @@ public class BulkJobManager implements Runnable {
                 List<String> values = new ArrayList<>();
                 for (Object item : listValue) {
                     if (item == null) {
-                        LOGGER.warn("Skipping null entry in label '{}' list", key);
+                        LOGGER.warn(LOG_LABEL_NULL_LIST_ENTRY, key);
                         continue;
                     }
                     if (!(item instanceof String)) {
-                        LOGGER.warn("Skipping non-string entry in label '{}' list: {}", key, item.getClass().getSimpleName());
+                        LOGGER.warn(LOG_LABEL_NON_STRING_ENTRY, key, item.getClass().getSimpleName());
                         continue;
                     }
                     String str = ((String) item).trim();
@@ -628,7 +640,7 @@ public class BulkJobManager implements Runnable {
                     }
                 }
                 if (values.isEmpty()) {
-                    LOGGER.warn("Label '{}' has no valid values after filtering, skipping", key);
+                    LOGGER.warn(LOG_LABEL_NO_VALID_VALUES, key);
                     continue;
                 }
                 if (sb.length() > 0) sb.append(",");
@@ -645,7 +657,7 @@ public class BulkJobManager implements Runnable {
             } else if (value instanceof String strValue) {
                 String trimmed = strValue.trim();
                 if (trimmed.isEmpty()) {
-                    LOGGER.warn("Skipping label '{}' with empty string value", key);
+                    LOGGER.warn(LOG_LABEL_EMPTY_VALUE, key);
                     continue;
                 }
                 if (sb.length() > 0) sb.append(",");
@@ -653,7 +665,7 @@ public class BulkJobManager implements Runnable {
                 sb.append(promKey).append(exclude ? "!=" : "=")
                         .append("\"").append(escaped).append("\"");
             } else {
-                LOGGER.warn("Skipping label '{}' with unsupported value type: {}", key, value.getClass().getSimpleName());
+                LOGGER.warn(LOG_LABEL_UNSUPPORTED_TYPE, key, value.getClass().getSimpleName());
             }
         }
         return sb.toString();

--- a/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
+++ b/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
@@ -569,7 +569,7 @@ public class BulkJobManager implements Runnable {
                 }
             }
         } catch (Exception e) {
-            LOGGER.error(KruizeConstants.BulkAPIConstants.LabelFilterConstants.LOG_LABEL_EXPERIMENT_NAME_ERROR, e.getMessage(), e);
+            LOGGER.error(KruizeConstants.KRUIZE_BULK_API.LabelFilterConstants.LOG_LABEL_EXPERIMENT_NAME_ERROR, e.getMessage(), e);
         }
         return null;
     }
@@ -586,7 +586,7 @@ public class BulkJobManager implements Runnable {
             if (filter.getLabels() != null && !filter.getLabels().isEmpty()) {
                 String labelFilter = buildLabelFilters(filter.getLabels(), exclude);
                 if (labelFilter.isEmpty()) {
-                    LOGGER.warn(KruizeConstants.BulkAPIConstants.LabelFilterConstants.LOG_LABEL_ALL_INVALID);
+                    LOGGER.warn(KruizeConstants.KRUIZE_BULK_API.LabelFilterConstants.LOG_LABEL_ALL_INVALID);
                 } else {
                     resourceFilters.put("podLabelFilter", labelFilter);
                 }
@@ -602,11 +602,11 @@ public class BulkJobManager implements Runnable {
             Object value = entry.getValue();
 
             if (key == null || key.isBlank()) {
-                LOGGER.warn(KruizeConstants.BulkAPIConstants.LabelFilterConstants.LOG_LABEL_NULL_KEY);
+                LOGGER.warn(KruizeConstants.KRUIZE_BULK_API.LabelFilterConstants.LOG_LABEL_NULL_KEY);
                 continue;
             }
             if (value == null) {
-                LOGGER.warn(KruizeConstants.BulkAPIConstants.LabelFilterConstants.LOG_LABEL_NULL_VALUE, key);
+                LOGGER.warn(KruizeConstants.KRUIZE_BULK_API.LabelFilterConstants.LOG_LABEL_NULL_VALUE, key);
                 continue;
             }
 
@@ -616,11 +616,11 @@ public class BulkJobManager implements Runnable {
                 List<String> values = new ArrayList<>();
                 for (Object item : listValue) {
                     if (item == null) {
-                        LOGGER.warn(KruizeConstants.BulkAPIConstants.LabelFilterConstants.LOG_LABEL_NULL_LIST_ENTRY, key);
+                        LOGGER.warn(KruizeConstants.KRUIZE_BULK_API.LabelFilterConstants.LOG_LABEL_NULL_LIST_ENTRY, key);
                         continue;
                     }
                     if (!(item instanceof String)) {
-                        LOGGER.warn(KruizeConstants.BulkAPIConstants.LabelFilterConstants.LOG_LABEL_NON_STRING_ENTRY, key, item.getClass().getSimpleName());
+                        LOGGER.warn(KruizeConstants.KRUIZE_BULK_API.LabelFilterConstants.LOG_LABEL_NON_STRING_ENTRY, key, item.getClass().getSimpleName());
                         continue;
                     }
                     String str = ((String) item).trim();
@@ -629,7 +629,7 @@ public class BulkJobManager implements Runnable {
                     }
                 }
                 if (values.isEmpty()) {
-                    LOGGER.warn(KruizeConstants.BulkAPIConstants.LabelFilterConstants.LOG_LABEL_NO_VALID_VALUES, key);
+                    LOGGER.warn(KruizeConstants.KRUIZE_BULK_API.LabelFilterConstants.LOG_LABEL_NO_VALID_VALUES, key);
                     continue;
                 }
                 if (sb.length() > 0) sb.append(",");
@@ -646,7 +646,7 @@ public class BulkJobManager implements Runnable {
             } else if (value instanceof String strValue) {
                 String trimmed = strValue.trim();
                 if (trimmed.isEmpty()) {
-                    LOGGER.warn(KruizeConstants.BulkAPIConstants.LabelFilterConstants.LOG_LABEL_EMPTY_VALUE, key);
+                    LOGGER.warn(KruizeConstants.KRUIZE_BULK_API.LabelFilterConstants.LOG_LABEL_EMPTY_VALUE, key);
                     continue;
                 }
                 if (sb.length() > 0) sb.append(",");
@@ -654,7 +654,7 @@ public class BulkJobManager implements Runnable {
                 sb.append(promKey).append(exclude ? "!=" : "=")
                         .append("\"").append(escaped).append("\"");
             } else {
-                LOGGER.warn(KruizeConstants.BulkAPIConstants.LabelFilterConstants.LOG_LABEL_UNSUPPORTED_TYPE, key, value.getClass().getSimpleName());
+                LOGGER.warn(KruizeConstants.KRUIZE_BULK_API.LabelFilterConstants.LOG_LABEL_UNSUPPORTED_TYPE, key, value.getClass().getSimpleName());
             }
         }
         return sb.toString();

--- a/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
+++ b/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
@@ -101,17 +101,6 @@ import static com.autotune.utils.KruizeConstants.KRUIZE_BULK_API.NotificationCon
 public class BulkJobManager implements Runnable {
     private static final Logger LOGGER = LoggerFactory.getLogger(BulkJobManager.class);
 
-    // Label filter log messages
-    private static final String LOG_LABEL_EXPERIMENT_NAME_ERROR = "Error building label string for experiment name: {}";
-    private static final String LOG_LABEL_ALL_INVALID = "All label entries were invalid or empty — no pod label filter will be applied";
-    private static final String LOG_LABEL_NULL_KEY = "Skipping label with null or empty key";
-    private static final String LOG_LABEL_NULL_VALUE = "Skipping label '{}' with null value";
-    private static final String LOG_LABEL_NULL_LIST_ENTRY = "Skipping null entry in label '{}' list";
-    private static final String LOG_LABEL_NON_STRING_ENTRY = "Skipping non-string entry in label '{}' list: {}";
-    private static final String LOG_LABEL_NO_VALID_VALUES = "Label '{}' has no valid values after filtering, skipping";
-    private static final String LOG_LABEL_EMPTY_VALUE = "Skipping label '{}' with empty string value";
-    private static final String LOG_LABEL_UNSUPPORTED_TYPE = "Skipping label '{}' with unsupported value type: {}";
-
     ExecutorService createExecutor = Executors.newFixedThreadPool(bulk_thread_pool_size);
     ExecutorService generateExecutor = Executors.newFixedThreadPool(bulk_thread_pool_size);
     private String jobID;
@@ -580,7 +569,7 @@ public class BulkJobManager implements Runnable {
                 }
             }
         } catch (Exception e) {
-            LOGGER.error(LOG_LABEL_EXPERIMENT_NAME_ERROR, e.getMessage());
+            LOGGER.error(KruizeConstants.BulkAPIConstants.LabelFilterConstants.LOG_LABEL_EXPERIMENT_NAME_ERROR, e.getMessage(), e);
         }
         return null;
     }
@@ -597,7 +586,7 @@ public class BulkJobManager implements Runnable {
             if (filter.getLabels() != null && !filter.getLabels().isEmpty()) {
                 String labelFilter = buildLabelFilters(filter.getLabels(), exclude);
                 if (labelFilter.isEmpty()) {
-                    LOGGER.warn(LOG_LABEL_ALL_INVALID);
+                    LOGGER.warn(KruizeConstants.BulkAPIConstants.LabelFilterConstants.LOG_LABEL_ALL_INVALID);
                 } else {
                     resourceFilters.put("podLabelFilter", labelFilter);
                 }
@@ -613,11 +602,11 @@ public class BulkJobManager implements Runnable {
             Object value = entry.getValue();
 
             if (key == null || key.isBlank()) {
-                LOGGER.warn(LOG_LABEL_NULL_KEY);
+                LOGGER.warn(KruizeConstants.BulkAPIConstants.LabelFilterConstants.LOG_LABEL_NULL_KEY);
                 continue;
             }
             if (value == null) {
-                LOGGER.warn(LOG_LABEL_NULL_VALUE, key);
+                LOGGER.warn(KruizeConstants.BulkAPIConstants.LabelFilterConstants.LOG_LABEL_NULL_VALUE, key);
                 continue;
             }
 
@@ -627,11 +616,11 @@ public class BulkJobManager implements Runnable {
                 List<String> values = new ArrayList<>();
                 for (Object item : listValue) {
                     if (item == null) {
-                        LOGGER.warn(LOG_LABEL_NULL_LIST_ENTRY, key);
+                        LOGGER.warn(KruizeConstants.BulkAPIConstants.LabelFilterConstants.LOG_LABEL_NULL_LIST_ENTRY, key);
                         continue;
                     }
                     if (!(item instanceof String)) {
-                        LOGGER.warn(LOG_LABEL_NON_STRING_ENTRY, key, item.getClass().getSimpleName());
+                        LOGGER.warn(KruizeConstants.BulkAPIConstants.LabelFilterConstants.LOG_LABEL_NON_STRING_ENTRY, key, item.getClass().getSimpleName());
                         continue;
                     }
                     String str = ((String) item).trim();
@@ -640,7 +629,7 @@ public class BulkJobManager implements Runnable {
                     }
                 }
                 if (values.isEmpty()) {
-                    LOGGER.warn(LOG_LABEL_NO_VALID_VALUES, key);
+                    LOGGER.warn(KruizeConstants.BulkAPIConstants.LabelFilterConstants.LOG_LABEL_NO_VALID_VALUES, key);
                     continue;
                 }
                 if (sb.length() > 0) sb.append(",");
@@ -657,7 +646,7 @@ public class BulkJobManager implements Runnable {
             } else if (value instanceof String strValue) {
                 String trimmed = strValue.trim();
                 if (trimmed.isEmpty()) {
-                    LOGGER.warn(LOG_LABEL_EMPTY_VALUE, key);
+                    LOGGER.warn(KruizeConstants.BulkAPIConstants.LabelFilterConstants.LOG_LABEL_EMPTY_VALUE, key);
                     continue;
                 }
                 if (sb.length() > 0) sb.append(",");
@@ -665,7 +654,7 @@ public class BulkJobManager implements Runnable {
                 sb.append(promKey).append(exclude ? "!=" : "=")
                         .append("\"").append(escaped).append("\"");
             } else {
-                LOGGER.warn(LOG_LABEL_UNSUPPORTED_TYPE, key, value.getClass().getSimpleName());
+                LOGGER.warn(KruizeConstants.BulkAPIConstants.LabelFilterConstants.LOG_LABEL_UNSUPPORTED_TYPE, key, value.getClass().getSimpleName());
             }
         }
         return sb.toString();

--- a/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
+++ b/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
@@ -154,9 +154,9 @@ public class BulkJobManager implements Runnable {
             Map<String, String> excludeResourcesMap = new HashMap<>();
             try {
                 if (this.bulkInput.getFilter() != null) {
-                    labelString = getLabels(this.bulkInput.getFilter());
-                    includeResourcesMap = buildRegexFilters(this.bulkInput.getFilter().getInclude());
-                    excludeResourcesMap = buildRegexFilters(this.bulkInput.getFilter().getExclude());
+                    labelString = getLabelsForExperimentName(this.bulkInput.getFilter());
+                    includeResourcesMap = buildResourceFilters(this.bulkInput.getFilter().getInclude(), false);
+                    excludeResourcesMap = buildResourceFilters(this.bulkInput.getFilter().getExclude(), true);
                 }
                 if (null == this.bulkInput.getDatasource()) {
                     this.bulkInput.setDatasource(CREATE_EXPERIMENT_CONFIG_BEAN.getDatasourceName());
@@ -192,7 +192,9 @@ public class BulkJobManager implements Runnable {
                         //  TODO: Remove getExperimentMap and instead collect all metadata, process it, and create experiments dynamically during metadata iteration.
                         jobData.getSummary().setTotal_experiments(createExperimentAPIObjectMap.size());
                         jobData.getSummary().setProcessed_experiments(0);
-                        if (jobData.getSummary().getTotal_experiments() > KruizeDeploymentInfo.bulk_api_limit) {
+                        if (createExperimentAPIObjectMap.isEmpty()) {
+                            setFinalJobStatus(COMPLETED, String.valueOf(HttpURLConnection.HTTP_OK), NOTHING_INFO, datasource);
+                        } else if (jobData.getSummary().getTotal_experiments() > KruizeDeploymentInfo.bulk_api_limit) {
                             setFinalJobStatus(FAILED, String.valueOf(HttpURLConnection.HTTP_BAD_REQUEST), LIMIT_INFO, datasource);
                         } else {
                             if (!KruizeDeploymentInfo.test_use_only_cache_job_in_mem) {                       // Todo Try to avoid this check in multiple places
@@ -547,34 +549,31 @@ public class BulkJobManager implements Runnable {
         }
     }
 
-    private String getLabels(BulkInput.FilterWrapper filter) {
-        String uniqueKey = null;
+    private String getLabelsForExperimentName(BulkInput.FilterWrapper filter) {
         try {
-            // Process labels in the 'include' section
             if (filter.getInclude() != null) {
-                // Initialize StringBuilder for uniqueKey
-                StringBuilder includeLabelsBuilder = new StringBuilder();
-                Map<String, String> includeLabels = filter.getInclude().getLabels();
+                Map<String, Object> includeLabels = filter.getInclude().getLabels();
                 if (includeLabels != null && !includeLabels.isEmpty()) {
-                    includeLabels.forEach((key, value) ->
-                            includeLabelsBuilder.append(key).append("=").append("\"" + value + "\"").append(",")
-                    );
-                    // Remove trailing comma
-                    if (!includeLabelsBuilder.isEmpty()) {
-                        includeLabelsBuilder.setLength(includeLabelsBuilder.length() - 1);
-                    }
-                    LOGGER.debug("Include Labels: {}", includeLabelsBuilder);
-                    uniqueKey = includeLabelsBuilder.toString();
+                    StringBuilder sb = new StringBuilder();
+                    includeLabels.forEach((key, value) -> {
+                        if (value == null) return;
+                        String val = (value instanceof List) ?
+                                ((List<?>) value).stream().findFirst().map(Object::toString).orElse("") :
+                                value.toString();
+                        if (val.isEmpty()) return;
+                        sb.append(key).append("=\"").append(val).append("\",");
+                    });
+                    if (sb.length() > 0) sb.setLength(sb.length() - 1);
+                    return sb.toString();
                 }
             }
         } catch (Exception e) {
-            e.printStackTrace();
-            LOGGER.error(e.getMessage());
+            LOGGER.error("Error building label string for experiment name: {}", e.getMessage());
         }
-        return uniqueKey;
+        return null;
     }
 
-    private Map<String, String> buildRegexFilters(BulkInput.Filter filter) {
+    Map<String, String> buildResourceFilters(BulkInput.Filter filter, boolean exclude) {
         Map<String, String> resourceFilters = new HashMap<>();
         if (filter != null) {
             resourceFilters.put("namespaceRegex", filter.getNamespace() != null ?
@@ -583,8 +582,85 @@ public class BulkJobManager implements Runnable {
                     filter.getWorkload().stream().map(String::trim).collect(Collectors.joining("|")) : "");
             resourceFilters.put("containerRegex", filter.getContainers() != null ?
                     filter.getContainers().stream().map(String::trim).collect(Collectors.joining("|")) : "");
+            if (filter.getLabels() != null && !filter.getLabels().isEmpty()) {
+                String labelFilter = buildLabelFilters(filter.getLabels(), exclude);
+                if (labelFilter.isEmpty()) {
+                    LOGGER.warn("All label entries were invalid or empty — no pod label filter will be applied");
+                } else {
+                    resourceFilters.put("podLabelFilter", labelFilter);
+                }
+            }
         }
         return resourceFilters;
+    }
+
+    String buildLabelFilters(Map<String, Object> labels, boolean exclude) {
+        StringBuilder sb = new StringBuilder();
+        for (Map.Entry<String, Object> entry : labels.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+
+            if (key == null || key.isBlank()) {
+                LOGGER.warn("Skipping label with null or empty key");
+                continue;
+            }
+            if (value == null) {
+                LOGGER.warn("Skipping label '{}' with null value", key);
+                continue;
+            }
+
+            String promKey = "label_" + key.replace(".", "_").replace("/", "_");
+
+            if (value instanceof List<?> listValue) {
+                List<String> values = new ArrayList<>();
+                for (Object item : listValue) {
+                    if (item == null) {
+                        LOGGER.warn("Skipping null entry in label '{}' list", key);
+                        continue;
+                    }
+                    if (!(item instanceof String)) {
+                        LOGGER.warn("Skipping non-string entry in label '{}' list: {}", key, item.getClass().getSimpleName());
+                        continue;
+                    }
+                    String str = ((String) item).trim();
+                    if (!str.isEmpty()) {
+                        values.add(escapePromQLLabelValue(str));
+                    }
+                }
+                if (values.isEmpty()) {
+                    LOGGER.warn("Label '{}' has no valid values after filtering, skipping", key);
+                    continue;
+                }
+                if (sb.length() > 0) sb.append(",");
+                if (values.size() == 1) {
+                    sb.append(promKey).append(exclude ? "!=" : "=")
+                            .append("\"").append(values.get(0)).append("\"");
+                } else {
+                    String regex = String.join("|", values);
+                    sb.append(promKey).append(exclude ? "!~" : "=~")
+                            .append("\"").append(regex).append("\"");
+                }
+            } else if (value instanceof String strValue) {
+                String trimmed = strValue.trim();
+                if (trimmed.isEmpty()) {
+                    LOGGER.warn("Skipping label '{}' with empty string value", key);
+                    continue;
+                }
+                if (sb.length() > 0) sb.append(",");
+                String escaped = escapePromQLLabelValue(trimmed);
+                sb.append(promKey).append(exclude ? "!=" : "=")
+                        .append("\"").append(escaped).append("\"");
+            } else {
+                LOGGER.warn("Skipping label '{}' with unsupported value type: {}", key, value.getClass().getSimpleName());
+            }
+        }
+        return sb.toString();
+    }
+
+    static String escapePromQLLabelValue(String value) {
+        return value.replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n");
     }
 
     private JSONObject processDateRange(BulkInput.TimeRange timeRange) {

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -1096,6 +1096,18 @@ public class KruizeConstants {
 
 
         }
+
+        public static class LabelFilterConstants {
+            public static final String LOG_LABEL_EXPERIMENT_NAME_ERROR = "Error building label string for experiment name: {}";
+            public static final String LOG_LABEL_ALL_INVALID = "All label entries were invalid or empty — no pod label filter will be applied";
+            public static final String LOG_LABEL_NULL_KEY = "Skipping label with null or empty key";
+            public static final String LOG_LABEL_NULL_VALUE = "Skipping label '{}' with null value";
+            public static final String LOG_LABEL_NULL_LIST_ENTRY = "Skipping null entry in label '{}' list";
+            public static final String LOG_LABEL_NON_STRING_ENTRY = "Skipping non-string entry in label '{}' list: {}";
+            public static final String LOG_LABEL_NO_VALID_VALUES = "Label '{}' has no valid values after filtering, skipping";
+            public static final String LOG_LABEL_EMPTY_VALUE = "Skipping label '{}' with empty string value";
+            public static final String LOG_LABEL_UNSUPPORTED_TYPE = "Skipping label '{}' with unsupported value type: {}";
+        }
     }
 
     public static final class MetadataProfileConstants {


### PR DESCRIPTION
## Description
   Adds support for filtering Bulk API experiments by Kubernetes pod labels.

  ### 1. Label filter builder (`BulkJobManager.buildLabelFilters()`)

  Converts user-provided labels into PromQL filter strings.

  **Single value — exact match:**
  Input: `{"app": "heap-oom"}`
  Output: `label_app="heap-oom"`

  **Multiple values — OR match:**
  Input: `{"app": ["heap-oom", "system-oom"]}`
  Output: `label_app=~"heap-oom|system-oom"`

  **Multiple keys — AND (comma-separated):**
  Input: `{"app": "heap-oom", "version": "v1"}`
  Output: `label_app="heap-oom",label_version="v1"`

  **Exclude mode — negated operators:**
  Input: `{"app": "heap-oom"}` (exclude)
  Output: `label_app!="heap-oom"`

  ### 2. Key sanitization

  Kubernetes label keys can contain `.` and `/` (e.g. `app.kubernetes.io/name`), but Prometheus replaces them with `_`. The builder does the same:
  - `app.kubernetes.io/name` → `label_app_kubernetes_io_name`

  ### 3. Labels type change (`BulkInput.java`)
  
  Changed `labels` field from `Map<String, String>` to `Map<String, Object>` so it accepts both:
  - Single value: `"app": "heap-oom"`
  - List of values: `"app": ["heap-oom", "system-oom"]`

  ### 4. Query template (`metadata profiles`)

  Added `workloadsWithPodLabelFilter` query to metadata profiles with placeholders:
  kube_pod_labels{pod!="" LABEL_FILTER ADDITIONAL_LABEL}
  Placeholders are space-separated — commas are prepended only during substitution when the value is non-empty, avoiding stray commas in the final PromQL.
  
  ### 5. Resource filter integration
  
  `buildResourceFilters()` now puts the generated label filter string into the resource map under `podLabelFilter` key, which is used downstream by `DataSourceMetadataOperator` for query substitution.
  
  ## Note
  Part 1 of 2 — this PR adds label filter building + query template. Part 2 adds query substitution logic in `DataSourceMetadataOperator`.


### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [x] Functional testsuite - will add test cases in subsequent PR


**Test Configuration**
* Kubernetes clusters tested on: Openshift, Unit Tests

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

Related PRs:
 1. Label filter builder + metadata profiles — https://github.com/kruize/autotune/pull/2042
 Builds PromQL label filter strings from user-provided pod labels, key sanitization, escaping, metadata profile query templates
 2. Query template substitution — https://github.com/kruize/autotune/pull/2043
 Substitutes LABEL_FILTER/ADDITIONAL_LABEL placeholders in workload queries, removes uniqueKey parameter, zero-workload handling
 3. Unit tests — https://github.com/kruize/autotune/pull/2045
 42 tests for label filter builder + 7 tests for query template substitution

## Summary by Sourcery

Add Kubernetes pod label filtering support to Bulk API resource selection and workload metadata queries.

New Features:
- Add Bulk API support for filtering experiments by Kubernetes pod labels, including exact, multi-value, and exclusion matching.
- Add a metadata profile query for retrieving workloads associated with pods matching label filters.

Bug Fixes:
- Complete Bulk API jobs successfully when no experiments match the requested filters.

Enhancements:
- Allow label filters to accept either scalar or list values and sanitize Kubernetes label keys for PromQL.
- Integrate generated pod label filters into resource filtering for downstream query processing and add validation and escaping for label values.