### PR TITLE
Add query template substitution for pod label filters in Bulk API

### DIFF
--- a/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.json
+++ b/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.json
@@ -40,7 +40,7 @@
       "aggregation_functions": [
         {
           "function": "sum",
-          "query": "sum by (namespace, workload, workload_type) (max_over_time(kube_pod_labels{pod!=\"\" LABEL_FILTER ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (namespace, pod) group_left(workload, workload_type) max_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!=\"\", $UNSUPPORTED_WORKLOAD_TYPES$ ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          "query": "sum by (namespace, workload, workload_type) (max_over_time(kube_pod_labels{pod!=\"\" LABEL_FILTER ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (namespace, pod) group_left(workload, workload_type) max_over_time(namespace_workload_pod:kube_pod_owner:relabel{%s, $UNSUPPORTED_WORKLOAD_TYPES$ ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))"
         }
       ]
     },

--- a/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.json
+++ b/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.json
@@ -52,7 +52,7 @@
       "aggregation_functions": [
         {
           "function": "sum",
-          "query": "sum by (container, image, workload, workload_type, namespace) (avg_over_time(kube_pod_container_info{$CONTAINER_FILTERS$ $NAMESPACE_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (pod, namespace) group_left(workload, workload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{$WORKLOAD_FILTERS$ $UNSUPPORTED_WORKLOAD_TYPES$  $LABELS$}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          "query": "sum by (container, image, workload, workload_type, namespace) (avg_over_time(kube_pod_container_info{$CONTAINER_FILTERS$ $NAMESPACE_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (pod, namespace) group_left(workload, workload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{$WORKLOAD_FILTERS$ $UNSUPPORTED_WORKLOAD_TYPES$}[$MEASUREMENT_DURATION_IN_MIN$m]))"
         }
       ]
     }

--- a/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.json
+++ b/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.json
@@ -16,7 +16,11 @@
       "aggregation_functions": [
         {
           "function": "sum",
+<<<<<<< Updated upstream
           "query": "sum by (namespace) (avg_over_time(kube_namespace_status_phase{NAMESPACE_FILTERS LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+=======
+          "query": "sum by (namespace) (avg_over_time(kube_namespace_status_phase{$NAMESPACE_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+>>>>>>> Stashed changes
         }
       ]
     },
@@ -28,19 +32,31 @@
       "aggregation_functions": [
         {
           "function": "sum",
+<<<<<<< Updated upstream
           "query": "sum by (namespace, workload, workload_type) (avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{WORKLOAD_FILTERS, $UNSUPPORTED_WORKLOAD_TYPES$ LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+=======
+          "query": "sum by (namespace, workload, workload_type) (avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{$UNSUPPORTED_WORKLOAD_TYPES$ $WORKLOAD_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+>>>>>>> Stashed changes
         }
       ]
     },
     {
+<<<<<<< Updated upstream
       "name":  "workloadsWithPodLabelFilter",
+=======
+      "name": "workloadsWithPodLabelFilter",
+>>>>>>> Stashed changes
       "datasource": "prometheus",
       "value_type": "double",
       "kubernetes_object": "container",
       "aggregation_functions": [
         {
           "function": "sum",
+<<<<<<< Updated upstream
           "query": "sum by (namespace, workload, workload_type) (max_over_time(kube_pod_labels{pod!=\"\" WORKLOAD_FILTERS LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (namespace, pod) group_left(workload, workload_type) max_over_time(namespace_workload_pod:kube_pod_owner:relabel{WORKLOAD_FILTERS, $UNSUPPORTED_WORKLOAD_TYPES$ LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+=======
+          "query": "sum by (namespace, workload, workload_type) (max_over_time(kube_pod_labels{$NAMESPACE_FILTERS$ $CONTAINER_FILTERS$ $LABELS$}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (namespace, pod) group_left(workload, workload_type) max_over_time(namespace_workload_pod:kube_pod_owner:relabel{$UNSUPPORTED_WORKLOAD_TYPES$ $WORKLOAD_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+>>>>>>> Stashed changes
         }
       ]
     },
@@ -52,7 +68,11 @@
       "aggregation_functions": [
         {
           "function": "sum",
+<<<<<<< Updated upstream
           "query": "sum by (container, image, workload, workload_type, namespace) (avg_over_time(kube_pod_container_info{CONTAINER_FILTERS LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (pod, namespace) group_left(workload, workload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{WORKLOAD_FILTERS, $UNSUPPORTED_WORKLOAD_TYPES$ LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+=======
+          "query": "sum by (container, image, workload, workload_type, namespace) (avg_over_time(kube_pod_container_info{$CONTAINER_FILTERS$ $NAMESPACE_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (pod, namespace) group_left(workload, workload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{$WORKLOAD_FILTERS$ $UNSUPPORTED_WORKLOAD_TYPES$}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+>>>>>>> Stashed changes
         }
       ]
     }

--- a/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.json
+++ b/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.json
@@ -16,7 +16,7 @@
       "aggregation_functions": [
         {
           "function": "sum",
-          "query": "sum by (namespace) (avg_over_time(kube_namespace_status_phase{namespace!=\"\" ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          "query": "sum by (namespace) (avg_over_time(kube_namespace_status_phase{NAMESPACE_FILTERS LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]))"
         }
       ]
     },
@@ -28,7 +28,7 @@
       "aggregation_functions": [
         {
           "function": "sum",
-          "query": "sum by (namespace, workload, workload_type) (avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!=\"\", $UNSUPPORTED_WORKLOAD_TYPES$ ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          "query": "sum by (namespace, workload, workload_type) (avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{WORKLOAD_FILTERS, $UNSUPPORTED_WORKLOAD_TYPES$ LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]))"
         }
       ]
     },
@@ -40,7 +40,7 @@
       "aggregation_functions": [
         {
           "function": "sum",
-          "query": "sum by (namespace, workload, workload_type) (max_over_time(kube_pod_labels{pod!=\"\" LABEL_FILTER ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (namespace, pod) group_left(workload, workload_type) max_over_time(namespace_workload_pod:kube_pod_owner:relabel{%s, $UNSUPPORTED_WORKLOAD_TYPES$ ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          "query": "sum by (namespace, workload, workload_type) (max_over_time(kube_pod_labels{pod!=\"\" WORKLOAD_FILTERS LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (namespace, pod) group_left(workload, workload_type) max_over_time(namespace_workload_pod:kube_pod_owner:relabel{WORKLOAD_FILTERS, $UNSUPPORTED_WORKLOAD_TYPES$ LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]))"
         }
       ]
     },
@@ -52,7 +52,7 @@
       "aggregation_functions": [
         {
           "function": "sum",
-          "query": "sum by (container, image, workload, workload_type, namespace) (avg_over_time(kube_pod_container_info{container!=\"\" ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (pod, namespace) group_left(workload, workload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!=\"\", $UNSUPPORTED_WORKLOAD_TYPES$ ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+          "query": "sum by (container, image, workload, workload_type, namespace) (avg_over_time(kube_pod_container_info{CONTAINER_FILTERS LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (pod, namespace) group_left(workload, workload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{WORKLOAD_FILTERS, $UNSUPPORTED_WORKLOAD_TYPES$ LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]))"
         }
       ]
     }

--- a/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.json
+++ b/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.json
@@ -16,11 +16,7 @@
       "aggregation_functions": [
         {
           "function": "sum",
-<<<<<<< Updated upstream
-          "query": "sum by (namespace) (avg_over_time(kube_namespace_status_phase{NAMESPACE_FILTERS LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]))"
-=======
           "query": "sum by (namespace) (avg_over_time(kube_namespace_status_phase{$NAMESPACE_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]))"
->>>>>>> Stashed changes
         }
       ]
     },
@@ -32,31 +28,19 @@
       "aggregation_functions": [
         {
           "function": "sum",
-<<<<<<< Updated upstream
-          "query": "sum by (namespace, workload, workload_type) (avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{WORKLOAD_FILTERS, $UNSUPPORTED_WORKLOAD_TYPES$ LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]))"
-=======
           "query": "sum by (namespace, workload, workload_type) (avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{$UNSUPPORTED_WORKLOAD_TYPES$ $WORKLOAD_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]))"
->>>>>>> Stashed changes
         }
       ]
     },
     {
-<<<<<<< Updated upstream
-      "name":  "workloadsWithPodLabelFilter",
-=======
       "name": "workloadsWithPodLabelFilter",
->>>>>>> Stashed changes
       "datasource": "prometheus",
       "value_type": "double",
       "kubernetes_object": "container",
       "aggregation_functions": [
         {
           "function": "sum",
-<<<<<<< Updated upstream
-          "query": "sum by (namespace, workload, workload_type) (max_over_time(kube_pod_labels{pod!=\"\" WORKLOAD_FILTERS LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (namespace, pod) group_left(workload, workload_type) max_over_time(namespace_workload_pod:kube_pod_owner:relabel{WORKLOAD_FILTERS, $UNSUPPORTED_WORKLOAD_TYPES$ LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]))"
-=======
           "query": "sum by (namespace, workload, workload_type) (max_over_time(kube_pod_labels{$NAMESPACE_FILTERS$ $CONTAINER_FILTERS$ $LABELS$}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (namespace, pod) group_left(workload, workload_type) max_over_time(namespace_workload_pod:kube_pod_owner:relabel{$UNSUPPORTED_WORKLOAD_TYPES$ $WORKLOAD_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]))"
->>>>>>> Stashed changes
         }
       ]
     },
@@ -68,11 +52,7 @@
       "aggregation_functions": [
         {
           "function": "sum",
-<<<<<<< Updated upstream
-          "query": "sum by (container, image, workload, workload_type, namespace) (avg_over_time(kube_pod_container_info{CONTAINER_FILTERS LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (pod, namespace) group_left(workload, workload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{WORKLOAD_FILTERS, $UNSUPPORTED_WORKLOAD_TYPES$ LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]))"
-=======
-          "query": "sum by (container, image, workload, workload_type, namespace) (avg_over_time(kube_pod_container_info{$CONTAINER_FILTERS$ $NAMESPACE_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (pod, namespace) group_left(workload, workload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{$WORKLOAD_FILTERS$ $UNSUPPORTED_WORKLOAD_TYPES$}[$MEASUREMENT_DURATION_IN_MIN$m]))"
->>>>>>> Stashed changes
+          "query": "sum by (container, image, workload, workload_type, namespace) (avg_over_time(kube_pod_container_info{$CONTAINER_FILTERS$ $NAMESPACE_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (pod, namespace) group_left(workload, workload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{$WORKLOAD_FILTERS$ $UNSUPPORTED_WORKLOAD_TYPES$  $LABELS$}[$MEASUREMENT_DURATION_IN_MIN$m]))"
         }
       ]
     }

--- a/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.yaml
+++ b/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.yaml
@@ -29,7 +29,7 @@ query_variables:
   kubernetes_object: "container"
   aggregation_functions:
   - function: sum
-    query: 'sum by (namespace, workload, workload_type) (max_over_time(kube_pod_labels{pod!="" LABEL_FILTER ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (namespace, pod) group_left(workload, workload_type) max_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!="", $UNSUPPORTED_WORKLOAD_TYPES$ ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+    query: 'sum by (namespace, workload, workload_type) (max_over_time(kube_pod_labels{pod!="" LABEL_FILTER ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (namespace, pod) group_left(workload, workload_type) max_over_time(namespace_workload_pod:kube_pod_owner:relabel{%s, $UNSUPPORTED_WORKLOAD_TYPES$ ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
 - name: containersForAdditionalLabel
   datasource: prometheus

--- a/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.yaml
+++ b/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.yaml
@@ -37,4 +37,4 @@ query_variables:
   kubernetes_object: "container"
   aggregation_functions:
   - function: sum
-    query: 'sum by (container, image, workload, workload_type, namespace) (avg_over_time(kube_pod_container_info{$CONTAINER_FILTERS$ $NAMESPACE_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (pod, namespace) group_left(workload, workload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{$WORKLOAD_FILTERS$ $UNSUPPORTED_WORKLOAD_TYPES$  $LABELS$}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+    query: 'sum by (container, image, workload, workload_type, namespace) (avg_over_time(kube_pod_container_info{$CONTAINER_FILTERS$ $NAMESPACE_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (pod, namespace) group_left(workload, workload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{$WORKLOAD_FILTERS$ $UNSUPPORTED_WORKLOAD_TYPES$}[$MEASUREMENT_DURATION_IN_MIN$m]))'

--- a/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.yaml
+++ b/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.yaml
@@ -13,11 +13,7 @@ query_variables:
   kubernetes_object: "namespace"
   aggregation_functions:
   - function: sum
-<<<<<<< Updated upstream
-    query: 'sum by (namespace) (avg_over_time(kube_namespace_status_phase{NAMESPACE_FILTERS LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]))'
-=======
     query: 'sum by (namespace) (avg_over_time(kube_namespace_status_phase{$NAMESPACE_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]))'
->>>>>>> Stashed changes
 
 - name: workloadsForAdditionalLabel
   datasource: prometheus
@@ -25,11 +21,7 @@ query_variables:
   kubernetes_object: "container"
   aggregation_functions:
   - function: sum
-<<<<<<< Updated upstream
-    query: 'sum by (namespace, workload, workload_type) (avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{WORKLOAD_FILTERS, $UNSUPPORTED_WORKLOAD_TYPES$ LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]))'
-=======
     query: 'sum by (namespace, workload, workload_type) (avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{$UNSUPPORTED_WORKLOAD_TYPES$ $WORKLOAD_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]))'
->>>>>>> Stashed changes
 
 - name: workloadsWithPodLabelFilter
   datasource: prometheus
@@ -37,11 +29,7 @@ query_variables:
   kubernetes_object: "container"
   aggregation_functions:
   - function: sum
-<<<<<<< Updated upstream
-    query: 'sum by (namespace, workload, workload_type) (max_over_time(kube_pod_labels{pod!="" WORKLOAD_FILTERS LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (namespace, pod) group_left(workload, workload_type) max_over_time(namespace_workload_pod:kube_pod_owner:relabel{WORKLOAD_FILTERS, $UNSUPPORTED_WORKLOAD_TYPES$ LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]))'
-=======
     query: 'sum by (namespace, workload, workload_type) (max_over_time(kube_pod_labels{$NAMESPACE_FILTERS$ $CONTAINER_FILTERS$ $LABELS$}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (namespace, pod) group_left(workload, workload_type) max_over_time(namespace_workload_pod:kube_pod_owner:relabel{$UNSUPPORTED_WORKLOAD_TYPES$ $WORKLOAD_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]))'
->>>>>>> Stashed changes
 
 - name: containersForAdditionalLabel
   datasource: prometheus
@@ -49,8 +37,4 @@ query_variables:
   kubernetes_object: "container"
   aggregation_functions:
   - function: sum
-<<<<<<< Updated upstream
-    query: 'sum by (container, image, workload, workload_type, namespace) (avg_over_time(kube_pod_container_info{CONTAINER_FILTERS LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (pod, namespace) group_left(workload, workload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{WORKLOAD_FILTERS, $UNSUPPORTED_WORKLOAD_TYPES$ LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]))'
-=======
-    query: 'sum by (container, image, workload, workload_type, namespace) (avg_over_time(kube_pod_container_info{$CONTAINER_FILTERS$ $NAMESPACE_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (pod, namespace) group_left(workload, workload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{$WORKLOAD_FILTERS$ $UNSUPPORTED_WORKLOAD_TYPES$}[$MEASUREMENT_DURATION_IN_MIN$m]))'
->>>>>>> Stashed changes
+    query: 'sum by (container, image, workload, workload_type, namespace) (avg_over_time(kube_pod_container_info{$CONTAINER_FILTERS$ $NAMESPACE_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (pod, namespace) group_left(workload, workload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{$WORKLOAD_FILTERS$ $UNSUPPORTED_WORKLOAD_TYPES$  $LABELS$}[$MEASUREMENT_DURATION_IN_MIN$m]))'

--- a/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.yaml
+++ b/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.yaml
@@ -21,7 +21,7 @@ query_variables:
   kubernetes_object: "container"
   aggregation_functions:
   - function: sum
-    query: 'sum by (namespaceworkloadworkload_type) (avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{$UNSUPPORTED_WORKLOAD_TYPES$$WORKLOAD_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+    query: 'sum by (namespace, workload, workload_type) (avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{$UNSUPPORTED_WORKLOAD_TYPES$ $WORKLOAD_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
 - name: workloadsWithPodLabelFilter
   datasource: prometheus
@@ -29,7 +29,7 @@ query_variables:
   kubernetes_object: "container"
   aggregation_functions:
   - function: sum
-    query: 'sum by (namespaceworkloadworkload_type) (max_over_time(kube_pod_labels{$NAMESPACE_FILTERS$$CONTAINER_FILTERS$$LABELS$}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (namespacepod) group_left(workloadworkload_type) max_over_time(namespace_workload_pod:kube_pod_owner:relabel{$UNSUPPORTED_WORKLOAD_TYPES$$WORKLOAD_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+    query: 'sum by (namespace, workload, workload_type) (max_over_time(kube_pod_labels{$NAMESPACE_FILTERS$ $CONTAINER_FILTERS$ $LABELS$}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (namespace, pod) group_left(workload, workload_type) max_over_time(namespace_workload_pod:kube_pod_owner:relabel{$UNSUPPORTED_WORKLOAD_TYPES$ $WORKLOAD_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
 - name: containersForAdditionalLabel
   datasource: prometheus
@@ -37,4 +37,4 @@ query_variables:
   kubernetes_object: "container"
   aggregation_functions:
   - function: sum
-    query: 'sum by (containerimageworkloadworkload_typenamespace) (avg_over_time(kube_pod_container_info{$CONTAINER_FILTERS$$NAMESPACE_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (podnamespace) group_left(workloadworkload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{$WORKLOAD_FILTERS$$UNSUPPORTED_WORKLOAD_TYPES$$LABELS$}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+    query: 'sum by (container, image, workload, workload_type, namespace) (avg_over_time(kube_pod_container_info{$CONTAINER_FILTERS$ $NAMESPACE_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (pod, namespace) group_left(workload, workload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{$WORKLOAD_FILTERS$ $UNSUPPORTED_WORKLOAD_TYPES$  $LABELS$}[$MEASUREMENT_DURATION_IN_MIN$m]))'

--- a/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.yaml
+++ b/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.yaml
@@ -21,7 +21,7 @@ query_variables:
   kubernetes_object: "container"
   aggregation_functions:
   - function: sum
-    query: 'sum by (namespace, workload, workload_type) (avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{$UNSUPPORTED_WORKLOAD_TYPES$ $WORKLOAD_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+    query: 'sum by (namespaceworkloadworkload_type) (avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{$UNSUPPORTED_WORKLOAD_TYPES$$WORKLOAD_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
 - name: workloadsWithPodLabelFilter
   datasource: prometheus
@@ -29,7 +29,7 @@ query_variables:
   kubernetes_object: "container"
   aggregation_functions:
   - function: sum
-    query: 'sum by (namespace, workload, workload_type) (max_over_time(kube_pod_labels{$NAMESPACE_FILTERS$ $CONTAINER_FILTERS$ $LABELS$}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (namespace, pod) group_left(workload, workload_type) max_over_time(namespace_workload_pod:kube_pod_owner:relabel{$UNSUPPORTED_WORKLOAD_TYPES$ $WORKLOAD_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+    query: 'sum by (namespaceworkloadworkload_type) (max_over_time(kube_pod_labels{$NAMESPACE_FILTERS$$CONTAINER_FILTERS$$LABELS$}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (namespacepod) group_left(workloadworkload_type) max_over_time(namespace_workload_pod:kube_pod_owner:relabel{$UNSUPPORTED_WORKLOAD_TYPES$$WORKLOAD_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
 - name: containersForAdditionalLabel
   datasource: prometheus
@@ -37,4 +37,4 @@ query_variables:
   kubernetes_object: "container"
   aggregation_functions:
   - function: sum
-    query: 'sum by (container, image, workload, workload_type, namespace) (avg_over_time(kube_pod_container_info{$CONTAINER_FILTERS$ $NAMESPACE_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (pod, namespace) group_left(workload, workload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{$WORKLOAD_FILTERS$ $UNSUPPORTED_WORKLOAD_TYPES$  $LABELS$}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+    query: 'sum by (containerimageworkloadworkload_typenamespace) (avg_over_time(kube_pod_container_info{$CONTAINER_FILTERS$$NAMESPACE_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (podnamespace) group_left(workloadworkload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{$WORKLOAD_FILTERS$$UNSUPPORTED_WORKLOAD_TYPES$$LABELS$}[$MEASUREMENT_DURATION_IN_MIN$m]))'

--- a/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.yaml
+++ b/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.yaml
@@ -13,7 +13,11 @@ query_variables:
   kubernetes_object: "namespace"
   aggregation_functions:
   - function: sum
+<<<<<<< Updated upstream
     query: 'sum by (namespace) (avg_over_time(kube_namespace_status_phase{NAMESPACE_FILTERS LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+=======
+    query: 'sum by (namespace) (avg_over_time(kube_namespace_status_phase{$NAMESPACE_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+>>>>>>> Stashed changes
 
 - name: workloadsForAdditionalLabel
   datasource: prometheus
@@ -21,7 +25,11 @@ query_variables:
   kubernetes_object: "container"
   aggregation_functions:
   - function: sum
+<<<<<<< Updated upstream
     query: 'sum by (namespace, workload, workload_type) (avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{WORKLOAD_FILTERS, $UNSUPPORTED_WORKLOAD_TYPES$ LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+=======
+    query: 'sum by (namespace, workload, workload_type) (avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{$UNSUPPORTED_WORKLOAD_TYPES$ $WORKLOAD_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+>>>>>>> Stashed changes
 
 - name: workloadsWithPodLabelFilter
   datasource: prometheus
@@ -29,7 +37,11 @@ query_variables:
   kubernetes_object: "container"
   aggregation_functions:
   - function: sum
+<<<<<<< Updated upstream
     query: 'sum by (namespace, workload, workload_type) (max_over_time(kube_pod_labels{pod!="" WORKLOAD_FILTERS LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (namespace, pod) group_left(workload, workload_type) max_over_time(namespace_workload_pod:kube_pod_owner:relabel{WORKLOAD_FILTERS, $UNSUPPORTED_WORKLOAD_TYPES$ LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+=======
+    query: 'sum by (namespace, workload, workload_type) (max_over_time(kube_pod_labels{$NAMESPACE_FILTERS$ $CONTAINER_FILTERS$ $LABELS$}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (namespace, pod) group_left(workload, workload_type) max_over_time(namespace_workload_pod:kube_pod_owner:relabel{$UNSUPPORTED_WORKLOAD_TYPES$ $WORKLOAD_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+>>>>>>> Stashed changes
 
 - name: containersForAdditionalLabel
   datasource: prometheus
@@ -37,4 +49,8 @@ query_variables:
   kubernetes_object: "container"
   aggregation_functions:
   - function: sum
+<<<<<<< Updated upstream
     query: 'sum by (container, image, workload, workload_type, namespace) (avg_over_time(kube_pod_container_info{CONTAINER_FILTERS LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (pod, namespace) group_left(workload, workload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{WORKLOAD_FILTERS, $UNSUPPORTED_WORKLOAD_TYPES$ LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+=======
+    query: 'sum by (container, image, workload, workload_type, namespace) (avg_over_time(kube_pod_container_info{$CONTAINER_FILTERS$ $NAMESPACE_FILTERS$}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (pod, namespace) group_left(workload, workload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{$WORKLOAD_FILTERS$ $UNSUPPORTED_WORKLOAD_TYPES$}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+>>>>>>> Stashed changes

--- a/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.yaml
+++ b/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.yaml
@@ -13,7 +13,7 @@ query_variables:
   kubernetes_object: "namespace"
   aggregation_functions:
   - function: sum
-    query: 'sum by (namespace) (avg_over_time(kube_namespace_status_phase{namespace!="" ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+    query: 'sum by (namespace) (avg_over_time(kube_namespace_status_phase{NAMESPACE_FILTERS LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
 - name: workloadsForAdditionalLabel
   datasource: prometheus
@@ -21,7 +21,7 @@ query_variables:
   kubernetes_object: "container"
   aggregation_functions:
   - function: sum
-    query: 'sum by (namespace, workload, workload_type) (avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!="", $UNSUPPORTED_WORKLOAD_TYPES$ ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+    query: 'sum by (namespace, workload, workload_type) (avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{WORKLOAD_FILTERS, $UNSUPPORTED_WORKLOAD_TYPES$ LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
 - name: workloadsWithPodLabelFilter
   datasource: prometheus
@@ -29,7 +29,7 @@ query_variables:
   kubernetes_object: "container"
   aggregation_functions:
   - function: sum
-    query: 'sum by (namespace, workload, workload_type) (max_over_time(kube_pod_labels{pod!="" LABEL_FILTER ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (namespace, pod) group_left(workload, workload_type) max_over_time(namespace_workload_pod:kube_pod_owner:relabel{%s, $UNSUPPORTED_WORKLOAD_TYPES$ ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+    query: 'sum by (namespace, workload, workload_type) (max_over_time(kube_pod_labels{pod!="" WORKLOAD_FILTERS LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (namespace, pod) group_left(workload, workload_type) max_over_time(namespace_workload_pod:kube_pod_owner:relabel{WORKLOAD_FILTERS, $UNSUPPORTED_WORKLOAD_TYPES$ LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]))'
 
 - name: containersForAdditionalLabel
   datasource: prometheus
@@ -37,4 +37,4 @@ query_variables:
   kubernetes_object: "container"
   aggregation_functions:
   - function: sum
-    query: 'sum by (container, image, workload, workload_type, namespace) (avg_over_time(kube_pod_container_info{container!="" ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (pod, namespace) group_left(workload, workload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!="", $UNSUPPORTED_WORKLOAD_TYPES$ ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))'
+    query: 'sum by (container, image, workload, workload_type, namespace) (avg_over_time(kube_pod_container_info{CONTAINER_FILTERS LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (pod, namespace) group_left(workload, workload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{WORKLOAD_FILTERS, $UNSUPPORTED_WORKLOAD_TYPES$ LABELS}[$MEASUREMENT_DURATION_IN_MIN$m]))'

--- a/src/main/java/com/autotune/analyzer/services/DSMetadataService.java
+++ b/src/main/java/com/autotune/analyzer/services/DSMetadataService.java
@@ -157,7 +157,7 @@ public class DSMetadataService extends HttpServlet {
                 }
 
                 DataSourceMetadataInfo metadataInfo = dataSourceManager.importMetadataFromDataSource(metadataProfileName,
-                        datasource,"",0, 0, 0, measurementDuration, new HashMap<>(), new HashMap<>());
+                        datasource, 0, 0, 0, measurementDuration, new HashMap<>(), new HashMap<>());
 
                 // Validate imported metadataInfo object
                 DataSourceMetadataValidation validationObject = new DataSourceMetadataValidation();

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -109,9 +109,9 @@ public class AnalyzerConstants {
     public static final String CONTAINER = "container";
 
     // Metadata query constants - exact metric names in metadata profiles
-    public static final String WORKLOAD_METADATA_QUERY = "workloadsAcrossCluster";
-    public static final String NAMESPACE_METADATA_QUERY = "namespacesAcrossCluster";
-    public static final String CONTAINER_METADATA_QUERY = "containersAcrossCluster";
+    public static final String WORKLOAD_METADATA_QUERY = "workloadsForAdditionalLabel";
+    public static final String NAMESPACE_METADATA_QUERY = "namespacesForAdditionalLabel";
+    public static final String CONTAINER_METADATA_QUERY = "containersForAdditionalLabel";
 
     public static final int DEFAULT_MEASUREMENT_DURATION_INT = 15;
     public static final String KRUIZE_PROFILE_FILTER = "kruize";

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -110,6 +110,7 @@ public class AnalyzerConstants {
 
     // Metadata query constants - exact metric names in metadata profiles
     public static final String WORKLOAD_METADATA_QUERY = "workloadsForAdditionalLabel";
+    public static final String WORKLOAD_METADATA_QUERY_WITH_LABEL_FILTER = "workloadsWithPodLabelFilter";
     public static final String NAMESPACE_METADATA_QUERY = "namespacesForAdditionalLabel";
     public static final String CONTAINER_METADATA_QUERY = "containersForAdditionalLabel";
 

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -107,6 +107,12 @@ public class AnalyzerConstants {
     public static final String METADATA_PROFILE = "metadataProfile";
     public static final String WORKLOAD = "workload";
     public static final String CONTAINER = "container";
+
+    // Metadata query constants - exact metric names in metadata profiles
+    public static final String WORKLOAD_METADATA_QUERY = "workloadsAcrossCluster";
+    public static final String NAMESPACE_METADATA_QUERY = "namespacesAcrossCluster";
+    public static final String CONTAINER_METADATA_QUERY = "containersAcrossCluster";
+
     public static final int DEFAULT_MEASUREMENT_DURATION_INT = 15;
     public static final String KRUIZE_PROFILE_FILTER = "kruize";
     public static final String NAMESPACE_PROFILE_FILTER = "openshift-tuning|monitoring";

--- a/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
+++ b/src/main/java/com/autotune/analyzer/utils/AnalyzerConstants.java
@@ -1157,6 +1157,8 @@ public class AnalyzerConstants {
             filter.append("workload_type!~").append("\"(?i)").append(typeString).append("\"");
         }
         
-        return filter.toString();
+        // Add leading comma for chaining with other filters in PromQL selectors
+        String result = filter.toString();
+        return result.isEmpty() ? "" : ", " + result;
     }
 }

--- a/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
+++ b/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
@@ -179,11 +179,12 @@ public class BulkJobManager implements Runnable {
                 if (null != datasource) {
                     JSONObject daterange = processDateRange(this.bulkInput.getTime_range());
                     if (null != daterange) {
-                        metadataInfo = dataSourceManager.importMetadataFromDataSource(metadataProfileName, datasource, labelString, (Long) daterange.get(START_TIME),
-                                (Long) daterange.get(END_TIME), (Integer) daterange.get(STEPS), measurementDuration, includeResourcesMap, excludeResourcesMap);
+                        metadataInfo = dataSourceManager.importMetadataFromDataSource(metadataProfileName, datasource,
+                                (Long) daterange.get(START_TIME), (Long) daterange.get(END_TIME),
+                                (Integer) daterange.get(STEPS), measurementDuration, includeResourcesMap, excludeResourcesMap);
                     } else {
-                        metadataInfo = dataSourceManager.importMetadataFromDataSource(metadataProfileName, datasource, labelString, 0, 0,
-                                0, measurementDuration, includeResourcesMap, excludeResourcesMap);
+                        metadataInfo = dataSourceManager.importMetadataFromDataSource(metadataProfileName, datasource,
+                                0L, 0L, 0, measurementDuration, includeResourcesMap, excludeResourcesMap);
                     }
                     if (null == metadataInfo) {
                         setFinalJobStatus(COMPLETED, String.valueOf(HttpURLConnection.HTTP_OK), NOTHING_INFO, datasource);

--- a/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
+++ b/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
@@ -554,6 +554,7 @@ public class BulkJobManager implements Runnable {
     private String getLabelsForExperimentName(BulkInput.FilterWrapper filter) {
         try {
             if (filter.getInclude() != null) {
+<<<<<<< Updated upstream
                 Map<String, Object> includeLabels = filter.getInclude().getLabels();
                 if (includeLabels != null && !includeLabels.isEmpty()) {
                     StringBuilder sb = new StringBuilder();
@@ -564,6 +565,14 @@ public class BulkJobManager implements Runnable {
                                 value.toString();
                         if (val.isEmpty()) return;
                         sb.append(key).append("=\"").append(val).append("\",");
+=======
+                Map<String, String> includeLabels = filter.getInclude().getLabels();
+                if (includeLabels != null && !includeLabels.isEmpty()) {
+                    StringBuilder sb = new StringBuilder();
+                    includeLabels.forEach((key, value) -> {
+                        if (value == null || value.isEmpty()) return;
+                        sb.append(key).append("=\"").append(value).append("\",");
+>>>>>>> Stashed changes
                     });
                     if (sb.length() > 0) sb.setLength(sb.length() - 1);
                     return sb.toString();
@@ -596,11 +605,19 @@ public class BulkJobManager implements Runnable {
         return resourceFilters;
     }
 
+<<<<<<< Updated upstream
     private String buildLabelFilters(Map<String, Object> labels, boolean exclude) {
         StringBuilder sb = new StringBuilder();
         for (Map.Entry<String, Object> entry : labels.entrySet()) {
             String key = entry.getKey();
             Object value = entry.getValue();
+=======
+    String buildLabelFilters(Map<String, String> labels, boolean exclude) {
+        StringBuilder sb = new StringBuilder();
+        for (Map.Entry<String, String> entry : labels.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+>>>>>>> Stashed changes
 
             if (key == null || key.isBlank()) {
                 LOGGER.warn(KruizeConstants.KRUIZE_BULK_API.LabelFilterConstants.LOG_LABEL_NULL_KEY);
@@ -611,6 +628,7 @@ public class BulkJobManager implements Runnable {
                 continue;
             }
 
+<<<<<<< Updated upstream
             String promKey = "label_" + key.replace(".", "_").replace("/", "_");
 
             if (value instanceof List<?> listValue) {
@@ -657,6 +675,19 @@ public class BulkJobManager implements Runnable {
             } else {
                 LOGGER.warn(KruizeConstants.KRUIZE_BULK_API.LabelFilterConstants.LOG_LABEL_UNSUPPORTED_TYPE, key, value.getClass().getSimpleName());
             }
+=======
+            String trimmed = value.trim();
+            if (trimmed.isEmpty()) {
+                LOGGER.warn(KruizeConstants.KRUIZE_BULK_API.LabelFilterConstants.LOG_LABEL_EMPTY_VALUE, key);
+                continue;
+            }
+
+            String promKey = "label_" + key.replace(".", "_").replace("/", "_");
+            if (sb.length() > 0) sb.append(",");
+            String escaped = escapePromQLLabelValue(trimmed);
+            sb.append(promKey).append(exclude ? "!=" : "=")
+                    .append("\"").append(escaped).append("\"");
+>>>>>>> Stashed changes
         }
         return sb.toString();
     }

--- a/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
+++ b/src/main/java/com/autotune/analyzer/workerimpl/BulkJobManager.java
@@ -554,7 +554,6 @@ public class BulkJobManager implements Runnable {
     private String getLabelsForExperimentName(BulkInput.FilterWrapper filter) {
         try {
             if (filter.getInclude() != null) {
-<<<<<<< Updated upstream
                 Map<String, Object> includeLabels = filter.getInclude().getLabels();
                 if (includeLabels != null && !includeLabels.isEmpty()) {
                     StringBuilder sb = new StringBuilder();
@@ -565,14 +564,6 @@ public class BulkJobManager implements Runnable {
                                 value.toString();
                         if (val.isEmpty()) return;
                         sb.append(key).append("=\"").append(val).append("\",");
-=======
-                Map<String, String> includeLabels = filter.getInclude().getLabels();
-                if (includeLabels != null && !includeLabels.isEmpty()) {
-                    StringBuilder sb = new StringBuilder();
-                    includeLabels.forEach((key, value) -> {
-                        if (value == null || value.isEmpty()) return;
-                        sb.append(key).append("=\"").append(value).append("\",");
->>>>>>> Stashed changes
                     });
                     if (sb.length() > 0) sb.setLength(sb.length() - 1);
                     return sb.toString();
@@ -605,19 +596,11 @@ public class BulkJobManager implements Runnable {
         return resourceFilters;
     }
 
-<<<<<<< Updated upstream
     private String buildLabelFilters(Map<String, Object> labels, boolean exclude) {
         StringBuilder sb = new StringBuilder();
         for (Map.Entry<String, Object> entry : labels.entrySet()) {
             String key = entry.getKey();
             Object value = entry.getValue();
-=======
-    String buildLabelFilters(Map<String, String> labels, boolean exclude) {
-        StringBuilder sb = new StringBuilder();
-        for (Map.Entry<String, String> entry : labels.entrySet()) {
-            String key = entry.getKey();
-            String value = entry.getValue();
->>>>>>> Stashed changes
 
             if (key == null || key.isBlank()) {
                 LOGGER.warn(KruizeConstants.KRUIZE_BULK_API.LabelFilterConstants.LOG_LABEL_NULL_KEY);
@@ -628,7 +611,6 @@ public class BulkJobManager implements Runnable {
                 continue;
             }
 
-<<<<<<< Updated upstream
             String promKey = "label_" + key.replace(".", "_").replace("/", "_");
 
             if (value instanceof List<?> listValue) {
@@ -675,19 +657,6 @@ public class BulkJobManager implements Runnable {
             } else {
                 LOGGER.warn(KruizeConstants.KRUIZE_BULK_API.LabelFilterConstants.LOG_LABEL_UNSUPPORTED_TYPE, key, value.getClass().getSimpleName());
             }
-=======
-            String trimmed = value.trim();
-            if (trimmed.isEmpty()) {
-                LOGGER.warn(KruizeConstants.KRUIZE_BULK_API.LabelFilterConstants.LOG_LABEL_EMPTY_VALUE, key);
-                continue;
-            }
-
-            String promKey = "label_" + key.replace(".", "_").replace("/", "_");
-            if (sb.length() > 0) sb.append(",");
-            String escaped = escapePromQLLabelValue(trimmed);
-            sb.append(promKey).append(exclude ? "!=" : "=")
-                    .append("\"").append(escaped).append("\"");
->>>>>>> Stashed changes
         }
         return sb.toString();
     }

--- a/src/main/java/com/autotune/common/datasource/DataSourceManager.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceManager.java
@@ -60,7 +60,6 @@ public class DataSourceManager {
      * Imports Metadata for a specific data source using associated DataSourceInfo.
      *
      * @param dataSourceInfo
-     * @param uniqueKey        this is used as labels in query example container="xyz" namespace="abc"
      * @param startTime        Get metadata from starttime to endtime
      * @param endTime          Get metadata from starttime to endtime
      * @param steps            the interval between data points in a range query
@@ -68,7 +67,7 @@ public class DataSourceManager {
      * @param excludeResources
      * @return
      */
-    public DataSourceMetadataInfo importMetadataFromDataSource(String metadataProfileName, DataSourceInfo dataSourceInfo, String uniqueKey, long startTime, long endTime, int steps, int measurementDuration, Map<String, String> includeResources,
+    public DataSourceMetadataInfo importMetadataFromDataSource(String metadataProfileName, DataSourceInfo dataSourceInfo, long startTime, long endTime, int steps, int measurementDuration, Map<String, String> includeResources,
                                                                Map<String, String> excludeResources) throws DataSourceDoesNotExist, IOException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
         String statusValue = "failure";
         io.micrometer.core.instrument.Timer.Sample timerImportMetadata = Timer.start(MetricsConfig.meterRegistry());
@@ -77,7 +76,7 @@ public class DataSourceManager {
                 throw new DataSourceDoesNotExist(KruizeConstants.DataSourceConstants.DataSourceErrorMsgs.MISSING_DATASOURCE_INFO);
             }
             DataSourceMetadataInfo dataSourceMetadataInfo = dataSourceMetadataOperator.createDataSourceMetadata(metadataProfileName,
-                    dataSourceInfo, uniqueKey, startTime, endTime, steps, measurementDuration, includeResources, excludeResources);
+                    dataSourceInfo, startTime, endTime, steps, measurementDuration, includeResources, excludeResources);
             if (null == dataSourceMetadataInfo) {
                 LOGGER.error(KruizeConstants.DataSourceConstants.DataSourceMetadataErrorMsgs.DATASOURCE_METADATA_INFO_NOT_AVAILABLE, "for datasource {}" + dataSourceInfo.getName());
                 return null;
@@ -142,7 +141,7 @@ public class DataSourceManager {
             if (null == dataSourceMetadataInfo) {
                 throw new DataSourceDoesNotExist(DATASOURCE_METADATA_INFO_NOT_AVAILABLE);
             }
-            dataSourceMetadataOperator.updateDataSourceMetadata(metadataProfileName, dataSource, "", 0, 0, 0, measurementDuration, null, null);
+            dataSourceMetadataOperator.updateDataSourceMetadata(metadataProfileName, dataSource, 0, 0, 0, measurementDuration, new HashMap<>(), new HashMap<>());
         } catch (Exception e) {
             LOGGER.error(e.getMessage());
         }

--- a/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
@@ -67,7 +67,6 @@ public class DataSourceMetadataOperator {
      * Currently supported DataSourceProvider - Prometheus
      *
      * @param dataSourceInfo   The DataSourceInfo object containing information about the data source.
-     * @param uniqueKey        this is used as labels in query example container="xyz" namespace="abc"
      * @param startTime        Get metadata from starttime to endtime
      * @param endTime          Get metadata from starttime to endtime
      * @param steps            the interval between data points in a range query
@@ -75,10 +74,10 @@ public class DataSourceMetadataOperator {
      * @param includeResources
      * @param excludeResources
      */
-    public DataSourceMetadataInfo createDataSourceMetadata(String metadataProfileName, DataSourceInfo dataSourceInfo, String uniqueKey, long startTime,
+    public DataSourceMetadataInfo createDataSourceMetadata(String metadataProfileName, DataSourceInfo dataSourceInfo, long startTime,
                                                            long endTime, int steps,  int measurementDuration, Map<String, String> includeResources,
                                                            Map<String, String> excludeResources) throws IOException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
-        return processQueriesAndPopulateDataSourceMetadataInfo(metadataProfileName, dataSourceInfo, uniqueKey, startTime,
+        return processQueriesAndPopulateDataSourceMetadataInfo(metadataProfileName, dataSourceInfo, startTime,
                 endTime, steps, measurementDuration, includeResources, excludeResources);
     }
 
@@ -121,10 +120,10 @@ public class DataSourceMetadataOperator {
      *                                                                                                                                                                                                                                                                          TODO - Currently Create and Update functions have identical functionalities, based on UI workflow and requirements
      *                                                                                                                                                                                                                                                                                 need to further enhance updateDataSourceMetadata() to support namespace, workload level granular updates
      */
-    public DataSourceMetadataInfo updateDataSourceMetadata(String metadataProfileName,DataSourceInfo dataSourceInfo, String uniqueKey, long startTime,
+    public DataSourceMetadataInfo updateDataSourceMetadata(String metadataProfileName,DataSourceInfo dataSourceInfo, long startTime,
                                                            long endTime, int steps, int measurementDuration, Map<String, String> includeResources,
                                                            Map<String, String> excludeResources) throws Exception {
-        return processQueriesAndPopulateDataSourceMetadataInfo(metadataProfileName, dataSourceInfo, uniqueKey, startTime,
+        return processQueriesAndPopulateDataSourceMetadataInfo(metadataProfileName, dataSourceInfo, startTime,
                 endTime, steps, measurementDuration, includeResources, excludeResources);
     }
 
@@ -158,7 +157,6 @@ public class DataSourceMetadataOperator {
      * DataSourceMetadataInfo object
      *
      * @param dataSourceInfo   The DataSourceInfo object containing information about the data source
-     * @param uniqueKey        this is used as labels in query example container="xyz" namespace="abc"
      * @param startTime        Get metadata from starttime to endtime
      * @param endTime          Get metadata from starttime to endtime
      * @param steps            the interval between data points in a range query
@@ -167,7 +165,7 @@ public class DataSourceMetadataOperator {
      * @return DataSourceMetadataInfo object with populated metadata fields
      * todo rename processQueriesAndFetchClusterMetadataInfo
      */
-    public DataSourceMetadataInfo processQueriesAndPopulateDataSourceMetadataInfo(String metadataProfileName, DataSourceInfo dataSourceInfo, String uniqueKey,
+    public DataSourceMetadataInfo processQueriesAndPopulateDataSourceMetadataInfo(String metadataProfileName, DataSourceInfo dataSourceInfo,
                                                                                   long startTime, long endTime, int steps, int measurementDuration,
                                                                                   Map<String, String> includeResources,
                                                                                   Map<String, String> excludeResources) throws IOException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
@@ -193,17 +191,54 @@ public class DataSourceMetadataOperator {
 
         MetadataProfile metadataProfile = MetadataProfileCollection.getInstance().getMetadataProfileCollection().get(metadataProfileName);
 
+        if (null == metadataProfile) {
+            LOGGER.error("Metadata profile '{}' not found in MetadataProfileCollection", metadataProfileName);
+            return null;
+        }
+
+        // Determine if pod label filters are present — if so, use label-aware workload template
+        String includePodLabelFilter = includeResources.getOrDefault("podLabelFilter", "");
+        String excludePodLabelFilter = excludeResources.getOrDefault("podLabelFilter", "");
+        boolean hasLabelFilter = !includePodLabelFilter.isEmpty() || !excludePodLabelFilter.isEmpty();
+
+        String labelWorkloadTemplate = null;
+        if (hasLabelFilter) {
+            labelWorkloadTemplate = dataSourceDetailsHelper.getQueryFromProfile(metadataProfile, "workloadsWithPodLabelFilter");
+            if (labelWorkloadTemplate == null) {
+                LOGGER.warn("workloadsWithPodLabelFilter query not found in metadata profile, falling back to standard query");
+                hasLabelFilter = false;
+            } else {
+                LOGGER.info("Label filter present — using workloadsWithPodLabelFilter template for workload query");
+            }
+        }
+
+        final boolean useLabelTemplate = hasLabelFilter;
+        final String finalLabelWorkloadTemplate = labelWorkloadTemplate;
+
         // Populate filters for each field
         fields.forEach(field -> {
             String includeRegex = includeResources.getOrDefault(field + "Regex", "");
             String excludeRegex = excludeResources.getOrDefault(field + "Regex", "");
             String filter = constructDynamicFilter(field, includeRegex, excludeRegex);
-            String queryTemplate = getQueryTemplate(field, metadataProfile);
+
+            // For the workload field, use the label-aware template when a label filter is present
+            String queryTemplate = (field.equals("workload") && useLabelTemplate)
+                    ? finalLabelWorkloadTemplate
+                    : getQueryTemplate(field, metadataProfile);
+
+            if (queryTemplate == null) {
+                LOGGER.error("Query template is null for field {}, cannot proceed", field);
+                queries.put(field, null);
+                return;
+            }
             String filteredQuery;
+            // For the label workload template, only allow %s substitution; avoid replacing
+            // the field!="" pattern which may legitimately appear inside PromQL label selectors.
+            boolean isLabelTemplate = useLabelTemplate && field.equals("workload");
             if (queryTemplate.contains("%s")) {
                 filteredQuery = String.format(queryTemplate, filter);
 
-            } else if (queryTemplate.contains(field + "!=\"\"")) {
+            } else if (!isLabelTemplate && queryTemplate.contains(field + "!=\"\"")) {
                 filteredQuery = queryTemplate.replace(
                     field + "!=\"\"",
                     filter.isEmpty() ? field + "!=\"\"" : filter
@@ -221,22 +256,24 @@ public class DataSourceMetadataOperator {
             queries.put(field, filteredQuery);
         });
 
+        // Abort if any required query template was missing
+        if (queries.containsValue(null)) {
+            LOGGER.error("One or more query templates could not be resolved for metadata profile '{}', aborting metadata fetch", metadataProfileName);
+            return null;
+        }
+
         // Construct queries
         String namespaceQuery = queries.get("namespace");
         String workloadQuery = queries.get("workload");
         String containerQuery = queries.get("container");
 
         String dataSourceName = dataSourceInfo.getName();
-        if (null != uniqueKey && !uniqueKey.isEmpty()) {
-            LOGGER.debug("uniquekey: {}", uniqueKey);
-            namespaceQuery = namespaceQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "," + uniqueKey);
-            workloadQuery = workloadQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "," + uniqueKey);
-            containerQuery = containerQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "," + uniqueKey);
-        } else {
-            namespaceQuery = namespaceQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "");
-            workloadQuery = workloadQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "");
-            containerQuery = containerQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "");
-        }
+
+        workloadQuery = substituteWorkloadQueryPlaceholders(
+                workloadQuery, includePodLabelFilter, excludePodLabelFilter, hasLabelFilter);
+
+        namespaceQuery = namespaceQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "");
+        containerQuery = containerQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "");
 
         namespaceQuery = namespaceQuery.replace(AnalyzerConstants.MEASUREMENT_DURATION_IN_MIN_VARAIBLE, Integer.toString(measurementDuration));
         workloadQuery = workloadQuery.replace(AnalyzerConstants.MEASUREMENT_DURATION_IN_MIN_VARAIBLE, Integer.toString(measurementDuration));
@@ -279,6 +316,10 @@ public class DataSourceMetadataOperator {
 
             if (op.validateResultArray(workloadDataResultArray)) {
                 datasourceWorkloads = dataSourceDetailsHelper.getWorkloadInfo(workloadDataResultArray);
+            }
+            if (hasLabelFilter && datasourceWorkloads.isEmpty()) {
+                LOGGER.info("Label filter matched zero workloads — skipping experiment creation");
+                return null;
             }
             dataSourceDetailsHelper.updateWorkloadDataSourceMetadataInfoObject(dataSourceName, dataSourceMetadataInfo,
                     datasourceWorkloads);
@@ -337,6 +378,28 @@ public class DataSourceMetadataOperator {
         }
         LOGGER.info("filterBuilder: {}", filterBuilder);
         return filterBuilder.toString();
+    }
+
+    static String substituteWorkloadQueryPlaceholders(String workloadQuery,
+                                                         String includePodLabelFilter,
+                                                         String excludePodLabelFilter,
+                                                         boolean hasLabelFilter) {
+        if (hasLabelFilter) {
+            StringBuilder labelFilter = new StringBuilder();
+            if (!includePodLabelFilter.isEmpty()) labelFilter.append(",").append(includePodLabelFilter);
+            if (!excludePodLabelFilter.isEmpty()) {
+                labelFilter.append(",").append(excludePodLabelFilter);
+            }
+            workloadQuery = workloadQuery.replace(KruizeConstants.KRUIZE_BULK_API.LABEL_FILTER, labelFilter.toString());
+        } else {
+            workloadQuery = workloadQuery.replace(KruizeConstants.KRUIZE_BULK_API.LABEL_FILTER, "");
+        }
+
+        workloadQuery = workloadQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "");
+
+        workloadQuery = workloadQuery.replaceAll("\\s{2,}", " ").replaceAll("\\s+}", "}").replaceAll("\\{\\s+", "{");
+
+        return workloadQuery;
     }
 
     private JsonArray fetchQueryResults(DataSourceInfo dataSourceInfo, String query, long startTime, long endTime, int steps) throws IOException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException {

--- a/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
@@ -203,12 +203,13 @@ public class DataSourceMetadataOperator {
 
         String labelWorkloadTemplate = null;
         if (hasLabelFilter) {
-            labelWorkloadTemplate = dataSourceDetailsHelper.getQueryFromProfile(metadataProfile, "workloadsWithPodLabelFilter");
+            labelWorkloadTemplate = dataSourceDetailsHelper.getQueryFromProfile(metadataProfile, AnalyzerConstants.WORKLOAD_METADATA_QUERY_WITH_LABEL_FILTER);
             if (labelWorkloadTemplate == null) {
-                LOGGER.error("Pod label filtering requested but 'workloadsWithPodLabelFilter' query not found in metadata profile '{}'", metadataProfileName);
+                LOGGER.error("Pod label filtering requested but '{}' query not found in metadata profile '{}'",
+                    AnalyzerConstants.WORKLOAD_METADATA_QUERY_WITH_LABEL_FILTER, metadataProfileName);
                 return null;
             }
-            LOGGER.info("Label filter present — using workloadsWithPodLabelFilter template for workload query");
+            LOGGER.info("Label filter present — using {} template for workload query", AnalyzerConstants.WORKLOAD_METADATA_QUERY_WITH_LABEL_FILTER);
         }
 
         final boolean useLabelTemplate = hasLabelFilter;

--- a/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
@@ -205,11 +205,10 @@ public class DataSourceMetadataOperator {
         if (hasLabelFilter) {
             labelWorkloadTemplate = dataSourceDetailsHelper.getQueryFromProfile(metadataProfile, "workloadsWithPodLabelFilter");
             if (labelWorkloadTemplate == null) {
-                LOGGER.warn("workloadsWithPodLabelFilter query not found in metadata profile, falling back to standard query");
-                hasLabelFilter = false;
-            } else {
-                LOGGER.info("Label filter present — using workloadsWithPodLabelFilter template for workload query");
+                LOGGER.error("Pod label filtering requested but 'workloadsWithPodLabelFilter' query not found in metadata profile '{}'", metadataProfileName);
+                return null;
             }
+            LOGGER.info("Label filter present — using workloadsWithPodLabelFilter template for workload query");
         }
 
         final boolean useLabelTemplate = hasLabelFilter;
@@ -236,7 +235,9 @@ public class DataSourceMetadataOperator {
             // the field!="" pattern which may legitimately appear inside PromQL label selectors.
             boolean isLabelTemplate = useLabelTemplate && field.equals("workload");
             if (queryTemplate.contains("%s")) {
-                filteredQuery = String.format(queryTemplate, filter);
+                // Use default field!="" filter if no regex provided
+                String filterToUse = filter.isEmpty() ? field + "!=\"\"" : filter;
+                filteredQuery = String.format(queryTemplate, filterToUse);
 
             } else if (!isLabelTemplate && queryTemplate.contains(field + "!=\"\"")) {
                 filteredQuery = queryTemplate.replace(
@@ -319,6 +320,8 @@ public class DataSourceMetadataOperator {
             }
             if (hasLabelFilter && datasourceWorkloads.isEmpty()) {
                 LOGGER.info("Label filter matched zero workloads — skipping experiment creation");
+                // Clear singleton to avoid leaving partial state (namespaces populated but no workloads/containers)
+                this.dataSourceMetadataInfo = null;
                 return null;
             }
             dataSourceDetailsHelper.updateWorkloadDataSourceMetadataInfoObject(dataSourceName, dataSourceMetadataInfo,
@@ -355,9 +358,9 @@ public class DataSourceMetadataOperator {
         DataSourceMetadataHelper dataSourceDetailsHelper = new DataSourceMetadataHelper();
 
         return switch (field) {
-            case "namespace" -> dataSourceDetailsHelper.getQueryFromProfile(metadataProfile, AnalyzerConstants.NAMESPACE);
-            case "workload" -> dataSourceDetailsHelper.getQueryFromProfile(metadataProfile, AnalyzerConstants.WORKLOAD);
-            case "container" -> dataSourceDetailsHelper.getQueryFromProfile(metadataProfile, AnalyzerConstants.CONTAINER);
+            case "namespace" -> dataSourceDetailsHelper.getQueryFromProfile(metadataProfile, AnalyzerConstants.NAMESPACE_METADATA_QUERY);
+            case "workload" -> dataSourceDetailsHelper.getQueryFromProfile(metadataProfile, AnalyzerConstants.WORKLOAD_METADATA_QUERY);
+            case "container" -> dataSourceDetailsHelper.getQueryFromProfile(metadataProfile, AnalyzerConstants.CONTAINER_METADATA_QUERY);
             default -> throw new IllegalArgumentException("Unknown field: " + field);
         };
     }

--- a/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
@@ -196,86 +196,55 @@ public class DataSourceMetadataOperator {
             return null;
         }
 
+        // Get query templates for each field
+        String namespaceQueryTemplate = getQueryTemplate("namespace", metadataProfile);
+        String workloadQueryTemplate;
+        String containerQueryTemplate = getQueryTemplate("container", metadataProfile);
+
         // Determine if pod label filters are present — if so, use label-aware workload template
         String includePodLabelFilter = includeResources.getOrDefault("podLabelFilter", "");
         String excludePodLabelFilter = excludeResources.getOrDefault("podLabelFilter", "");
         boolean hasLabelFilter = !includePodLabelFilter.isEmpty() || !excludePodLabelFilter.isEmpty();
 
-        String labelWorkloadTemplate = null;
         if (hasLabelFilter) {
-            labelWorkloadTemplate = dataSourceDetailsHelper.getQueryFromProfile(metadataProfile, AnalyzerConstants.WORKLOAD_METADATA_QUERY_WITH_LABEL_FILTER);
-            if (labelWorkloadTemplate == null) {
+            workloadQueryTemplate = dataSourceDetailsHelper.getQueryFromProfile(metadataProfile, AnalyzerConstants.WORKLOAD_METADATA_QUERY_WITH_LABEL_FILTER);
+            if (workloadQueryTemplate == null) {
                 LOGGER.error("Pod label filtering requested but '{}' query not found in metadata profile '{}'",
                     AnalyzerConstants.WORKLOAD_METADATA_QUERY_WITH_LABEL_FILTER, metadataProfileName);
                 return null;
             }
             LOGGER.info("Label filter present — using {} template for workload query", AnalyzerConstants.WORKLOAD_METADATA_QUERY_WITH_LABEL_FILTER);
+        } else {
+            workloadQueryTemplate = getQueryTemplate("workload", metadataProfile);
         }
 
-        final boolean useLabelTemplate = hasLabelFilter;
-        final String finalLabelWorkloadTemplate = labelWorkloadTemplate;
-
-        // Populate filters for each field
-        fields.forEach(field -> {
-            String includeRegex = includeResources.getOrDefault(field + "Regex", "");
-            String excludeRegex = excludeResources.getOrDefault(field + "Regex", "");
-            String filter = constructDynamicFilter(field, includeRegex, excludeRegex);
-
-            // For the workload field, use the label-aware template when a label filter is present
-            String queryTemplate = (field.equals("workload") && useLabelTemplate)
-                    ? finalLabelWorkloadTemplate
-                    : getQueryTemplate(field, metadataProfile);
-
-            if (queryTemplate == null) {
-                LOGGER.error("Query template is null for field {}, cannot proceed", field);
-                queries.put(field, null);
-                return;
-            }
-            String filteredQuery;
-            // For the label workload template, only allow %s substitution; avoid replacing
-            // the field!="" pattern which may legitimately appear inside PromQL label selectors.
-            boolean isLabelTemplate = useLabelTemplate && field.equals("workload");
-            if (queryTemplate.contains("%s")) {
-                // Use default field!="" filter if no regex provided
-                String filterToUse = filter.isEmpty() ? field + "!=\"\"" : filter;
-                filteredQuery = String.format(queryTemplate, filterToUse);
-
-            } else if (!isLabelTemplate && queryTemplate.contains(field + "!=\"\"")) {
-                filteredQuery = queryTemplate.replace(
-                    field + "!=\"\"",
-                    filter.isEmpty() ? field + "!=\"\"" : filter
-                );
-
-            } else {
-                LOGGER.warn(
-                    "No injectable filter placeholder found for field {} in queryTemplate={}",
-                    field,
-                    queryTemplate
-                );
-                filteredQuery = queryTemplate; // fallback
-            }
-
-            queries.put(field, filteredQuery);
-        });
-
-        // Abort if any required query template was missing
-        if (queries.containsValue(null)) {
+        // Validate all templates are present
+        if (namespaceQueryTemplate == null || workloadQueryTemplate == null || containerQueryTemplate == null) {
             LOGGER.error("One or more query templates could not be resolved for metadata profile '{}', aborting metadata fetch", metadataProfileName);
             return null;
         }
 
-        // Construct queries
-        String namespaceQuery = queries.get("namespace");
-        String workloadQuery = queries.get("workload");
-        String containerQuery = queries.get("container");
+        // Build named filters for each query type
+        String namespaceFilters = buildNamespaceFilters(includeResources, excludeResources);
+        String workloadFilters = buildWorkloadFilters(includeResources, excludeResources);
+        String containerFilters = buildContainerFilters(includeResources, excludeResources);
+        String labels = buildLabels(includeResources, excludeResources);
+
+        // Replace named placeholders in queries
+        String namespaceQuery = namespaceQueryTemplate
+                .replace(KruizeConstants.KRUIZE_BULK_API.NAMESPACE_FILTERS, namespaceFilters)
+                .replace(KruizeConstants.KRUIZE_BULK_API.LABELS, labels);
+
+        String workloadQuery = workloadQueryTemplate
+                .replace(KruizeConstants.KRUIZE_BULK_API.WORKLOAD_FILTERS, workloadFilters)
+                .replace(KruizeConstants.KRUIZE_BULK_API.LABELS, labels);
+
+        String containerQuery = containerQueryTemplate
+                .replace(KruizeConstants.KRUIZE_BULK_API.CONTAINER_FILTERS, containerFilters)
+                .replace(KruizeConstants.KRUIZE_BULK_API.WORKLOAD_FILTERS, workloadFilters)
+                .replace(KruizeConstants.KRUIZE_BULK_API.LABELS, labels);
 
         String dataSourceName = dataSourceInfo.getName();
-
-        workloadQuery = substituteWorkloadQueryPlaceholders(
-                workloadQuery, includePodLabelFilter, excludePodLabelFilter, hasLabelFilter);
-
-        namespaceQuery = namespaceQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "");
-        containerQuery = containerQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "");
 
         namespaceQuery = namespaceQuery.replace(AnalyzerConstants.MEASUREMENT_DURATION_IN_MIN_VARAIBLE, Integer.toString(measurementDuration));
         workloadQuery = workloadQuery.replace(AnalyzerConstants.MEASUREMENT_DURATION_IN_MIN_VARAIBLE, Integer.toString(measurementDuration));
@@ -384,26 +353,60 @@ public class DataSourceMetadataOperator {
         return filterBuilder.toString();
     }
 
-    static String substituteWorkloadQueryPlaceholders(String workloadQuery,
-                                                         String includePodLabelFilter,
-                                                         String excludePodLabelFilter,
-                                                         boolean hasLabelFilter) {
-        if (hasLabelFilter) {
-            StringBuilder labelFilter = new StringBuilder();
-            if (!includePodLabelFilter.isEmpty()) labelFilter.append(",").append(includePodLabelFilter);
-            if (!excludePodLabelFilter.isEmpty()) {
-                labelFilter.append(",").append(excludePodLabelFilter);
-            }
-            workloadQuery = workloadQuery.replace(KruizeConstants.KRUIZE_BULK_API.LABEL_FILTER, labelFilter.toString());
-        } else {
-            workloadQuery = workloadQuery.replace(KruizeConstants.KRUIZE_BULK_API.LABEL_FILTER, "");
+    /**
+     * Build NAMESPACE_FILTERS placeholder value
+     */
+    private String buildNamespaceFilters(Map<String, String> includeResources, Map<String, String> excludeResources) {
+        String includeRegex = includeResources.getOrDefault("namespaceRegex", "");
+        String excludeRegex = excludeResources.getOrDefault("namespaceRegex", "");
+        return constructDynamicFilter("namespace", includeRegex, excludeRegex);
+    }
+
+    /**
+     * Build WORKLOAD_FILTERS placeholder value (includes workload name + pod labels)
+     */
+    private String buildWorkloadFilters(Map<String, String> includeResources, Map<String, String> excludeResources) {
+        StringBuilder filters = new StringBuilder();
+
+        // Add workload name filter
+        String workloadIncludeRegex = includeResources.getOrDefault("workloadRegex", "");
+        String workloadExcludeRegex = excludeResources.getOrDefault("workloadRegex", "");
+        String workloadFilter = constructDynamicFilter("workload", workloadIncludeRegex, workloadExcludeRegex);
+        filters.append(workloadFilter);
+
+        // Add pod label filters
+        String includePodLabelFilter = includeResources.getOrDefault("podLabelFilter", "");
+        String excludePodLabelFilter = excludeResources.getOrDefault("podLabelFilter", "");
+
+        if (!includePodLabelFilter.isEmpty()) {
+            if (filters.length() > 0) filters.append(", ");
+            filters.append(includePodLabelFilter);
+        }
+        if (!excludePodLabelFilter.isEmpty()) {
+            if (filters.length() > 0) filters.append(", ");
+            filters.append(excludePodLabelFilter);
         }
 
-        workloadQuery = workloadQuery.replace(KruizeConstants.KRUIZE_BULK_API.ADDITIONAL_LABEL, "");
+        return filters.toString();
+    }
 
-        workloadQuery = workloadQuery.replaceAll("\\s{2,}", " ").replaceAll("\\s+}", "}").replaceAll("\\{\\s+", "{");
+    /**
+     * Build CONTAINER_FILTERS placeholder value
+     */
+    private String buildContainerFilters(Map<String, String> includeResources, Map<String, String> excludeResources) {
+        String includeRegex = includeResources.getOrDefault("containerRegex", "");
+        String excludeRegex = excludeResources.getOrDefault("containerRegex", "");
+        return constructDynamicFilter("container", includeRegex, excludeRegex);
+    }
 
-        return workloadQuery;
+    /**
+     * Build LABELS placeholder value (global labels like cluster_id, org_id)
+     * Currently returns empty string - can be enhanced to support labels from request
+     */
+    private String buildLabels(Map<String, String> includeResources, Map<String, String> excludeResources) {
+        // TODO: Support labels from request (cluster_id, org_id, etc.)
+        // For now, return empty string
+        return "";
     }
 
     private JsonArray fetchQueryResults(DataSourceInfo dataSourceInfo, String query, long startTime, long endTime, int steps) throws IOException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException {

--- a/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
@@ -375,32 +375,13 @@ public class DataSourceMetadataOperator {
     }
 
     /**
-     * Build WORKLOAD_FILTERS placeholder value (includes workload name + pod labels)
+     * Build WORKLOAD_FILTERS placeholder value (workload name filters only)
      */
     private String buildWorkloadFilters(Map<String, String> includeResources, Map<String, String> excludeResources) {
-        StringBuilder filters = new StringBuilder();
-
-        // Add workload name filter
         String workloadIncludeRegex = includeResources.getOrDefault("workloadRegex", "");
         String workloadExcludeRegex = excludeResources.getOrDefault("workloadRegex", "");
         String workloadFilter = constructDynamicFilter("workload", workloadIncludeRegex, workloadExcludeRegex);
-        filters.append(workloadFilter);
-
-        // Add pod label filters
-        String includePodLabelFilter = includeResources.getOrDefault("podLabelFilter", "");
-        String excludePodLabelFilter = excludeResources.getOrDefault("podLabelFilter", "");
-
-        if (!includePodLabelFilter.isEmpty()) {
-            if (filters.length() > 0) filters.append(", ");
-            filters.append(includePodLabelFilter);
-        }
-        if (!excludePodLabelFilter.isEmpty()) {
-            if (filters.length() > 0) filters.append(", ");
-            filters.append(excludePodLabelFilter);
-        }
-
-        String result = filters.toString();
-        return result.isEmpty() ? "" : ", " + result;
+        return workloadFilter.isEmpty() ? "" : ", " + workloadFilter;
     }
 
     /**
@@ -414,14 +395,26 @@ public class DataSourceMetadataOperator {
     }
 
     /**
-     * Build LABELS placeholder value (global labels like cluster_id, org_id)
+     * Build LABELS placeholder value (pod label filters)
      * Returns with leading comma for chaining
-     * Currently returns empty string - can be enhanced to support labels from request
      */
     private String buildLabels(Map<String, String> includeResources, Map<String, String> excludeResources) {
-        // TODO: Support labels from request (cluster_id, org_id, etc.)
-        // For now, return empty string (no leading comma needed for empty)
-        return "";
+        StringBuilder filters = new StringBuilder();
+
+        // Add pod label filters
+        String includePodLabelFilter = includeResources.getOrDefault("podLabelFilter", "");
+        String excludePodLabelFilter = excludeResources.getOrDefault("podLabelFilter", "");
+
+        if (!includePodLabelFilter.isEmpty()) {
+            filters.append(includePodLabelFilter);
+        }
+        if (!excludePodLabelFilter.isEmpty()) {
+            if (filters.length() > 0) filters.append(", ");
+            filters.append(excludePodLabelFilter);
+        }
+
+        String result = filters.toString();
+        return result.isEmpty() ? "" : ", " + result;
     }
 
     private JsonArray fetchQueryResults(DataSourceInfo dataSourceInfo, String query, long startTime, long endTime, int steps) throws IOException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException {

--- a/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
+++ b/src/main/java/com/autotune/common/datasource/DataSourceMetadataOperator.java
@@ -236,11 +236,14 @@ public class DataSourceMetadataOperator {
                 .replace(KruizeConstants.KRUIZE_BULK_API.LABELS, labels);
 
         String workloadQuery = workloadQueryTemplate
+                .replace(KruizeConstants.KRUIZE_BULK_API.NAMESPACE_FILTERS, namespaceFilters)
+                .replace(KruizeConstants.KRUIZE_BULK_API.CONTAINER_FILTERS, containerFilters)
                 .replace(KruizeConstants.KRUIZE_BULK_API.WORKLOAD_FILTERS, workloadFilters)
                 .replace(KruizeConstants.KRUIZE_BULK_API.LABELS, labels);
 
         String containerQuery = containerQueryTemplate
                 .replace(KruizeConstants.KRUIZE_BULK_API.CONTAINER_FILTERS, containerFilters)
+                .replace(KruizeConstants.KRUIZE_BULK_API.NAMESPACE_FILTERS, namespaceFilters)
                 .replace(KruizeConstants.KRUIZE_BULK_API.WORKLOAD_FILTERS, workloadFilters)
                 .replace(KruizeConstants.KRUIZE_BULK_API.LABELS, labels);
 
@@ -254,6 +257,14 @@ public class DataSourceMetadataOperator {
         String unsupportedWorkloadTypesFilter = AnalyzerConstants.getUnsupportedWorkloadTypesFilter();
         workloadQuery = workloadQuery.replace(AnalyzerConstants.UNSUPPORTED_WORKLOAD_TYPES_VARIABLE, unsupportedWorkloadTypesFilter);
         containerQuery = containerQuery.replace(AnalyzerConstants.UNSUPPORTED_WORKLOAD_TYPES_VARIABLE, unsupportedWorkloadTypesFilter);
+
+        // Clean up label selector formatting (from filter chaining with leading commas)
+        // Remove leading commas: {, filter} -> {filter}
+        // Remove trailing commas: {filter, } -> {filter}
+        // Normalize spacing: filter , filter -> filter, filter
+        namespaceQuery = namespaceQuery.replaceAll("\\{,\\s*", "{").replaceAll(",\\s*\\}", "}").replaceAll("\\s+,", ",");
+        workloadQuery = workloadQuery.replaceAll("\\{,\\s*", "{").replaceAll(",\\s*\\}", "}").replaceAll("\\s+,", ",");
+        containerQuery = containerQuery.replaceAll("\\{,\\s*", "{").replaceAll(",\\s*\\}", "}").replaceAll("\\s+,", ",");
 
         LOGGER.info("namespaceQuery: {}", namespaceQuery);
         LOGGER.info("workloadQuery: {}", workloadQuery);
@@ -354,12 +365,13 @@ public class DataSourceMetadataOperator {
     }
 
     /**
-     * Build NAMESPACE_FILTERS placeholder value
+     * Build NAMESPACE_FILTERS placeholder value with leading comma for chaining
      */
     private String buildNamespaceFilters(Map<String, String> includeResources, Map<String, String> excludeResources) {
         String includeRegex = includeResources.getOrDefault("namespaceRegex", "");
         String excludeRegex = excludeResources.getOrDefault("namespaceRegex", "");
-        return constructDynamicFilter("namespace", includeRegex, excludeRegex);
+        String filter = constructDynamicFilter("namespace", includeRegex, excludeRegex);
+        return filter.isEmpty() ? "" : ", " + filter;
     }
 
     /**
@@ -387,25 +399,28 @@ public class DataSourceMetadataOperator {
             filters.append(excludePodLabelFilter);
         }
 
-        return filters.toString();
+        String result = filters.toString();
+        return result.isEmpty() ? "" : ", " + result;
     }
 
     /**
-     * Build CONTAINER_FILTERS placeholder value
+     * Build CONTAINER_FILTERS placeholder value with leading comma for chaining
      */
     private String buildContainerFilters(Map<String, String> includeResources, Map<String, String> excludeResources) {
         String includeRegex = includeResources.getOrDefault("containerRegex", "");
         String excludeRegex = excludeResources.getOrDefault("containerRegex", "");
-        return constructDynamicFilter("container", includeRegex, excludeRegex);
+        String filter = constructDynamicFilter("container", includeRegex, excludeRegex);
+        return filter.isEmpty() ? "" : ", " + filter;
     }
 
     /**
      * Build LABELS placeholder value (global labels like cluster_id, org_id)
+     * Returns with leading comma for chaining
      * Currently returns empty string - can be enhanced to support labels from request
      */
     private String buildLabels(Map<String, String> includeResources, Map<String, String> excludeResources) {
         // TODO: Support labels from request (cluster_id, org_id, etc.)
-        // For now, return empty string
+        // For now, return empty string (no leading comma needed for empty)
         return "";
     }
 

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -957,6 +957,7 @@ public class KruizeConstants {
         public static final String END_TIME = "end_time";
         public static final String STEPS = "steps";
         public static final String ADDITIONAL_LABEL = "ADDITIONAL_LABEL";
+        public static final String LABEL_FILTER = "LABEL_FILTER";
         public static final String SUMMARY = "summary";
         public static final String SUMMARY_FILTER = "summaryFilter";
         public static final String EXPERIMENTS = "experiments";

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -956,6 +956,7 @@ public class KruizeConstants {
         public static final String START_TIME = "start_time";
         public static final String END_TIME = "end_time";
         public static final String STEPS = "steps";
+<<<<<<< Updated upstream
         public static final String ADDITIONAL_LABEL = "ADDITIONAL_LABEL";
         public static final String LABEL_FILTER = "LABEL_FILTER";
         // Named filter placeholders for query templates
@@ -963,6 +964,13 @@ public class KruizeConstants {
         public static final String WORKLOAD_FILTERS = "WORKLOAD_FILTERS";
         public static final String CONTAINER_FILTERS = "CONTAINER_FILTERS";
         public static final String LABELS = "LABELS";
+=======
+        // Named filter placeholders for query templates ($ wrapped for consistency)
+        public static final String NAMESPACE_FILTERS = "$NAMESPACE_FILTERS$";
+        public static final String WORKLOAD_FILTERS = "$WORKLOAD_FILTERS$";
+        public static final String CONTAINER_FILTERS = "$CONTAINER_FILTERS$";
+        public static final String LABELS = "$LABELS$";
+>>>>>>> Stashed changes
         public static final String SUMMARY = "summary";
         public static final String SUMMARY_FILTER = "summaryFilter";
         public static final String EXPERIMENTS = "experiments";
@@ -1008,6 +1016,18 @@ public class KruizeConstants {
             CREATE_EXPERIMENT_CONFIG_BEAN.setMeasurementDurationStr("15min");
             CREATE_EXPERIMENT_CONFIG_BEAN.setMeasurementDuration(15);
             CREATE_EXPERIMENT_CONFIG_BEAN.setMetadataProfile(AnalyzerConstants.MetadataProfileConstants.CLUSTER_METADATA_LOCAL_MON_PROFILE);
+        }
+
+        public static class LabelFilterConstants {
+            public static final String LOG_LABEL_EXPERIMENT_NAME_ERROR = "Error building label string for experiment name: {}";
+            public static final String LOG_LABEL_ALL_INVALID = "All label entries were invalid or empty — no pod label filter will be applied";
+            public static final String LOG_LABEL_NULL_KEY = "Skipping label with null or empty key";
+            public static final String LOG_LABEL_NULL_VALUE = "Skipping label '{}' with null value";
+            public static final String LOG_LABEL_NULL_LIST_ENTRY = "Skipping null entry in label '{}' list";
+            public static final String LOG_LABEL_NON_STRING_ENTRY = "Skipping non-string entry in label '{}' list: {}";
+            public static final String LOG_LABEL_NO_VALID_VALUES = "Label '{}' has no valid values after filtering, skipping";
+            public static final String LOG_LABEL_EMPTY_VALUE = "Skipping label '{}' with empty string value";
+            public static final String LOG_LABEL_UNSUPPORTED_TYPE = "Skipping label '{}' with unsupported value type: {}";
         }
 
         public static class NotificationConstants {

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -958,6 +958,11 @@ public class KruizeConstants {
         public static final String STEPS = "steps";
         public static final String ADDITIONAL_LABEL = "ADDITIONAL_LABEL";
         public static final String LABEL_FILTER = "LABEL_FILTER";
+        // Named filter placeholders for query templates
+        public static final String NAMESPACE_FILTERS = "NAMESPACE_FILTERS";
+        public static final String WORKLOAD_FILTERS = "WORKLOAD_FILTERS";
+        public static final String CONTAINER_FILTERS = "CONTAINER_FILTERS";
+        public static final String LABELS = "LABELS";
         public static final String SUMMARY = "summary";
         public static final String SUMMARY_FILTER = "summaryFilter";
         public static final String EXPERIMENTS = "experiments";

--- a/src/main/java/com/autotune/utils/KruizeConstants.java
+++ b/src/main/java/com/autotune/utils/KruizeConstants.java
@@ -956,21 +956,12 @@ public class KruizeConstants {
         public static final String START_TIME = "start_time";
         public static final String END_TIME = "end_time";
         public static final String STEPS = "steps";
-<<<<<<< Updated upstream
-        public static final String ADDITIONAL_LABEL = "ADDITIONAL_LABEL";
-        public static final String LABEL_FILTER = "LABEL_FILTER";
-        // Named filter placeholders for query templates
-        public static final String NAMESPACE_FILTERS = "NAMESPACE_FILTERS";
-        public static final String WORKLOAD_FILTERS = "WORKLOAD_FILTERS";
-        public static final String CONTAINER_FILTERS = "CONTAINER_FILTERS";
-        public static final String LABELS = "LABELS";
-=======
         // Named filter placeholders for query templates ($ wrapped for consistency)
         public static final String NAMESPACE_FILTERS = "$NAMESPACE_FILTERS$";
         public static final String WORKLOAD_FILTERS = "$WORKLOAD_FILTERS$";
         public static final String CONTAINER_FILTERS = "$CONTAINER_FILTERS$";
         public static final String LABELS = "$LABELS$";
->>>>>>> Stashed changes
+
         public static final String SUMMARY = "summary";
         public static final String SUMMARY_FILTER = "summaryFilter";
         public static final String EXPERIMENTS = "experiments";
@@ -1123,17 +1114,6 @@ public class KruizeConstants {
 
         }
 
-        public static class LabelFilterConstants {
-            public static final String LOG_LABEL_EXPERIMENT_NAME_ERROR = "Error building label string for experiment name: {}";
-            public static final String LOG_LABEL_ALL_INVALID = "All label entries were invalid or empty — no pod label filter will be applied";
-            public static final String LOG_LABEL_NULL_KEY = "Skipping label with null or empty key";
-            public static final String LOG_LABEL_NULL_VALUE = "Skipping label '{}' with null value";
-            public static final String LOG_LABEL_NULL_LIST_ENTRY = "Skipping null entry in label '{}' list";
-            public static final String LOG_LABEL_NON_STRING_ENTRY = "Skipping non-string entry in label '{}' list: {}";
-            public static final String LOG_LABEL_NO_VALID_VALUES = "Label '{}' has no valid values after filtering, skipping";
-            public static final String LOG_LABEL_EMPTY_VALUE = "Skipping label '{}' with empty string value";
-            public static final String LOG_LABEL_UNSUPPORTED_TYPE = "Skipping label '{}' with unsupported value type: {}";
-        }
     }
 
     public static final class MetadataProfileConstants {


### PR DESCRIPTION
## Description

 - DataSourceMetadataOperator.java — Core logic:
    - Adds substituteWorkloadQueryPlaceholders() method that replaces LABEL_FILTER and ADDITIONAL_LABEL placeholders in the PromQL query template with actual filter strings (commas prepended during substitution,
  not baked into templates)
    - Cleans up stray whitespace after substitution (\s{2,} →  , \s+} → }, {\s+ → {)
    - Selects workloadsWithPodLabelFilter template when pod label filters are present, falls back to standard workload query otherwise
    - Adds null check for metadata profile and query templates
    - Returns null with log message when label filter matches zero workloads — prevents empty experiment creation
    - Removes uniqueKey parameter from createDataSourceMetadata(), updateDataSourceMetadata(), and processQueriesAndPopulateDataSourceMetadataInfo()
 - DSMetadataService.java — Removes the now-unused uniqueKey argument ("") from the importMetadataFromDataSource() call
  - KruizeConstants.java — Adds LABEL_FILTER constant used for placeholder substitution
  - DataSourceManager.java — Removes uniqueKey parameter from importMetadataFromDataSource() and updates internal calls to match -- > uniqueKey was a pass-through string (e.g. container="xyz" namespace="abc") that got blindly appended into queries via ADDITIONAL_LABEL replacement. It was the old way of injecting labels into queries.
  
  This PR replaces it with a structured approach:

  - Before: Caller builds a raw PromQL snippet as uniqueKey → DataSourceMetadataOperator does query.replace(ADDITIONAL_LABEL, "," + uniqueKey) on all 3 queries (namespace, workload, container)
  - After: Label filters come in via includeResources.get("podLabelFilter") / excludeResources.get("podLabelFilter") → substituteWorkloadQueryPlaceholders() substitutes LABEL_FILTER and ADDITIONAL_LABEL
  placeholders only on the workload query, with proper comma handling and whitespace cleanup

  So uniqueKey is removed because its job is now handled by the dedicated podLabelFilter entries in the include/exclude resource maps + the LABEL_FILTER placeholder substitution logic. It's not a separate parameter
  anymore — it flows through the existing resource filter maps.


  

  Depends on

  - PR #2042 (label filter builder + metadata profiles)


### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [x] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Support structured pod label filters in Bulk API metadata discovery while removing the legacy uniqueKey query injection path.

New Features:
- Add pod label filtering to Bulk API metadata queries through dedicated include and exclude resource filters.
- Skip metadata and experiment creation when pod label filters match no workloads.

Bug Fixes:
- Prevent metadata processing when profiles or required query templates are missing.

Enhancements:
- Remove the obsolete uniqueKey parameter from metadata import and query-processing APIs.
- Improve workload query template selection and placeholder cleanup for label-filtered PromQL.

Tests:
- Run the functional test suite.

Chores:
- Update the local monitoring bulk metadata profile to support label-filter query substitution.