### PR TITLE
add resource requests and limits to apps in all deployment yamls

### DIFF
--- a/manifests/autotune/autotune-operator-deployment.yaml_template
+++ b/manifests/autotune/autotune-operator-deployment.yaml_template
@@ -34,6 +34,13 @@ spec:
                 name: autotune-config
                 key: root_logging_level
                 optional: true
+        resources:
+          requests:
+            memory: "768Mi"
+            cpu: "0.7"
+          limits:
+            memory: "768Mi"
+            cpu: "0.7"
       - name: autotune
         image: "{{ AUTOTUNE_IMAGE }}"
         imagePullPolicy: Always
@@ -90,6 +97,13 @@ spec:
         envFrom: 
           - configMapRef:
               name: autotune-config
+        resources:
+          requests:
+            memory: "768Mi"
+            cpu: "0.7"
+          limits:
+            memory: "768Mi"
+            cpu: "0.7"
         ports:
          - name: autotune-port
            containerPort: 8080

--- a/manifests/autotune/autotune-operator-openshift-deployment.yaml_template
+++ b/manifests/autotune/autotune-operator-openshift-deployment.yaml_template
@@ -35,6 +35,13 @@ spec:
                 name: autotune-config
                 key: root_logging_level
                 optional: true
+        resources:
+          requests:
+            memory: "768Mi"
+            cpu: "0.7"
+          limits:
+            memory: "768Mi"
+            cpu: "0.7"
       - name: autotune
         image: "{{ AUTOTUNE_IMAGE }}"
         imagePullPolicy: Always
@@ -91,6 +98,13 @@ spec:
         envFrom: 
           - configMapRef:
               name: autotune-config
+        resources:
+          requests:
+            memory: "768Mi"
+            cpu: "0.7"
+          limits:
+            memory: "768Mi"
+            cpu: "0.7"
         ports:
          - name: autotune-port
            containerPort: 8080

--- a/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/BYODB-installation/minikube/kruize-crc-minikube.yaml
@@ -116,6 +116,13 @@ spec:
               value: "summary"
             - name: KAFKA_RESPONSE_FILTER_EXCLUDE
               value: ""
+          resources:
+            requests:
+              memory: "768Mi"
+              cpu: "0.7"
+            limits:
+              memory: "768Mi"
+              cpu: "0.7"
           ports:
             - name: kruize-port
               containerPort: 8080
@@ -237,6 +244,13 @@ spec:
           env:
             - name: KRUIZE_UI_ENV
               value: "production"
+          resources:
+            requests:
+              memory: "10Mi"
+              cpu: "0.002"
+            limits:
+              memory: "10Mi"
+              cpu: "0.002"
           volumeMounts:
             - name: nginx-config-volume
               mountPath: /etc/nginx/nginx.conf

--- a/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/BYODB-installation/openshift/kruize-crc-openshift.yaml
@@ -277,6 +277,13 @@ spec:
           env:
             - name: KRUIZE_UI_ENV
               value: "production"
+          resources:
+            requests:
+              memory: "10Mi"
+              cpu: "0.002"
+            limits:
+              memory: "10Mi"
+              cpu: "0.002"
           volumeMounts:
             - name: nginx-config-volume
               mountPath: /etc/nginx/nginx.conf

--- a/manifests/crc/default-db-included-installation/aks/kruize-crc-aks.yaml
+++ b/manifests/crc/default-db-included-installation/aks/kruize-crc-aks.yaml
@@ -41,6 +41,13 @@ spec:
               value: kruizeDB
             - name: PGDATA
               value: /var/lib/postgresql/backup
+          resources:
+            requests:
+              memory: "100Mi"
+              cpu: "0.5"
+            limits:
+              memory: "100Mi"
+              cpu: "0.5"
           ports:
             - containerPort: 5432
           volumeMounts:
@@ -172,6 +179,13 @@ spec:
               value: "/etc/config/kruizeconfigjson"
             - name: JAVA_TOOL_OPTIONS
               value: "-XX:MaxRAMPercentage=80"
+          resources:
+            requests:
+              memory: "768Mi"
+              cpu: "0.7"
+            limits:
+              memory: "768Mi"
+              cpu: "0.7"
           ports:
             - name: kruize-port
               containerPort: 8080
@@ -334,6 +348,13 @@ spec:
           env:
             - name: KRUIZE_UI_ENV
               value: "production"
+          resources:
+            requests:
+              memory: "10Mi"
+              cpu: "0.002"
+            limits:
+              memory: "10Mi"
+              cpu: "0.002"
           volumeMounts:
             - name: nginx-config-volume
               mountPath: /etc/nginx/nginx.conf

--- a/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
+++ b/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
@@ -157,6 +157,13 @@ spec:
               value: admin
             - name: POSTGRES_DB
               value: kruizeDB
+          resources:
+            requests:
+              memory: "100Mi"
+              cpu: "0.5"
+            limits:
+              memory: "100Mi"
+              cpu: "0.5"
           ports:
             - containerPort: 5432
           volumeMounts:
@@ -309,6 +316,13 @@ spec:
               value: "summary"
             - name: KAFKA_RESPONSE_FILTER_EXCLUDE
               value: ""
+          resources:
+            requests:
+              memory: "768Mi"
+              cpu: "0.7"
+            limits:
+              memory: "768Mi"
+              cpu: "0.7"
           ports:
             - name: kruize-port
               containerPort: 8080
@@ -471,6 +485,13 @@ spec:
           env:
             - name: KRUIZE_UI_ENV
               value: "production"
+          resources:
+            requests:
+              memory: "10Mi"
+              cpu: "0.002"
+            limits:
+              memory: "10Mi"
+              cpu: "0.002"
           volumeMounts:
             - name: nginx-config-volume
               mountPath: /etc/nginx/nginx.conf

--- a/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+++ b/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
@@ -606,6 +606,13 @@ spec:
           env:
             - name: KRUIZE_UI_ENV
               value: "production"
+          resources:
+            requests:
+              memory: "10Mi"
+              cpu: "0.002"
+            limits:
+              memory: "10Mi"
+              cpu: "0.002"
           volumeMounts:
             - name: nginx-config-volume
               mountPath: /etc/nginx/nginx.conf


### PR DESCRIPTION
## Description

Automation pipeline reported violations as resources limits / requests is missing in the deployment yamls of some applications.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Breaking change (What changes might users need to make in their application due to this PR?)
- [ ] Requires DB changes

## How has this been tested?

Please describe the tests that were run to verify your changes and steps to reproduce. Please specify any test configuration required. 

- [ ] New Test X
- [ ] Functional testsuite

**Test Configuration**
* Kubernetes clusters tested on: 

## Checklist :dart:

- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information

Include any additional information such as links, test results, screenshots here

## Summary by Sourcery

Define CPU and memory resource requests and limits across all application deployment manifests.

Bug Fixes:
- Add CPU and memory requests and limits to application containers across the deployment manifests to address resource-policy violations.

Deployment:
- Apply resource requests and limits consistently across Autotune and Kruize deployment configurations for Minikube, OpenShift, and AKS environments.