### PR TITLE
Skip workload app deletion in optimizer demo

### DIFF
--- a/tests/scripts/kruize_demos_test/kruize_demos_test.sh
+++ b/tests/scripts/kruize_demos_test/kruize_demos_test.sh
@@ -349,6 +349,10 @@ function run_demo() {
 		fi
 	fi
 
+	if [ "${DEMO_NAME}" == "optimizer" ]; then
+		CMD+=( --skip-app)
+	fi
+
 	CLEANUP_CMD="${CMD[@]} -t"
 
 	DEMO_LOG_DIR="${LOG_DIR}/${DEMO_NAME}"


### PR DESCRIPTION
## Description

Skip workload app deletion in optimizer demo
### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Enhancements:
- Preserve workload applications when running the optimizer demo by skipping application deletion during cleanup.