### PR TITLE
Fix: Resolve "Transaction already active" crash on Kruize restart during DDL execution

### DIFF
--- a/migrations/lm/v104__add_fk_metadata_id_to_kruize_lm_experiments.sql
+++ b/migrations/lm/v104__add_fk_metadata_id_to_kruize_lm_experiments.sql
@@ -1,1 +1,1 @@
-alter table kruize_lm_experiments  add column metadata_id bigint references kruize_dsmetadata(id);
+alter table kruize_lm_experiments add column if not exists metadata_id bigint references kruize_dsmetadata(id);

--- a/migrations/lm/v109__add_uk_lm_experiment_name.sql
+++ b/migrations/lm/v109__add_uk_lm_experiment_name.sql
@@ -1,1 +1,9 @@
-alter table if exists kruize_lm_experiments add constraint UK_lm_experiment_name unique (experiment_name);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'uk_lm_experiment_name'
+    ) THEN
+        ALTER TABLE kruize_lm_experiments ADD CONSTRAINT UK_lm_experiment_name UNIQUE (experiment_name);
+    END IF;
+END
+$$;

--- a/src/main/java/com/autotune/Autotune.java
+++ b/src/main/java/com/autotune/Autotune.java
@@ -372,7 +372,6 @@ public class Autotune {
             for (Path sqlFilePath : sqlFiles) {
                 LOGGER.debug("Applying SQL file: {}", sqlFilePath.toString());
                 String sqlStatement = Files.readString(sqlFilePath, StandardCharsets.UTF_8);
-                Transaction transaction = session.beginTransaction();
                 String trimmed = sqlStatement.trim();
                 // skip blank and comment-only statements
                 if (trimmed.isEmpty()
@@ -382,8 +381,10 @@ public class Autotune {
                     continue;
                 }
 
+                Transaction transaction = session.beginTransaction();
                 try {
                     session.createNativeQuery(trimmed).executeUpdate();
+                    transaction.commit();
                 } catch (Exception e) {
                     String msg = Optional.ofNullable(e.getMessage()).orElse("");
                     if (msg.contains(DBConstants.DB_MESSAGES.ADD_CONSTRAINT)) {
@@ -394,19 +395,11 @@ public class Autotune {
                         LOGGER.error("sql: {} failed due to : {}", trimmed, msg);
                     }
 
-                    // Commit current transaction and begin a new one
+                    // Roll back the failed transaction so the session is clean for the next file
                     try {
-                        transaction.commit();
+                        transaction.rollback();
                     } catch (Exception ignore) {
                     }
-                    transaction = session.beginTransaction();
-                }
-
-                // commit file-level transaction
-                try {
-                    transaction.commit();
-                } catch (Exception e) {
-                    LOGGER.error("Failed to commit transaction after processing file {}: {}", sqlFilePath, e.getMessage());
                 }
             }
 

--- a/src/main/java/com/autotune/Autotune.java
+++ b/src/main/java/com/autotune/Autotune.java
@@ -398,7 +398,8 @@ public class Autotune {
                     // Roll back the failed transaction so the session is clean for the next file
                     try {
                         transaction.rollback();
-                    } catch (Exception ignore) {
+                    } catch (Exception ex) {
+                        LOGGER.warn("Failed to rollback transaction after failure of SQL: {}", trimmed, ex);
                     }
                 }
             }


### PR DESCRIPTION
## Description

When Kruize is restarted, the `executeDDLs()` method crashes with `Transaction already active` after processing the first DDL that was already applied (e.g. `ADD COLUMN` / `ADD CONSTRAINT`):

```
ERROR Exception occurred while trying to read the DDL(s): Transaction already active
java.lang.IllegalStateException: Transaction already active
at org.hibernate.engine.transaction.internal.TransactionImpl.begin(TransactionImpl.java:74)
```

## Root Cause

Three bugs in `Autotune.executeDDLs()`:

### 1. Leaked transaction on blank/comment skip
`session.beginTransaction()` was called *before* the blank/comment guard. When a file was
skipped via `continue`, the opened transaction was never committed or rolled back, leaving it
dangling on the session. The next iteration then hit `Transaction already active`.

### 2. `commit()` called on a broken transaction
After a DDL failure (e.g. column/constraint already exists), Hibernate marks the transaction
as rolled-back internally. The recovery path called `transaction.commit()`, which was silently
swallowed by a `catch (Exception ignore)` — but the transaction handle remained "active" on
the session. The subsequent `session.beginTransaction()` therefore threw the same exception.

### 3. Unnecessary double-commit on the happy path
On success, `transaction.commit()` was called once inside the catch-recovery block and once
again in the outer finally-style block, resulting in a redundant commit on an empty transaction.

## Fix

- Move `session.beginTransaction()` to *after* the skip guard, so no transaction is ever
  opened for blank/comment-only files.
- Replace `transaction.commit()` in the error path with `transaction.rollback()`, which
  correctly ends the failed transaction and returns the session to a clean state.
- Move `transaction.commit()` into the `try` block immediately after the successful
  `executeUpdate()`, eliminating the redundant outer commit.

## Testing

Restart Kruize against an existing database (schema already migrated). Previously this would
crash with `Transaction already active` on the first idempotent DDL. After this fix, the
expected `WARN` messages are logged for already-applied DDLs and startup completes normally.

Fixes #2044 

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Ensure Kruize startup completes reliably when rerunning database migrations after a restart.

Bug Fixes:
- Prevent DDL execution from leaving Hibernate transactions active after skipped or failed statements, allowing Kruize to restart cleanly against an already-migrated database.
- Make migration DDLs idempotent when columns or constraints already exist.